### PR TITLE
feat(whatsapp): add messaging controls and lifecycle hardening

### DIFF
--- a/src/channels/accounts.ts
+++ b/src/channels/accounts.ts
@@ -71,6 +71,7 @@ const SNAKE_TO_CAMEL: Record<string, string> = {
   thread_policy_by_channel: "threadPolicyByChannel",
   transcribe_voice: "transcribeVoice",
   download_media: "downloadMedia",
+  waiting_behavior: "waitingBehavior",
 };
 
 let warnedAboutDualKeys = false;
@@ -386,6 +387,8 @@ function normalizeLoadedAccount<T extends ChannelAccount>(account: T): T {
     next.attachmentAllowedPaths = [...(next.attachmentAllowedPaths ?? [])];
     next.attachmentPathRecursive = next.attachmentPathRecursive === true;
     next.inboundDebounceMs = normalizeInboundDebounceMs(next.inboundDebounceMs);
+    next.waitingBehavior =
+      next.waitingBehavior === "typing_indicator" ? "typing_indicator" : "off";
   }
   if (isSignalChannelAccount(next)) {
     next.baseUrl = next.baseUrl ?? "";
@@ -480,6 +483,7 @@ function makeDefaultLegacyAccount(
       attachmentAllowedPaths: [...(config.attachmentAllowedPaths ?? [])],
       attachmentPathRecursive: config.attachmentPathRecursive === true,
       inboundDebounceMs: config.inboundDebounceMs,
+      waitingBehavior: config.waitingBehavior ?? "off",
       createdAt: now,
       updatedAt: now,
     };

--- a/src/channels/accounts.ts
+++ b/src/channels/accounts.ts
@@ -212,6 +212,13 @@ function prepareAccountForStorage(account: ChannelAccount): ChannelAccount {
   return cloned;
 }
 
+function normalizeInboundDebounceMs(value: unknown): number | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
+    return undefined;
+  }
+  return Math.trunc(Math.min(value, 10000));
+}
+
 function cloneAccount<T extends ChannelAccount>(account: T): T {
   const cloned = {
     ...account,
@@ -378,6 +385,7 @@ function normalizeLoadedAccount<T extends ChannelAccount>(account: T): T {
     ];
     next.attachmentAllowedPaths = [...(next.attachmentAllowedPaths ?? [])];
     next.attachmentPathRecursive = next.attachmentPathRecursive === true;
+    next.inboundDebounceMs = normalizeInboundDebounceMs(next.inboundDebounceMs);
   }
   if (isSignalChannelAccount(next)) {
     next.baseUrl = next.baseUrl ?? "";
@@ -471,6 +479,7 @@ function makeDefaultLegacyAccount(
       ],
       attachmentAllowedPaths: [...(config.attachmentAllowedPaths ?? [])],
       attachmentPathRecursive: config.attachmentPathRecursive === true,
+      inboundDebounceMs: config.inboundDebounceMs,
       createdAt: now,
       updatedAt: now,
     };

--- a/src/channels/accounts.ts
+++ b/src/channels/accounts.ts
@@ -57,6 +57,7 @@ const SNAKE_TO_CAMEL: Record<string, string> = {
   group_mode: "groupMode",
   inbound_debounce_ms: "inboundDebounceMs",
   listen_mode: "listenMode",
+  message_prefix: "messagePrefix",
   media_max_bytes: "mediaMaxBytes",
   attachment_filter: "attachmentFilter",
   attachment_mime_types: "attachmentMimeTypes",
@@ -389,6 +390,8 @@ function normalizeLoadedAccount<T extends ChannelAccount>(account: T): T {
     next.inboundDebounceMs = normalizeInboundDebounceMs(next.inboundDebounceMs);
     next.waitingBehavior =
       next.waitingBehavior === "typing_indicator" ? "typing_indicator" : "off";
+    next.messagePrefix =
+      typeof next.messagePrefix === "string" ? next.messagePrefix : undefined;
   }
   if (isSignalChannelAccount(next)) {
     next.baseUrl = next.baseUrl ?? "";
@@ -484,6 +487,7 @@ function makeDefaultLegacyAccount(
       attachmentPathRecursive: config.attachmentPathRecursive === true,
       inboundDebounceMs: config.inboundDebounceMs,
       waitingBehavior: config.waitingBehavior ?? "off",
+      messagePrefix: config.messagePrefix,
       createdAt: now,
       updatedAt: now,
     };

--- a/src/channels/accounts.ts
+++ b/src/channels/accounts.ts
@@ -58,6 +58,11 @@ const SNAKE_TO_CAMEL: Record<string, string> = {
   inbound_debounce_ms: "inboundDebounceMs",
   listen_mode: "listenMode",
   media_max_bytes: "mediaMaxBytes",
+  attachment_filter: "attachmentFilter",
+  attachment_mime_types: "attachmentMimeTypes",
+  attachment_allowed_recipients: "attachmentAllowedRecipients",
+  attachment_allowed_paths: "attachmentAllowedPaths",
+  attachment_path_recursive: "attachmentPathRecursive",
   mention_patterns: "mentionPatterns",
   recipient_aliases: "recipientAliases",
   remove_stale_routes: "removeStaleRoutes",
@@ -239,6 +244,15 @@ function cloneAccount<T extends ChannelAccount>(account: T): T {
     (cloned as WhatsAppChannelAccount).mentionPatterns = [
       ...(account.mentionPatterns ?? []),
     ];
+    (cloned as WhatsAppChannelAccount).attachmentMimeTypes = [
+      ...(account.attachmentMimeTypes ?? []),
+    ];
+    (cloned as WhatsAppChannelAccount).attachmentAllowedRecipients = [
+      ...(account.attachmentAllowedRecipients ?? []),
+    ];
+    (cloned as WhatsAppChannelAccount).attachmentAllowedPaths = [
+      ...(account.attachmentAllowedPaths ?? []),
+    ];
   }
 
   if (isSignalChannelAccount(account)) {
@@ -357,6 +371,13 @@ function normalizeLoadedAccount<T extends ChannelAccount>(account: T): T {
     next.mentionPatterns = [...(next.mentionPatterns ?? [])];
     next.downloadMedia = next.downloadMedia === true;
     next.transcribeVoice = next.transcribeVoice === true;
+    next.attachmentFilter = next.attachmentFilter === true;
+    next.attachmentMimeTypes = [...(next.attachmentMimeTypes ?? [])];
+    next.attachmentAllowedRecipients = [
+      ...(next.attachmentAllowedRecipients ?? []),
+    ];
+    next.attachmentAllowedPaths = [...(next.attachmentAllowedPaths ?? [])];
+    next.attachmentPathRecursive = next.attachmentPathRecursive === true;
   }
   if (isSignalChannelAccount(next)) {
     next.baseUrl = next.baseUrl ?? "";
@@ -443,6 +464,13 @@ function makeDefaultLegacyAccount(
       transcribeVoice: config.transcribeVoice === true,
       downloadMedia: config.downloadMedia === true,
       mediaMaxBytes: config.mediaMaxBytes,
+      attachmentFilter: config.attachmentFilter === true,
+      attachmentMimeTypes: [...(config.attachmentMimeTypes ?? [])],
+      attachmentAllowedRecipients: [
+        ...(config.attachmentAllowedRecipients ?? []),
+      ],
+      attachmentAllowedPaths: [...(config.attachmentAllowedPaths ?? [])],
+      attachmentPathRecursive: config.attachmentPathRecursive === true,
       createdAt: now,
       updatedAt: now,
     };
@@ -577,7 +605,13 @@ function saveChannelAccounts(channelId: string): void {
   if (saveAccountsOverride) {
     saveAccountsOverride(
       channelId,
-      writeAccounts.map((account) => cloneAccount(account)),
+      writeAccounts.map((account) => {
+        const cloned = cloneAccount(account);
+        for (const camelKey of Object.values(SNAKE_TO_CAMEL)) {
+          delete (cloned as unknown as Record<string, unknown>)[camelKey];
+        }
+        return cloned;
+      }),
     );
     return;
   }

--- a/src/channels/config.ts
+++ b/src/channels/config.ts
@@ -297,6 +297,12 @@ const whatsappConfigCodec: ChannelConfigCodec<WhatsAppChannelConfig> = {
         ? (rawAttachmentAllowedPaths as string[])
         : [],
       attachmentPathRecursive: parsed.attachment_path_recursive === true,
+      inboundDebounceMs:
+        typeof parsed.inbound_debounce_ms === "number" &&
+        Number.isFinite(parsed.inbound_debounce_ms) &&
+        parsed.inbound_debounce_ms >= 0
+          ? Math.trunc(Math.min(parsed.inbound_debounce_ms, 10000))
+          : undefined,
     };
   },
 };

--- a/src/channels/config.ts
+++ b/src/channels/config.ts
@@ -309,6 +309,10 @@ const whatsappConfigCodec: ChannelConfigCodec<WhatsAppChannelConfig> = {
           ? Math.trunc(Math.min(parsed.inbound_debounce_ms, 10000))
           : undefined,
       waitingBehavior: parseWhatsAppWaitingBehavior(parsed.waiting_behavior),
+      messagePrefix:
+        typeof parsed.message_prefix === "string"
+          ? parsed.message_prefix
+          : undefined,
     };
   },
 };

--- a/src/channels/config.ts
+++ b/src/channels/config.ts
@@ -28,11 +28,16 @@ import type {
   WhatsAppChannelConfig,
   WhatsAppGroupMode,
 } from "./types";
+import type { WhatsAppWaitingBehavior } from "./whatsapp/waiting-behavior-config-types";
 
 // ── Paths ─────────────────────────────────────────────────────────
 
 const CHANNELS_ROOT = join(homedir(), ".letta", "channels");
 let channelsRootOverride: string | null = null;
+
+function parseWhatsAppWaitingBehavior(value: unknown): WhatsAppWaitingBehavior {
+  return value === "typing_indicator" ? "typing_indicator" : "off";
+}
 
 export function getChannelsRoot(): string {
   return channelsRootOverride ?? CHANNELS_ROOT;
@@ -303,6 +308,7 @@ const whatsappConfigCodec: ChannelConfigCodec<WhatsAppChannelConfig> = {
         parsed.inbound_debounce_ms >= 0
           ? Math.trunc(Math.min(parsed.inbound_debounce_ms, 10000))
           : undefined,
+      waitingBehavior: parseWhatsAppWaitingBehavior(parsed.waiting_behavior),
     };
   },
 };

--- a/src/channels/config.ts
+++ b/src/channels/config.ts
@@ -263,6 +263,9 @@ const whatsappConfigCodec: ChannelConfigCodec<WhatsAppChannelConfig> = {
   parse(parsed) {
     const rawAllowedGroups = parsed.allowed_groups;
     const rawMentionPatterns = parsed.mention_patterns;
+    const rawAttachmentMimeTypes = parsed.attachment_mime_types;
+    const rawAttachmentAllowedRecipients = parsed.attachment_allowed_recipients;
+    const rawAttachmentAllowedPaths = parsed.attachment_allowed_paths;
     return {
       channel: "whatsapp",
       enabled: parsed.enabled !== false,
@@ -283,6 +286,17 @@ const whatsappConfigCodec: ChannelConfigCodec<WhatsAppChannelConfig> = {
         typeof parsed.media_max_bytes === "number"
           ? parsed.media_max_bytes
           : undefined,
+      attachmentFilter: parsed.attachment_filter === true,
+      attachmentMimeTypes: Array.isArray(rawAttachmentMimeTypes)
+        ? (rawAttachmentMimeTypes as string[])
+        : [],
+      attachmentAllowedRecipients: Array.isArray(rawAttachmentAllowedRecipients)
+        ? (rawAttachmentAllowedRecipients as string[])
+        : [],
+      attachmentAllowedPaths: Array.isArray(rawAttachmentAllowedPaths)
+        ? (rawAttachmentAllowedPaths as string[])
+        : [],
+      attachmentPathRecursive: parsed.attachment_path_recursive === true,
     };
   },
 };

--- a/src/channels/inbound-debounce.test.ts
+++ b/src/channels/inbound-debounce.test.ts
@@ -165,6 +165,41 @@ describe("createInboundDebouncer", () => {
     expect(flushed).toEqual([["a", "b"]]);
   });
 
+  test("flushAll forces every pending key to flush", async () => {
+    const debouncer = createInboundDebouncer<Item>({
+      debounceMs: 1000,
+      buildKey: (item) => item.key,
+      onFlush: async (items) => {
+        flushed.push(items.map((i) => i.value));
+      },
+    });
+
+    await debouncer.enqueue({ key: "a", value: "a1" });
+    await debouncer.enqueue({ key: "b", value: "b1" });
+    await debouncer.enqueue({ key: "a", value: "a2" });
+    await debouncer.flushAll();
+    const sorted = flushed.map((batch) => [...batch].sort()).sort();
+    expect(sorted).toEqual([["a1", "a2"], ["b1"]]);
+  });
+
+  test("cancelAll drops pending debounced buffers", async () => {
+    const debouncer = createInboundDebouncer<Item>({
+      debounceMs: 20,
+      buildKey: (item) => item.key,
+      onFlush: async (items) => {
+        flushed.push(items.map((i) => i.value));
+      },
+    });
+
+    await debouncer.enqueue({ key: "k", value: "a" });
+    debouncer.cancelAll();
+    await sleep(50);
+    expect(flushed).toEqual([]);
+    await debouncer.enqueue({ key: "k", value: "b" });
+    await sleep(50);
+    expect(flushed).toEqual([["b"]]);
+  });
+
   test("null key forces immediate flush", async () => {
     const debouncer = createInboundDebouncer<Item>({
       debounceMs: 50,

--- a/src/channels/inbound-debounce.ts
+++ b/src/channels/inbound-debounce.ts
@@ -54,6 +54,10 @@ export interface InboundDebouncer<T> {
   enqueue: (item: T) => Promise<void>;
   /** Force an immediate flush for a specific key, if any buffer is pending. */
   flushKey: (key: string) => Promise<void>;
+  /** Force every pending key to flush immediately. */
+  flushAll: () => Promise<void>;
+  /** Cancel every pending debounced buffer without calling `onFlush`. */
+  cancelAll: () => void;
 }
 
 export function createInboundDebouncer<T>(
@@ -151,6 +155,27 @@ export function createInboundDebouncer<T>(
     await flushBuffer(key, buffer);
   };
 
+  const flushAllInternal = async (): Promise<void> => {
+    await Promise.all(
+      Array.from(buffers.entries()).map(([key, buffer]) =>
+        flushBuffer(key, buffer),
+      ),
+    );
+  };
+
+  const cancelAllInternal = (): void => {
+    for (const [key, buffer] of Array.from(buffers.entries())) {
+      buffers.delete(key);
+      if (buffer.timeout) {
+        clearTimeout(buffer.timeout);
+        buffer.timeout = null;
+      }
+      buffer.items = [];
+      releaseBuffer(buffer);
+      void buffer.task.catch(() => undefined);
+    }
+  };
+
   const scheduleFlush = (key: string, buffer: DebounceBuffer<T>): void => {
     if (buffer.timeout) {
       clearTimeout(buffer.timeout);
@@ -240,5 +265,7 @@ export function createInboundDebouncer<T>(
   return {
     enqueue,
     flushKey: flushKeyInternal,
+    flushAll: flushAllInternal,
+    cancelAll: cancelAllInternal,
   };
 }

--- a/src/channels/plugin-types.ts
+++ b/src/channels/plugin-types.ts
@@ -182,6 +182,11 @@ export interface ChannelPluginAccountPatch {
   richDraftStreaming?: boolean;
   downloadMedia?: boolean;
   mediaMaxBytes?: number;
+  attachmentFilter?: boolean;
+  attachmentMimeTypes?: string[];
+  attachmentAllowedRecipients?: string[];
+  attachmentAllowedPaths?: string[];
+  attachmentPathRecursive?: boolean;
 }
 
 export type ChannelAccountPatch = ChannelCommonAccountPatch &

--- a/src/channels/plugin-types.ts
+++ b/src/channels/plugin-types.ts
@@ -13,6 +13,7 @@ import type {
   TelegramGroupMode,
   WhatsAppGroupMode,
 } from "./types";
+import type { WhatsAppWaitingBehavior } from "./whatsapp/waiting-behavior-config-types";
 
 export interface ChannelPluginMetadata {
   id: string;
@@ -187,6 +188,7 @@ export interface ChannelPluginAccountPatch {
   attachmentAllowedRecipients?: string[];
   attachmentAllowedPaths?: string[];
   attachmentPathRecursive?: boolean;
+  waitingBehavior?: WhatsAppWaitingBehavior;
 }
 
 export type ChannelAccountPatch = ChannelCommonAccountPatch &

--- a/src/channels/plugin-types.ts
+++ b/src/channels/plugin-types.ts
@@ -173,6 +173,7 @@ export interface ChannelPluginAccountPatch {
   allowBots?: ChannelAllowBotsMode;
   removeStaleRoutes?: boolean;
   inboundDebounceMs?: number;
+  messagePrefix?: string;
   selfChatMode?: boolean;
   allowedGroups?: string[];
   mentionPatterns?: string[];

--- a/src/channels/registry-inbound.ts
+++ b/src/channels/registry-inbound.ts
@@ -360,6 +360,9 @@ export function createChannelInboundRouter(deps: {
     // exact topic route exists; a disabled exact route remains authoritative.
     const route = loadRouteForInboundMessage(msg, accountId);
     if (!route) {
+      if (msg.reaction) {
+        return;
+      }
       await adapter.sendDirectReply(
         msg.chatId,
         buildUnboundRouteInstructions(msg.channel, msg.chatId),

--- a/src/channels/service-account-model.ts
+++ b/src/channels/service-account-model.ts
@@ -128,6 +128,7 @@ export function createAccountFromPatch(
         normalizedPatch.attachmentAllowedRecipients ?? [],
       attachmentAllowedPaths: normalizedPatch.attachmentAllowedPaths ?? [],
       attachmentPathRecursive: normalizedPatch.attachmentPathRecursive === true,
+      inboundDebounceMs: normalizedPatch.inboundDebounceMs,
       createdAt: now,
       updatedAt: now,
     };
@@ -306,6 +307,8 @@ export function mergeAccountPatch(
         normalizedPatch.attachmentPathRecursive ??
         existing.attachmentPathRecursive ??
         false,
+      inboundDebounceMs:
+        normalizedPatch.inboundDebounceMs ?? existing.inboundDebounceMs,
       updatedAt: nextUpdatedAt,
     };
   }

--- a/src/channels/service-account-model.ts
+++ b/src/channels/service-account-model.ts
@@ -130,6 +130,7 @@ export function createAccountFromPatch(
       attachmentPathRecursive: normalizedPatch.attachmentPathRecursive === true,
       inboundDebounceMs: normalizedPatch.inboundDebounceMs,
       waitingBehavior: normalizedPatch.waitingBehavior ?? "off",
+      messagePrefix: normalizedPatch.messagePrefix,
       createdAt: now,
       updatedAt: now,
     };
@@ -312,6 +313,10 @@ export function mergeAccountPatch(
         normalizedPatch.inboundDebounceMs ?? existing.inboundDebounceMs,
       waitingBehavior:
         normalizedPatch.waitingBehavior ?? existing.waitingBehavior ?? "off",
+      messagePrefix:
+        normalizedPatch.messagePrefix !== undefined
+          ? normalizedPatch.messagePrefix
+          : existing.messagePrefix,
       updatedAt: nextUpdatedAt,
     };
   }

--- a/src/channels/service-account-model.ts
+++ b/src/channels/service-account-model.ts
@@ -122,6 +122,12 @@ export function createAccountFromPatch(
       transcribeVoice: normalizedPatch.transcribeVoice === true,
       downloadMedia: normalizedPatch.downloadMedia === true,
       mediaMaxBytes: normalizedPatch.mediaMaxBytes,
+      attachmentFilter: normalizedPatch.attachmentFilter === true,
+      attachmentMimeTypes: normalizedPatch.attachmentMimeTypes ?? [],
+      attachmentAllowedRecipients:
+        normalizedPatch.attachmentAllowedRecipients ?? [],
+      attachmentAllowedPaths: normalizedPatch.attachmentAllowedPaths ?? [],
+      attachmentPathRecursive: normalizedPatch.attachmentPathRecursive === true,
       createdAt: now,
       updatedAt: now,
     };
@@ -282,6 +288,24 @@ export function mergeAccountPatch(
       downloadMedia:
         normalizedPatch.downloadMedia ?? existing.downloadMedia ?? false,
       mediaMaxBytes: normalizedPatch.mediaMaxBytes ?? existing.mediaMaxBytes,
+      attachmentFilter:
+        normalizedPatch.attachmentFilter ?? existing.attachmentFilter ?? false,
+      attachmentMimeTypes:
+        normalizedPatch.attachmentMimeTypes ??
+        existing.attachmentMimeTypes ??
+        [],
+      attachmentAllowedRecipients:
+        normalizedPatch.attachmentAllowedRecipients ??
+        existing.attachmentAllowedRecipients ??
+        [],
+      attachmentAllowedPaths:
+        normalizedPatch.attachmentAllowedPaths ??
+        existing.attachmentAllowedPaths ??
+        [],
+      attachmentPathRecursive:
+        normalizedPatch.attachmentPathRecursive ??
+        existing.attachmentPathRecursive ??
+        false,
       updatedAt: nextUpdatedAt,
     };
   }

--- a/src/channels/service-account-model.ts
+++ b/src/channels/service-account-model.ts
@@ -129,6 +129,7 @@ export function createAccountFromPatch(
       attachmentAllowedPaths: normalizedPatch.attachmentAllowedPaths ?? [],
       attachmentPathRecursive: normalizedPatch.attachmentPathRecursive === true,
       inboundDebounceMs: normalizedPatch.inboundDebounceMs,
+      waitingBehavior: normalizedPatch.waitingBehavior ?? "off",
       createdAt: now,
       updatedAt: now,
     };
@@ -309,6 +310,8 @@ export function mergeAccountPatch(
         false,
       inboundDebounceMs:
         normalizedPatch.inboundDebounceMs ?? existing.inboundDebounceMs,
+      waitingBehavior:
+        normalizedPatch.waitingBehavior ?? existing.waitingBehavior ?? "off",
       updatedAt: nextUpdatedAt,
     };
   }

--- a/src/channels/service-runtime.ts
+++ b/src/channels/service-runtime.ts
@@ -75,6 +75,7 @@ export async function setChannelConfigLive(
       downloadMedia: normalizedPatch.downloadMedia,
       mediaMaxBytes: normalizedPatch.mediaMaxBytes,
       waitingBehavior: normalizedPatch.waitingBehavior,
+      messagePrefix: normalizedPatch.messagePrefix,
       config: normalizedPatch.config,
       displayName: existing.displayName,
     });
@@ -116,6 +117,7 @@ export async function setChannelConfigLive(
         downloadMedia: normalizedPatch.downloadMedia,
         mediaMaxBytes: normalizedPatch.mediaMaxBytes,
         waitingBehavior: normalizedPatch.waitingBehavior,
+        messagePrefix: normalizedPatch.messagePrefix,
         config: normalizedPatch.config,
       },
       accountId ? { accountId } : undefined,

--- a/src/channels/service-runtime.ts
+++ b/src/channels/service-runtime.ts
@@ -74,6 +74,7 @@ export async function setChannelConfigLive(
       richDraftStreaming: normalizedPatch.richDraftStreaming,
       downloadMedia: normalizedPatch.downloadMedia,
       mediaMaxBytes: normalizedPatch.mediaMaxBytes,
+      waitingBehavior: normalizedPatch.waitingBehavior,
       config: normalizedPatch.config,
       displayName: existing.displayName,
     });
@@ -114,6 +115,7 @@ export async function setChannelConfigLive(
         richDraftStreaming: normalizedPatch.richDraftStreaming,
         downloadMedia: normalizedPatch.downloadMedia,
         mediaMaxBytes: normalizedPatch.mediaMaxBytes,
+        waitingBehavior: normalizedPatch.waitingBehavior,
         config: normalizedPatch.config,
       },
       accountId ? { accountId } : undefined,

--- a/src/channels/service-snapshots.ts
+++ b/src/channels/service-snapshots.ts
@@ -204,6 +204,7 @@ export function toAccountSnapshot(
       attachmentAllowedPaths: [...(account.attachmentAllowedPaths ?? [])],
       attachmentPathRecursive: account.attachmentPathRecursive === true,
       inboundDebounceMs: account.inboundDebounceMs,
+      waitingBehavior: account.waitingBehavior ?? "off",
       createdAt: account.createdAt,
       updatedAt: account.updatedAt,
     };
@@ -403,6 +404,7 @@ export function getChannelConfigSnapshot(
       attachmentAllowedPaths: [...(account.attachmentAllowedPaths ?? [])],
       attachmentPathRecursive: account.attachmentPathRecursive === true,
       inboundDebounceMs: account.inboundDebounceMs,
+      waitingBehavior: account.waitingBehavior ?? "off",
     };
   }
 

--- a/src/channels/service-snapshots.ts
+++ b/src/channels/service-snapshots.ts
@@ -196,6 +196,13 @@ export function toAccountSnapshot(
       transcribeVoice: account.transcribeVoice === true,
       downloadMedia: account.downloadMedia === true,
       mediaMaxBytes: account.mediaMaxBytes,
+      attachmentFilter: account.attachmentFilter === true,
+      attachmentMimeTypes: [...(account.attachmentMimeTypes ?? [])],
+      attachmentAllowedRecipients: [
+        ...(account.attachmentAllowedRecipients ?? []),
+      ],
+      attachmentAllowedPaths: [...(account.attachmentAllowedPaths ?? [])],
+      attachmentPathRecursive: account.attachmentPathRecursive === true,
       createdAt: account.createdAt,
       updatedAt: account.updatedAt,
     };
@@ -387,6 +394,13 @@ export function getChannelConfigSnapshot(
       transcribeVoice: account.transcribeVoice === true,
       downloadMedia: account.downloadMedia === true,
       mediaMaxBytes: account.mediaMaxBytes,
+      attachmentFilter: account.attachmentFilter === true,
+      attachmentMimeTypes: [...(account.attachmentMimeTypes ?? [])],
+      attachmentAllowedRecipients: [
+        ...(account.attachmentAllowedRecipients ?? []),
+      ],
+      attachmentAllowedPaths: [...(account.attachmentAllowedPaths ?? [])],
+      attachmentPathRecursive: account.attachmentPathRecursive === true,
     };
   }
 

--- a/src/channels/service-snapshots.ts
+++ b/src/channels/service-snapshots.ts
@@ -205,6 +205,7 @@ export function toAccountSnapshot(
       attachmentPathRecursive: account.attachmentPathRecursive === true,
       inboundDebounceMs: account.inboundDebounceMs,
       waitingBehavior: account.waitingBehavior ?? "off",
+      messagePrefix: account.messagePrefix,
       createdAt: account.createdAt,
       updatedAt: account.updatedAt,
     };
@@ -405,6 +406,7 @@ export function getChannelConfigSnapshot(
       attachmentPathRecursive: account.attachmentPathRecursive === true,
       inboundDebounceMs: account.inboundDebounceMs,
       waitingBehavior: account.waitingBehavior ?? "off",
+      messagePrefix: account.messagePrefix,
     };
   }
 

--- a/src/channels/service-snapshots.ts
+++ b/src/channels/service-snapshots.ts
@@ -203,6 +203,7 @@ export function toAccountSnapshot(
       ],
       attachmentAllowedPaths: [...(account.attachmentAllowedPaths ?? [])],
       attachmentPathRecursive: account.attachmentPathRecursive === true,
+      inboundDebounceMs: account.inboundDebounceMs,
       createdAt: account.createdAt,
       updatedAt: account.updatedAt,
     };
@@ -401,6 +402,7 @@ export function getChannelConfigSnapshot(
       ],
       attachmentAllowedPaths: [...(account.attachmentAllowedPaths ?? [])],
       attachmentPathRecursive: account.attachmentPathRecursive === true,
+      inboundDebounceMs: account.inboundDebounceMs,
     };
   }
 

--- a/src/channels/service-types.ts
+++ b/src/channels/service-types.ts
@@ -55,6 +55,11 @@ export interface ChannelConfigSnapshot {
   richDraftStreaming?: boolean;
   downloadMedia?: boolean;
   mediaMaxBytes?: number;
+  attachmentFilter?: boolean;
+  attachmentMimeTypes?: string[];
+  attachmentAllowedRecipients?: string[];
+  attachmentAllowedPaths?: string[];
+  attachmentPathRecursive?: boolean;
 }
 
 export interface PendingPairingSnapshot {
@@ -132,6 +137,11 @@ export interface ChannelAccountSnapshot {
   recipientAliases?: Record<string, string>;
   downloadMedia?: boolean;
   mediaMaxBytes?: number;
+  attachmentFilter?: boolean;
+  attachmentMimeTypes?: string[];
+  attachmentAllowedRecipients?: string[];
+  attachmentAllowedPaths?: string[];
+  attachmentPathRecursive?: boolean;
   createdAt: string;
   updatedAt: string;
 }

--- a/src/channels/service-types.ts
+++ b/src/channels/service-types.ts
@@ -62,6 +62,7 @@ export interface ChannelConfigSnapshot {
   attachmentAllowedPaths?: string[];
   attachmentPathRecursive?: boolean;
   waitingBehavior?: WhatsAppWaitingBehavior;
+  messagePrefix?: string;
 }
 
 export interface PendingPairingSnapshot {
@@ -145,6 +146,7 @@ export interface ChannelAccountSnapshot {
   attachmentAllowedPaths?: string[];
   attachmentPathRecursive?: boolean;
   waitingBehavior?: WhatsAppWaitingBehavior;
+  messagePrefix?: string;
   createdAt: string;
   updatedAt: string;
 }

--- a/src/channels/service-types.ts
+++ b/src/channels/service-types.ts
@@ -9,6 +9,7 @@ import type {
   TelegramGroupMode,
   WhatsAppGroupMode,
 } from "./types";
+import type { WhatsAppWaitingBehavior } from "./whatsapp/waiting-behavior-config-types";
 
 export interface ChannelSummary {
   channelId: string;
@@ -60,6 +61,7 @@ export interface ChannelConfigSnapshot {
   attachmentAllowedRecipients?: string[];
   attachmentAllowedPaths?: string[];
   attachmentPathRecursive?: boolean;
+  waitingBehavior?: WhatsAppWaitingBehavior;
 }
 
 export interface PendingPairingSnapshot {
@@ -142,6 +144,7 @@ export interface ChannelAccountSnapshot {
   attachmentAllowedRecipients?: string[];
   attachmentAllowedPaths?: string[];
   attachmentPathRecursive?: boolean;
+  waitingBehavior?: WhatsAppWaitingBehavior;
   createdAt: string;
   updatedAt: string;
 }

--- a/src/channels/types.ts
+++ b/src/channels/types.ts
@@ -14,6 +14,7 @@ import type {
   StopReasonType,
 } from "@/types/protocol_v2";
 import type { WhatsAppAttachmentPolicyConfig } from "./whatsapp/attachment-policy-types";
+import type { WhatsAppWaitingBehavior } from "./whatsapp/waiting-behavior-config-types";
 
 /**
  * Vendor-neutral model-picker payload produced by the generic channel
@@ -678,11 +679,10 @@ export interface WhatsAppChannelConfig extends WhatsAppAttachmentPolicyConfig {
   mentionPatterns?: string[];
   /** When true and OPENAI_API_KEY is set, voice memos are auto-transcribed. */
   transcribeVoice?: boolean;
-  /** When true, supported inbound media is downloaded to local channel storage. */
   downloadMedia?: boolean;
-  /** Maximum inbound media bytes to download. Undefined uses channel default. */
   mediaMaxBytes?: number;
   inboundDebounceMs?: number;
+  waitingBehavior?: WhatsAppWaitingBehavior;
 }
 
 export interface SignalChannelConfig {
@@ -866,11 +866,10 @@ export interface WhatsAppChannelAccount
   mentionPatterns?: string[];
   /** When true and OPENAI_API_KEY is set, voice memos are auto-transcribed. */
   transcribeVoice?: boolean;
-  /** When true, supported inbound media is downloaded to local channel storage. */
   downloadMedia?: boolean;
-  /** Maximum inbound media bytes to download. Undefined uses channel default. */
   mediaMaxBytes?: number;
   inboundDebounceMs?: number;
+  waitingBehavior?: WhatsAppWaitingBehavior;
 }
 
 export interface SignalChannelAccount extends ChannelAccountBase {

--- a/src/channels/types.ts
+++ b/src/channels/types.ts
@@ -321,6 +321,8 @@ export interface ChannelAdapter {
        * example Slack Block Kit) may render it; others fall back to text.
        */
       modelPicker?: ChannelModelPickerData;
+      /** Channel-specific opt-in for direct replies that should be treated as ordinary outbound agent text. */
+      applyMessagePrefix?: boolean;
     },
   ): Promise<void>;
 
@@ -674,7 +676,6 @@ export interface WhatsAppChannelConfig
   agentId: string | null;
   /** Default true. When true, only the user's own Message Yourself chat routes. */
   selfChatMode: boolean;
-  /** Default disabled. Controls group-message ingestion. */
   groupMode: WhatsAppGroupMode;
   /** Optional allowlist of WhatsApp group JIDs. Empty/undefined allows any group when groupMode is not disabled. */
   allowedGroups?: string[];
@@ -860,7 +861,6 @@ export interface WhatsAppChannelAccount
   agentId: string | null;
   /** Default true. Explicitly set false before replying under the linked user's identity. */
   selfChatMode: boolean;
-  /** Default disabled. Controls group-message ingestion. */
   groupMode: WhatsAppGroupMode;
   /** Optional allowlist of WhatsApp group JIDs. */
   allowedGroups?: string[];

--- a/src/channels/types.ts
+++ b/src/channels/types.ts
@@ -13,6 +13,7 @@ import type {
   ListModelsResponseModelEntry,
   StopReasonType,
 } from "@/types/protocol_v2";
+import type { WhatsAppAttachmentPolicyConfig } from "./whatsapp/attachment-policy-types";
 
 /**
  * Vendor-neutral model-picker payload produced by the generic channel
@@ -661,7 +662,7 @@ export interface DiscordChannelConfig {
   allowBots?: DiscordAllowBotsMode;
 }
 
-export interface WhatsAppChannelConfig {
+export interface WhatsAppChannelConfig extends WhatsAppAttachmentPolicyConfig {
   channel: "whatsapp";
   enabled: boolean;
   dmPolicy: DmPolicy;
@@ -848,7 +849,9 @@ export interface DiscordChannelAccount extends ChannelAccountBase {
   allowBots?: DiscordAllowBotsMode;
 }
 
-export interface WhatsAppChannelAccount extends ChannelAccountBase {
+export interface WhatsAppChannelAccount
+  extends ChannelAccountBase,
+    WhatsAppAttachmentPolicyConfig {
   channel: "whatsapp";
   /** Agent ID used for account-bound DM and group auto-routing. */
   agentId: string | null;

--- a/src/channels/types.ts
+++ b/src/channels/types.ts
@@ -7,6 +7,7 @@
  * platform chat IDs to agent+conversation pairs.
  */
 
+import type { WhatsAppMessagePrefixConfig } from "@/channels/whatsapp/message-prefix-config-types";
 import type { PermissionMode } from "@/permissions/mode";
 import type {
   ApprovalResponseBody,
@@ -663,7 +664,9 @@ export interface DiscordChannelConfig {
   allowBots?: DiscordAllowBotsMode;
 }
 
-export interface WhatsAppChannelConfig extends WhatsAppAttachmentPolicyConfig {
+export interface WhatsAppChannelConfig
+  extends WhatsAppAttachmentPolicyConfig,
+    WhatsAppMessagePrefixConfig {
   channel: "whatsapp";
   enabled: boolean;
   dmPolicy: DmPolicy;
@@ -675,9 +678,7 @@ export interface WhatsAppChannelConfig extends WhatsAppAttachmentPolicyConfig {
   groupMode: WhatsAppGroupMode;
   /** Optional allowlist of WhatsApp group JIDs. Empty/undefined allows any group when groupMode is not disabled. */
   allowedGroups?: string[];
-  /** Optional textual aliases for group mention detection. */
   mentionPatterns?: string[];
-  /** When true and OPENAI_API_KEY is set, voice memos are auto-transcribed. */
   transcribeVoice?: boolean;
   downloadMedia?: boolean;
   mediaMaxBytes?: number;
@@ -852,7 +853,8 @@ export interface DiscordChannelAccount extends ChannelAccountBase {
 
 export interface WhatsAppChannelAccount
   extends ChannelAccountBase,
-    WhatsAppAttachmentPolicyConfig {
+    WhatsAppAttachmentPolicyConfig,
+    WhatsAppMessagePrefixConfig {
   channel: "whatsapp";
   /** Agent ID used for account-bound DM and group auto-routing. */
   agentId: string | null;
@@ -862,9 +864,7 @@ export interface WhatsAppChannelAccount
   groupMode: WhatsAppGroupMode;
   /** Optional allowlist of WhatsApp group JIDs. */
   allowedGroups?: string[];
-  /** Optional textual aliases for group mention detection. */
   mentionPatterns?: string[];
-  /** When true and OPENAI_API_KEY is set, voice memos are auto-transcribed. */
   transcribeVoice?: boolean;
   downloadMedia?: boolean;
   mediaMaxBytes?: number;

--- a/src/channels/types.ts
+++ b/src/channels/types.ts
@@ -682,6 +682,7 @@ export interface WhatsAppChannelConfig extends WhatsAppAttachmentPolicyConfig {
   downloadMedia?: boolean;
   /** Maximum inbound media bytes to download. Undefined uses channel default. */
   mediaMaxBytes?: number;
+  inboundDebounceMs?: number;
 }
 
 export interface SignalChannelConfig {
@@ -869,6 +870,7 @@ export interface WhatsAppChannelAccount
   downloadMedia?: boolean;
   /** Maximum inbound media bytes to download. Undefined uses channel default. */
   mediaMaxBytes?: number;
+  inboundDebounceMs?: number;
 }
 
 export interface SignalChannelAccount extends ChannelAccountBase {

--- a/src/channels/whatsapp-adapter.test.ts
+++ b/src/channels/whatsapp-adapter.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
+import { rmSync } from "node:fs";
 import {
   createWhatsAppAdapter,
   isWhatsAppConflictDisconnect,
@@ -7,8 +8,13 @@ import {
 } from "@/channels/whatsapp/adapter";
 import type { LidStore } from "@/channels/whatsapp/lid-store";
 import {
+  createWhatsAppSocket,
+  getWhatsAppAuthDir,
+} from "@/channels/whatsapp/session";
+import {
   clearWhatsAppConnectionState,
   getWhatsAppConnectionState,
+  setWhatsAppConnectionState,
 } from "@/channels/whatsapp/state";
 
 const activeHarnesses: Array<{
@@ -100,6 +106,46 @@ type SchedulerEntry = {
   unref: boolean;
 };
 
+type SocketResult = Awaited<
+  ReturnType<NonNullable<WhatsAppAdapterDependencies["createSocket"]>>
+>;
+
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve;
+    reject = promiseReject;
+  });
+  return { promise, reject, resolve };
+}
+
+function createSessionRuntimeHarness() {
+  const handlers = new Map<
+    string,
+    (payload?: unknown) => void | Promise<void>
+  >();
+  const sock = {
+    ev: {
+      on(event: string, handler: (payload?: unknown) => void | Promise<void>) {
+        handlers.set(event, handler);
+      },
+    },
+    user: { id: "15551234567@s.whatsapp.net", lid: "15551234567@lid" },
+    ws: { close() {} },
+  };
+  const runtime = {
+    makeWASocket: () => sock,
+    useMultiFileAuthState: async () => ({
+      state: { creds: {}, keys: {} },
+      saveCreds: async () => undefined,
+    }),
+    fetchLatestBaileysVersion: async () => ({ version: [2, 3000, 0] }),
+    DisconnectReason: { loggedOut: 401 },
+  };
+  return { handlers, runtime };
+}
+
 function createTestScheduler() {
   const entries: SchedulerEntry[] = [];
   let nowMs = 0;
@@ -165,7 +211,12 @@ function createTestScheduler() {
   };
 }
 
-function createReconnectHarness(accountId: string) {
+function createReconnectHarness(
+  accountId: string,
+  options: {
+    socketResults?: Array<Promise<SocketResult> | SocketResult | undefined>;
+  } = {},
+) {
   type ConnectionUpdate = (update: Record<string, unknown>) => void;
   const scheduler = createTestScheduler();
   const updates: ConnectionUpdate[] = [];
@@ -180,11 +231,7 @@ function createReconnectHarness(accountId: string) {
     },
     flush() {},
   };
-  const createSocket: NonNullable<
-    WhatsAppAdapterDependencies["createSocket"]
-  > = async ({ onConnectionUpdate }) => {
-    createSocketCalls += 1;
-    updates.push(onConnectionUpdate as ConnectionUpdate);
+  function createDefaultSocketResult(): SocketResult {
     return {
       sock: {
         ev: { on: () => undefined },
@@ -197,6 +244,15 @@ function createReconnectHarness(accountId: string) {
         releaseCalls += 1;
       },
     };
+  }
+  const createSocket: NonNullable<
+    WhatsAppAdapterDependencies["createSocket"]
+  > = async ({ onConnectionUpdate }) => {
+    createSocketCalls += 1;
+    updates.push(onConnectionUpdate as ConnectionUpdate);
+    const plannedResult = options.socketResults?.[createSocketCalls - 1];
+    if (plannedResult) return await plannedResult;
+    return createDefaultSocketResult();
   };
   const adapter = createWhatsAppAdapter(
     {
@@ -258,7 +314,7 @@ describe("WhatsApp reconnect circuit breaker", () => {
     harness.open(0);
     expect(harness.scheduler.pending()).toHaveLength(1);
     expect(harness.scheduler.pending()[0]?.delayMs).toBe(2000);
-    expect(harness.scheduler.pending()[0]?.unref).toBe(false);
+    expect(harness.scheduler.pending()[0]?.unref).toBe(true);
 
     harness.scheduler.advanceToNext();
     await flushReconnectMicrotasks();
@@ -280,6 +336,27 @@ describe("WhatsApp reconnect circuit breaker", () => {
 
     harness.close(1);
     expect(harness.scheduler.pending()).toHaveLength(1);
+  });
+
+  test("ignores a stale close from a stopped socket after a newer start", async () => {
+    const accountId = "reconnect-stale-after-restart";
+    const harness = createReconnectHarness(accountId);
+    await harness.adapter.start();
+    await harness.adapter.stop();
+    await harness.adapter.start();
+    const releaseCallsAfterRestart = harness.releaseCalls;
+    setWhatsAppConnectionState(accountId, {
+      status: "connected",
+      phoneJid: "current@s.whatsapp.net",
+    });
+    const currentState = getWhatsAppConnectionState(accountId);
+
+    harness.close(0, "late generation one close");
+
+    expect(harness.createSocketCalls).toBe(2);
+    expect(harness.releaseCalls).toBe(releaseCallsAfterRestart);
+    expect(harness.scheduler.pending()).toHaveLength(0);
+    expect(getWhatsAppConnectionState(accountId)).toEqual(currentState);
   });
 
   test("trips after six distinct unstable generations despite brief opens", async () => {
@@ -321,7 +398,7 @@ describe("WhatsApp reconnect circuit breaker", () => {
     harness.scheduler.advanceBy(59_999);
     harness.close();
     expect(harness.scheduler.pending()[0]?.delayMs).toBe(4000);
-    expect(harness.scheduler.pending()[0]?.unref).toBe(false);
+    expect(harness.scheduler.pending()[0]?.unref).toBe(true);
 
     harness.scheduler.advanceToNext();
     await flushReconnectMicrotasks();
@@ -350,6 +427,104 @@ describe("WhatsApp reconnect circuit breaker", () => {
     harness.scheduler.runCanceled();
     await flushReconnectMicrotasks();
     expect(harness.createSocketCalls).toBe(2);
+  });
+
+  test("stale reconnect rejection after stop does not write error state", async () => {
+    const accountId = "reconnect-reject-after-stop";
+    const reconnectAttempt = createDeferred<SocketResult>();
+    const harness = createReconnectHarness(accountId, {
+      socketResults: [undefined, reconnectAttempt.promise],
+    });
+    await harness.adapter.start();
+    harness.close();
+    harness.scheduler.advanceToNext();
+    await flushReconnectMicrotasks();
+    expect(harness.createSocketCalls).toBe(2);
+
+    await harness.adapter.stop();
+    const stoppedState = getWhatsAppConnectionState(accountId);
+    reconnectAttempt.reject(new Error("late stale reconnect failure"));
+    await flushReconnectMicrotasks();
+
+    expect(getWhatsAppConnectionState(accountId)).toEqual(stoppedState);
+    expect(harness.scheduler.pending()).toHaveLength(0);
+  });
+
+  test("stale reconnect rejection after newer start does not overwrite current state", async () => {
+    const accountId = "reconnect-reject-after-restart";
+    const reconnectAttempt = createDeferred<SocketResult>();
+    const harness = createReconnectHarness(accountId, {
+      socketResults: [undefined, reconnectAttempt.promise],
+    });
+    await harness.adapter.start();
+    harness.close();
+    harness.scheduler.advanceToNext();
+    await flushReconnectMicrotasks();
+    expect(harness.createSocketCalls).toBe(2);
+
+    await harness.adapter.stop();
+    await harness.adapter.start();
+    setWhatsAppConnectionState(accountId, {
+      status: "connected",
+      phoneJid: "current@s.whatsapp.net",
+    });
+    const currentState = getWhatsAppConnectionState(accountId);
+    reconnectAttempt.reject(new Error("late stale reconnect failure"));
+    await flushReconnectMicrotasks();
+
+    expect(harness.createSocketCalls).toBe(3);
+    expect(getWhatsAppConnectionState(accountId)).toEqual(currentState);
+    expect(harness.scheduler.pending()).toHaveLength(0);
+  });
+
+  test("preserves conflict error through real session close ordering", async () => {
+    const accountId = `reconnect-session-conflict-${Date.now()}-${Math.random()}`;
+    const scheduler = createTestScheduler();
+    const session = createSessionRuntimeHarness();
+    const adapter = createWhatsAppAdapter(
+      {
+        channel: "whatsapp",
+        accountId,
+        enabled: true,
+        dmPolicy: "pairing",
+        allowedUsers: [],
+        createdAt: new Date(0).toISOString(),
+        updatedAt: new Date(0).toISOString(),
+        agentId: "agent-whatsapp",
+        selfChatMode: false,
+        groupMode: "disabled",
+      },
+      {
+        createSocket: async (params) =>
+          createWhatsAppSocket({
+            ...params,
+            printQr: false,
+            loadRuntimeModule: async () => session.runtime,
+          }),
+        loadRuntimeModule: async () => ({}),
+        reconnectScheduler: scheduler.scheduler,
+      },
+    );
+
+    try {
+      await adapter.start();
+      await session.handlers.get("connection.update")?.({
+        connection: "close",
+        lastDisconnect: { error: { message: "Stream Errored (conflict)" } },
+      });
+
+      expect(adapter.isRunning()).toBe(false);
+      expect(scheduler.pending()).toHaveLength(0);
+      expect(getWhatsAppConnectionState(accountId)).toMatchObject({
+        status: "error",
+        lastError:
+          "Stream Errored (conflict). Another WhatsApp client is using this linked-device session; not reconnecting automatically.",
+      });
+    } finally {
+      await adapter.stop();
+      clearWhatsAppConnectionState(accountId);
+      rmSync(getWhatsAppAuthDir(accountId), { recursive: true, force: true });
+    }
   });
 
   test("explicit conflict stops without another reconnect and preserves conflict error", async () => {

--- a/src/channels/whatsapp-adapter.test.ts
+++ b/src/channels/whatsapp-adapter.test.ts
@@ -1,8 +1,28 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
 import {
   createWhatsAppAdapter,
   isWhatsAppConflictDisconnect,
+  type WhatsAppAdapterDependencies,
+  type WhatsAppReconnectScheduler,
 } from "@/channels/whatsapp/adapter";
+import type { LidStore } from "@/channels/whatsapp/lid-store";
+import {
+  clearWhatsAppConnectionState,
+  getWhatsAppConnectionState,
+} from "@/channels/whatsapp/state";
+
+const activeHarnesses: Array<{
+  accountId: string;
+  adapter: { stop(): Promise<void> };
+}> = [];
+
+afterEach(async () => {
+  for (const harness of activeHarnesses) {
+    await harness.adapter.stop();
+    clearWhatsAppConnectionState(harness.accountId);
+  }
+  activeHarnesses.length = 0;
+});
 
 describe("WhatsApp adapter helpers", () => {
   test("detects session conflict disconnects by message", () => {
@@ -67,5 +87,313 @@ describe("WhatsApp adapter helpers", () => {
         ],
       }),
     ).resolves.toBeUndefined();
+    await adapter.stop();
+  });
+});
+
+type SchedulerEntry = {
+  callback: () => void;
+  canceled: boolean;
+  delayMs: number;
+  dueAt: number;
+  fired: boolean;
+  unref: boolean;
+};
+
+function createTestScheduler() {
+  const entries: SchedulerEntry[] = [];
+  let nowMs = 0;
+  const scheduler: WhatsAppReconnectScheduler = {
+    now: () => nowMs,
+    schedule(delayMs, callback, options) {
+      const entry: SchedulerEntry = {
+        callback,
+        canceled: false,
+        delayMs,
+        dueAt: nowMs + delayMs,
+        fired: false,
+        unref: options?.unref === true,
+      };
+      entries.push(entry);
+      return {
+        cancel() {
+          entry.canceled = true;
+        },
+      };
+    },
+  };
+
+  function run(entry: SchedulerEntry): void {
+    entry.fired = true;
+    nowMs = entry.dueAt;
+    entry.callback();
+  }
+
+  return {
+    entries,
+    scheduler,
+    advanceToNext() {
+      const next = entries
+        .filter((entry) => !entry.canceled && !entry.fired)
+        .sort((left, right) => left.dueAt - right.dueAt)[0];
+      if (!next) throw new Error("expected pending scheduler task");
+      run(next);
+    },
+    advanceBy(delayMs: number) {
+      const target = nowMs + delayMs;
+      for (;;) {
+        const next = entries
+          .filter(
+            (entry) => !entry.canceled && !entry.fired && entry.dueAt <= target,
+          )
+          .sort((left, right) => left.dueAt - right.dueAt)[0];
+        if (!next) break;
+        run(next);
+      }
+      nowMs = target;
+    },
+    pending() {
+      return entries.filter((entry) => !entry.canceled && !entry.fired);
+    },
+    runCanceled() {
+      for (const entry of entries.filter(
+        (candidate) => candidate.canceled && !candidate.fired,
+      )) {
+        run(entry);
+      }
+    },
+  };
+}
+
+function createReconnectHarness(accountId: string) {
+  type ConnectionUpdate = (update: Record<string, unknown>) => void;
+  const scheduler = createTestScheduler();
+  const updates: ConnectionUpdate[] = [];
+  let createSocketCalls = 0;
+  let releaseCalls = 0;
+  const emptyStore: LidStore = {
+    resolve() {
+      return null;
+    },
+    record() {
+      return { status: "idempotent" };
+    },
+    flush() {},
+  };
+  const createSocket: NonNullable<
+    WhatsAppAdapterDependencies["createSocket"]
+  > = async ({ onConnectionUpdate }) => {
+    createSocketCalls += 1;
+    updates.push(onConnectionUpdate as ConnectionUpdate);
+    return {
+      sock: {
+        ev: { on: () => undefined },
+        ws: { close: () => undefined },
+        user: { id: "15551234567@s.whatsapp.net", lid: undefined },
+      },
+      saveCreds: async () => undefined,
+      DisconnectReason: {},
+      release: () => {
+        releaseCalls += 1;
+      },
+    };
+  };
+  const adapter = createWhatsAppAdapter(
+    {
+      channel: "whatsapp",
+      accountId,
+      enabled: true,
+      dmPolicy: "pairing",
+      allowedUsers: [],
+      createdAt: new Date(0).toISOString(),
+      updatedAt: new Date(0).toISOString(),
+      agentId: "agent-whatsapp",
+      selfChatMode: false,
+      groupMode: "disabled",
+    },
+    {
+      createSocket,
+      loadRuntimeModule: async () => ({}),
+      lidStore: emptyStore,
+      reconnectScheduler: scheduler.scheduler,
+    },
+  );
+  activeHarnesses.push({ accountId, adapter });
+
+  return {
+    adapter,
+    scheduler,
+    get createSocketCalls() {
+      return createSocketCalls;
+    },
+    get releaseCalls() {
+      return releaseCalls;
+    },
+    close(index = updates.length - 1, message = "timed out") {
+      updates[index]?.({
+        connection: "close",
+        lastDisconnect: { error: { message } },
+      });
+    },
+    open(index = updates.length - 1) {
+      updates[index]?.({ connection: "open" });
+    },
+  };
+}
+
+async function flushReconnectMicrotasks(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe("WhatsApp reconnect circuit breaker", () => {
+  test("counts duplicate closes from one socket generation once", async () => {
+    const harness = createReconnectHarness("reconnect-duplicate-close");
+    await harness.adapter.start();
+
+    for (let index = 0; index < 6; index += 1) {
+      harness.close();
+    }
+    harness.open(0);
+    expect(harness.scheduler.pending()).toHaveLength(1);
+    expect(harness.scheduler.pending()[0]?.delayMs).toBe(2000);
+    expect(harness.scheduler.pending()[0]?.unref).toBe(false);
+
+    harness.scheduler.advanceToNext();
+    await flushReconnectMicrotasks();
+    expect(harness.createSocketCalls).toBe(2);
+    expect(harness.adapter.isRunning()).toBe(true);
+  });
+
+  test("ignores stale closes from older socket generations", async () => {
+    const harness = createReconnectHarness("reconnect-stale-generation");
+    await harness.adapter.start();
+
+    harness.close(0);
+    harness.scheduler.advanceToNext();
+    await flushReconnectMicrotasks();
+    expect(harness.createSocketCalls).toBe(2);
+
+    harness.close(0, "late stale close");
+    expect(harness.scheduler.pending()).toHaveLength(0);
+
+    harness.close(1);
+    expect(harness.scheduler.pending()).toHaveLength(1);
+  });
+
+  test("trips after six distinct unstable generations despite brief opens", async () => {
+    const accountId = "reconnect-six-generations";
+    const harness = createReconnectHarness(accountId);
+    await harness.adapter.start();
+
+    for (let index = 0; index < 6; index += 1) {
+      harness.open();
+      harness.close(index, `unstable ${index}`);
+      if (index < 5) {
+        harness.scheduler.advanceToNext();
+        await flushReconnectMicrotasks();
+      }
+    }
+
+    expect(harness.adapter.isRunning()).toBe(false);
+    expect(harness.scheduler.pending()).toHaveLength(0);
+    expect(getWhatsAppConnectionState(accountId).lastError).toContain(
+      "disconnected 6 times in 60s",
+    );
+    expect(getWhatsAppConnectionState(accountId).lastError).toContain(
+      "Another client may be competing",
+    );
+    expect(harness.releaseCalls).toBe(6);
+  });
+
+  test("resets history and backoff only after sixty seconds of stable uptime", async () => {
+    const harness = createReconnectHarness("reconnect-stable-reset");
+    await harness.adapter.start();
+
+    harness.close();
+    expect(harness.scheduler.pending()[0]?.delayMs).toBe(2000);
+    harness.scheduler.advanceToNext();
+    await flushReconnectMicrotasks();
+    harness.open();
+    expect(harness.scheduler.pending()[0]?.delayMs).toBe(60_000);
+    expect(harness.scheduler.pending()[0]?.unref).toBe(true);
+    harness.scheduler.advanceBy(59_999);
+    harness.close();
+    expect(harness.scheduler.pending()[0]?.delayMs).toBe(4000);
+    expect(harness.scheduler.pending()[0]?.unref).toBe(false);
+
+    harness.scheduler.advanceToNext();
+    await flushReconnectMicrotasks();
+    harness.open();
+    harness.scheduler.advanceBy(60_000);
+    harness.close();
+    expect(harness.scheduler.pending()[0]?.delayMs).toBe(2000);
+  });
+
+  test("stop cancels reconnect and stability tasks and stale callbacks cannot reconnect", async () => {
+    const harness = createReconnectHarness("reconnect-stop-cancels");
+    await harness.adapter.start();
+    harness.open();
+    const stableTask = harness.scheduler.pending()[0];
+
+    await harness.adapter.stop();
+    expect(stableTask?.canceled).toBe(true);
+    harness.scheduler.runCanceled();
+    expect(harness.createSocketCalls).toBe(1);
+
+    await harness.adapter.start();
+    harness.close();
+    const reconnectTask = harness.scheduler.pending()[0];
+    await harness.adapter.stop();
+    expect(reconnectTask?.canceled).toBe(true);
+    harness.scheduler.runCanceled();
+    await flushReconnectMicrotasks();
+    expect(harness.createSocketCalls).toBe(2);
+  });
+
+  test("explicit conflict stops without another reconnect and preserves conflict error", async () => {
+    const accountId = "reconnect-explicit-conflict";
+    const harness = createReconnectHarness(accountId);
+    await harness.adapter.start();
+    harness.close();
+    const reconnectTask = harness.scheduler.pending()[0];
+
+    harness.close(undefined, "Stream Errored (conflict)");
+
+    expect(harness.adapter.isRunning()).toBe(false);
+    expect(reconnectTask?.canceled).toBe(true);
+    expect(harness.scheduler.pending()).toHaveLength(0);
+    harness.scheduler.runCanceled();
+    await flushReconnectMicrotasks();
+    expect(harness.createSocketCalls).toBe(1);
+    expect(getWhatsAppConnectionState(accountId).lastError).toContain(
+      "Another WhatsApp client is using this linked-device session",
+    );
+  });
+
+  test("explicit start after circuit-breaker stop begins with clean history", async () => {
+    const harness = createReconnectHarness("reconnect-explicit-start");
+    await harness.adapter.start();
+    for (let index = 0; index < 6; index += 1) {
+      harness.close();
+      if (index < 5) {
+        harness.scheduler.advanceToNext();
+        await flushReconnectMicrotasks();
+      }
+    }
+    expect(harness.adapter.isRunning()).toBe(false);
+
+    await harness.adapter.start();
+    harness.close();
+    expect(harness.scheduler.pending()[0]?.delayMs).toBe(2000);
+    harness.scheduler.advanceToNext();
+    await flushReconnectMicrotasks();
+    for (let index = 0; index < 4; index += 1) {
+      harness.close();
+      harness.scheduler.advanceToNext();
+      await flushReconnectMicrotasks();
+    }
+    expect(harness.adapter.isRunning()).toBe(true);
   });
 });

--- a/src/channels/whatsapp-media.test.ts
+++ b/src/channels/whatsapp-media.test.ts
@@ -58,13 +58,56 @@ describe("WhatsApp media helpers", () => {
     });
   });
 
-  test("rejects non-Ogg/Opus audio for outbound voice memos", () => {
-    expect(() =>
+  test("sends non-Ogg audio as document attachments", () => {
+    expect(
       buildWhatsAppOutboundPayload({
-        text: "",
+        text: "listen",
         mediaPath: "/tmp/voice.mp3",
       }),
-    ).toThrow(/Ogg\/Opus/);
+    ).toEqual({
+      document: { url: "/tmp/voice.mp3" },
+      fileName: "voice.mp3",
+      mimetype: "audio/mpeg",
+      caption: "listen",
+    });
+  });
+
+  test("uses policy-resolved canonical path, basename, and MIME", () => {
+    expect(
+      buildWhatsAppOutboundPayload(
+        {
+          text: "caption",
+          mediaPath: "/tmp/link.bin",
+          fileName: "fake.bin",
+        },
+        {
+          mediaPath: "/tmp/real/photo.png",
+          mimeType: "image/png",
+        },
+      ),
+    ).toEqual({
+      image: { url: "/tmp/real/photo.png" },
+      caption: "caption",
+    });
+
+    expect(
+      buildWhatsAppOutboundPayload(
+        {
+          text: "doc",
+          mediaPath: "/tmp/link.bin",
+          fileName: "fake.bin",
+        },
+        {
+          mediaPath: "/tmp/real/report.pdf",
+          mimeType: "application/pdf",
+        },
+      ),
+    ).toEqual({
+      document: { url: "/tmp/real/report.pdf" },
+      fileName: "report.pdf",
+      mimetype: "application/pdf",
+      caption: "doc",
+    });
   });
 
   test("returns attachment metadata without downloading when media is disabled", async () => {

--- a/src/channels/whatsapp-message-channel.test.ts
+++ b/src/channels/whatsapp-message-channel.test.ts
@@ -51,14 +51,18 @@ describe("WhatsApp MessageChannel actions", () => {
     ]);
   });
 
-  test("documents the Ogg/Opus requirement for media uploads", () => {
-    expect(whatsappMessageActions.describeMessageTool({}).schema).toEqual({
+  test("documents WhatsApp voice memo and regular document upload behavior", () => {
+    const schema = whatsappMessageActions.describeMessageTool({}).schema;
+    expect(schema).toEqual({
       properties: {
         media: expect.objectContaining({
           description: expect.stringContaining("Ogg/Opus"),
         }),
       },
     });
+    const serializedSchema = JSON.stringify(schema);
+    expect(serializedSchema).toContain("push-to-talk voice memos");
+    expect(serializedSchema).toContain("regular document attachments");
   });
 
   test("sends text messages", async () => {
@@ -83,15 +87,17 @@ describe("WhatsApp MessageChannel actions", () => {
     );
   });
 
-  test("rejects MP3 voice memo uploads before calling the adapter", async () => {
+  test("passes MP3 uploads through to the adapter as document attachments", async () => {
     const { ctx, sent } = makeContext("upload-file", {
       mediaPath: "/tmp/voice.mp3",
     });
 
-    await expect(whatsappMessageActions.handleAction(ctx)).resolves.toMatch(
-      /Ogg\/Opus/,
+    await expect(whatsappMessageActions.handleAction(ctx)).resolves.toContain(
+      "Attachment sent",
     );
-    expect(sent).toHaveLength(0);
+    expect(sent[0]).toEqual(
+      expect.objectContaining({ mediaPath: "/tmp/voice.mp3" }),
+    );
   });
 
   test("sends reactions", async () => {

--- a/src/channels/whatsapp-message-channel.test.ts
+++ b/src/channels/whatsapp-message-channel.test.ts
@@ -109,4 +109,21 @@ describe("WhatsApp MessageChannel actions", () => {
       }),
     );
   });
+
+  test("removes reactions without requiring an emoji", async () => {
+    const { ctx, sent } = makeContext("react", {
+      remove: true,
+      messageId: "target-msg",
+    });
+    await expect(whatsappMessageActions.handleAction(ctx)).resolves.toContain(
+      "Reaction removed",
+    );
+    expect(sent[0]).toEqual(
+      expect.objectContaining({
+        reaction: undefined,
+        removeReaction: true,
+        targetMessageId: "target-msg",
+      }),
+    );
+  });
 });

--- a/src/channels/whatsapp-protocol.test.ts
+++ b/src/channels/whatsapp-protocol.test.ts
@@ -7,6 +7,7 @@ describe("whatsapp gateway config validators", () => {
       isValidChannelPluginConfigPayload("whatsapp", {
         config: {
           agent_id: "agent-1",
+          message_prefix: "[bot] ",
           self_chat_mode: true,
           group_mode: "disabled",
         },
@@ -38,6 +39,14 @@ describe("whatsapp gateway config validators", () => {
     expect(
       isValidChannelPluginConfigPayload("whatsapp", {
         config: { group_mode: "all" },
+      }),
+    ).toBe(false);
+  });
+
+  test("rejects non-string message prefixes", () => {
+    expect(
+      isValidChannelPluginConfigPayload("whatsapp", {
+        config: { message_prefix: 42 },
       }),
     ).toBe(false);
   });

--- a/src/channels/whatsapp-protocol.test.ts
+++ b/src/channels/whatsapp-protocol.test.ts
@@ -24,6 +24,11 @@ describe("whatsapp gateway config validators", () => {
           mention_patterns: ["\\bloop\\b"],
           download_media: true,
           media_max_bytes: 1048576,
+          attachment_filter: true,
+          attachment_mime_types: ["image/png"],
+          attachment_allowed_recipients: ["15551234567"],
+          attachment_allowed_paths: ["/tmp/uploads"],
+          attachment_path_recursive: true,
         },
       }),
     ).toBe(true);
@@ -54,6 +59,8 @@ describe("whatsapp gateway config validators", () => {
           plugin_config: {
             agent_id: "agent-1",
             self_chat_mode: false,
+            attachment_filter: true,
+            attachment_mime_types: ["image/png"],
           },
         },
         "plugin_config",

--- a/src/channels/whatsapp-registry.test.ts
+++ b/src/channels/whatsapp-registry.test.ts
@@ -61,6 +61,7 @@ type RegistryHarness = {
   deliveries: ChannelInboundDelivery[];
   sendCount: number;
   emit: (messages: Record<string, unknown>[]) => Promise<void>;
+  emitReaction: (entries: Record<string, unknown>[]) => Promise<void>;
 };
 
 function makeAccount(
@@ -93,11 +94,27 @@ function makeMessage(
   };
 }
 
+function makeReactionEntry(
+  remoteJid: string,
+  id: string,
+  key: Record<string, unknown> = {},
+): Record<string, unknown> {
+  return {
+    key: { remoteJid, id: "target-message", fromMe: true },
+    reaction: {
+      key: { remoteJid, id, fromMe: false, ...key },
+      text: "👍",
+      senderTimestampMs: Date.now(),
+    },
+  };
+}
+
 async function makeHarness(
   account: WhatsAppChannelAccount,
   lidPath: string,
 ): Promise<RegistryHarness> {
   const upsertHandlers: Array<(payload: unknown) => unknown> = [];
+  const reactionHandlers: Array<(payload: unknown) => unknown> = [];
   const deliveries: ChannelInboundDelivery[] = [];
   let sendCount = 0;
 
@@ -108,6 +125,7 @@ async function makeHarness(
       ev: {
         on(event: string, handler: (payload: unknown) => void) {
           if (event === "messages.upsert") upsertHandlers.push(handler);
+          if (event === "messages.reaction") reactionHandlers.push(handler);
         },
       },
       ws: { close() {} },
@@ -147,6 +165,12 @@ async function makeHarness(
       const handler = upsertHandlers.at(-1);
       if (!handler) throw new Error("messages.upsert handler was not captured");
       await handler({ type: "notify", messages });
+    },
+    async emitReaction(entries) {
+      const handler = reactionHandlers.at(-1);
+      if (!handler)
+        throw new Error("messages.reaction handler was not captured");
+      await handler(entries);
     },
   };
 }
@@ -234,6 +258,23 @@ describe("WhatsApp canonical identity through ChannelRegistry", () => {
       });
     }
     expect(getRoutesForChannel("whatsapp", ACCOUNT_ID)).toHaveLength(1);
+    expect(getPendingPairings("whatsapp", ACCOUNT_ID)).toHaveLength(0);
+    expect(harness.sendCount).toBe(0);
+  });
+
+  test("unpaired reactions do not create pairing prompts", async () => {
+    const account = makeAccount();
+    __testOverrideLoadChannelAccounts(() => [account]);
+    const harness = await makeHarness(account, join(tempDir, "lid.json"));
+
+    await harness.emitReaction([
+      makeReactionEntry(RAW_LID, "pending-reaction", {
+        senderPn: CANONICAL_PHONE_JID,
+        senderLid: RAW_LID,
+      }),
+    ]);
+
+    expect(harness.deliveries).toHaveLength(0);
     expect(getPendingPairings("whatsapp", ACCOUNT_ID)).toHaveLength(0);
     expect(harness.sendCount).toBe(0);
   });

--- a/src/channels/whatsapp-service.test.ts
+++ b/src/channels/whatsapp-service.test.ts
@@ -1,8 +1,14 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import {
   __testOverrideLoadChannelAccounts,
   __testOverrideSaveChannelAccounts,
   clearChannelAccountStores,
+  getChannelAccount,
+  loadChannelAccounts,
+  upsertChannelAccount,
 } from "@/channels/accounts";
 import {
   __testOverrideLoadPairingStore,
@@ -25,6 +31,12 @@ import {
   __testOverrideSaveTargetStore,
   clearTargetStores,
 } from "@/channels/targets";
+import { __testOverrideChannelsRoot, readChannelConfig } from "./config";
+import type {
+  ChannelAccount,
+  WhatsAppChannelAccount,
+  WhatsAppChannelConfig,
+} from "./types";
 
 describe("WhatsApp channel service", () => {
   beforeEach(() => {
@@ -55,6 +67,7 @@ describe("WhatsApp channel service", () => {
     __testOverrideSavePairingStore(null);
     __testOverrideLoadTargetStore(null);
     __testOverrideSaveTargetStore(null);
+    __testOverrideChannelsRoot(null);
   });
 
   test("creates conservative defaults", () => {
@@ -172,6 +185,7 @@ describe("WhatsApp channel service", () => {
           attachment_allowed_paths: ["/tmp/uploads"],
           attachment_path_recursive: true,
           inbound_debounce_ms: 250.9,
+          message_prefix: "[bot] ",
         },
       },
       { accountId: "personal" },
@@ -190,6 +204,7 @@ describe("WhatsApp channel service", () => {
     expect(created.attachmentAllowedPaths).toEqual(["/tmp/uploads"]);
     expect(created.attachmentPathRecursive).toBe(true);
     expect(created.inboundDebounceMs).toBe(250);
+    expect(created.messagePrefix).toBe("[bot] ");
     expect(created.config).toEqual(
       expect.objectContaining({
         attachment_filter: true,
@@ -198,6 +213,7 @@ describe("WhatsApp channel service", () => {
         attachment_allowed_paths: ["/tmp/uploads"],
         attachment_path_recursive: true,
         inbound_debounce_ms: 250,
+        message_prefix: "[bot] ",
       }),
     );
 
@@ -212,6 +228,15 @@ describe("WhatsApp channel service", () => {
     expect(updated.groupMode).toBe("open");
     expect(updated.selfChatMode).toBe(true);
     expect(updated.inboundDebounceMs).toBe(10_000);
+    expect(updated.messagePrefix).toBe("[bot] ");
+    expect(updated.config).toEqual(
+      expect.objectContaining({ message_prefix: "[bot] " }),
+    );
+
+    const cleared = updateChannelAccountLive("whatsapp", "personal", {
+      config: { message_prefix: "" },
+    });
+    expect(cleared.messagePrefix).toBe("");
   });
 
   test("loads old WhatsApp accounts without debounce and accepts stored snake_case debounce", () => {
@@ -259,6 +284,74 @@ describe("WhatsApp channel service", () => {
         config: expect.objectContaining({ inbound_debounce_ms: 999 }),
       }),
     );
+  });
+
+  test("migrates snake_case message prefix and saves the canonical key", () => {
+    let persisted: Record<string, unknown> | undefined;
+    __testOverrideLoadChannelAccounts(() => [
+      {
+        channel: "whatsapp",
+        accountId: "personal",
+        enabled: true,
+        dmPolicy: "pairing",
+        allowedUsers: [],
+        agentId: null,
+        selfChatMode: true,
+        groupMode: "disabled",
+        message_prefix: "[bot] ",
+        createdAt: new Date(0).toISOString(),
+        updatedAt: new Date(0).toISOString(),
+      } as unknown as ChannelAccount,
+    ]);
+    __testOverrideSaveChannelAccounts((_channelId, accounts) => {
+      persisted = accounts[0] as unknown as Record<string, unknown>;
+    });
+
+    loadChannelAccounts("whatsapp");
+    const loaded = getChannelAccount("whatsapp", "personal");
+    expect((loaded as WhatsAppChannelAccount | null)?.messagePrefix).toBe(
+      "[bot] ",
+    );
+    if (!loaded) throw new Error("migrated account was not loaded");
+
+    upsertChannelAccount("whatsapp", loaded);
+    expect(persisted?.message_prefix).toBe("[bot] ");
+    expect(persisted).not.toHaveProperty("messagePrefix");
+  });
+
+  test("migrates message prefix from legacy YAML", () => {
+    const root = mkdtempSync(join(tmpdir(), "whatsapp-prefix-"));
+    try {
+      mkdirSync(join(root, "whatsapp"), { recursive: true });
+      writeFileSync(
+        join(root, "whatsapp", "config.yaml"),
+        [
+          "enabled: true",
+          "dm_policy: pairing",
+          "message_prefix: '[bot] '",
+          "",
+        ].join("\n"),
+      );
+      __testOverrideChannelsRoot(root);
+      __testOverrideLoadChannelAccounts(null);
+
+      expect(
+        (readChannelConfig("whatsapp") as WhatsAppChannelConfig | null)
+          ?.messagePrefix,
+      ).toBe("[bot] ");
+      loadChannelAccounts("whatsapp");
+      expect(
+        (
+          getChannelAccount(
+            "whatsapp",
+            "__legacy_migrated__",
+          ) as WhatsAppChannelAccount | null
+        )?.messagePrefix,
+      ).toBe("[bot] ");
+    } finally {
+      __testOverrideChannelsRoot(null);
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 
   test("bind updates the account-level agent id", () => {

--- a/src/channels/whatsapp-service.test.ts
+++ b/src/channels/whatsapp-service.test.ts
@@ -73,6 +73,11 @@ describe("WhatsApp channel service", () => {
         groupMode: "disabled",
         dmPolicy: "pairing",
         agentId: null,
+        attachmentFilter: false,
+        attachmentMimeTypes: [],
+        attachmentAllowedRecipients: [],
+        attachmentAllowedPaths: [],
+        attachmentPathRecursive: false,
       }),
     );
     expect(created.config).toEqual(
@@ -80,8 +85,71 @@ describe("WhatsApp channel service", () => {
         self_chat_mode: true,
         group_mode: "disabled",
         agent_id: null,
+        attachment_filter: false,
+        attachment_mime_types: [],
+        attachment_allowed_recipients: [],
+        attachment_allowed_paths: [],
+        attachment_path_recursive: false,
       }),
     );
+  });
+
+  test("loads legacy accounts default-off and saves attachment policy as snake_case", () => {
+    let savedAccounts: Array<Record<string, unknown>> = [];
+    __testOverrideLoadChannelAccounts((channelId) =>
+      channelId === "whatsapp"
+        ? [
+            {
+              channel: "whatsapp",
+              accountId: "legacy",
+              enabled: true,
+              dmPolicy: "pairing",
+              allowedUsers: [],
+              agentId: null,
+              selfChatMode: false,
+              groupMode: "open",
+              createdAt: "2026-04-30T00:00:00.000Z",
+              updatedAt: "2026-04-30T00:00:00.000Z",
+            },
+          ]
+        : [],
+    );
+    __testOverrideSaveChannelAccounts((_channelId, accounts) => {
+      savedAccounts = accounts as unknown as Array<Record<string, unknown>>;
+    });
+    clearChannelAccountStores();
+
+    const snapshot = getChannelConfigSnapshot("whatsapp", "legacy");
+    expect(snapshot).toEqual(
+      expect.objectContaining({
+        attachmentFilter: false,
+        attachmentMimeTypes: [],
+        attachmentAllowedRecipients: [],
+        attachmentAllowedPaths: [],
+        attachmentPathRecursive: false,
+      }),
+    );
+
+    updateChannelAccountLive("whatsapp", "legacy", {
+      config: {
+        attachment_filter: true,
+        attachment_mime_types: ["image/png"],
+        attachment_allowed_recipients: ["15551234567"],
+        attachment_allowed_paths: ["/tmp/uploads"],
+        attachment_path_recursive: true,
+      },
+    });
+
+    expect(savedAccounts[0]).toEqual(
+      expect.objectContaining({
+        attachment_filter: true,
+        attachment_mime_types: ["image/png"],
+        attachment_allowed_recipients: ["15551234567"],
+        attachment_allowed_paths: ["/tmp/uploads"],
+        attachment_path_recursive: true,
+      }),
+    );
+    expect(savedAccounts[0]).not.toHaveProperty("attachmentFilter");
   });
 
   test("normalizes plugin config from snake_case", () => {
@@ -98,6 +166,11 @@ describe("WhatsApp channel service", () => {
           mention_patterns: ["\\bloop\\b"],
           download_media: true,
           media_max_bytes: 1048576,
+          attachment_filter: true,
+          attachment_mime_types: ["image/png"],
+          attachment_allowed_recipients: ["15551234567"],
+          attachment_allowed_paths: ["/tmp/uploads"],
+          attachment_path_recursive: true,
         },
       },
       { accountId: "personal" },
@@ -110,6 +183,20 @@ describe("WhatsApp channel service", () => {
     expect(created.mentionPatterns).toEqual(["\\bloop\\b"]);
     expect(created.downloadMedia).toBe(true);
     expect(created.mediaMaxBytes).toBe(1048576);
+    expect(created.attachmentFilter).toBe(true);
+    expect(created.attachmentMimeTypes).toEqual(["image/png"]);
+    expect(created.attachmentAllowedRecipients).toEqual(["15551234567"]);
+    expect(created.attachmentAllowedPaths).toEqual(["/tmp/uploads"]);
+    expect(created.attachmentPathRecursive).toBe(true);
+    expect(created.config).toEqual(
+      expect.objectContaining({
+        attachment_filter: true,
+        attachment_mime_types: ["image/png"],
+        attachment_allowed_recipients: ["15551234567"],
+        attachment_allowed_paths: ["/tmp/uploads"],
+        attachment_path_recursive: true,
+      }),
+    );
 
     const updated = updateChannelAccountLive("whatsapp", "personal", {
       config: { group_mode: "open", self_chat_mode: true },

--- a/src/channels/whatsapp-service.test.ts
+++ b/src/channels/whatsapp-service.test.ts
@@ -171,6 +171,7 @@ describe("WhatsApp channel service", () => {
           attachment_allowed_recipients: ["15551234567"],
           attachment_allowed_paths: ["/tmp/uploads"],
           attachment_path_recursive: true,
+          inbound_debounce_ms: 250.9,
         },
       },
       { accountId: "personal" },
@@ -188,6 +189,7 @@ describe("WhatsApp channel service", () => {
     expect(created.attachmentAllowedRecipients).toEqual(["15551234567"]);
     expect(created.attachmentAllowedPaths).toEqual(["/tmp/uploads"]);
     expect(created.attachmentPathRecursive).toBe(true);
+    expect(created.inboundDebounceMs).toBe(250);
     expect(created.config).toEqual(
       expect.objectContaining({
         attachment_filter: true,
@@ -195,14 +197,68 @@ describe("WhatsApp channel service", () => {
         attachment_allowed_recipients: ["15551234567"],
         attachment_allowed_paths: ["/tmp/uploads"],
         attachment_path_recursive: true,
+        inbound_debounce_ms: 250,
       }),
     );
+
+    const clamped = updateChannelAccountLive("whatsapp", "personal", {
+      config: { inbound_debounce_ms: 20_000 },
+    });
+    expect(clamped.inboundDebounceMs).toBe(10_000);
 
     const updated = updateChannelAccountLive("whatsapp", "personal", {
       config: { group_mode: "open", self_chat_mode: true },
     });
     expect(updated.groupMode).toBe("open");
     expect(updated.selfChatMode).toBe(true);
+    expect(updated.inboundDebounceMs).toBe(10_000);
+  });
+
+  test("loads old WhatsApp accounts without debounce and accepts stored snake_case debounce", () => {
+    const oldAccount = {
+      channel: "whatsapp" as const,
+      accountId: "old",
+      enabled: true,
+      dmPolicy: "pairing" as const,
+      allowedUsers: [],
+      agentId: null,
+      selfChatMode: true,
+      groupMode: "disabled" as const,
+      allowedGroups: [],
+      mentionPatterns: [],
+      createdAt: new Date(0).toISOString(),
+      updatedAt: new Date(0).toISOString(),
+    };
+    const storedSnakeAccount = {
+      channel: "whatsapp" as const,
+      accountId: "snake",
+      enabled: true,
+      dmPolicy: "pairing" as const,
+      allowedUsers: [],
+      agentId: null,
+      selfChatMode: true,
+      groupMode: "disabled" as const,
+      allowedGroups: [],
+      mentionPatterns: [],
+      inbound_debounce_ms: 999.8,
+      createdAt: new Date(0).toISOString(),
+      updatedAt: new Date(0).toISOString(),
+    };
+    __testOverrideLoadChannelAccounts(() => [oldAccount, storedSnakeAccount]);
+    clearChannelAccountStores();
+
+    expect(getChannelConfigSnapshot("whatsapp", "old")).toEqual(
+      expect.objectContaining({
+        inboundDebounceMs: undefined,
+        config: expect.objectContaining({ inbound_debounce_ms: 0 }),
+      }),
+    );
+    expect(getChannelConfigSnapshot("whatsapp", "snake")).toEqual(
+      expect.objectContaining({
+        inboundDebounceMs: 999,
+        config: expect.objectContaining({ inbound_debounce_ms: 999 }),
+      }),
+    );
   });
 
   test("bind updates the account-level agent id", () => {

--- a/src/channels/whatsapp-session.test.ts
+++ b/src/channels/whatsapp-session.test.ts
@@ -4,8 +4,41 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
   acquireWhatsAppSessionLease,
+  createWhatsAppSocket,
+  getWhatsAppAuthDir,
   renderQrTerminal,
 } from "@/channels/whatsapp/session";
+import {
+  clearWhatsAppConnectionState,
+  getWhatsAppConnectionState,
+  setWhatsAppConnectionState,
+} from "@/channels/whatsapp/state";
+
+function createSocketRuntimeHarness() {
+  const handlers = new Map<
+    string,
+    (payload?: unknown) => void | Promise<void>
+  >();
+  const sock = {
+    ev: {
+      on(event: string, handler: (payload?: unknown) => void | Promise<void>) {
+        handlers.set(event, handler);
+      },
+    },
+    user: { id: "15551234567@s.whatsapp.net", lid: "15551234567@lid" },
+    ws: { close() {} },
+  };
+  const runtime = {
+    makeWASocket: () => sock,
+    useMultiFileAuthState: async () => ({
+      state: { creds: {}, keys: {} },
+      saveCreds: async () => undefined,
+    }),
+    fetchLatestBaileysVersion: async () => ({ version: [2, 3000, 0] }),
+    DisconnectReason: { loggedOut: 401 },
+  };
+  return { handlers, runtime };
+}
 
 describe("WhatsApp session", () => {
   test("renders qrcode-terminal with the module as this", () => {
@@ -37,6 +70,42 @@ describe("WhatsApp session", () => {
     };
 
     expect(renderQrTerminal(qrMod, "pairing-payload")).toBeUndefined();
+  });
+
+  test("preserves adapter-claimed terminal close state", async () => {
+    const accountId = `session-claimed-close-${Date.now()}-${Math.random()}`;
+    const { handlers, runtime } = createSocketRuntimeHarness();
+    let result: Awaited<ReturnType<typeof createWhatsAppSocket>> | null = null;
+
+    try {
+      result = await createWhatsAppSocket({
+        accountId,
+        printQr: false,
+        loadRuntimeModule: async () => runtime,
+        onConnectionUpdate(update) {
+          if (update.connection !== "close") return;
+          setWhatsAppConnectionState(accountId, {
+            status: "error",
+            lastError: "terminal conflict wins",
+          });
+          return { claimedConnectionState: true };
+        },
+      });
+
+      await handlers.get("connection.update")?.({
+        connection: "close",
+        lastDisconnect: { error: { message: "generic disconnected loser" } },
+      });
+
+      expect(getWhatsAppConnectionState(accountId)).toMatchObject({
+        status: "error",
+        lastError: "terminal conflict wins",
+      });
+    } finally {
+      result?.release();
+      clearWhatsAppConnectionState(accountId);
+      rmSync(getWhatsAppAuthDir(accountId), { recursive: true, force: true });
+    }
   });
 
   test("prevents concurrent session leases for the same account", () => {

--- a/src/channels/whatsapp/account-config.ts
+++ b/src/channels/whatsapp/account-config.ts
@@ -14,6 +14,11 @@ const WHATSAPP_CONFIG_KEYS = new Set([
   "transcribe_voice",
   "download_media",
   "media_max_bytes",
+  "attachment_filter",
+  "attachment_mime_types",
+  "attachment_allowed_recipients",
+  "attachment_allowed_paths",
+  "attachment_path_recursive",
 ]);
 
 function isNullableString(value: unknown): value is string | null {
@@ -60,7 +65,17 @@ export const whatsappAccountConfigAdapter: ChannelAccountConfigAdapter<WhatsAppC
         (config.download_media === undefined ||
           isBoolean(config.download_media)) &&
         (config.media_max_bytes === undefined ||
-          isPositiveNumber(config.media_max_bytes))
+          isPositiveNumber(config.media_max_bytes)) &&
+        (config.attachment_filter === undefined ||
+          isBoolean(config.attachment_filter)) &&
+        (config.attachment_mime_types === undefined ||
+          isStringArray(config.attachment_mime_types)) &&
+        (config.attachment_allowed_recipients === undefined ||
+          isStringArray(config.attachment_allowed_recipients)) &&
+        (config.attachment_allowed_paths === undefined ||
+          isStringArray(config.attachment_allowed_paths)) &&
+        (config.attachment_path_recursive === undefined ||
+          isBoolean(config.attachment_path_recursive))
       );
     },
 
@@ -90,6 +105,23 @@ export const whatsappAccountConfigAdapter: ChannelAccountConfigAdapter<WhatsAppC
         mediaMaxBytes: isPositiveNumber(config.media_max_bytes)
           ? config.media_max_bytes
           : undefined,
+        attachmentFilter: isBoolean(config.attachment_filter)
+          ? config.attachment_filter
+          : undefined,
+        attachmentMimeTypes: isStringArray(config.attachment_mime_types)
+          ? [...config.attachment_mime_types]
+          : undefined,
+        attachmentAllowedRecipients: isStringArray(
+          config.attachment_allowed_recipients,
+        )
+          ? [...config.attachment_allowed_recipients]
+          : undefined,
+        attachmentAllowedPaths: isStringArray(config.attachment_allowed_paths)
+          ? [...config.attachment_allowed_paths]
+          : undefined,
+        attachmentPathRecursive: isBoolean(config.attachment_path_recursive)
+          ? config.attachment_path_recursive
+          : undefined,
       };
     },
 
@@ -103,6 +135,13 @@ export const whatsappAccountConfigAdapter: ChannelAccountConfigAdapter<WhatsAppC
         transcribe_voice: account.transcribeVoice === true,
         download_media: account.downloadMedia === true,
         media_max_bytes: account.mediaMaxBytes,
+        attachment_filter: account.attachmentFilter === true,
+        attachment_mime_types: [...(account.attachmentMimeTypes ?? [])],
+        attachment_allowed_recipients: [
+          ...(account.attachmentAllowedRecipients ?? []),
+        ],
+        attachment_allowed_paths: [...(account.attachmentAllowedPaths ?? [])],
+        attachment_path_recursive: account.attachmentPathRecursive === true,
         ...toWhatsAppConnectionConfig(account.accountId),
       };
     },
@@ -117,6 +156,13 @@ export const whatsappAccountConfigAdapter: ChannelAccountConfigAdapter<WhatsAppC
         transcribe_voice: account.transcribeVoice === true,
         download_media: account.downloadMedia === true,
         media_max_bytes: account.mediaMaxBytes,
+        attachment_filter: account.attachmentFilter === true,
+        attachment_mime_types: [...(account.attachmentMimeTypes ?? [])],
+        attachment_allowed_recipients: [
+          ...(account.attachmentAllowedRecipients ?? []),
+        ],
+        attachment_allowed_paths: [...(account.attachmentAllowedPaths ?? [])],
+        attachment_path_recursive: account.attachmentPathRecursive === true,
         ...toWhatsAppConnectionConfig(account.accountId),
       };
     },

--- a/src/channels/whatsapp/account-config.ts
+++ b/src/channels/whatsapp/account-config.ts
@@ -22,6 +22,7 @@ const WHATSAPP_CONFIG_KEYS = new Set([
   "attachment_path_recursive",
   "inbound_debounce_ms",
   "waiting_behavior",
+  "message_prefix",
 ]);
 
 function isNullableString(value: unknown): value is string | null {
@@ -52,6 +53,10 @@ function isValidInboundDebounceMs(value: unknown): value is number {
 
 function isWaitingBehavior(value: unknown): value is WhatsAppWaitingBehavior {
   return value === "off" || value === "typing_indicator";
+}
+
+function isString(value: unknown): value is string {
+  return typeof value === "string";
 }
 
 export const whatsappAccountConfigAdapter: ChannelAccountConfigAdapter<WhatsAppChannelAccount> =
@@ -90,7 +95,8 @@ export const whatsappAccountConfigAdapter: ChannelAccountConfigAdapter<WhatsAppC
         (config.inbound_debounce_ms === undefined ||
           isValidInboundDebounceMs(config.inbound_debounce_ms)) &&
         (config.waiting_behavior === undefined ||
-          isWaitingBehavior(config.waiting_behavior))
+          isWaitingBehavior(config.waiting_behavior)) &&
+        (config.message_prefix === undefined || isString(config.message_prefix))
       );
     },
 
@@ -143,6 +149,9 @@ export const whatsappAccountConfigAdapter: ChannelAccountConfigAdapter<WhatsAppC
         waitingBehavior: isWaitingBehavior(config.waiting_behavior)
           ? config.waiting_behavior
           : undefined,
+        messagePrefix: isString(config.message_prefix)
+          ? config.message_prefix
+          : undefined,
       };
     },
 
@@ -165,6 +174,7 @@ export const whatsappAccountConfigAdapter: ChannelAccountConfigAdapter<WhatsAppC
         attachment_path_recursive: account.attachmentPathRecursive === true,
         inbound_debounce_ms: account.inboundDebounceMs ?? 0,
         waiting_behavior: account.waitingBehavior ?? "off",
+        message_prefix: account.messagePrefix,
         ...toWhatsAppConnectionConfig(account.accountId),
       };
     },
@@ -188,6 +198,7 @@ export const whatsappAccountConfigAdapter: ChannelAccountConfigAdapter<WhatsAppC
         attachment_path_recursive: account.attachmentPathRecursive === true,
         inbound_debounce_ms: account.inboundDebounceMs ?? 0,
         waiting_behavior: account.waitingBehavior ?? "off",
+        message_prefix: account.messagePrefix,
         ...toWhatsAppConnectionConfig(account.accountId),
       };
     },

--- a/src/channels/whatsapp/account-config.ts
+++ b/src/channels/whatsapp/account-config.ts
@@ -4,6 +4,7 @@ import type {
   WhatsAppGroupMode,
 } from "@/channels/types";
 import { toWhatsAppConnectionConfig } from "./state";
+import type { WhatsAppWaitingBehavior } from "./waiting-behavior-config-types";
 
 const WHATSAPP_CONFIG_KEYS = new Set([
   "agent_id",
@@ -20,6 +21,7 @@ const WHATSAPP_CONFIG_KEYS = new Set([
   "attachment_allowed_paths",
   "attachment_path_recursive",
   "inbound_debounce_ms",
+  "waiting_behavior",
 ]);
 
 function isNullableString(value: unknown): value is string | null {
@@ -46,6 +48,10 @@ function isPositiveNumber(value: unknown): value is number {
 
 function isValidInboundDebounceMs(value: unknown): value is number {
   return typeof value === "number" && Number.isFinite(value) && value >= 0;
+}
+
+function isWaitingBehavior(value: unknown): value is WhatsAppWaitingBehavior {
+  return value === "off" || value === "typing_indicator";
 }
 
 export const whatsappAccountConfigAdapter: ChannelAccountConfigAdapter<WhatsAppChannelAccount> =
@@ -82,7 +88,9 @@ export const whatsappAccountConfigAdapter: ChannelAccountConfigAdapter<WhatsAppC
         (config.attachment_path_recursive === undefined ||
           isBoolean(config.attachment_path_recursive)) &&
         (config.inbound_debounce_ms === undefined ||
-          isValidInboundDebounceMs(config.inbound_debounce_ms))
+          isValidInboundDebounceMs(config.inbound_debounce_ms)) &&
+        (config.waiting_behavior === undefined ||
+          isWaitingBehavior(config.waiting_behavior))
       );
     },
 
@@ -132,6 +140,9 @@ export const whatsappAccountConfigAdapter: ChannelAccountConfigAdapter<WhatsAppC
         inboundDebounceMs: isValidInboundDebounceMs(config.inbound_debounce_ms)
           ? Math.trunc(Math.min(config.inbound_debounce_ms, 10000))
           : undefined,
+        waitingBehavior: isWaitingBehavior(config.waiting_behavior)
+          ? config.waiting_behavior
+          : undefined,
       };
     },
 
@@ -153,6 +164,7 @@ export const whatsappAccountConfigAdapter: ChannelAccountConfigAdapter<WhatsAppC
         attachment_allowed_paths: [...(account.attachmentAllowedPaths ?? [])],
         attachment_path_recursive: account.attachmentPathRecursive === true,
         inbound_debounce_ms: account.inboundDebounceMs ?? 0,
+        waiting_behavior: account.waitingBehavior ?? "off",
         ...toWhatsAppConnectionConfig(account.accountId),
       };
     },
@@ -175,6 +187,7 @@ export const whatsappAccountConfigAdapter: ChannelAccountConfigAdapter<WhatsAppC
         attachment_allowed_paths: [...(account.attachmentAllowedPaths ?? [])],
         attachment_path_recursive: account.attachmentPathRecursive === true,
         inbound_debounce_ms: account.inboundDebounceMs ?? 0,
+        waiting_behavior: account.waitingBehavior ?? "off",
         ...toWhatsAppConnectionConfig(account.accountId),
       };
     },

--- a/src/channels/whatsapp/account-config.ts
+++ b/src/channels/whatsapp/account-config.ts
@@ -19,6 +19,7 @@ const WHATSAPP_CONFIG_KEYS = new Set([
   "attachment_allowed_recipients",
   "attachment_allowed_paths",
   "attachment_path_recursive",
+  "inbound_debounce_ms",
 ]);
 
 function isNullableString(value: unknown): value is string | null {
@@ -41,6 +42,10 @@ function isGroupMode(value: unknown): value is WhatsAppGroupMode {
 
 function isPositiveNumber(value: unknown): value is number {
   return typeof value === "number" && Number.isFinite(value) && value > 0;
+}
+
+function isValidInboundDebounceMs(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0;
 }
 
 export const whatsappAccountConfigAdapter: ChannelAccountConfigAdapter<WhatsAppChannelAccount> =
@@ -75,7 +80,9 @@ export const whatsappAccountConfigAdapter: ChannelAccountConfigAdapter<WhatsAppC
         (config.attachment_allowed_paths === undefined ||
           isStringArray(config.attachment_allowed_paths)) &&
         (config.attachment_path_recursive === undefined ||
-          isBoolean(config.attachment_path_recursive))
+          isBoolean(config.attachment_path_recursive)) &&
+        (config.inbound_debounce_ms === undefined ||
+          isValidInboundDebounceMs(config.inbound_debounce_ms))
       );
     },
 
@@ -122,6 +129,9 @@ export const whatsappAccountConfigAdapter: ChannelAccountConfigAdapter<WhatsAppC
         attachmentPathRecursive: isBoolean(config.attachment_path_recursive)
           ? config.attachment_path_recursive
           : undefined,
+        inboundDebounceMs: isValidInboundDebounceMs(config.inbound_debounce_ms)
+          ? Math.trunc(Math.min(config.inbound_debounce_ms, 10000))
+          : undefined,
       };
     },
 
@@ -142,6 +152,7 @@ export const whatsappAccountConfigAdapter: ChannelAccountConfigAdapter<WhatsAppC
         ],
         attachment_allowed_paths: [...(account.attachmentAllowedPaths ?? [])],
         attachment_path_recursive: account.attachmentPathRecursive === true,
+        inbound_debounce_ms: account.inboundDebounceMs ?? 0,
         ...toWhatsAppConnectionConfig(account.accountId),
       };
     },
@@ -163,6 +174,7 @@ export const whatsappAccountConfigAdapter: ChannelAccountConfigAdapter<WhatsAppC
         ],
         attachment_allowed_paths: [...(account.attachmentAllowedPaths ?? [])],
         attachment_path_recursive: account.attachmentPathRecursive === true,
+        inbound_debounce_ms: account.inboundDebounceMs ?? 0,
         ...toWhatsAppConnectionConfig(account.accountId),
       };
     },

--- a/src/channels/whatsapp/adapter-helpers.ts
+++ b/src/channels/whatsapp/adapter-helpers.ts
@@ -1,5 +1,6 @@
 import type {
   ChannelTurnSource,
+  OutboundChannelMessage,
   WhatsAppChannelAccount,
 } from "@/channels/types";
 import { stripDeviceSuffix } from "./jid";
@@ -56,6 +57,26 @@ export function getWhatsAppDisplayName(
   account: WhatsAppChannelAccount,
 ): string {
   return account.displayName ?? "WhatsApp";
+}
+
+export function applyWhatsAppMessagePrefix(
+  text: string,
+  prefix: string | undefined,
+): string {
+  return prefix && text.trim().length > 0 ? `${prefix}${text}` : text;
+}
+
+export function withWhatsAppMessagePrefix(
+  message: OutboundChannelMessage,
+  prefix: string | undefined,
+): OutboundChannelMessage {
+  if (message.reaction || message.removeReaction || !message.text) {
+    return message;
+  }
+  return {
+    ...message,
+    text: applyWhatsAppMessagePrefix(message.text, prefix),
+  };
 }
 
 function matchesSelf(

--- a/src/channels/whatsapp/adapter-helpers.ts
+++ b/src/channels/whatsapp/adapter-helpers.ts
@@ -1,6 +1,5 @@
 import type {
   ChannelTurnSource,
-  OutboundChannelMessage,
   WhatsAppChannelAccount,
 } from "@/channels/types";
 import { stripDeviceSuffix } from "./jid";
@@ -66,17 +65,24 @@ export function applyWhatsAppMessagePrefix(
   return prefix && text.trim().length > 0 ? `${prefix}${text}` : text;
 }
 
-export function withWhatsAppMessagePrefix(
-  message: OutboundChannelMessage,
+export function withWhatsAppPayloadMessagePrefix(
+  payload: Record<string, unknown>,
   prefix: string | undefined,
-): OutboundChannelMessage {
-  if (message.reaction || message.removeReaction || !message.text) {
-    return message;
+): Record<string, unknown> {
+  if (!prefix) return payload;
+  if (typeof payload.text === "string") {
+    return {
+      ...payload,
+      text: applyWhatsAppMessagePrefix(payload.text, prefix),
+    };
   }
-  return {
-    ...message,
-    text: applyWhatsAppMessagePrefix(message.text, prefix),
-  };
+  if (typeof payload.caption === "string") {
+    return {
+      ...payload,
+      caption: applyWhatsAppMessagePrefix(payload.caption, prefix),
+    };
+  }
+  return payload;
 }
 
 function matchesSelf(

--- a/src/channels/whatsapp/adapter-helpers.ts
+++ b/src/channels/whatsapp/adapter-helpers.ts
@@ -1,0 +1,138 @@
+import type {
+  ChannelTurnSource,
+  WhatsAppChannelAccount,
+} from "@/channels/types";
+import { stripDeviceSuffix } from "./jid";
+import { unwrapWhatsAppMessageContent } from "./media";
+
+const MAX_MENTION_PATTERN_LENGTH = 256;
+const MENTION_MATCH_TEXT_MAX_LENGTH = 2000;
+
+export function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object"
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+export function isWhatsAppReactionMessage(message: unknown): boolean {
+  const content = unwrapWhatsAppMessageContent(message);
+  return !!content?.reactionMessage;
+}
+
+export function isWhatsAppConflictDisconnect(update: unknown): boolean {
+  const record = asRecord(update);
+  if (record.connection !== "close") return false;
+  const lastDisconnect = asRecord(record.lastDisconnect);
+  const error = asRecord(lastDisconnect.error);
+  const output = asRecord(error.output);
+  const statusCode = output.statusCode;
+  const message = typeof error.message === "string" ? error.message : "";
+  return (
+    statusCode === 440 ||
+    /\bconflict\b/i.test(message) ||
+    /connection replaced/i.test(message)
+  );
+}
+
+export function timestampToMs(value: unknown): number {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value * 1000;
+  }
+  if (value && typeof value === "object") {
+    const toNumber = (value as { toNumber?: () => number }).toNumber;
+    if (typeof toNumber === "function") {
+      return toNumber.call(value) * 1000;
+    }
+  }
+  return Date.now();
+}
+
+export function previewWhatsAppText(text: string): string {
+  const normalized = text.replace(/\s+/g, " ").trim();
+  return normalized.length <= 80 ? normalized : `${normalized.slice(0, 79)}…`;
+}
+
+export function getWhatsAppDisplayName(
+  account: WhatsAppChannelAccount,
+): string {
+  return account.displayName ?? "WhatsApp";
+}
+
+function matchesSelf(
+  jid: string,
+  selfPhoneJid: string | null,
+  selfLid: string | null,
+): boolean {
+  const normalized = stripDeviceSuffix(jid);
+  return (
+    (!!selfPhoneJid && normalized === stripDeviceSuffix(selfPhoneJid)) ||
+    (!!selfLid && normalized === stripDeviceSuffix(selfLid))
+  );
+}
+
+export function shouldProcessWhatsAppGroup(params: {
+  account: WhatsAppChannelAccount;
+  groupJid: string;
+  text: string;
+  mentionedJids: string[];
+  replyParticipant: string | null;
+  selfPhoneJid: string | null;
+  selfLid: string | null;
+}): boolean {
+  const {
+    account,
+    groupJid,
+    text,
+    mentionedJids,
+    replyParticipant,
+    selfPhoneJid,
+    selfLid,
+  } = params;
+  if (account.groupMode === "disabled") return false;
+  if (
+    account.allowedGroups?.length &&
+    !account.allowedGroups.includes(groupJid)
+  ) {
+    return false;
+  }
+  if (account.groupMode === "open") return true;
+  if (mentionedJids.some((jid) => matchesSelf(jid, selfPhoneJid, selfLid))) {
+    return true;
+  }
+  if (
+    replyParticipant &&
+    matchesSelf(replyParticipant, selfPhoneJid, selfLid)
+  ) {
+    return true;
+  }
+  const matchText = text.slice(0, MENTION_MATCH_TEXT_MAX_LENGTH);
+  for (const pattern of account.mentionPatterns ?? []) {
+    if (pattern.length > MAX_MENTION_PATTERN_LENGTH) continue;
+    try {
+      if (new RegExp(pattern, "i").test(matchText)) return true;
+    } catch {
+      // Ignore invalid user-provided patterns.
+    }
+  }
+  return false;
+}
+
+export function buildWhatsAppQuotedOptions(
+  targetJid: string,
+  replyToMessageId?: string,
+): Record<string, unknown> | undefined {
+  if (!replyToMessageId) return undefined;
+  return {
+    quoted: {
+      key: { remoteJid: targetJid, id: replyToMessageId },
+      message: { conversation: "" },
+    },
+  };
+}
+
+export function getWhatsAppLifecycleErrorReplyKey(
+  source: ChannelTurnSource,
+): string | null {
+  if (!source.chatId) return null;
+  return `${source.chatId}:${source.messageId ?? ""}`;
+}

--- a/src/channels/whatsapp/adapter-types.ts
+++ b/src/channels/whatsapp/adapter-types.ts
@@ -1,0 +1,35 @@
+type EventEmitterLike = {
+  on?: (event: string, handler: (payload: unknown) => void) => void;
+};
+
+export type WhatsAppMessageKey = {
+  remoteJid?: string | null;
+  id?: string | null;
+  fromMe?: boolean | null;
+  participant?: string | null;
+  senderPn?: string | null;
+  senderLid?: string | null;
+  participantPn?: string | null;
+  participantLid?: string | null;
+};
+
+export type WhatsAppSocket = {
+  ev?: EventEmitterLike;
+  ws?: { close?: () => void };
+  user?: { id?: string; lid?: string };
+  sendMessage?: (
+    jid: string,
+    payload: Record<string, unknown>,
+    options?: Record<string, unknown>,
+  ) => Promise<{ key?: { id?: string }; message?: unknown }>;
+  sendPresenceUpdate?: (presence: string, jid?: string) => Promise<void>;
+  groupMetadata?: (jid: string) => Promise<{ subject?: string }>;
+  readMessages?: (keys: WhatsAppMessageKey[]) => Promise<unknown>;
+};
+
+export type WhatsAppMessage = {
+  key?: WhatsAppMessageKey;
+  message?: unknown;
+  messageTimestamp?: number | { toNumber?: () => number } | null;
+  pushName?: string | null;
+};

--- a/src/channels/whatsapp/adapter.test.ts
+++ b/src/channels/whatsapp/adapter.test.ts
@@ -807,6 +807,15 @@ describe("WhatsApp adapter inbound debounce and read receipts", () => {
     await sleep(70);
     expect(received.map((message) => message.text)).toEqual(["replayed"]);
     expect(harness.sockets[1]?.readCalls).toEqual([["old"]]);
+
+    await harness.adapter.stop();
+    await harness.adapter.start();
+    await harness.emit([
+      makeTextMessage(phone("15550000061"), "old", "duplicate replay"),
+    ]);
+    await sleep(70);
+    expect(received.map((message) => message.text)).toEqual(["replayed"]);
+    expect(harness.sockets[2]?.readCalls).toEqual([]);
   });
 
   test("connection close invalidates pending debounce and stale socket traffic without reads", async () => {

--- a/src/channels/whatsapp/adapter.test.ts
+++ b/src/channels/whatsapp/adapter.test.ts
@@ -46,11 +46,24 @@ function makeMessage(
   id: string,
   key: Record<string, unknown> = {},
 ): Record<string, unknown> {
+  return makeTextMessage(remoteJid, id, "hello", key);
+}
+
+function makeTextMessage(
+  remoteJid: string,
+  id: string,
+  text: string,
+  key: Record<string, unknown> = {},
+): Record<string, unknown> {
   return {
     key: { remoteJid, id, ...key },
-    message: { conversation: "hello" },
+    message: { conversation: text },
     messageTimestamp: Math.floor(Date.now() / 1000),
   };
+}
+
+async function sleep(ms: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 function instrumentStore(store: LidStore): LidStore & { flushes: number } {
@@ -127,6 +140,79 @@ function makeHarness(
     sentPayloads,
     sentOptions,
     presenceUpdates,
+  };
+}
+
+type DebounceHarnessSocket = {
+  upsertHandler?: (payload: unknown) => unknown;
+  readCalls: string[][];
+  closed: number;
+};
+
+function makeDebounceHarness(options: {
+  store: LidStore;
+  accountPatch?: Partial<WhatsAppChannelAccount>;
+  onMessage: (message: InboundChannelMessage) => Promise<void>;
+  readMessages?: (keys: Record<string, unknown>[]) => Promise<unknown>;
+}) {
+  const sockets: DebounceHarnessSocket[] = [];
+  const testAccount: WhatsAppChannelAccount = {
+    ...account,
+    accountId: options.accountPatch?.accountId ?? "debounce-test",
+    ...options.accountPatch,
+  };
+  const createSocket: NonNullable<
+    WhatsAppAdapterDependencies["createSocket"]
+  > = async () => {
+    const socketRecord: DebounceHarnessSocket = { readCalls: [], closed: 0 };
+    const socket = {
+      ev: {
+        on(event: string, handler: (payload: unknown) => void) {
+          if (event === "messages.upsert") socketRecord.upsertHandler = handler;
+        },
+      },
+      ws: {
+        close() {
+          socketRecord.closed += 1;
+        },
+      },
+      user: { id: phone("15551234567"), lid: lid("777000111") },
+      async readMessages(keys: Record<string, unknown>[]) {
+        socketRecord.readCalls.push(keys.map((key) => String(key.id)));
+        if (options.readMessages) return options.readMessages(keys);
+        return undefined;
+      },
+      async sendMessage() {
+        return { key: { id: "outbound" } };
+      },
+    };
+    sockets.push(socketRecord);
+    return {
+      sock: socket,
+      saveCreds: async () => undefined,
+      DisconnectReason: {},
+      release: () => undefined,
+    };
+  };
+  const adapter = createWhatsAppAdapter(testAccount, {
+    createSocket,
+    loadRuntimeModule: async () => ({}),
+    lidStore: options.store,
+  });
+  adapter.onMessage = options.onMessage;
+  return {
+    adapter,
+    sockets,
+    async emit(
+      messages: Record<string, unknown>[],
+      emitOptions?: { socketIndex?: number; type?: "notify" | "append" },
+    ) {
+      const socketIndex = emitOptions?.socketIndex ?? sockets.length - 1;
+      await sockets[socketIndex]?.upsertHandler?.({
+        type: emitOptions?.type ?? "notify",
+        messages,
+      });
+    },
   };
 }
 
@@ -525,5 +611,179 @@ describe("WhatsApp adapter canonical identity integration", () => {
     expect(
       createLidStore(join(dir, "retry.json")).resolve(lid("11110000")),
     ).toBe(phone("15550000011"));
+  });
+});
+
+describe("WhatsApp adapter inbound debounce and read receipts", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "adapter-debounce-test-"));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("batches canonical sender/chat text and marks one socket-bound read receipt batch", async () => {
+    const received: InboundChannelMessage[] = [];
+    const harness = makeDebounceHarness({
+      store: createLidStore(join(dir, "lid.json")),
+      accountPatch: { inboundDebounceMs: 20, groupMode: "open" },
+      onMessage: async (message) => {
+        received.push(message);
+      },
+    });
+    await harness.adapter.start();
+
+    await harness.emit([
+      makeTextMessage(group("120363"), "one", "first", {
+        participant: lid("44445555"),
+        participantPn: phone("15550000006"),
+      }),
+      makeTextMessage(group("120363"), "two", "second", {
+        participant: lid("44445555"),
+      }),
+    ]);
+
+    expect(harness.sockets[0]?.readCalls).toEqual([["one", "two"]]);
+    expect(received).toEqual([]);
+    await sleep(60);
+    expect(received).toHaveLength(1);
+    expect(received[0]?.chatId).toBe(group("120363"));
+    expect(received[0]?.senderId).toBe("15550000006");
+    expect(received[0]?.text).toBe("first\nsecond");
+    expect(Array.isArray(received[0]?.raw)).toBe(true);
+  });
+
+  test("keeps unrelated chats and senders independent", async () => {
+    const received: InboundChannelMessage[] = [];
+    const harness = makeDebounceHarness({
+      store: createLidStore(join(dir, "lid.json")),
+      accountPatch: { inboundDebounceMs: 20, groupMode: "open" },
+      onMessage: async (message) => {
+        received.push(message);
+      },
+    });
+    await harness.adapter.start();
+
+    await harness.emit([
+      makeTextMessage(group("120363"), "sender-a", "sender a", {
+        participant: phone("15550000021"),
+      }),
+      makeTextMessage(group("120363"), "sender-b", "sender b", {
+        participant: phone("15550000022"),
+      }),
+      makeTextMessage(phone("15550000023"), "direct", "direct"),
+    ]);
+
+    await sleep(60);
+    expect(received.map((message) => message.text).sort()).toEqual([
+      "direct",
+      "sender a",
+      "sender b",
+    ]);
+  });
+
+  test("default debounce remains immediate while read receipt ownership is per upsert", async () => {
+    const received: InboundChannelMessage[] = [];
+    const harness = makeDebounceHarness({
+      store: createLidStore(join(dir, "lid.json")),
+      onMessage: async (message) => {
+        received.push(message);
+      },
+    });
+    await harness.adapter.start();
+
+    await harness.emit([
+      makeTextMessage(phone("15550000031"), "one", "one"),
+      makeTextMessage(phone("15550000031"), "two", "two"),
+    ]);
+
+    expect(received.map((message) => message.text)).toEqual(["one", "two"]);
+    expect(harness.sockets[0]?.readCalls).toEqual([["one", "two"]]);
+  });
+
+  test("read receipt failures do not block delivery", async () => {
+    const received: InboundChannelMessage[] = [];
+    const harness = makeDebounceHarness({
+      store: createLidStore(join(dir, "lid.json")),
+      onMessage: async (message) => {
+        received.push(message);
+      },
+      readMessages: async () => {
+        throw new Error("read receipt failed");
+      },
+    });
+    await harness.adapter.start();
+
+    await harness.emit([makeTextMessage(phone("15550000041"), "one", "body")]);
+
+    expect(received.map((message) => message.text)).toEqual(["body"]);
+    expect(harness.sockets[0]?.readCalls).toEqual([["one"]]);
+  });
+
+  test("does not mark read or deliver dropped group traffic and reactions", async () => {
+    const received: InboundChannelMessage[] = [];
+    const harness = makeDebounceHarness({
+      store: createLidStore(join(dir, "lid.json")),
+      accountPatch: { groupMode: "mention" },
+      onMessage: async (message) => {
+        received.push(message);
+      },
+    });
+    await harness.adapter.start();
+
+    await harness.emit([
+      makeTextMessage(group("120363"), "unmentioned", "not for you", {
+        participant: phone("15550000051"),
+      }),
+      {
+        key: {
+          remoteJid: group("120363"),
+          id: "reaction",
+          participant: phone("15550000051"),
+        },
+        message: { reactionMessage: { text: "👍" } },
+        messageTimestamp: Math.floor(Date.now() / 1000),
+      },
+    ]);
+
+    await sleep(20);
+    expect(received).toEqual([]);
+    expect(harness.sockets[0]?.readCalls).toEqual([]);
+  });
+
+  test("stop and restarted socket ownership cancel pending debounce batches", async () => {
+    const received: InboundChannelMessage[] = [];
+    const harness = makeDebounceHarness({
+      store: createLidStore(join(dir, "lid.json")),
+      accountPatch: { inboundDebounceMs: 40 },
+      onMessage: async (message) => {
+        received.push(message);
+      },
+    });
+    await harness.adapter.start();
+
+    await harness.emit([makeTextMessage(phone("15550000061"), "old", "old")]);
+    await harness.adapter.stop();
+    await sleep(70);
+    expect(received).toEqual([]);
+
+    await harness.adapter.start();
+    await harness.emit(
+      [makeTextMessage(phone("15550000062"), "stale", "stale")],
+      { socketIndex: 0 },
+    );
+    await sleep(70);
+    expect(received).toEqual([]);
+    expect(harness.sockets[1]?.readCalls).toEqual([]);
+
+    await harness.emit([
+      makeTextMessage(phone("15550000063"), "fresh", "fresh"),
+    ]);
+    expect(harness.sockets[1]?.readCalls).toEqual([["fresh"]]);
+    await sleep(70);
+    expect(received.map((message) => message.text)).toEqual(["fresh"]);
   });
 });

--- a/src/channels/whatsapp/adapter.test.ts
+++ b/src/channels/whatsapp/adapter.test.ts
@@ -143,8 +143,15 @@ function makeHarness(
   };
 }
 
+type DebounceConnectionUpdateHandler = NonNullable<
+  Parameters<
+    NonNullable<WhatsAppAdapterDependencies["createSocket"]>
+  >[0]["onConnectionUpdate"]
+>;
+
 type DebounceHarnessSocket = {
   upsertHandler?: (payload: unknown) => unknown;
+  connectionUpdate?: DebounceConnectionUpdateHandler;
   readCalls: string[][];
   closed: number;
 };
@@ -163,8 +170,12 @@ function makeDebounceHarness(options: {
   };
   const createSocket: NonNullable<
     WhatsAppAdapterDependencies["createSocket"]
-  > = async () => {
-    const socketRecord: DebounceHarnessSocket = { readCalls: [], closed: 0 };
+  > = async (runtimeOptions) => {
+    const socketRecord: DebounceHarnessSocket = {
+      connectionUpdate: runtimeOptions.onConnectionUpdate,
+      readCalls: [],
+      closed: 0,
+    };
     const socket = {
       ev: {
         on(event: string, handler: (payload: unknown) => void) {
@@ -211,6 +222,12 @@ function makeDebounceHarness(options: {
       await sockets[socketIndex]?.upsertHandler?.({
         type: emitOptions?.type ?? "notify",
         messages,
+      });
+    },
+    closeConnection(socketIndex = sockets.length - 1) {
+      sockets[socketIndex]?.connectionUpdate?.({
+        connection: "close",
+        lastDisconnect: { error: { message: "network" } },
       });
     },
   };
@@ -646,10 +663,11 @@ describe("WhatsApp adapter inbound debounce and read receipts", () => {
       }),
     ]);
 
-    expect(harness.sockets[0]?.readCalls).toEqual([["one", "two"]]);
     expect(received).toEqual([]);
+    expect(harness.sockets[0]?.readCalls).toEqual([]);
     await sleep(60);
     expect(received).toHaveLength(1);
+    expect(harness.sockets[0]?.readCalls).toEqual([["one", "two"]]);
     expect(received[0]?.chatId).toBe(group("120363"));
     expect(received[0]?.senderId).toBe("15550000006");
     expect(received[0]?.text).toBe("first\nsecond");
@@ -766,9 +784,11 @@ describe("WhatsApp adapter inbound debounce and read receipts", () => {
     await harness.adapter.start();
 
     await harness.emit([makeTextMessage(phone("15550000061"), "old", "old")]);
+    expect(harness.sockets[0]?.readCalls).toEqual([]);
     await harness.adapter.stop();
     await sleep(70);
     expect(received).toEqual([]);
+    expect(harness.sockets[0]?.readCalls).toEqual([]);
 
     await harness.adapter.start();
     await harness.emit(
@@ -777,13 +797,60 @@ describe("WhatsApp adapter inbound debounce and read receipts", () => {
     );
     await sleep(70);
     expect(received).toEqual([]);
+    expect(harness.sockets[0]?.readCalls).toEqual([]);
     expect(harness.sockets[1]?.readCalls).toEqual([]);
 
     await harness.emit([
       makeTextMessage(phone("15550000063"), "fresh", "fresh"),
     ]);
-    expect(harness.sockets[1]?.readCalls).toEqual([["fresh"]]);
+    expect(harness.sockets[1]?.readCalls).toEqual([]);
     await sleep(70);
     expect(received.map((message) => message.text)).toEqual(["fresh"]);
+    expect(harness.sockets[1]?.readCalls).toEqual([["fresh"]]);
+  });
+
+  test("connection close invalidates pending debounce and stale socket traffic without reads", async () => {
+    const received: InboundChannelMessage[] = [];
+    const harness = makeDebounceHarness({
+      store: createLidStore(join(dir, "lid.json")),
+      accountPatch: { inboundDebounceMs: 40 },
+      onMessage: async (message) => {
+        received.push(message);
+      },
+    });
+    await harness.adapter.start();
+
+    await harness.emit([makeTextMessage(phone("15550000071"), "old", "old")]);
+    expect(harness.sockets[0]?.readCalls).toEqual([]);
+    harness.closeConnection(0);
+    await sleep(70);
+    expect(received).toEqual([]);
+    expect(harness.sockets[0]?.readCalls).toEqual([]);
+
+    await harness.emit(
+      [makeTextMessage(phone("15550000072"), "stale", "stale")],
+      { socketIndex: 0 },
+    );
+    await sleep(70);
+    expect(received).toEqual([]);
+    expect(harness.sockets[0]?.readCalls).toEqual([]);
+    await harness.adapter.stop();
+  });
+
+  test("handler rejection does not mark messages read", async () => {
+    const harness = makeDebounceHarness({
+      store: createLidStore(join(dir, "lid.json")),
+      accountPatch: { inboundDebounceMs: 20 },
+      onMessage: async () => {
+        throw new Error("handler failed");
+      },
+    });
+    await harness.adapter.start();
+
+    await harness.emit([
+      makeTextMessage(phone("15550000081"), "rejected", "rejected"),
+    ]);
+    await sleep(60);
+    expect(harness.sockets[0]?.readCalls).toEqual([]);
   });
 });

--- a/src/channels/whatsapp/adapter.test.ts
+++ b/src/channels/whatsapp/adapter.test.ts
@@ -801,12 +801,12 @@ describe("WhatsApp adapter inbound debounce and read receipts", () => {
     expect(harness.sockets[1]?.readCalls).toEqual([]);
 
     await harness.emit([
-      makeTextMessage(phone("15550000063"), "fresh", "fresh"),
+      makeTextMessage(phone("15550000061"), "old", "replayed"),
     ]);
     expect(harness.sockets[1]?.readCalls).toEqual([]);
     await sleep(70);
-    expect(received.map((message) => message.text)).toEqual(["fresh"]);
-    expect(harness.sockets[1]?.readCalls).toEqual([["fresh"]]);
+    expect(received.map((message) => message.text)).toEqual(["replayed"]);
+    expect(harness.sockets[1]?.readCalls).toEqual([["old"]]);
   });
 
   test("connection close invalidates pending debounce and stale socket traffic without reads", async () => {

--- a/src/channels/whatsapp/adapter.test.ts
+++ b/src/channels/whatsapp/adapter.test.ts
@@ -1,8 +1,18 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { mkdtempSync, rmSync } from "node:fs";
+import {
+  mkdirSync,
+  mkdtempSync,
+  realpathSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import type { InboundChannelMessage } from "@/channels/types";
+import type {
+  InboundChannelMessage,
+  WhatsAppChannelAccount,
+} from "@/channels/types";
 import {
   createWhatsAppAdapter,
   type WhatsAppAdapterDependencies,
@@ -14,8 +24,8 @@ import {
 } from "@/channels/whatsapp/jid";
 import { createLidStore, type LidStore } from "@/channels/whatsapp/lid-store";
 
-const account = {
-  channel: "whatsapp" as const,
+const account: WhatsAppChannelAccount = {
+  channel: "whatsapp",
   accountId: "phase-b-test",
   enabled: true,
   dmPolicy: "pairing" as const,
@@ -61,9 +71,13 @@ function instrumentStore(store: LidStore): LidStore & { flushes: number } {
 function makeHarness(
   store: LidStore,
   onMessage: (message: InboundChannelMessage) => Promise<void>,
+  accountOverrides: Partial<WhatsAppChannelAccount> = {},
 ) {
   let upsertHandler: ((payload: unknown) => unknown) | undefined;
   const sentJids: string[] = [];
+  const sentPayloads: Array<Record<string, unknown>> = [];
+  const sentOptions: Array<Record<string, unknown> | undefined> = [];
+  const presenceUpdates: Array<{ presence: string; jid?: string }> = [];
   const socket = {
     ev: {
       on(event: string, handler: (payload: unknown) => void) {
@@ -72,9 +86,18 @@ function makeHarness(
     },
     ws: { close() {} },
     user: { id: phone("15551234567"), lid: lid("777000111") },
-    async sendMessage(jid: string) {
+    async sendMessage(
+      jid: string,
+      payload: Record<string, unknown>,
+      options?: Record<string, unknown>,
+    ) {
       sentJids.push(jid);
+      sentPayloads.push(payload);
+      sentOptions.push(options);
       return { key: { id: "outbound" } };
+    },
+    async sendPresenceUpdate(presence: string, jid?: string) {
+      presenceUpdates.push({ presence, jid });
     },
   };
   const createSocket: NonNullable<
@@ -90,7 +113,10 @@ function makeHarness(
     loadRuntimeModule: async () => ({}),
     lidStore: store,
   };
-  const adapter = createWhatsAppAdapter(account, dependencies);
+  const adapter = createWhatsAppAdapter(
+    { ...account, ...accountOverrides },
+    dependencies,
+  );
   adapter.onMessage = onMessage;
   return {
     adapter,
@@ -98,6 +124,9 @@ function makeHarness(
       await upsertHandler?.({ type: "notify", messages });
     },
     sentJids,
+    sentPayloads,
+    sentOptions,
+    presenceUpdates,
   };
 }
 
@@ -326,6 +355,127 @@ describe("WhatsApp adapter canonical identity integration", () => {
 
     await harness.adapter.sendDirectReply(known, "reply");
     expect(harness.sentJids).toEqual([mapped, mapped]);
+  });
+
+  test("attachment policy denial happens before presence or network send", async () => {
+    const store = instrumentStore(createLidStore(join(dir, "lid.json")));
+    const filePath = join(dir, "deny.txt");
+    writeFileSync(filePath, "nope");
+    const harness = makeHarness(store, async () => undefined, {
+      attachmentFilter: true,
+      attachmentAllowedRecipients: [phone("15550000013")],
+      attachmentMimeTypes: ["image/png"],
+      attachmentAllowedPaths: [dir],
+    });
+    await harness.adapter.start();
+
+    await expect(
+      harness.adapter.sendMessage({
+        channel: "whatsapp",
+        accountId: account.accountId,
+        chatId: phone("15550000013"),
+        text: "blocked",
+        mediaPath: filePath,
+      }),
+    ).rejects.toThrow(/MIME type .*text\/plain.* is not allowed/);
+    expect(harness.presenceUpdates).toHaveLength(0);
+    expect(harness.sentJids).toHaveLength(0);
+  });
+
+  test("attachment policy evaluates the resolved phone for stored LID targets", async () => {
+    const store = instrumentStore(createLidStore(join(dir, "lid.json")));
+    const known = lid("13131313");
+    const mapped = phone("15550000013");
+    store.record(known, mapped);
+    const filePath = join(dir, "photo.png");
+    writeFileSync(filePath, "png");
+    const harness = makeHarness(store, async () => undefined, {
+      attachmentFilter: true,
+      attachmentAllowedRecipients: ["15550000013"],
+      attachmentMimeTypes: ["image/png"],
+      attachmentAllowedPaths: [dir],
+    });
+    await harness.adapter.start();
+
+    await harness.adapter.sendMessage({
+      channel: "whatsapp",
+      accountId: account.accountId,
+      chatId: known,
+      text: "ok",
+      mediaPath: filePath,
+    });
+
+    expect(harness.sentJids).toEqual([mapped]);
+    expect(harness.sentPayloads[0]).toEqual({
+      image: { url: realpathSync(filePath) },
+      caption: "ok",
+    });
+  });
+
+  test("attachment policy preserves exact group JID allowlists", async () => {
+    const store = instrumentStore(createLidStore(join(dir, "lid.json")));
+    const filePath = join(dir, "photo.png");
+    writeFileSync(filePath, "png");
+    const targetGroup = group("120363000000");
+    const harness = makeHarness(store, async () => undefined, {
+      attachmentFilter: true,
+      attachmentAllowedRecipients: [targetGroup],
+      attachmentMimeTypes: ["image/png"],
+      attachmentAllowedPaths: [dir],
+    });
+    await harness.adapter.start();
+
+    await harness.adapter.sendMessage({
+      channel: "whatsapp",
+      accountId: account.accountId,
+      chatId: targetGroup,
+      text: "group",
+      mediaPath: filePath,
+    });
+    await expect(
+      harness.adapter.sendMessage({
+        channel: "whatsapp",
+        accountId: account.accountId,
+        chatId: group("120363000001"),
+        text: "group",
+        mediaPath: filePath,
+      }),
+    ).rejects.toThrow(/not allowed/);
+
+    expect(harness.sentJids).toEqual([targetGroup]);
+  });
+
+  test("attachment policy passes canonical symlink target and MIME to Baileys", async () => {
+    const store = instrumentStore(createLidStore(join(dir, "lid.json")));
+    const root = join(dir, "allowed");
+    mkdirSync(root);
+    const realFile = join(root, "song.mp3");
+    const linkPath = join(dir, "song-link.bin");
+    writeFileSync(realFile, "audio");
+    symlinkSync(realFile, linkPath);
+    const harness = makeHarness(store, async () => undefined, {
+      attachmentFilter: true,
+      attachmentAllowedRecipients: [phone("15550000014")],
+      attachmentMimeTypes: ["audio/mpeg"],
+      attachmentAllowedPaths: [root],
+    });
+    await harness.adapter.start();
+
+    await harness.adapter.sendMessage({
+      channel: "whatsapp",
+      accountId: account.accountId,
+      chatId: phone("15550000014"),
+      text: "listen",
+      mediaPath: linkPath,
+      fileName: "fake.bin",
+    });
+
+    expect(harness.sentPayloads[0]).toEqual({
+      document: { url: realpathSync(realFile) },
+      fileName: "song.mp3",
+      mimetype: "audio/mpeg",
+      caption: "listen",
+    });
   });
 
   test("handler failure still flushes dirty observations", async () => {

--- a/src/channels/whatsapp/adapter.ts
+++ b/src/channels/whatsapp/adapter.ts
@@ -21,6 +21,11 @@ import {
   shouldProcessWhatsAppGroup,
   timestampToMs,
 } from "./adapter-helpers";
+import type {
+  WhatsAppMessage,
+  WhatsAppMessageKey,
+  WhatsAppSocket,
+} from "./adapter-types";
 import { decideWhatsAppAttachmentPolicy } from "./attachment-policy";
 import { resolveInboundIdentity } from "./identity";
 import {
@@ -53,11 +58,22 @@ import {
   parseWhatsAppReactionEntry,
   type WhatsAppReaction,
 } from "./reactions";
+import {
+  createDefaultWhatsAppReconnectScheduler,
+  type WhatsAppReconnectScheduler,
+  type WhatsAppReconnectTimer,
+} from "./reconnect-scheduler";
 import { loadWhatsAppModule } from "./runtime";
 import { createWhatsAppSocket, getWhatsAppAuthDir } from "./session";
 import { setWhatsAppConnectionState } from "./state";
+import {
+  createWhatsAppTypingController,
+  type WhatsAppTypingController,
+  type WhatsAppTypingPresence,
+} from "./typing-controller";
 
 export { isWhatsAppConflictDisconnect };
+export type { WhatsAppReconnectScheduler };
 
 const CHANNEL_ID = "whatsapp";
 const DEDUPE_MAX_SIZE = 5000;
@@ -66,74 +82,11 @@ const MAX_UNSTABLE_DISCONNECTS = 6;
 const RECONNECT_WINDOW_MS = 60_000;
 const STABLE_OPEN_RESET_MS = RECONNECT_WINDOW_MS;
 
-type EventEmitterLike = {
-  on?: (event: string, handler: (payload: unknown) => void) => void;
-};
-
-type WhatsAppSocket = {
-  ev?: EventEmitterLike;
-  ws?: { close?: () => void };
-  user?: { id?: string; lid?: string };
-  sendMessage?: (
-    jid: string,
-    payload: Record<string, unknown>,
-    options?: Record<string, unknown>,
-  ) => Promise<{ key?: { id?: string }; message?: unknown }>;
-  sendPresenceUpdate?: (presence: string, jid?: string) => Promise<void>;
-  groupMetadata?: (jid: string) => Promise<{ subject?: string }>;
-  readMessages?: (keys: WhatsAppMessageKey[]) => Promise<unknown>;
-};
-
-type WhatsAppMessageKey = {
-  remoteJid?: string | null;
-  id?: string | null;
-  fromMe?: boolean | null;
-  participant?: string | null;
-  senderPn?: string | null;
-  senderLid?: string | null;
-  participantPn?: string | null;
-  participantLid?: string | null;
-};
-
-type WhatsAppMessage = {
-  key?: WhatsAppMessageKey;
-  message?: unknown;
-  messageTimestamp?: number | { toNumber?: () => number } | null;
-  pushName?: string | null;
-};
-
-export type WhatsAppReconnectScheduler = {
-  now(): number;
-  schedule(
-    delayMs: number,
-    callback: () => void,
-    options?: { unref?: boolean },
-  ): { cancel(): void };
-};
-
-function createDefaultReconnectScheduler(): WhatsAppReconnectScheduler {
-  return {
-    now: () => Date.now(),
-    schedule(delayMs, callback, options) {
-      const timer = setTimeout(callback, delayMs) as ReturnType<
-        typeof setTimeout
-      > & { unref?: () => void };
-      if (options?.unref) timer.unref?.();
-      return { cancel: () => clearTimeout(timer) };
-    },
-  };
-}
-
 export type WhatsAppAdapterDependencies = {
   createSocket?: typeof createWhatsAppSocket;
   loadRuntimeModule?: typeof loadWhatsAppModule;
   lidStore?: LidStore;
   reconnectScheduler?: WhatsAppReconnectScheduler;
-};
-
-type ReconnectTimer = {
-  generation: number;
-  task: { cancel(): void } | null;
 };
 
 const CLAIM_CONNECTION_STATE = { claimedConnectionState: true } as const;
@@ -145,8 +98,8 @@ export function createWhatsAppAdapter(
   let running = false;
   let stopping = false;
   let reconnectAttempts = 0;
-  let reconnectTimer: ReconnectTimer | null = null;
-  let stableOpenTimer: ReconnectTimer | null = null;
+  let reconnectTimer: WhatsAppReconnectTimer | null = null;
+  let stableOpenTimer: WhatsAppReconnectTimer | null = null;
   let selfPhoneJid: string | null = null;
   let selfLid: string | null = null;
   let connectedAtMs = 0;
@@ -154,8 +107,10 @@ export function createWhatsAppAdapter(
   const recentDisconnects: number[] = [];
   let closedGeneration: number | null = null;
   const reconnectScheduler =
-    dependencies.reconnectScheduler ?? createDefaultReconnectScheduler();
+    dependencies.reconnectScheduler ??
+    createDefaultWhatsAppReconnectScheduler();
   let releaseSocketLease: (() => void) | null = null;
+  let typing!: WhatsAppTypingController<WhatsAppSocket>;
   let downloadContentFromMessage:
     | ((message: unknown, type: string) => Promise<AsyncIterable<Uint8Array>>)
     | null = null;
@@ -223,7 +178,7 @@ export function createWhatsAppAdapter(
     releaseLease?.();
   }
 
-  function clearReconnectTimer(): void {
+  function clearWhatsAppReconnectTimer(): void {
     const timer = reconnectTimer;
     reconnectTimer = null;
     timer?.task?.cancel();
@@ -237,7 +192,7 @@ export function createWhatsAppAdapter(
 
   function scheduleStableOpenReset(generation: number): void {
     clearStableOpenTimer();
-    const timer: ReconnectTimer = {
+    const timer: WhatsAppReconnectTimer = {
       generation,
       task: null,
     };
@@ -268,12 +223,37 @@ export function createWhatsAppAdapter(
     }
   }
 
+  function canonicalizeChatId(chatId: string): string | null {
+    try {
+      return resolveSendJid({
+        chatId,
+        selfPhoneJid,
+        selfLid,
+        resolveLid: (lidJid) => lidStore.resolve(lidJid),
+      });
+    } catch {
+      return null;
+    }
+  }
+
+  function getTypingOwner(): WhatsAppSocket | null {
+    return sock;
+  }
+
+  function sendTypingPresence(
+    owner: WhatsAppSocket,
+    chatId: string,
+    presence: WhatsAppTypingPresence,
+  ): unknown {
+    return owner.sendPresenceUpdate?.(presence, chatId);
+  }
+
   function scheduleReconnect(reason?: string): void {
     if (stopping || !running || reconnectTimer) return;
     reconnectAttempts += 1;
     const delay = Math.min(RECONNECT_MAX_MS, 1000 * 2 ** reconnectAttempts);
     const generation = connectionGeneration;
-    const timer: ReconnectTimer = {
+    const timer: WhatsAppReconnectTimer = {
       generation,
       task: null,
     };
@@ -312,9 +292,10 @@ export function createWhatsAppAdapter(
   }
 
   async function connect(): Promise<void> {
-    clearReconnectTimer();
+    clearWhatsAppReconnectTimer();
     connectionGeneration += 1;
     const generation = connectionGeneration;
+    if (sock) await typing.clearOwner(sock);
     clearActiveSocket(true);
     await ensureRuntimeHelpers();
     connectedAtMs = reconnectScheduler.now();
@@ -339,15 +320,17 @@ export function createWhatsAppAdapter(
           );
         }
         if (update.connection === "close" && !stopping) {
-          const isConflict = isWhatsAppConflictDisconnect(update);
-          if (isConflict) {
-            closedGeneration = generation;
-            clearActiveSocket(false);
-            const lastDisconnect = asRecord(update.lastDisconnect);
-            const error = asRecord(lastDisconnect.error);
+          if (closedGeneration === generation) return CLAIM_CONNECTION_STATE;
+          closedGeneration = generation;
+          const closingSocket = sock;
+          if (closingSocket) void typing.clearOwner(closingSocket);
+          clearActiveSocket(false);
+          const lastDisconnect = asRecord(update.lastDisconnect);
+          const error = asRecord(lastDisconnect.error);
+          if (isWhatsAppConflictDisconnect(update)) {
             running = false;
             stopping = true;
-            clearReconnectTimer();
+            clearWhatsAppReconnectTimer();
             clearStableOpenTimer();
             const message =
               typeof error.message === "string"
@@ -362,11 +345,6 @@ export function createWhatsAppAdapter(
             );
             return CLAIM_CONNECTION_STATE;
           }
-          if (closedGeneration === generation) return CLAIM_CONNECTION_STATE;
-          closedGeneration = generation;
-          clearActiveSocket(false);
-          const lastDisconnect = asRecord(update.lastDisconnect);
-          const error = asRecord(lastDisconnect.error);
           const now = reconnectScheduler.now();
           while (recentDisconnects.length > 0) {
             const oldest = recentDisconnects[0];
@@ -379,7 +357,7 @@ export function createWhatsAppAdapter(
           if (recentDisconnects.length >= MAX_UNSTABLE_DISCONNECTS) {
             running = false;
             stopping = true;
-            clearReconnectTimer();
+            clearWhatsAppReconnectTimer();
             clearStableOpenTimer();
             const loopMessage = `WhatsApp disconnected ${recentDisconnects.length} times in ${RECONNECT_WINDOW_MS / 1000}s; stopping to avoid reconnect loop. Another client may be competing for this session. Restart this WhatsApp channel to retry.`;
             setWhatsAppConnectionState(account.accountId, {
@@ -782,9 +760,10 @@ export function createWhatsAppAdapter(
       stopping = true;
       running = false;
       inboundDebounce?.cancelPending();
-      clearReconnectTimer();
+      clearWhatsAppReconnectTimer();
       clearStableOpenTimer();
       connectionGeneration += 1;
+      await typing.clearAll();
       clearActiveSocket(true);
       if (wasRunning) {
         setWhatsAppConnectionState(account.accountId, {
@@ -815,6 +794,8 @@ export function createWhatsAppAdapter(
         selfLid,
         resolveLid: (lidJid) => lidStore.resolve(lidJid),
       });
+      const hadManagedTyping = typing.isActive(targetJid);
+      await typing.clearChat(targetJid);
       let resolvedMedia: WhatsAppResolvedOutboundMedia | undefined;
       if (msg.mediaPath && account.attachmentFilter === true) {
         const decision = decideWhatsAppAttachmentPolicy({
@@ -849,10 +830,12 @@ export function createWhatsAppAdapter(
         outboundMessages.rememberSent(id, result);
         return { messageId: id };
       }
-      try {
-        await sock?.sendPresenceUpdate?.("composing", targetJid);
-      } catch {
-        // Presence is best-effort.
+      if (!hadManagedTyping) {
+        try {
+          await sock?.sendPresenceUpdate?.("composing", targetJid);
+        } catch {
+          // Presence is best-effort.
+        }
       }
       const payload = buildWhatsAppOutboundPayload(msg, resolvedMedia);
       const result = await sendToWhatsApp(
@@ -873,6 +856,7 @@ export function createWhatsAppAdapter(
         selfLid,
         resolveLid: (lidJid) => lidStore.resolve(lidJid),
       });
+      await typing.clearChat(targetJid);
       const result = await sendToWhatsApp(
         targetJid,
         { text },
@@ -895,7 +879,22 @@ export function createWhatsAppAdapter(
     async handleTurnLifecycleEvent(
       event: ChannelTurnLifecycleEvent,
     ): Promise<void> {
-      if (!running || event.type !== "finished") return;
+      if (!running) return;
+      if (event.type === "queued") return;
+      if (event.type === "processing") {
+        if (account.waitingBehavior === "typing_indicator") {
+          for (const source of event.sources) {
+            typing.start({ batchId: event.batchId, source });
+          }
+        }
+        return;
+      }
+
+      await Promise.all(
+        event.sources.map((source) =>
+          typing.stop({ batchId: event.batchId, source }),
+        ),
+      );
 
       const errorText = event.outcome === "error" ? event.error?.trim() : null;
       if (!errorText) return;
@@ -943,6 +942,12 @@ export function createWhatsAppAdapter(
         error instanceof Error ? error.message : error,
       );
     },
+  });
+  typing = createWhatsAppTypingController<WhatsAppSocket>({
+    accountId: account.accountId,
+    canonicalizeChatId,
+    getOwner: getTypingOwner,
+    sendPresence: sendTypingPresence,
   });
 
   return adapter;

--- a/src/channels/whatsapp/adapter.ts
+++ b/src/channels/whatsapp/adapter.ts
@@ -15,7 +15,9 @@ import {
   isGroupJid,
   isSelfChat,
   isStatusOrBroadcastJid,
+  isStrictPhoneJid,
   resolveSendJid,
+  senderIdFromJid,
   stripDeviceSuffix,
 } from "./jid";
 import type { LidStore } from "./lid-store";
@@ -27,6 +29,11 @@ import {
   extractReplyParticipant,
   extractWhatsAppText,
 } from "./media";
+import {
+  isWhatsAppReactionGroupEligible,
+  parseWhatsAppReactionEntry,
+  type WhatsAppReaction,
+} from "./reactions";
 import { loadWhatsAppModule } from "./runtime";
 import { createWhatsAppSocket, getWhatsAppAuthDir } from "./session";
 import { setWhatsAppConnectionState } from "./state";
@@ -385,6 +392,14 @@ export function createWhatsAppAdapter(
         );
       });
     });
+    connectedSocket.ev?.on?.("messages.reaction", (event) => {
+      return handleReactionBatch(event).catch((error) => {
+        console.error(
+          `[WhatsApp:${account.accountId}] reaction handler failed:`,
+          error instanceof Error ? error.message : error,
+        );
+      });
+    });
   }
 
   async function getGroupLabel(groupJid: string): Promise<string | undefined> {
@@ -511,6 +526,120 @@ export function createWhatsAppAdapter(
           `[WhatsApp:${account.accountId}] inbound chatId=${chatId} sender=${senderId} text="${preview(body)}"`,
         );
         await adapter.onMessage?.(inbound);
+      }
+    } finally {
+      flushLidStoreIfDirty();
+    }
+  }
+
+  async function handleReactionEntry(
+    parsed: WhatsAppReaction,
+    raw: unknown,
+  ): Promise<void> {
+    if (parsed.targetFromMe !== true) return;
+    if (parsed.reactionKey.fromMe === true) return;
+    if (isStatusOrBroadcastJid(parsed.chatId)) return;
+    if (
+      parsed.timestampMs !== undefined &&
+      parsed.timestampMs < connectedAtMs - 1000
+    ) {
+      return;
+    }
+    if (sentMessageIds.has(parsed.reactionMessageId)) {
+      sentMessageIds.delete(parsed.reactionMessageId);
+      return;
+    }
+    const identity = resolveInboundIdentity(
+      {
+        selfPhoneJid,
+        selfLid,
+        remoteJid: parsed.chatId,
+        participant: parsed.reactorParticipant,
+      },
+      lidStore,
+    );
+    if (!identity || !applyObservedMappings(identity.observedMappings)) return;
+    if (
+      rememberSeen(`reaction:${identity.chatId}:${parsed.reactionMessageId}`)
+    ) {
+      return;
+    }
+
+    const selfChat = isSelfChat(parsed.chatId, selfPhoneJid, selfLid);
+    if (account.selfChatMode && !selfChat) return;
+
+    const group = isGroupJid(identity.chatId);
+    if (
+      group &&
+      !isWhatsAppReactionGroupEligible({
+        groupMode: account.groupMode,
+        allowedGroups: account.allowedGroups,
+        groupJid: identity.chatId,
+        targetFromMe: parsed.targetFromMe,
+      })
+    ) {
+      return;
+    }
+
+    const chatLabel = group
+      ? await getGroupLabel(identity.chatId)
+      : selfChat
+        ? "Self (WhatsApp)"
+        : identity.senderId;
+    const targetSenderId = isStrictPhoneJid(selfPhoneJid)
+      ? senderIdFromJid(selfPhoneJid)
+      : isStrictPhoneJid(parsed.targetKey.participant)
+        ? senderIdFromJid(parsed.targetKey.participant)
+        : undefined;
+    const actor = identity.senderId;
+    const text =
+      parsed.action === "added"
+        ? `${actor} reacted ${parsed.emoji}`
+        : `${actor} removed a reaction`;
+    const inbound: InboundChannelMessage = {
+      channel: CHANNEL_ID,
+      accountId: account.accountId,
+      chatId: identity.chatId,
+      senderId: actor,
+      senderName: actor,
+      chatLabel,
+      text,
+      timestamp: parsed.timestampMs ?? Date.now(),
+      messageId: parsed.reactionMessageId,
+      chatType: group ? "channel" : "direct",
+      isMention: !group || account.groupMode === "mention",
+      raw,
+      reaction: {
+        action: parsed.action,
+        emoji: parsed.emoji,
+        targetMessageId: parsed.targetMessageId,
+        ...(targetSenderId ? { targetSenderId } : {}),
+      },
+    };
+
+    try {
+      await adapter.onMessage?.(inbound);
+    } catch (error) {
+      console.error(
+        `[WhatsApp:${account.accountId}] reaction delivery failed:`,
+        error instanceof Error ? error.message : error,
+      );
+    }
+  }
+
+  async function handleReactionBatch(event: unknown): Promise<void> {
+    try {
+      if (!Array.isArray(event)) return;
+      for (const raw of event) {
+        try {
+          const parsed = parseWhatsAppReactionEntry(raw);
+          if (parsed) await handleReactionEntry(parsed, raw);
+        } catch (error) {
+          console.error(
+            `[WhatsApp:${account.accountId}] reaction entry failed:`,
+            error instanceof Error ? error.message : error,
+          );
+        }
       }
     } finally {
       flushLidStoreIfDirty();

--- a/src/channels/whatsapp/adapter.ts
+++ b/src/channels/whatsapp/adapter.ts
@@ -278,6 +278,13 @@ export function createWhatsAppAdapter(
     );
   }
 
+  function isKnownOutboundMessage(messageId: string): boolean {
+    if (sentMessageIds.has(messageId)) return true;
+    const stored = messageStore.get(messageId);
+    if (!stored) return false;
+    return asRecord(asRecord(stored).key).fromMe === true;
+  }
+
   function clearActiveSocket(closeWebSocket: boolean): void {
     const currentSock = sock;
     const releaseLease = releaseSocketLease;
@@ -392,7 +399,7 @@ export function createWhatsAppAdapter(
         );
       });
     });
-    connectedSocket.ev?.on?.("messages.reaction", (event) => {
+    sock.ev?.on?.("messages.reaction", (event) => {
       return handleReactionBatch(event).catch((error) => {
         console.error(
           `[WhatsApp:${account.accountId}] reaction handler failed:`,
@@ -536,7 +543,14 @@ export function createWhatsAppAdapter(
     parsed: WhatsAppReaction,
     raw: unknown,
   ): Promise<void> {
-    if (parsed.targetFromMe !== true) return;
+    // Baileys may deliver reactions via a LID chat where it cannot equate
+    // our PN identity, producing targetFromMe:false for our own messages.
+    // isKnownOutboundMessage also checks sentMessageIds and the store's
+    // key.fromMe, but not mere store membership because inbound messages
+    // are stored there too.
+    const targetIsOurs =
+      parsed.targetFromMe === true || isKnownOutboundMessage(parsed.targetMessageId);
+    if (!targetIsOurs) return;
     if (parsed.reactionKey.fromMe === true) return;
     if (isStatusOrBroadcastJid(parsed.chatId)) return;
     if (
@@ -575,7 +589,7 @@ export function createWhatsAppAdapter(
         groupMode: account.groupMode,
         allowedGroups: account.allowedGroups,
         groupJid: identity.chatId,
-        targetFromMe: parsed.targetFromMe,
+        targetFromMe: targetIsOurs,
       })
     ) {
       return;

--- a/src/channels/whatsapp/adapter.ts
+++ b/src/channels/whatsapp/adapter.ts
@@ -28,6 +28,7 @@ import {
   extractMentionedJids,
   extractReplyParticipant,
   extractWhatsAppText,
+  unwrapWhatsAppMessageContent,
 } from "./media";
 import {
   isWhatsAppReactionGroupEligible,
@@ -40,6 +41,8 @@ import { setWhatsAppConnectionState } from "./state";
 
 const CHANNEL_ID = "whatsapp";
 const DEDUPE_MAX_SIZE = 5000;
+const MESSAGE_STORE_MAX_SIZE = DEDUPE_MAX_SIZE;
+const MESSAGE_STORE_TTL_MS = 24 * 60 * 60 * 1000;
 const RECONNECT_MAX_MS = 30_000;
 const MAX_MENTION_PATTERN_LENGTH = 256;
 const MENTION_MATCH_TEXT_MAX_LENGTH = 2000;
@@ -89,6 +92,16 @@ function asRecord(value: unknown): Record<string, unknown> {
   return value && typeof value === "object"
     ? (value as Record<string, unknown>)
     : {};
+}
+
+function unrefTimeout(timer: ReturnType<typeof setTimeout>): void {
+  const unref = (timer as { unref?: () => void }).unref;
+  if (typeof unref === "function") unref.call(timer);
+}
+
+function isSyntheticReactionMessage(message: unknown): boolean {
+  const content = unwrapWhatsAppMessageContent(message);
+  return !!content?.reactionMessage;
 }
 
 export function isWhatsAppConflictDisconnect(update: unknown): boolean {
@@ -230,7 +243,11 @@ export function createWhatsAppAdapter(
       join(getWhatsAppAuthDir(account.accountId), "lid-mappings.json"),
     );
   let lidStoreDirty = false;
+  // Process-local target cache. After restart we cannot prove ownership for
+  // LID target.fromMe:false reactions or reconstruct group participant keys
+  // until the target message is observed again.
   const messageStore = new Map<string, unknown>();
+  const messageStoreTimers = new Map<string, ReturnType<typeof setTimeout>>();
 
   function flushLidStoreIfDirty(): void {
     if (!lidStoreDirty) return;
@@ -265,17 +282,62 @@ export function createWhatsAppAdapter(
     return false;
   }
 
+  function clearMessageStoreTimer(id: string): void {
+    const timer = messageStoreTimers.get(id);
+    if (timer) clearTimeout(timer);
+    messageStoreTimers.delete(id);
+  }
+
+  function dropStoredMessage(id: string): void {
+    sentMessageIds.delete(id);
+    messageStore.delete(id);
+    clearMessageStoreTimer(id);
+  }
+
+  function scheduleMessageStoreExpiry(id: string): void {
+    clearMessageStoreTimer(id);
+    const timer = setTimeout(() => {
+      sentMessageIds.delete(id);
+      messageStore.delete(id);
+      messageStoreTimers.delete(id);
+    }, MESSAGE_STORE_TTL_MS);
+    unrefTimeout(timer);
+    messageStoreTimers.set(id, timer);
+  }
+
+  function capMessageStore(): void {
+    while (messageStore.size > MESSAGE_STORE_MAX_SIZE) {
+      const first = messageStore.keys().next().value;
+      if (typeof first !== "string") break;
+      dropStoredMessage(first);
+    }
+    while (sentMessageIds.size > MESSAGE_STORE_MAX_SIZE) {
+      const first = sentMessageIds.values().next().value;
+      if (typeof first !== "string") break;
+      dropStoredMessage(first);
+    }
+  }
+
+  function rememberStoredMessage(id: string, message: unknown): void {
+    if (!id) return;
+    messageStore.set(id, message);
+    scheduleMessageStoreExpiry(id);
+    capMessageStore();
+  }
+
   function rememberSent(id: string, message?: unknown): void {
     if (!id) return;
     sentMessageIds.add(id);
-    if (message) messageStore.set(id, message);
-    setTimeout(
-      () => {
-        sentMessageIds.delete(id);
-        messageStore.delete(id);
-      },
-      24 * 60 * 60 * 1000,
-    );
+    if (message !== undefined) messageStore.set(id, message);
+    scheduleMessageStoreExpiry(id);
+    capMessageStore();
+  }
+
+  function clearMessageStore(): void {
+    for (const timer of messageStoreTimers.values()) clearTimeout(timer);
+    messageStoreTimers.clear();
+    messageStore.clear();
+    sentMessageIds.clear();
   }
 
   function isKnownOutboundMessage(messageId: string): boolean {
@@ -283,6 +345,31 @@ export function createWhatsAppAdapter(
     const stored = messageStore.get(messageId);
     if (!stored) return false;
     return asRecord(asRecord(stored).key).fromMe === true;
+  }
+
+  function getStoredTargetKey(
+    messageId: string,
+  ): Record<string, unknown> | null {
+    const key = asRecord(asRecord(messageStore.get(messageId)).key);
+    if (typeof key.id !== "string" || key.id !== messageId) return null;
+    const remoteJid =
+      typeof key.remoteJid === "string" ? stripDeviceSuffix(key.remoteJid) : "";
+    if (!remoteJid) return null;
+    return { ...key, remoteJid, id: messageId };
+  }
+
+  function buildReactionTargetKey(
+    targetJid: string,
+    messageId: string,
+  ): Record<string, unknown> {
+    const storedKey = getStoredTargetKey(messageId);
+    if (storedKey) return storedKey;
+    if (isGroupJid(targetJid)) {
+      throw new Error(
+        "WhatsApp group reactions require the original target message key from the current adapter process; after restart, react only after the target message is observed again.",
+      );
+    }
+    return { remoteJid: targetJid, id: messageId };
   }
 
   function clearActiveSocket(closeWebSocket: boolean): void {
@@ -430,13 +517,14 @@ export function createWhatsAppAdapter(
         const messageId = msg.key?.id ?? "";
         if (!remoteJid || !messageId || !msg.message) continue;
         if (isStatusOrBroadcastJid(remoteJid)) continue;
+        if (isSyntheticReactionMessage(msg.message)) continue;
         if (sentMessageIds.has(messageId)) {
+          rememberStoredMessage(messageId, msg);
           sentMessageIds.delete(messageId);
           continue;
         }
         if (!messageStore.has(messageId)) {
-          messageStore.set(messageId, msg);
-          setTimeout(() => messageStore.delete(messageId), 24 * 60 * 60 * 1000);
+          rememberStoredMessage(messageId, msg);
         }
 
         const selfChat = isSelfChat(remoteJid, selfPhoneJid, selfLid);
@@ -549,7 +637,8 @@ export function createWhatsAppAdapter(
     // key.fromMe, but not mere store membership because inbound messages
     // are stored there too.
     const targetIsOurs =
-      parsed.targetFromMe === true || isKnownOutboundMessage(parsed.targetMessageId);
+      parsed.targetFromMe === true ||
+      isKnownOutboundMessage(parsed.targetMessageId);
     if (!targetIsOurs) return;
     if (parsed.reactionKey.fromMe === true) return;
     if (isStatusOrBroadcastJid(parsed.chatId)) return;
@@ -569,6 +658,10 @@ export function createWhatsAppAdapter(
         selfLid,
         remoteJid: parsed.chatId,
         participant: parsed.reactorParticipant,
+        senderPn: parsed.reactionKey.senderPn,
+        senderLid: parsed.reactionKey.senderLid,
+        participantPn: parsed.reactionKey.participantPn,
+        participantLid: parsed.reactionKey.participantLid,
       },
       lidStore,
     );
@@ -691,6 +784,7 @@ export function createWhatsAppAdapter(
 
     async stop() {
       if (!running) {
+        clearMessageStore();
         flushLidStoreIfDirty();
         return;
       }
@@ -703,6 +797,7 @@ export function createWhatsAppAdapter(
       connectionGeneration += 1;
       clearActiveSocket(true);
       setWhatsAppConnectionState(account.accountId, { status: "disconnected" });
+      clearMessageStore();
       flushLidStoreIfDirty();
     },
 
@@ -712,7 +807,12 @@ export function createWhatsAppAdapter(
 
     async sendMessage(msg: OutboundChannelMessage) {
       if (!running) throw new Error("WhatsApp adapter is not running.");
-      if (!msg.text?.trim() && !msg.mediaPath?.trim() && !msg.reaction) {
+      if (
+        !msg.text?.trim() &&
+        !msg.mediaPath?.trim() &&
+        !msg.reaction &&
+        !msg.removeReaction
+      ) {
         throw new Error("WhatsApp send requires message or media.");
       }
       const targetJid = resolveSendJid({
@@ -727,7 +827,7 @@ export function createWhatsAppAdapter(
         const result = await sendToWhatsApp(targetJid, {
           react: {
             text: msg.removeReaction ? "" : (msg.reaction ?? ""),
-            key: { remoteJid: targetJid, id: target },
+            key: buildReactionTargetKey(targetJid, target),
           },
         });
         const id = result.key?.id ?? target;

--- a/src/channels/whatsapp/adapter.ts
+++ b/src/channels/whatsapp/adapter.ts
@@ -11,6 +11,7 @@ import type {
   WhatsAppChannelAccount,
 } from "@/channels/types";
 import {
+  applyWhatsAppMessagePrefix,
   asRecord,
   buildWhatsAppQuotedOptions,
   getWhatsAppDisplayName,
@@ -20,6 +21,7 @@ import {
   previewWhatsAppText,
   shouldProcessWhatsAppGroup,
   timestampToMs,
+  withWhatsAppMessagePrefix,
 } from "./adapter-helpers";
 import type {
   WhatsAppMessage,
@@ -837,11 +839,12 @@ export function createWhatsAppAdapter(
           // Presence is best-effort.
         }
       }
-      const payload = buildWhatsAppOutboundPayload(msg, resolvedMedia);
+      const outbound = withWhatsAppMessagePrefix(msg, account.messagePrefix);
+      const payload = buildWhatsAppOutboundPayload(outbound, resolvedMedia);
       const result = await sendToWhatsApp(
         targetJid,
         payload,
-        buildWhatsAppQuotedOptions(targetJid, msg.replyToMessageId),
+        buildWhatsAppQuotedOptions(targetJid, outbound.replyToMessageId),
       );
       const id = result.key?.id ?? "";
       outboundMessages.rememberSent(id, result);
@@ -859,7 +862,7 @@ export function createWhatsAppAdapter(
       await typing.clearChat(targetJid);
       const result = await sendToWhatsApp(
         targetJid,
-        { text },
+        { text: applyWhatsAppMessagePrefix(text, account.messagePrefix) },
         buildWhatsAppQuotedOptions(targetJid, options?.replyToMessageId),
       );
       outboundMessages.rememberSent(result.key?.id ?? "", result);

--- a/src/channels/whatsapp/adapter.ts
+++ b/src/channels/whatsapp/adapter.ts
@@ -13,6 +13,11 @@ import type {
 import { decideWhatsAppAttachmentPolicy } from "./attachment-policy";
 import { resolveInboundIdentity } from "./identity";
 import {
+  createWhatsAppInboundDebounceController,
+  type WhatsAppInboundDebounceController,
+  type WhatsAppInboundDebounceEntry,
+} from "./inbound-debounce";
+import {
   isGroupJid,
   isSelfChat,
   isStatusOrBroadcastJid,
@@ -32,6 +37,7 @@ import {
   unwrapWhatsAppMessageContent,
   type WhatsAppResolvedOutboundMedia,
 } from "./media";
+import { createWhatsAppMessageStore } from "./message-store";
 import {
   isWhatsAppReactionGroupEligible,
   parseWhatsAppReactionEntry,
@@ -43,8 +49,6 @@ import { setWhatsAppConnectionState } from "./state";
 
 const CHANNEL_ID = "whatsapp";
 const DEDUPE_MAX_SIZE = 5000;
-const MESSAGE_STORE_MAX_SIZE = DEDUPE_MAX_SIZE;
-const MESSAGE_STORE_TTL_MS = 24 * 60 * 60 * 1000;
 const RECONNECT_MAX_MS = 30_000;
 const MAX_MENTION_PATTERN_LENGTH = 256;
 const MENTION_MATCH_TEXT_MAX_LENGTH = 2000;
@@ -64,6 +68,7 @@ type WhatsAppSocket = {
   ) => Promise<{ key?: { id?: string }; message?: unknown }>;
   sendPresenceUpdate?: (presence: string, jid?: string) => Promise<void>;
   groupMetadata?: (jid: string) => Promise<{ subject?: string }>;
+  readMessages?: (keys: WhatsAppMessageKey[]) => Promise<unknown>;
 };
 
 type WhatsAppMessageKey = {
@@ -94,11 +99,6 @@ function asRecord(value: unknown): Record<string, unknown> {
   return value && typeof value === "object"
     ? (value as Record<string, unknown>)
     : {};
-}
-
-function unrefTimeout(timer: ReturnType<typeof setTimeout>): void {
-  const unref = (timer as { unref?: () => void }).unref;
-  if (typeof unref === "function") unref.call(timer);
 }
 
 function isSyntheticReactionMessage(message: unknown): boolean {
@@ -220,6 +220,11 @@ function getLifecycleErrorReplyKey(source: ChannelTurnSource): string | null {
   return `${source.chatId}:${source.messageId ?? ""}`;
 }
 
+function isWhatsAppReactionMessage(message: unknown): boolean {
+  const content = unwrapWhatsAppMessageContent(message);
+  return !!content?.reactionMessage;
+}
+
 export function createWhatsAppAdapter(
   account: WhatsAppChannelAccount,
   dependencies: WhatsAppAdapterDependencies = {},
@@ -237,7 +242,6 @@ export function createWhatsAppAdapter(
   let downloadContentFromMessage:
     | ((message: unknown, type: string) => Promise<AsyncIterable<Uint8Array>>)
     | null = null;
-  const sentMessageIds = new Set<string>();
   const seenMessageIds = new Set<string>();
   const lidStore =
     dependencies.lidStore ??
@@ -245,11 +249,12 @@ export function createWhatsAppAdapter(
       join(getWhatsAppAuthDir(account.accountId), "lid-mappings.json"),
     );
   let lidStoreDirty = false;
-  // Process-local target cache. After restart we cannot prove ownership for
-  // LID target.fromMe:false reactions or reconstruct group participant keys
-  // until the target message is observed again.
-  const messageStore = new Map<string, unknown>();
-  const messageStoreTimers = new Map<string, ReturnType<typeof setTimeout>>();
+  const outboundMessages = createWhatsAppMessageStore();
+  const { messages: messageStore } = outboundMessages;
+  let inboundDebounce: WhatsAppInboundDebounceController<
+    WhatsAppSocket,
+    WhatsAppMessageKey
+  > | null = null;
 
   function flushLidStoreIfDirty(): void {
     if (!lidStoreDirty) return;
@@ -284,99 +289,10 @@ export function createWhatsAppAdapter(
     return false;
   }
 
-  function clearMessageStoreTimer(id: string): void {
-    const timer = messageStoreTimers.get(id);
-    if (timer) clearTimeout(timer);
-    messageStoreTimers.delete(id);
-  }
-
-  function dropStoredMessage(id: string): void {
-    sentMessageIds.delete(id);
-    messageStore.delete(id);
-    clearMessageStoreTimer(id);
-  }
-
-  function scheduleMessageStoreExpiry(id: string): void {
-    clearMessageStoreTimer(id);
-    const timer = setTimeout(() => {
-      sentMessageIds.delete(id);
-      messageStore.delete(id);
-      messageStoreTimers.delete(id);
-    }, MESSAGE_STORE_TTL_MS);
-    unrefTimeout(timer);
-    messageStoreTimers.set(id, timer);
-  }
-
-  function capMessageStore(): void {
-    while (messageStore.size > MESSAGE_STORE_MAX_SIZE) {
-      const first = messageStore.keys().next().value;
-      if (typeof first !== "string") break;
-      dropStoredMessage(first);
-    }
-    while (sentMessageIds.size > MESSAGE_STORE_MAX_SIZE) {
-      const first = sentMessageIds.values().next().value;
-      if (typeof first !== "string") break;
-      dropStoredMessage(first);
-    }
-  }
-
-  function rememberStoredMessage(id: string, message: unknown): void {
-    if (!id) return;
-    messageStore.set(id, message);
-    scheduleMessageStoreExpiry(id);
-    capMessageStore();
-  }
-
-  function rememberSent(id: string, message?: unknown): void {
-    if (!id) return;
-    sentMessageIds.add(id);
-    if (message !== undefined) messageStore.set(id, message);
-    scheduleMessageStoreExpiry(id);
-    capMessageStore();
-  }
-
-  function clearMessageStore(): void {
-    for (const timer of messageStoreTimers.values()) clearTimeout(timer);
-    messageStoreTimers.clear();
-    messageStore.clear();
-    sentMessageIds.clear();
-  }
-
-  function isKnownOutboundMessage(messageId: string): boolean {
-    if (sentMessageIds.has(messageId)) return true;
-    const stored = messageStore.get(messageId);
-    if (!stored) return false;
-    return asRecord(asRecord(stored).key).fromMe === true;
-  }
-
-  function getStoredTargetKey(
-    messageId: string,
-  ): Record<string, unknown> | null {
-    const key = asRecord(asRecord(messageStore.get(messageId)).key);
-    if (typeof key.id !== "string" || key.id !== messageId) return null;
-    const remoteJid =
-      typeof key.remoteJid === "string" ? stripDeviceSuffix(key.remoteJid) : "";
-    if (!remoteJid) return null;
-    return { ...key, remoteJid, id: messageId };
-  }
-
-  function buildReactionTargetKey(
-    targetJid: string,
-    messageId: string,
-  ): Record<string, unknown> {
-    const storedKey = getStoredTargetKey(messageId);
-    if (storedKey) return storedKey;
-    if (isGroupJid(targetJid)) {
-      throw new Error(
-        "WhatsApp group reactions require the original target message key from the current adapter process; after restart, react only after the target message is observed again.",
-      );
-    }
-    return { remoteJid: targetJid, id: messageId };
-  }
-
   function clearActiveSocket(closeWebSocket: boolean): void {
     const currentSock = sock;
     const releaseLease = releaseSocketLease;
+    inboundDebounce?.cancelPending();
     sock = null;
     releaseSocketLease = null;
     if (closeWebSocket) {
@@ -418,6 +334,7 @@ export function createWhatsAppAdapter(
         scheduleReconnect(message);
       });
     }, delay);
+    reconnectTimer.unref?.();
   }
 
   async function connect(): Promise<void> {
@@ -478,36 +395,64 @@ export function createWhatsAppAdapter(
       result.release();
       return;
     }
-    sock = result.sock as WhatsAppSocket;
+    const connectedSocket = result.sock as WhatsAppSocket;
+    sock = connectedSocket;
     releaseSocketLease = result.release;
-    sock.ev?.on?.("messages.upsert", (event) => {
-      return handleMessagesUpsert(event).catch((error) => {
-        console.error(
-          `[WhatsApp:${account.accountId}] inbound handler failed:`,
-          error instanceof Error ? error.message : error,
-        );
-      });
+    connectedSocket.ev?.on?.("messages.upsert", (event) => {
+      return handleMessagesUpsert(event, connectedSocket, generation).catch(
+        (error) => {
+          console.error(
+            `[WhatsApp:${account.accountId}] inbound handler failed:`,
+            error instanceof Error ? error.message : error,
+          );
+        },
+      );
     });
-    sock.ev?.on?.("messages.reaction", (event) => {
-      return handleReactionBatch(event).catch((error) => {
-        console.error(
-          `[WhatsApp:${account.accountId}] reaction handler failed:`,
-          error instanceof Error ? error.message : error,
-        );
-      });
+    connectedSocket.ev?.on?.("messages.reaction", (event) => {
+      return handleReactionBatch(event, connectedSocket, generation).catch(
+        (error) => {
+          console.error(
+            `[WhatsApp:${account.accountId}] reaction handler failed:`,
+            error instanceof Error ? error.message : error,
+          );
+        },
+      );
     });
   }
 
-  async function getGroupLabel(groupJid: string): Promise<string | undefined> {
+  async function getGroupLabel(
+    groupJid: string,
+    batchSocket: WhatsAppSocket,
+  ): Promise<string | undefined> {
     try {
-      return (await sock?.groupMetadata?.(groupJid))?.subject;
+      return (await batchSocket.groupMetadata?.(groupJid))?.subject;
     } catch {
       return undefined;
     }
   }
 
-  async function handleMessagesUpsert(event: unknown): Promise<void> {
+  function isActiveBatch(
+    batchSocket: WhatsAppSocket,
+    generation: number,
+  ): boolean {
+    return (
+      running &&
+      !stopping &&
+      sock === batchSocket &&
+      generation === connectionGeneration
+    );
+  }
+
+  async function handleMessagesUpsert(
+    event: unknown,
+    batchSocket: WhatsAppSocket,
+    generation: number,
+  ): Promise<void> {
+    const acceptedEntries: Array<
+      WhatsAppInboundDebounceEntry<WhatsAppSocket, WhatsAppMessageKey>
+    > = [];
     try {
+      if (!isActiveBatch(batchSocket, generation)) return;
       const record = asRecord(event);
       if (record.type !== "notify" && record.type !== "append") return;
       const messages = Array.isArray(record.messages)
@@ -515,18 +460,20 @@ export function createWhatsAppAdapter(
         : [];
       const isHistory = record.type === "append";
       for (const msg of messages) {
+        if (!isActiveBatch(batchSocket, generation)) return;
         const remoteJid = msg.key?.remoteJid ?? "";
         const messageId = msg.key?.id ?? "";
         if (!remoteJid || !messageId || !msg.message) continue;
+        if (isWhatsAppReactionMessage(msg.message)) continue;
         if (isStatusOrBroadcastJid(remoteJid)) continue;
         if (isSyntheticReactionMessage(msg.message)) continue;
-        if (sentMessageIds.has(messageId)) {
-          rememberStoredMessage(messageId, msg);
-          sentMessageIds.delete(messageId);
+        if (outboundMessages.isSent(messageId)) {
+          outboundMessages.rememberStored(messageId, msg);
+          outboundMessages.forgetSent(messageId);
           continue;
         }
         if (!messageStore.has(messageId)) {
-          rememberStoredMessage(messageId, msg);
+          outboundMessages.rememberStored(messageId, msg);
         }
 
         const selfChat = isSelfChat(remoteJid, selfPhoneJid, selfLid);
@@ -574,6 +521,7 @@ export function createWhatsAppAdapter(
           mediaMaxBytes: account.mediaMaxBytes,
           transcribeVoice: account.transcribeVoice === true,
         });
+        if (!isActiveBatch(batchSocket, generation)) return;
         const body = attachmentResult.transcriptionText || text;
         if (!body.trim() && attachmentResult.attachments.length === 0) continue;
 
@@ -595,10 +543,11 @@ export function createWhatsAppAdapter(
         if (!groupAllowed) continue;
 
         const chatLabel = group
-          ? await getGroupLabel(chatId)
+          ? await getGroupLabel(chatId, batchSocket)
           : selfChat
             ? "Self (WhatsApp)"
             : msg.pushName?.trim() || senderId;
+        if (!isActiveBatch(batchSocket, generation)) return;
 
         const inbound: InboundChannelMessage = {
           channel: CHANNEL_ID,
@@ -622,17 +571,36 @@ export function createWhatsAppAdapter(
         console.log(
           `[WhatsApp:${account.accountId}] inbound chatId=${chatId} sender=${senderId} text="${preview(body)}"`,
         );
-        await adapter.onMessage?.(inbound);
+        acceptedEntries.push({
+          inbound,
+          receipt:
+            msg.key && batchSocket.readMessages
+              ? {
+                  owner: batchSocket,
+                  key: msg.key,
+                  markRead: (keys) => batchSocket.readMessages?.(keys),
+                }
+              : undefined,
+        });
       }
     } finally {
       flushLidStoreIfDirty();
+      if (
+        acceptedEntries.length > 0 &&
+        isActiveBatch(batchSocket, generation)
+      ) {
+        await inboundDebounce?.dispatch(acceptedEntries);
+      }
     }
   }
 
   async function handleReactionEntry(
     parsed: WhatsAppReaction,
     raw: unknown,
+    batchSocket: WhatsAppSocket,
+    generation: number,
   ): Promise<void> {
+    if (!isActiveBatch(batchSocket, generation)) return;
     // Baileys may deliver reactions via a LID chat where it cannot equate
     // our PN identity, producing targetFromMe:false for our own messages.
     // isKnownOutboundMessage also checks sentMessageIds and the store's
@@ -640,7 +608,7 @@ export function createWhatsAppAdapter(
     // are stored there too.
     const targetIsOurs =
       parsed.targetFromMe === true ||
-      isKnownOutboundMessage(parsed.targetMessageId);
+      outboundMessages.isKnownOutbound(parsed.targetMessageId);
     if (!targetIsOurs) return;
     if (parsed.reactionKey.fromMe === true) return;
     if (isStatusOrBroadcastJid(parsed.chatId)) return;
@@ -650,8 +618,8 @@ export function createWhatsAppAdapter(
     ) {
       return;
     }
-    if (sentMessageIds.has(parsed.reactionMessageId)) {
-      sentMessageIds.delete(parsed.reactionMessageId);
+    if (outboundMessages.isSent(parsed.reactionMessageId)) {
+      outboundMessages.forgetSent(parsed.reactionMessageId);
       return;
     }
     const identity = resolveInboundIdentity(
@@ -691,10 +659,11 @@ export function createWhatsAppAdapter(
     }
 
     const chatLabel = group
-      ? await getGroupLabel(identity.chatId)
+      ? await getGroupLabel(identity.chatId, batchSocket)
       : selfChat
         ? "Self (WhatsApp)"
         : identity.senderId;
+    if (!isActiveBatch(batchSocket, generation)) return;
     const targetSenderId = isStrictPhoneJid(selfPhoneJid)
       ? senderIdFromJid(selfPhoneJid)
       : isStrictPhoneJid(parsed.targetKey.participant)
@@ -736,13 +705,22 @@ export function createWhatsAppAdapter(
     }
   }
 
-  async function handleReactionBatch(event: unknown): Promise<void> {
+  async function handleReactionBatch(
+    event: unknown,
+    batchSocket: WhatsAppSocket,
+    generation: number,
+  ): Promise<void> {
     try {
-      if (!Array.isArray(event)) return;
+      if (!isActiveBatch(batchSocket, generation) || !Array.isArray(event)) {
+        return;
+      }
       for (const raw of event) {
+        if (!isActiveBatch(batchSocket, generation)) return;
         try {
           const parsed = parseWhatsAppReactionEntry(raw);
-          if (parsed) await handleReactionEntry(parsed, raw);
+          if (parsed) {
+            await handleReactionEntry(parsed, raw, batchSocket, generation);
+          }
         } catch (error) {
           console.error(
             `[WhatsApp:${account.accountId}] reaction entry failed:`,
@@ -786,12 +764,14 @@ export function createWhatsAppAdapter(
 
     async stop() {
       if (!running) {
-        clearMessageStore();
+        inboundDebounce?.cancelPending();
+        outboundMessages.clear();
         flushLidStoreIfDirty();
         return;
       }
       stopping = true;
       running = false;
+      inboundDebounce?.cancelPending();
       if (reconnectTimer) {
         clearTimeout(reconnectTimer);
         reconnectTimer = null;
@@ -799,7 +779,7 @@ export function createWhatsAppAdapter(
       connectionGeneration += 1;
       clearActiveSocket(true);
       setWhatsAppConnectionState(account.accountId, { status: "disconnected" });
-      clearMessageStore();
+      outboundMessages.clear();
       flushLidStoreIfDirty();
     },
 
@@ -850,11 +830,11 @@ export function createWhatsAppAdapter(
         const result = await sendToWhatsApp(targetJid, {
           react: {
             text: msg.removeReaction ? "" : (msg.reaction ?? ""),
-            key: buildReactionTargetKey(targetJid, target),
+            key: outboundMessages.buildReactionTargetKey(targetJid, target),
           },
         });
         const id = result.key?.id ?? target;
-        rememberSent(id, result);
+        outboundMessages.rememberSent(id, result);
         return { messageId: id };
       }
       try {
@@ -869,7 +849,7 @@ export function createWhatsAppAdapter(
         buildQuotedOptions(targetJid, msg.replyToMessageId),
       );
       const id = result.key?.id ?? "";
-      rememberSent(id, result);
+      outboundMessages.rememberSent(id, result);
       return { messageId: id };
     },
 
@@ -886,7 +866,7 @@ export function createWhatsAppAdapter(
         { text },
         buildQuotedOptions(targetJid, options?.replyToMessageId),
       );
-      rememberSent(result.key?.id ?? "", result);
+      outboundMessages.rememberSent(result.key?.id ?? "", result);
     },
 
     async handleControlRequestEvent(event: ChannelControlRequestEvent) {
@@ -935,6 +915,23 @@ export function createWhatsAppAdapter(
       );
     },
   };
+
+  inboundDebounce = createWhatsAppInboundDebounceController({
+    account,
+    getDeliver: () => adapter.onMessage,
+    onDeliveryError(error) {
+      console.warn(
+        `[WhatsApp:${account.accountId}] failed to deliver inbound batch:`,
+        error instanceof Error ? error.message : error,
+      );
+    },
+    onReadReceiptError(error) {
+      console.warn(
+        `[WhatsApp:${account.accountId}] failed to mark messages read:`,
+        error instanceof Error ? error.message : error,
+      );
+    },
+  });
 
   return adapter;
 }

--- a/src/channels/whatsapp/adapter.ts
+++ b/src/channels/whatsapp/adapter.ts
@@ -10,6 +10,17 @@ import type {
   OutboundChannelMessage,
   WhatsAppChannelAccount,
 } from "@/channels/types";
+import {
+  asRecord,
+  buildWhatsAppQuotedOptions,
+  getWhatsAppDisplayName,
+  getWhatsAppLifecycleErrorReplyKey,
+  isWhatsAppConflictDisconnect,
+  isWhatsAppReactionMessage,
+  previewWhatsAppText,
+  shouldProcessWhatsAppGroup,
+  timestampToMs,
+} from "./adapter-helpers";
 import { decideWhatsAppAttachmentPolicy } from "./attachment-policy";
 import { resolveInboundIdentity } from "./identity";
 import {
@@ -34,7 +45,6 @@ import {
   extractMentionedJids,
   extractReplyParticipant,
   extractWhatsAppText,
-  unwrapWhatsAppMessageContent,
   type WhatsAppResolvedOutboundMedia,
 } from "./media";
 import { createWhatsAppMessageStore } from "./message-store";
@@ -47,11 +57,14 @@ import { loadWhatsAppModule } from "./runtime";
 import { createWhatsAppSocket, getWhatsAppAuthDir } from "./session";
 import { setWhatsAppConnectionState } from "./state";
 
+export { isWhatsAppConflictDisconnect };
+
 const CHANNEL_ID = "whatsapp";
 const DEDUPE_MAX_SIZE = 5000;
 const RECONNECT_MAX_MS = 30_000;
-const MAX_MENTION_PATTERN_LENGTH = 256;
-const MENTION_MATCH_TEXT_MAX_LENGTH = 2000;
+const MAX_UNSTABLE_DISCONNECTS = 6;
+const RECONNECT_WINDOW_MS = 60_000;
+const STABLE_OPEN_RESET_MS = RECONNECT_WINDOW_MS;
 
 type EventEmitterLike = {
   on?: (event: string, handler: (payload: unknown) => void) => void;
@@ -89,141 +102,39 @@ type WhatsAppMessage = {
   pushName?: string | null;
 };
 
-export type WhatsAppAdapterDependencies = {
-  createSocket?: typeof createWhatsAppSocket;
-  loadRuntimeModule?: typeof loadWhatsAppModule;
-  lidStore?: LidStore;
+export type WhatsAppReconnectScheduler = {
+  now(): number;
+  schedule(
+    delayMs: number,
+    callback: () => void,
+    options?: { unref?: boolean },
+  ): { cancel(): void };
 };
 
-function asRecord(value: unknown): Record<string, unknown> {
-  return value && typeof value === "object"
-    ? (value as Record<string, unknown>)
-    : {};
-}
-
-function isSyntheticReactionMessage(message: unknown): boolean {
-  const content = unwrapWhatsAppMessageContent(message);
-  return !!content?.reactionMessage;
-}
-
-export function isWhatsAppConflictDisconnect(update: unknown): boolean {
-  const record = asRecord(update);
-  if (record.connection !== "close") return false;
-  const lastDisconnect = asRecord(record.lastDisconnect);
-  const error = asRecord(lastDisconnect.error);
-  const output = asRecord(error.output);
-  const statusCode = output.statusCode;
-  const message = typeof error.message === "string" ? error.message : "";
-  return (
-    statusCode === 440 ||
-    /\bconflict\b/i.test(message) ||
-    /connection replaced/i.test(message)
-  );
-}
-
-function timestampToMs(value: unknown): number {
-  if (typeof value === "number" && Number.isFinite(value)) {
-    return value * 1000;
-  }
-  if (value && typeof value === "object") {
-    const toNumber = (value as { toNumber?: () => number }).toNumber;
-    if (typeof toNumber === "function") {
-      return toNumber.call(value) * 1000;
-    }
-  }
-  return Date.now();
-}
-
-function preview(text: string): string {
-  const normalized = text.replace(/\s+/g, " ").trim();
-  return normalized.length <= 80 ? normalized : `${normalized.slice(0, 79)}…`;
-}
-
-function getDisplayName(account: WhatsAppChannelAccount): string {
-  return account.displayName ?? "WhatsApp";
-}
-
-function matchesSelf(
-  jid: string,
-  selfPhoneJid: string | null,
-  selfLid: string | null,
-): boolean {
-  const normalized = stripDeviceSuffix(jid);
-  return (
-    (!!selfPhoneJid && normalized === stripDeviceSuffix(selfPhoneJid)) ||
-    (!!selfLid && normalized === stripDeviceSuffix(selfLid))
-  );
-}
-
-function shouldProcessGroup(params: {
-  account: WhatsAppChannelAccount;
-  groupJid: string;
-  text: string;
-  mentionedJids: string[];
-  replyParticipant: string | null;
-  selfPhoneJid: string | null;
-  selfLid: string | null;
-}): boolean {
-  const {
-    account,
-    groupJid,
-    text,
-    mentionedJids,
-    replyParticipant,
-    selfPhoneJid,
-    selfLid,
-  } = params;
-  if (account.groupMode === "disabled") return false;
-  if (
-    account.allowedGroups?.length &&
-    !account.allowedGroups.includes(groupJid)
-  ) {
-    return false;
-  }
-  if (account.groupMode === "open") return true;
-  if (mentionedJids.some((jid) => matchesSelf(jid, selfPhoneJid, selfLid))) {
-    return true;
-  }
-  if (
-    replyParticipant &&
-    matchesSelf(replyParticipant, selfPhoneJid, selfLid)
-  ) {
-    return true;
-  }
-  const matchText = text.slice(0, MENTION_MATCH_TEXT_MAX_LENGTH);
-  for (const pattern of account.mentionPatterns ?? []) {
-    if (pattern.length > MAX_MENTION_PATTERN_LENGTH) continue;
-    try {
-      if (new RegExp(pattern, "i").test(matchText)) return true;
-    } catch {
-      // Ignore invalid user-provided patterns.
-    }
-  }
-  return false;
-}
-
-function buildQuotedOptions(
-  targetJid: string,
-  replyToMessageId?: string,
-): Record<string, unknown> | undefined {
-  if (!replyToMessageId) return undefined;
+function createDefaultReconnectScheduler(): WhatsAppReconnectScheduler {
   return {
-    quoted: {
-      key: { remoteJid: targetJid, id: replyToMessageId },
-      message: { conversation: "" },
+    now: () => Date.now(),
+    schedule(delayMs, callback, options) {
+      const timer = setTimeout(callback, delayMs) as ReturnType<
+        typeof setTimeout
+      > & { unref?: () => void };
+      if (options?.unref) timer.unref?.();
+      return { cancel: () => clearTimeout(timer) };
     },
   };
 }
 
-function getLifecycleErrorReplyKey(source: ChannelTurnSource): string | null {
-  if (!source.chatId) return null;
-  return `${source.chatId}:${source.messageId ?? ""}`;
-}
+export type WhatsAppAdapterDependencies = {
+  createSocket?: typeof createWhatsAppSocket;
+  loadRuntimeModule?: typeof loadWhatsAppModule;
+  lidStore?: LidStore;
+  reconnectScheduler?: WhatsAppReconnectScheduler;
+};
 
-function isWhatsAppReactionMessage(message: unknown): boolean {
-  const content = unwrapWhatsAppMessageContent(message);
-  return !!content?.reactionMessage;
-}
+type ReconnectTimer = {
+  generation: number;
+  task: { cancel(): void } | null;
+};
 
 export function createWhatsAppAdapter(
   account: WhatsAppChannelAccount,
@@ -233,11 +144,16 @@ export function createWhatsAppAdapter(
   let running = false;
   let stopping = false;
   let reconnectAttempts = 0;
-  let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  let reconnectTimer: ReconnectTimer | null = null;
+  let stableOpenTimer: ReconnectTimer | null = null;
   let selfPhoneJid: string | null = null;
   let selfLid: string | null = null;
   let connectedAtMs = 0;
   let connectionGeneration = 0;
+  const recentDisconnects: number[] = [];
+  let closedGeneration: number | null = null;
+  const reconnectScheduler =
+    dependencies.reconnectScheduler ?? createDefaultReconnectScheduler();
   let releaseSocketLease: (() => void) | null = null;
   let downloadContentFromMessage:
     | ((message: unknown, type: string) => Promise<AsyncIterable<Uint8Array>>)
@@ -290,6 +206,7 @@ export function createWhatsAppAdapter(
   }
 
   function clearActiveSocket(closeWebSocket: boolean): void {
+    clearStableOpenTimer();
     const currentSock = sock;
     const releaseLease = releaseSocketLease;
     inboundDebounce?.cancelPending();
@@ -303,6 +220,40 @@ export function createWhatsAppAdapter(
       }
     }
     releaseLease?.();
+  }
+
+  function clearReconnectTimer(): void {
+    const timer = reconnectTimer;
+    reconnectTimer = null;
+    timer?.task?.cancel();
+  }
+
+  function clearStableOpenTimer(): void {
+    const timer = stableOpenTimer;
+    stableOpenTimer = null;
+    timer?.task?.cancel();
+  }
+
+  function scheduleStableOpenReset(generation: number): void {
+    clearStableOpenTimer();
+    const timer: ReconnectTimer = {
+      generation,
+      task: null,
+    };
+    stableOpenTimer = timer;
+    timer.task = reconnectScheduler.schedule(
+      STABLE_OPEN_RESET_MS,
+      () => {
+        if (stableOpenTimer !== timer) return;
+        stableOpenTimer = null;
+        if (timer.generation !== connectionGeneration || stopping || !running) {
+          return;
+        }
+        reconnectAttempts = 0;
+        recentDisconnects.length = 0;
+      },
+      { unref: true },
+    );
   }
 
   async function ensureRuntimeHelpers(): Promise<void> {
@@ -320,11 +271,21 @@ export function createWhatsAppAdapter(
     if (stopping || !running || reconnectTimer) return;
     reconnectAttempts += 1;
     const delay = Math.min(RECONNECT_MAX_MS, 1000 * 2 ** reconnectAttempts);
+    const generation = connectionGeneration;
+    const timer: ReconnectTimer = {
+      generation,
+      task: null,
+    };
     console.warn(
       `[WhatsApp:${account.accountId}] disconnected${reason ? ` (${reason})` : ""}; reconnecting in ${Math.round(delay / 1000)}s.`,
     );
-    reconnectTimer = setTimeout(() => {
+    reconnectTimer = timer;
+    timer.task = reconnectScheduler.schedule(delay, () => {
+      if (reconnectTimer !== timer) return;
       reconnectTimer = null;
+      if (timer.generation !== connectionGeneration || stopping || !running) {
+        return;
+      }
       void connect().catch((error) => {
         const message = error instanceof Error ? error.message : String(error);
         setWhatsAppConnectionState(account.accountId, {
@@ -333,16 +294,16 @@ export function createWhatsAppAdapter(
         });
         scheduleReconnect(message);
       });
-    }, delay);
-    reconnectTimer.unref?.();
+    });
   }
 
   async function connect(): Promise<void> {
+    clearReconnectTimer();
     connectionGeneration += 1;
     const generation = connectionGeneration;
     clearActiveSocket(true);
     await ensureRuntimeHelpers();
-    connectedAtMs = Date.now();
+    connectedAtMs = reconnectScheduler.now();
     const result = await (dependencies.createSocket ?? createWhatsAppSocket)({
       accountId: account.accountId,
       printQr: true,
@@ -350,7 +311,8 @@ export function createWhatsAppAdapter(
       onConnectionUpdate(update) {
         if (generation !== connectionGeneration) return;
         if (update.connection === "open") {
-          reconnectAttempts = 0;
+          if (stopping || !running || closedGeneration === generation) return;
+          scheduleStableOpenReset(generation);
           selfPhoneJid = stripDeviceSuffix(sock?.user?.id ?? null) || null;
           selfLid = stripDeviceSuffix(sock?.user?.lid ?? null) || null;
           const mode = account.selfChatMode
@@ -361,12 +323,16 @@ export function createWhatsAppAdapter(
           );
         }
         if (update.connection === "close" && !stopping) {
-          clearActiveSocket(false);
-          const lastDisconnect = asRecord(update.lastDisconnect);
-          const error = asRecord(lastDisconnect.error);
-          if (isWhatsAppConflictDisconnect(update)) {
+          const isConflict = isWhatsAppConflictDisconnect(update);
+          if (isConflict) {
+            closedGeneration = generation;
+            clearActiveSocket(false);
+            const lastDisconnect = asRecord(update.lastDisconnect);
+            const error = asRecord(lastDisconnect.error);
             running = false;
             stopping = true;
+            clearReconnectTimer();
+            clearStableOpenTimer();
             const message =
               typeof error.message === "string"
                 ? error.message
@@ -378,6 +344,33 @@ export function createWhatsAppAdapter(
             console.warn(
               `[WhatsApp:${account.accountId}] disconnected due to session conflict; not reconnecting automatically. Stop any other WhatsApp server using this account/auth session, then restart this server.`,
             );
+            return;
+          }
+          if (closedGeneration === generation) return;
+          closedGeneration = generation;
+          clearActiveSocket(false);
+          const lastDisconnect = asRecord(update.lastDisconnect);
+          const error = asRecord(lastDisconnect.error);
+          const now = reconnectScheduler.now();
+          while (recentDisconnects.length > 0) {
+            const oldest = recentDisconnects[0];
+            if (oldest === undefined || now - oldest <= RECONNECT_WINDOW_MS) {
+              break;
+            }
+            recentDisconnects.shift();
+          }
+          recentDisconnects.push(now);
+          if (recentDisconnects.length >= MAX_UNSTABLE_DISCONNECTS) {
+            running = false;
+            stopping = true;
+            clearReconnectTimer();
+            clearStableOpenTimer();
+            const loopMessage = `WhatsApp disconnected ${recentDisconnects.length} times in ${RECONNECT_WINDOW_MS / 1000}s; stopping to avoid reconnect loop. Another client may be competing for this session. Restart this WhatsApp channel to retry.`;
+            setWhatsAppConnectionState(account.accountId, {
+              status: "error",
+              lastError: loopMessage,
+            });
+            console.warn(`[WhatsApp:${account.accountId}] ${loopMessage}`);
             return;
           }
           scheduleReconnect(
@@ -466,7 +459,6 @@ export function createWhatsAppAdapter(
         if (!remoteJid || !messageId || !msg.message) continue;
         if (isWhatsAppReactionMessage(msg.message)) continue;
         if (isStatusOrBroadcastJid(remoteJid)) continue;
-        if (isSyntheticReactionMessage(msg.message)) continue;
         if (outboundMessages.isSent(messageId)) {
           outboundMessages.rememberStored(messageId, msg);
           outboundMessages.forgetSent(messageId);
@@ -531,7 +523,7 @@ export function createWhatsAppAdapter(
         const replyParticipant = extractReplyParticipant(msg.message);
         const groupAllowed = !group
           ? true
-          : shouldProcessGroup({
+          : shouldProcessWhatsAppGroup({
               account,
               groupJid: chatId,
               text: body,
@@ -569,7 +561,7 @@ export function createWhatsAppAdapter(
         };
 
         console.log(
-          `[WhatsApp:${account.accountId}] inbound chatId=${chatId} sender=${senderId} text="${preview(body)}"`,
+          `[WhatsApp:${account.accountId}] inbound chatId=${chatId} sender=${senderId} text="${previewWhatsAppText(body)}"`,
         );
         acceptedEntries.push({
           inbound,
@@ -752,33 +744,33 @@ export function createWhatsAppAdapter(
     id: `${CHANNEL_ID}:${account.accountId}`,
     channelId: CHANNEL_ID,
     accountId: account.accountId,
-    name: getDisplayName(account),
+    name: getWhatsAppDisplayName(account),
 
     async start() {
       if (running) return;
       running = true;
       stopping = false;
+      reconnectAttempts = 0;
+      recentDisconnects.length = 0;
+      closedGeneration = null;
       await connect();
       console.log(`[WhatsApp:${account.accountId}] Adapter started.`);
     },
 
     async stop() {
-      if (!running) {
-        inboundDebounce?.cancelPending();
-        outboundMessages.clear();
-        flushLidStoreIfDirty();
-        return;
-      }
+      const wasRunning = running;
       stopping = true;
       running = false;
       inboundDebounce?.cancelPending();
-      if (reconnectTimer) {
-        clearTimeout(reconnectTimer);
-        reconnectTimer = null;
-      }
+      clearReconnectTimer();
+      clearStableOpenTimer();
       connectionGeneration += 1;
       clearActiveSocket(true);
-      setWhatsAppConnectionState(account.accountId, { status: "disconnected" });
+      if (wasRunning) {
+        setWhatsAppConnectionState(account.accountId, {
+          status: "disconnected",
+        });
+      }
       outboundMessages.clear();
       flushLidStoreIfDirty();
     },
@@ -846,7 +838,7 @@ export function createWhatsAppAdapter(
       const result = await sendToWhatsApp(
         targetJid,
         payload,
-        buildQuotedOptions(targetJid, msg.replyToMessageId),
+        buildWhatsAppQuotedOptions(targetJid, msg.replyToMessageId),
       );
       const id = result.key?.id ?? "";
       outboundMessages.rememberSent(id, result);
@@ -864,7 +856,7 @@ export function createWhatsAppAdapter(
       const result = await sendToWhatsApp(
         targetJid,
         { text },
-        buildQuotedOptions(targetJid, options?.replyToMessageId),
+        buildWhatsAppQuotedOptions(targetJid, options?.replyToMessageId),
       );
       outboundMessages.rememberSent(result.key?.id ?? "", result);
     },
@@ -890,7 +882,7 @@ export function createWhatsAppAdapter(
 
       const uniqueSources = new Map<string, ChannelTurnSource>();
       for (const source of event.sources) {
-        const key = getLifecycleErrorReplyKey(source);
+        const key = getWhatsAppLifecycleErrorReplyKey(source);
         if (!key || uniqueSources.has(key)) continue;
         uniqueSources.set(key, source);
       }

--- a/src/channels/whatsapp/adapter.ts
+++ b/src/channels/whatsapp/adapter.ts
@@ -28,6 +28,7 @@ import type {
   WhatsAppSocket,
 } from "./adapter-types";
 import { decideWhatsAppAttachmentPolicy } from "./attachment-policy";
+import { createWhatsAppDedupeClaims } from "./dedupe-claims";
 import { resolveInboundIdentity } from "./identity";
 import {
   createWhatsAppInboundDebounceController,
@@ -115,14 +116,14 @@ export function createWhatsAppAdapter(
   let downloadContentFromMessage:
     | ((message: unknown, type: string) => Promise<AsyncIterable<Uint8Array>>)
     | null = null;
-  const seenMessageIds = new Set<string>();
+  const dedupeClaims = createWhatsAppDedupeClaims(DEDUPE_MAX_SIZE);
   const lidStore =
     dependencies.lidStore ??
     createLidStore(
       join(getWhatsAppAuthDir(account.accountId), "lid-mappings.json"),
     );
   let lidStoreDirty = false;
-  const outboundMessages = createWhatsAppMessageStore();
+  const outboundMessages = createWhatsAppMessageStore(canonicalizeChatId);
   const { messages: messageStore } = outboundMessages;
   let inboundDebounce: WhatsAppInboundDebounceController<
     WhatsAppSocket,
@@ -150,16 +151,6 @@ export function createWhatsAppAdapter(
       if (result.status === "recorded") lidStoreDirty = true;
     }
     return true;
-  }
-
-  function rememberSeen(id: string): boolean {
-    if (seenMessageIds.has(id)) return true;
-    seenMessageIds.add(id);
-    if (seenMessageIds.size > DEDUPE_MAX_SIZE) {
-      const first = seenMessageIds.values().next().value;
-      if (first) seenMessageIds.delete(first);
-    }
-    return false;
   }
 
   function clearActiveSocket(closeWebSocket: boolean): void {
@@ -505,22 +496,37 @@ export function createWhatsAppAdapter(
 
         const group = isGroupJid(remoteJid);
         const chatId = identity.chatId;
-        if (rememberSeen(`${chatId}:${messageId}`)) continue;
+        const dedupeKey = `${chatId}:${messageId}`;
+        if (!dedupeClaims.tryClaim(dedupeKey, generation)) continue;
 
         const text = extractWhatsAppText(msg.message);
-        const attachmentResult = await collectWhatsAppAttachments({
-          accountId: account.accountId,
-          chatId,
-          messageId,
-          message: msg.message,
-          downloadContentFromMessage: downloadContentFromMessage ?? undefined,
-          downloadMedia: account.downloadMedia === true,
-          mediaMaxBytes: account.mediaMaxBytes,
-          transcribeVoice: account.transcribeVoice === true,
-        });
-        if (!isActiveBatch(batchSocket, generation)) return;
+        let attachmentResult: Awaited<
+          ReturnType<typeof collectWhatsAppAttachments>
+        >;
+        try {
+          attachmentResult = await collectWhatsAppAttachments({
+            accountId: account.accountId,
+            chatId,
+            messageId,
+            message: msg.message,
+            downloadContentFromMessage: downloadContentFromMessage ?? undefined,
+            downloadMedia: account.downloadMedia === true,
+            mediaMaxBytes: account.mediaMaxBytes,
+            transcribeVoice: account.transcribeVoice === true,
+          });
+        } catch (error) {
+          dedupeClaims.release(dedupeKey, generation);
+          throw error;
+        }
+        if (!isActiveBatch(batchSocket, generation)) {
+          dedupeClaims.release(dedupeKey, generation);
+          return;
+        }
         const body = attachmentResult.transcriptionText || text;
-        if (!body.trim() && attachmentResult.attachments.length === 0) continue;
+        if (!body.trim() && attachmentResult.attachments.length === 0) {
+          dedupeClaims.commit(dedupeKey, generation);
+          continue;
+        }
 
         const senderId = identity.senderId;
 
@@ -537,14 +543,20 @@ export function createWhatsAppAdapter(
               selfPhoneJid,
               selfLid,
             });
-        if (!groupAllowed) continue;
+        if (!groupAllowed) {
+          dedupeClaims.commit(dedupeKey, generation);
+          continue;
+        }
 
         const chatLabel = group
           ? await getGroupLabel(chatId, batchSocket)
           : selfChat
             ? "Self (WhatsApp)"
             : msg.pushName?.trim() || senderId;
-        if (!isActiveBatch(batchSocket, generation)) return;
+        if (!isActiveBatch(batchSocket, generation)) {
+          dedupeClaims.release(dedupeKey, generation);
+          return;
+        }
 
         const inbound: InboundChannelMessage = {
           channel: CHANNEL_ID,
@@ -578,15 +590,18 @@ export function createWhatsAppAdapter(
                   markRead: (keys) => batchSocket.readMessages?.(keys),
                 }
               : undefined,
+          onDeliveryStarted: () => dedupeClaims.commit(dedupeKey, generation),
+          onDiscarded: () => dedupeClaims.release(dedupeKey, generation),
         });
       }
     } finally {
       flushLidStoreIfDirty();
-      if (
-        acceptedEntries.length > 0 &&
-        isActiveBatch(batchSocket, generation)
-      ) {
-        await inboundDebounce?.dispatch(acceptedEntries);
+      if (acceptedEntries.length > 0) {
+        if (isActiveBatch(batchSocket, generation)) {
+          await inboundDebounce?.dispatch(acceptedEntries);
+        } else {
+          for (const entry of acceptedEntries) entry.onDiscarded?.();
+        }
       }
     }
   }
@@ -633,14 +648,14 @@ export function createWhatsAppAdapter(
       lidStore,
     );
     if (!identity || !applyObservedMappings(identity.observedMappings)) return;
-    if (
-      rememberSeen(`reaction:${identity.chatId}:${parsed.reactionMessageId}`)
-    ) {
-      return;
-    }
+    const dedupeKey = `reaction:${identity.chatId}:${parsed.reactionMessageId}`;
+    if (!dedupeClaims.tryClaim(dedupeKey, generation)) return;
 
     const selfChat = isSelfChat(parsed.chatId, selfPhoneJid, selfLid);
-    if (account.selfChatMode && !selfChat) return;
+    if (account.selfChatMode && !selfChat) {
+      dedupeClaims.commit(dedupeKey, generation);
+      return;
+    }
 
     const group = isGroupJid(identity.chatId);
     if (
@@ -652,6 +667,7 @@ export function createWhatsAppAdapter(
         targetFromMe: targetIsOurs,
       })
     ) {
+      dedupeClaims.commit(dedupeKey, generation);
       return;
     }
 
@@ -660,7 +676,10 @@ export function createWhatsAppAdapter(
       : selfChat
         ? "Self (WhatsApp)"
         : identity.senderId;
-    if (!isActiveBatch(batchSocket, generation)) return;
+    if (!isActiveBatch(batchSocket, generation)) {
+      dedupeClaims.release(dedupeKey, generation);
+      return;
+    }
     const targetSenderId = isStrictPhoneJid(selfPhoneJid)
       ? senderIdFromJid(selfPhoneJid)
       : isStrictPhoneJid(parsed.targetKey.participant)
@@ -692,6 +711,7 @@ export function createWhatsAppAdapter(
       },
     };
 
+    dedupeClaims.commit(dedupeKey, generation);
     try {
       await adapter.onMessage?.(inbound);
     } catch (error) {
@@ -880,8 +900,7 @@ export function createWhatsAppAdapter(
     },
 
     async handleControlRequestEvent(event: ChannelControlRequestEvent) {
-      // Never post approval/control prompts into groups. Direct/self-chat
-      // routes may use the normal text approval flow.
+      // Never post approval/control prompts into groups.
       if (event.source.chatType === "channel") return;
       await adapter.sendDirectReply(
         event.source.chatId,

--- a/src/channels/whatsapp/adapter.ts
+++ b/src/channels/whatsapp/adapter.ts
@@ -10,6 +10,7 @@ import type {
   OutboundChannelMessage,
   WhatsAppChannelAccount,
 } from "@/channels/types";
+import { decideWhatsAppAttachmentPolicy } from "./attachment-policy";
 import { resolveInboundIdentity } from "./identity";
 import {
   isGroupJid,
@@ -29,6 +30,7 @@ import {
   extractReplyParticipant,
   extractWhatsAppText,
   unwrapWhatsAppMessageContent,
+  type WhatsAppResolvedOutboundMedia,
 } from "./media";
 import {
   isWhatsAppReactionGroupEligible,
@@ -821,6 +823,27 @@ export function createWhatsAppAdapter(
         selfLid,
         resolveLid: (lidJid) => lidStore.resolve(lidJid),
       });
+      let resolvedMedia: WhatsAppResolvedOutboundMedia | undefined;
+      if (msg.mediaPath && account.attachmentFilter === true) {
+        const decision = decideWhatsAppAttachmentPolicy({
+          policy: {
+            enabled: true,
+            allowedMimeTypes: account.attachmentMimeTypes ?? [],
+            allowedRecipients: account.attachmentAllowedRecipients ?? [],
+            allowedDirectories: account.attachmentAllowedPaths ?? [],
+            recursiveDirectories: account.attachmentPathRecursive === true,
+          },
+          mediaPath: msg.mediaPath,
+          targetJid,
+        });
+        if (!decision.allowed) {
+          throw new Error(decision.reason);
+        }
+        resolvedMedia = {
+          mediaPath: decision.mediaPath,
+          mimeType: decision.mimeType,
+        };
+      }
       if (msg.reaction || msg.removeReaction) {
         const target = msg.targetMessageId ?? msg.replyToMessageId;
         if (!target) throw new Error("WhatsApp reactions require messageId.");
@@ -839,7 +862,7 @@ export function createWhatsAppAdapter(
       } catch {
         // Presence is best-effort.
       }
-      const payload = buildWhatsAppOutboundPayload(msg);
+      const payload = buildWhatsAppOutboundPayload(msg, resolvedMedia);
       const result = await sendToWhatsApp(
         targetJid,
         payload,

--- a/src/channels/whatsapp/adapter.ts
+++ b/src/channels/whatsapp/adapter.ts
@@ -11,7 +11,6 @@ import type {
   WhatsAppChannelAccount,
 } from "@/channels/types";
 import {
-  applyWhatsAppMessagePrefix,
   asRecord,
   buildWhatsAppQuotedOptions,
   getWhatsAppDisplayName,
@@ -21,7 +20,7 @@ import {
   previewWhatsAppText,
   shouldProcessWhatsAppGroup,
   timestampToMs,
-  withWhatsAppMessagePrefix,
+  withWhatsAppPayloadMessagePrefix,
 } from "./adapter-helpers";
 import type {
   WhatsAppMessage,
@@ -839,12 +838,14 @@ export function createWhatsAppAdapter(
           // Presence is best-effort.
         }
       }
-      const outbound = withWhatsAppMessagePrefix(msg, account.messagePrefix);
-      const payload = buildWhatsAppOutboundPayload(outbound, resolvedMedia);
+      const payload = withWhatsAppPayloadMessagePrefix(
+        buildWhatsAppOutboundPayload(msg, resolvedMedia),
+        account.messagePrefix,
+      );
       const result = await sendToWhatsApp(
         targetJid,
         payload,
-        buildWhatsAppQuotedOptions(targetJid, outbound.replyToMessageId),
+        buildWhatsAppQuotedOptions(targetJid, msg.replyToMessageId),
       );
       const id = result.key?.id ?? "";
       outboundMessages.rememberSent(id, result);
@@ -860,9 +861,13 @@ export function createWhatsAppAdapter(
         resolveLid: (lidJid) => lidStore.resolve(lidJid),
       });
       await typing.clearChat(targetJid);
+      const payload = withWhatsAppPayloadMessagePrefix(
+        { text },
+        options?.applyMessagePrefix ? account.messagePrefix : undefined,
+      );
       const result = await sendToWhatsApp(
         targetJid,
-        { text: applyWhatsAppMessagePrefix(text, account.messagePrefix) },
+        payload,
         buildWhatsAppQuotedOptions(targetJid, options?.replyToMessageId),
       );
       outboundMessages.rememberSent(result.key?.id ?? "", result);

--- a/src/channels/whatsapp/adapter.ts
+++ b/src/channels/whatsapp/adapter.ts
@@ -136,6 +136,7 @@ type ReconnectTimer = {
   task: { cancel(): void } | null;
 };
 
+const CLAIM_CONNECTION_STATE = { claimedConnectionState: true } as const;
 export function createWhatsAppAdapter(
   account: WhatsAppChannelAccount,
   dependencies: WhatsAppAdapterDependencies = {},
@@ -280,21 +281,34 @@ export function createWhatsAppAdapter(
       `[WhatsApp:${account.accountId}] disconnected${reason ? ` (${reason})` : ""}; reconnecting in ${Math.round(delay / 1000)}s.`,
     );
     reconnectTimer = timer;
-    timer.task = reconnectScheduler.schedule(delay, () => {
-      if (reconnectTimer !== timer) return;
-      reconnectTimer = null;
-      if (timer.generation !== connectionGeneration || stopping || !running) {
-        return;
-      }
-      void connect().catch((error) => {
-        const message = error instanceof Error ? error.message : String(error);
-        setWhatsAppConnectionState(account.accountId, {
-          status: "error",
-          lastError: message,
+    timer.task = reconnectScheduler.schedule(
+      delay,
+      () => {
+        if (reconnectTimer !== timer) return;
+        reconnectTimer = null;
+        if (timer.generation !== connectionGeneration || stopping || !running) {
+          return;
+        }
+        const reconnectGeneration = connectionGeneration + 1;
+        void connect().catch((error) => {
+          if (
+            reconnectGeneration !== connectionGeneration ||
+            stopping ||
+            !running
+          ) {
+            return;
+          }
+          const message =
+            error instanceof Error ? error.message : String(error);
+          setWhatsAppConnectionState(account.accountId, {
+            status: "error",
+            lastError: message,
+          });
+          scheduleReconnect(message);
         });
-        scheduleReconnect(message);
-      });
-    });
+      },
+      { unref: true },
+    );
   }
 
   async function connect(): Promise<void> {
@@ -309,9 +323,11 @@ export function createWhatsAppAdapter(
       printQr: true,
       messageStore,
       onConnectionUpdate(update) {
-        if (generation !== connectionGeneration) return;
+        if (generation !== connectionGeneration) return CLAIM_CONNECTION_STATE;
         if (update.connection === "open") {
-          if (stopping || !running || closedGeneration === generation) return;
+          if (stopping || !running || closedGeneration === generation) {
+            return CLAIM_CONNECTION_STATE;
+          }
           scheduleStableOpenReset(generation);
           selfPhoneJid = stripDeviceSuffix(sock?.user?.id ?? null) || null;
           selfLid = stripDeviceSuffix(sock?.user?.lid ?? null) || null;
@@ -344,9 +360,9 @@ export function createWhatsAppAdapter(
             console.warn(
               `[WhatsApp:${account.accountId}] disconnected due to session conflict; not reconnecting automatically. Stop any other WhatsApp server using this account/auth session, then restart this server.`,
             );
-            return;
+            return CLAIM_CONNECTION_STATE;
           }
-          if (closedGeneration === generation) return;
+          if (closedGeneration === generation) return CLAIM_CONNECTION_STATE;
           closedGeneration = generation;
           clearActiveSocket(false);
           const lastDisconnect = asRecord(update.lastDisconnect);
@@ -371,12 +387,16 @@ export function createWhatsAppAdapter(
               lastError: loopMessage,
             });
             console.warn(`[WhatsApp:${account.accountId}] ${loopMessage}`);
-            return;
+            return CLAIM_CONNECTION_STATE;
           }
           scheduleReconnect(
             typeof error.message === "string" ? error.message : undefined,
           );
         }
+        if (update.connection === "close" && stopping) {
+          return CLAIM_CONNECTION_STATE;
+        }
+        return undefined;
       },
     });
     if (generation !== connectionGeneration || stopping || !running) {

--- a/src/channels/whatsapp/adapter.ts
+++ b/src/channels/whatsapp/adapter.ts
@@ -321,14 +321,13 @@ export function createWhatsAppAdapter(
           );
         }
         if (update.connection === "close" && !stopping) {
-          if (closedGeneration === generation) return CLAIM_CONNECTION_STATE;
-          closedGeneration = generation;
-          const closingSocket = sock;
-          if (closingSocket) void typing.clearOwner(closingSocket);
-          clearActiveSocket(false);
-          const lastDisconnect = asRecord(update.lastDisconnect);
-          const error = asRecord(lastDisconnect.error);
           if (isWhatsAppConflictDisconnect(update)) {
+            closedGeneration = generation;
+            const closingSocket = sock;
+            if (closingSocket) void typing.clearOwner(closingSocket);
+            clearActiveSocket(false);
+            const lastDisconnect = asRecord(update.lastDisconnect);
+            const error = asRecord(lastDisconnect.error);
             running = false;
             stopping = true;
             clearWhatsAppReconnectTimer();
@@ -346,6 +345,13 @@ export function createWhatsAppAdapter(
             );
             return CLAIM_CONNECTION_STATE;
           }
+          if (closedGeneration === generation) return CLAIM_CONNECTION_STATE;
+          closedGeneration = generation;
+          const closingSocket = sock;
+          if (closingSocket) void typing.clearOwner(closingSocket);
+          clearActiveSocket(false);
+          const lastDisconnect = asRecord(update.lastDisconnect);
+          const error = asRecord(lastDisconnect.error);
           const now = reconnectScheduler.now();
           while (recentDisconnects.length > 0) {
             const oldest = recentDisconnects[0];

--- a/src/channels/whatsapp/attachment-policy-types.ts
+++ b/src/channels/whatsapp/attachment-policy-types.ts
@@ -1,0 +1,12 @@
+export interface WhatsAppAttachmentPolicyConfig {
+  /** Enables outbound policy checks. */
+  attachmentFilter?: boolean;
+  /** Extension-derived MIME allowlist. */
+  attachmentMimeTypes?: string[];
+  /** Phone identities or exact group JIDs. */
+  attachmentAllowedRecipients?: string[];
+  /** Allowed media source directories. */
+  attachmentAllowedPaths?: string[];
+  /** Allows directory descendants. */
+  attachmentPathRecursive?: boolean;
+}

--- a/src/channels/whatsapp/attachment-policy.test.ts
+++ b/src/channels/whatsapp/attachment-policy.test.ts
@@ -1,0 +1,236 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import {
+  mkdir,
+  mkdtemp,
+  readlink,
+  realpath,
+  rm,
+  symlink,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  decideWhatsAppAttachmentPolicy,
+  type WhatsAppAttachmentPolicyInput,
+} from "@/channels/whatsapp/attachment-policy";
+
+const directTarget = "15551234567@s.whatsapp.net";
+const groupTarget = "120363000000000000@g.us";
+
+describe("WhatsApp attachment policy", () => {
+  let root: string;
+  let nested: string;
+  let outside: string;
+  let mediaPath: string;
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), "whatsapp-policy-"));
+    nested = join(root, "nested");
+    outside = await mkdtemp(join(tmpdir(), "whatsapp-policy-outside-"));
+    await mkdir(nested);
+    mediaPath = join(root, "photo.png");
+    await writeFile(mediaPath, "image");
+  });
+
+  afterEach(async () => {
+    await rm(root, { recursive: true, force: true });
+    await rm(outside, { recursive: true, force: true });
+  });
+
+  function input(
+    overrides: Partial<WhatsAppAttachmentPolicyInput["policy"]> = {},
+    extra: Partial<
+      Pick<WhatsAppAttachmentPolicyInput, "mediaPath" | "targetJid">
+    > = {},
+  ): WhatsAppAttachmentPolicyInput {
+    return {
+      policy: {
+        enabled: true,
+        allowedMimeTypes: ["*"],
+        allowedRecipients: ["*"],
+        allowedDirectories: [root],
+        recursiveDirectories: false,
+        ...overrides,
+      },
+      mediaPath,
+      targetJid: directTarget,
+      ...extra,
+    };
+  }
+
+  test("disabled policy passes through without touching the filesystem", () => {
+    const decision = decideWhatsAppAttachmentPolicy({
+      ...input({ enabled: false, allowedDirectories: [] }),
+      mediaPath: "/does/not/exist.mp3",
+    });
+    expect(decision).toEqual({
+      allowed: true,
+      mediaPath: "/does/not/exist.mp3",
+      mimeType: "audio/mpeg",
+    });
+  });
+
+  test("MIME exact, wildcard, empty and denied cases are table-driven", () => {
+    const cases = [
+      { name: "exact", allowedMimeTypes: ["image/png"], allowed: true },
+      { name: "wildcard", allowedMimeTypes: ["*"], allowed: true },
+      { name: "family wildcard", allowedMimeTypes: ["image/*"], allowed: true },
+      { name: "empty", allowedMimeTypes: [], allowed: false },
+      { name: "denied", allowedMimeTypes: ["image/jpeg"], allowed: false },
+    ];
+    for (const testCase of cases) {
+      const decision = decideWhatsAppAttachmentPolicy(
+        input({ allowedMimeTypes: testCase.allowedMimeTypes }),
+      );
+      expect(decision.allowed, testCase.name).toBe(testCase.allowed);
+    }
+  });
+
+  test("classifies known and unknown extensions through the decision", async () => {
+    const cases = [
+      ["image.png", "image/png"],
+      ["video.mp4", "video/mp4"],
+      ["document.pdf", "application/pdf"],
+      ["audio.mp3", "audio/mpeg"],
+      ["audio.m4a", "audio/mp4"],
+      ["audio.wav", "audio/wav"],
+      ["audio.ogg", "audio/ogg"],
+      ["audio.oga", "audio/ogg"],
+      ["audio.opus", "audio/opus"],
+      ["unknown.blob", "application/octet-stream"],
+    ] as const;
+    for (const [name, mimeType] of cases) {
+      const path = join(root, name);
+      await writeFile(path, "data");
+      const decision = decideWhatsAppAttachmentPolicy(
+        input({ allowedMimeTypes: [mimeType] }, { mediaPath: path }),
+      );
+      expect(decision.allowed, name).toBe(true);
+      if (decision.allowed) expect(decision.mimeType).toBe(mimeType);
+    }
+  });
+
+  test("normalizes direct recipients but compares groups by exact JID", () => {
+    const direct = decideWhatsAppAttachmentPolicy(
+      input({ allowedRecipients: ["+1 (555) 123-4567"] }),
+    );
+    expect(direct.allowed).toBe(true);
+
+    const wrongDirect = decideWhatsAppAttachmentPolicy(
+      input(
+        { allowedRecipients: ["15551234567"] },
+        { targetJid: "19990000000@s.whatsapp.net" },
+      ),
+    );
+    expect(wrongDirect.allowed).toBe(false);
+
+    const exactGroup = decideWhatsAppAttachmentPolicy(
+      input({ allowedRecipients: [groupTarget] }, { targetJid: groupTarget }),
+    );
+    expect(exactGroup.allowed).toBe(true);
+
+    const digitCollision = decideWhatsAppAttachmentPolicy(
+      input(
+        { allowedRecipients: ["120363000000000000"] },
+        { targetJid: groupTarget },
+      ),
+    );
+    expect(digitCollision.allowed).toBe(false);
+
+    for (const targetJid of [
+      "123456@lid",
+      "not-a-jid",
+      "@g.us",
+      "15551234567",
+    ]) {
+      expect(
+        decideWhatsAppAttachmentPolicy(
+          input({ allowedRecipients: ["*"] }, { targetJid }),
+        ).allowed,
+        targetJid,
+      ).toBe(false);
+    }
+  });
+
+  test("enforces direct-child and recursive directory rules", async () => {
+    const nestedMedia = join(nested, "nested.png");
+    await writeFile(nestedMedia, "nested");
+
+    expect(decideWhatsAppAttachmentPolicy(input()).allowed).toBe(true);
+    expect(
+      decideWhatsAppAttachmentPolicy(input({}, { mediaPath: nestedMedia }))
+        .allowed,
+    ).toBe(false);
+    expect(
+      decideWhatsAppAttachmentPolicy(
+        input({ recursiveDirectories: true }, { mediaPath: nestedMedia }),
+      ).allowed,
+    ).toBe(true);
+  });
+
+  test("rejects sibling-prefix and symlink escapes", async () => {
+    const sibling = `${root}-sibling`;
+    await mkdir(sibling);
+    const siblingMedia = join(sibling, "sibling.png");
+    const outsideMedia = join(outside, "secret.png");
+    const linkMedia = join(root, "link.png");
+    await writeFile(siblingMedia, "sibling");
+    await writeFile(outsideMedia, "secret");
+    await symlink(outsideMedia, linkMedia);
+    try {
+      expect(
+        decideWhatsAppAttachmentPolicy(
+          input({ recursiveDirectories: true }, { mediaPath: siblingMedia }),
+        ).allowed,
+      ).toBe(false);
+      expect(
+        decideWhatsAppAttachmentPolicy(
+          input({ recursiveDirectories: true }, { mediaPath: linkMedia }),
+        ).allowed,
+      ).toBe(false);
+    } finally {
+      await rm(sibling, { recursive: true, force: true });
+    }
+  });
+
+  test("rejects nonexistent, non-file, broken-link and missing directories", async () => {
+    const brokenLink = join(root, "broken.png");
+    await symlink(join(outside, "missing.png"), brokenLink);
+    const cases = ["/does/not/exist.png", root, brokenLink];
+    for (const candidate of cases) {
+      expect(
+        decideWhatsAppAttachmentPolicy(input({}, { mediaPath: candidate }))
+          .allowed,
+      ).toBe(false);
+    }
+    expect(
+      decideWhatsAppAttachmentPolicy(
+        input({ allowedDirectories: [join(root, "removed")] }),
+      ).allowed,
+    ).toBe(false);
+
+    expect(
+      decideWhatsAppAttachmentPolicy(
+        input({ allowedDirectories: [join(root, "removed"), root] }),
+      ).allowed,
+    ).toBe(true);
+  });
+
+  test("uses canonical extension and returns canonical media path", async () => {
+    const canonicalMedia = join(root, "secret.txt");
+    const linkMedia = join(root, "alias.png");
+    await writeFile(canonicalMedia, "secret");
+    await symlink(canonicalMedia, linkMedia);
+    const decision = decideWhatsAppAttachmentPolicy(
+      input({ allowedMimeTypes: ["text/plain"] }, { mediaPath: linkMedia }),
+    );
+    const canonicalRealPath = await realpath(canonicalMedia);
+    expect(decision.allowed).toBe(true);
+    if (decision.allowed) {
+      expect(decision.mimeType).toBe("text/plain");
+      expect(await realpath(decision.mediaPath)).toBe(canonicalRealPath);
+    }
+    expect(await readlink(linkMedia)).toBe(canonicalMedia);
+  });
+});

--- a/src/channels/whatsapp/attachment-policy.ts
+++ b/src/channels/whatsapp/attachment-policy.ts
@@ -1,0 +1,237 @@
+import { realpathSync, statSync } from "node:fs";
+import { extname, isAbsolute, relative, sep } from "node:path";
+import {
+  isGroupJid,
+  isLidJid,
+  isStrictPhoneJid,
+  normalizeMaybePhoneJid,
+  normalizePhoneLike,
+  stripDeviceSuffix,
+} from "./jid";
+
+/** Extension classification only; this does not inspect file contents. */
+const WHATSAPP_ATTACHMENT_MIME_TYPES: Readonly<Record<string, string>> = {
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".png": "image/png",
+  ".gif": "image/gif",
+  ".webp": "image/webp",
+  ".bmp": "image/bmp",
+  ".tif": "image/tiff",
+  ".tiff": "image/tiff",
+  ".heic": "image/heic",
+  ".mp4": "video/mp4",
+  ".mov": "video/quicktime",
+  ".m4v": "video/x-m4v",
+  ".webm": "video/webm",
+  ".mkv": "video/x-matroska",
+  ".mp3": "audio/mpeg",
+  ".m4a": "audio/mp4",
+  ".wav": "audio/wav",
+  ".ogg": "audio/ogg",
+  ".oga": "audio/ogg",
+  ".opus": "audio/opus",
+  ".pdf": "application/pdf",
+  ".doc": "application/msword",
+  ".docx":
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+  ".xls": "application/vnd.ms-excel",
+  ".xlsx": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+  ".ppt": "application/vnd.ms-powerpoint",
+  ".pptx":
+    "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+  ".txt": "text/plain",
+  ".csv": "text/csv",
+  ".json": "application/json",
+  ".zip": "application/zip",
+};
+
+export type WhatsAppAttachmentPolicyDecision =
+  | {
+      allowed: true;
+      mediaPath: string;
+      mimeType: string;
+    }
+  | {
+      allowed: false;
+      reason: string;
+    };
+
+export type WhatsAppAttachmentPolicyInput = {
+  policy: {
+    enabled: boolean;
+    allowedMimeTypes: readonly string[];
+    allowedRecipients: readonly string[];
+    allowedDirectories: readonly string[];
+    recursiveDirectories: boolean;
+  };
+  mediaPath: string;
+  targetJid: string;
+};
+
+function deny(reason: string): WhatsAppAttachmentPolicyDecision {
+  return { allowed: false, reason: `Attachment denied: ${reason}` };
+}
+
+function inferMimeType(mediaPath: string): string {
+  return (
+    WHATSAPP_ATTACHMENT_MIME_TYPES[extname(mediaPath).toLowerCase()] ??
+    "application/octet-stream"
+  );
+}
+
+export function inferWhatsAppAttachmentMimeType(mediaPath: string): string {
+  return inferMimeType(mediaPath);
+}
+
+function isMimeAllowed(
+  mimeType: string,
+  allowedMimeTypes: readonly string[],
+): boolean {
+  const normalizedMimeType = mimeType.toLowerCase();
+  return allowedMimeTypes.some((allowedMimeType) => {
+    const normalizedAllowedMimeType = allowedMimeType.trim().toLowerCase();
+    if (normalizedAllowedMimeType === "*") return true;
+    if (normalizedAllowedMimeType === normalizedMimeType) return true;
+    if (normalizedAllowedMimeType.endsWith("/*")) {
+      const prefix = normalizedAllowedMimeType.slice(0, -1);
+      return normalizedMimeType.startsWith(prefix);
+    }
+    return false;
+  });
+}
+
+function normalizeGroupRecipient(value: string): string | null {
+  const normalized = stripDeviceSuffix(value);
+  if (!isGroupJid(normalized)) return null;
+  const localPart = normalized.slice(0, -"@g.us".length);
+  return localPart && !/\s/.test(localPart) ? normalized : null;
+}
+
+type NormalizedRecipientTarget =
+  | { kind: "direct"; phoneDigits: string }
+  | { kind: "group"; groupJid: string };
+
+function normalizeRecipientTarget(
+  targetJid: string,
+): NormalizedRecipientTarget | null {
+  const normalizedTargetJid = stripDeviceSuffix(targetJid);
+  const groupJid = normalizeGroupRecipient(normalizedTargetJid);
+  if (groupJid) return { kind: "group", groupJid };
+  if (!isStrictPhoneJid(normalizedTargetJid)) return null;
+  return {
+    kind: "direct",
+    phoneDigits: normalizePhoneLike(normalizedTargetJid),
+  };
+}
+
+function isDirectRecipientAllowed(
+  targetPhoneDigits: string,
+  allowedRecipients: readonly string[],
+): boolean {
+  return allowedRecipients.some((recipient) => {
+    if (isGroupJid(recipient) || isLidJid(recipient)) return false;
+    const phoneJid = normalizeMaybePhoneJid(recipient);
+    return (
+      phoneJid !== null &&
+      isStrictPhoneJid(phoneJid) &&
+      normalizePhoneLike(phoneJid) === targetPhoneDigits
+    );
+  });
+}
+
+function isRecipientAllowed(
+  targetJid: string,
+  allowedRecipients: readonly string[],
+): boolean {
+  const normalizedTarget = normalizeRecipientTarget(targetJid);
+  if (!normalizedTarget) return false;
+  if (allowedRecipients.includes("*")) return true;
+  if (normalizedTarget.kind === "group") {
+    return allowedRecipients.some(
+      (recipient) =>
+        normalizeGroupRecipient(recipient) === normalizedTarget.groupJid,
+    );
+  }
+  return isDirectRecipientAllowed(
+    normalizedTarget.phoneDigits,
+    allowedRecipients,
+  );
+}
+
+function isContainedFile(
+  resolvedMediaPath: string,
+  resolvedDirectory: string,
+  recursiveDirectories: boolean,
+): boolean {
+  const relativePath = relative(resolvedDirectory, resolvedMediaPath);
+  if (
+    !relativePath ||
+    isAbsolute(relativePath) ||
+    relativePath === ".." ||
+    relativePath.startsWith(`..${sep}`)
+  ) {
+    return false;
+  }
+  return recursiveDirectories || !relativePath.includes(sep);
+}
+
+export function decideWhatsAppAttachmentPolicy(
+  input: WhatsAppAttachmentPolicyInput,
+): WhatsAppAttachmentPolicyDecision {
+  if (!input.policy.enabled) {
+    return {
+      allowed: true,
+      mediaPath: input.mediaPath,
+      mimeType: inferMimeType(input.mediaPath),
+    };
+  }
+
+  if (input.policy.allowedMimeTypes.length === 0) {
+    return deny("no MIME types are allowed");
+  }
+  if (input.policy.allowedRecipients.length === 0) {
+    return deny("no recipients are allowed");
+  }
+  if (!isRecipientAllowed(input.targetJid, input.policy.allowedRecipients)) {
+    return deny(`recipient "${input.targetJid}" is not allowed`);
+  }
+  if (input.policy.allowedDirectories.length === 0) {
+    return deny("no directories are allowed");
+  }
+
+  try {
+    const resolvedMediaPath = realpathSync(input.mediaPath);
+    if (!statSync(resolvedMediaPath).isFile()) {
+      return deny("media path is not a regular file");
+    }
+    const mimeType = inferMimeType(resolvedMediaPath);
+    if (!isMimeAllowed(mimeType, input.policy.allowedMimeTypes)) {
+      return deny(`MIME type "${mimeType}" is not allowed`);
+    }
+
+    for (const directory of input.policy.allowedDirectories) {
+      try {
+        const resolvedDirectory = realpathSync(directory);
+        if (!statSync(resolvedDirectory).isDirectory()) continue;
+        if (
+          isContainedFile(
+            resolvedMediaPath,
+            resolvedDirectory,
+            input.policy.recursiveDirectories,
+          )
+        ) {
+          return {
+            allowed: true,
+            mediaPath: resolvedMediaPath,
+            mimeType,
+          };
+        }
+      } catch {}
+    }
+  } catch {
+    return deny("media or directory path could not be safely resolved");
+  }
+
+  return deny("media path is outside the allowed directories");
+}

--- a/src/channels/whatsapp/dedupe-claims.ts
+++ b/src/channels/whatsapp/dedupe-claims.ts
@@ -1,0 +1,47 @@
+type DedupeClaim = {
+  generation: number;
+  committed: boolean;
+};
+
+type WhatsAppDedupeClaims = {
+  tryClaim: (key: string, generation: number) => boolean;
+  commit: (key: string, generation: number) => void;
+  release: (key: string, generation: number) => void;
+};
+
+export function createWhatsAppDedupeClaims(
+  maxSize: number,
+): WhatsAppDedupeClaims {
+  const claims = new Map<string, DedupeClaim>();
+
+  function cap(): void {
+    while (claims.size > maxSize) {
+      const first = claims.keys().next().value;
+      if (typeof first !== "string") return;
+      claims.delete(first);
+    }
+  }
+
+  return {
+    tryClaim(key, generation) {
+      const existing = claims.get(key);
+      if (existing?.committed || existing?.generation === generation) {
+        return false;
+      }
+      claims.delete(key);
+      claims.set(key, { generation, committed: false });
+      cap();
+      return true;
+    },
+    commit(key, generation) {
+      const claim = claims.get(key);
+      if (claim?.generation === generation) claim.committed = true;
+    },
+    release(key, generation) {
+      const claim = claims.get(key);
+      if (claim?.generation === generation && !claim.committed) {
+        claims.delete(key);
+      }
+    },
+  };
+}

--- a/src/channels/whatsapp/inbound-debounce.ts
+++ b/src/channels/whatsapp/inbound-debounce.ts
@@ -1,0 +1,206 @@
+import { createInboundDebouncer } from "@/channels/inbound-debounce";
+import type {
+  InboundChannelMessage,
+  WhatsAppChannelAccount,
+} from "@/channels/types";
+import { stripDeviceSuffix } from "./jid";
+
+const MAX_WHATSAPP_INBOUND_DEBOUNCE_MS = 10_000;
+
+type MaybePromise<T> = T | Promise<T>;
+
+export interface WhatsAppInboundReadReceipt<TOwner, TKey> {
+  owner: TOwner;
+  key: TKey;
+  markRead: (keys: TKey[]) => MaybePromise<unknown>;
+}
+
+export interface WhatsAppInboundDebounceEntry<TOwner, TKey> {
+  inbound: InboundChannelMessage;
+  receipt?: WhatsAppInboundReadReceipt<TOwner, TKey>;
+}
+
+interface PendingWhatsAppInboundDebounceEntry<TOwner, TKey>
+  extends WhatsAppInboundDebounceEntry<TOwner, TKey> {
+  generation: number;
+}
+
+export interface WhatsAppInboundDebounceController<TOwner, TKey> {
+  dispatch(
+    entries: WhatsAppInboundDebounceEntry<TOwner, TKey>[],
+  ): Promise<void>;
+  flushAll(): Promise<void>;
+  cancelPending(): void;
+}
+
+export interface WhatsAppInboundDebounceControllerParams<TOwner, TKey> {
+  account: Pick<WhatsAppChannelAccount, "accountId" | "inboundDebounceMs">;
+  getDeliver: () =>
+    | ((message: InboundChannelMessage) => Promise<void>)
+    | undefined;
+  onDeliveryError?: (
+    error: unknown,
+    entries: WhatsAppInboundDebounceEntry<TOwner, TKey>[],
+  ) => void;
+  onReadReceiptError?: (error: unknown, keys: TKey[]) => void;
+}
+
+export function resolveWhatsAppInboundDebounceMs(
+  account: Pick<WhatsAppChannelAccount, "inboundDebounceMs">,
+): number {
+  const value = account.inboundDebounceMs;
+  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
+    return 0;
+  }
+  return Math.trunc(Math.min(value, MAX_WHATSAPP_INBOUND_DEBOUNCE_MS));
+}
+
+function shouldDebounceMessage(message: InboundChannelMessage): boolean {
+  return message.text.trim().length > 0 && !(message.attachments?.length ?? 0);
+}
+
+function buildDebounceKey(message: InboundChannelMessage): string {
+  return [
+    message.accountId ?? "",
+    stripDeviceSuffix(message.chatId),
+    stripDeviceSuffix(message.senderId),
+  ].join(":");
+}
+
+function mergeInboundMessages<TOwner, TKey>(
+  entries: WhatsAppInboundDebounceEntry<TOwner, TKey>[],
+): InboundChannelMessage {
+  const latest = entries[entries.length - 1]?.inbound;
+  if (!latest) {
+    throw new Error("Cannot merge an empty WhatsApp inbound debounce batch.");
+  }
+  return {
+    ...latest,
+    text: entries
+      .map((entry) => entry.inbound.text.trim())
+      .filter((text) => text.length > 0)
+      .join("\n"),
+    raw: entries.map((entry) => entry.inbound.raw),
+  };
+}
+
+export function createWhatsAppInboundDebounceController<TOwner, TKey>(
+  params: WhatsAppInboundDebounceControllerParams<TOwner, TKey>,
+): WhatsAppInboundDebounceController<TOwner, TKey> {
+  const debounceMs = resolveWhatsAppInboundDebounceMs(params.account);
+  let generation = 0;
+
+  const reportDeliveryError = (
+    error: unknown,
+    entries: WhatsAppInboundDebounceEntry<TOwner, TKey>[],
+  ): void => {
+    try {
+      params.onDeliveryError?.(error, entries);
+    } catch {
+      // Error reporting must not break the debounce pipeline.
+    }
+  };
+
+  const reportReadReceiptError = (error: unknown, keys: TKey[]): void => {
+    try {
+      params.onReadReceiptError?.(error, keys);
+    } catch {
+      // Receipt error reporting is best-effort.
+    }
+  };
+
+  const startReadReceipts = (
+    entries: WhatsAppInboundDebounceEntry<TOwner, TKey>[],
+  ): void => {
+    const groups = new Map<
+      TOwner,
+      { keys: TKey[]; markRead: (keys: TKey[]) => MaybePromise<unknown> }
+    >();
+    for (const entry of entries) {
+      if (!entry.receipt) continue;
+      const existing = groups.get(entry.receipt.owner);
+      if (existing) {
+        existing.keys.push(entry.receipt.key);
+        continue;
+      }
+      groups.set(entry.receipt.owner, {
+        keys: [entry.receipt.key],
+        markRead: entry.receipt.markRead,
+      });
+    }
+
+    for (const { keys, markRead } of groups.values()) {
+      if (keys.length === 0) continue;
+      try {
+        const result = markRead(keys);
+        if (result && typeof (result as Promise<unknown>).then === "function") {
+          void (result as Promise<unknown>).catch((error) => {
+            reportReadReceiptError(error, keys);
+          });
+        }
+      } catch (error) {
+        reportReadReceiptError(error, keys);
+      }
+    }
+  };
+
+  const deliver = async (
+    entries: WhatsAppInboundDebounceEntry<TOwner, TKey>[],
+  ): Promise<void> => {
+    const deliverMessage = params.getDeliver();
+    const first = entries[0];
+    if (!deliverMessage || !first) return;
+    const inbound =
+      entries.length === 1 ? first.inbound : mergeInboundMessages(entries);
+    await deliverMessage(inbound);
+  };
+
+  const debouncer = createInboundDebouncer<
+    PendingWhatsAppInboundDebounceEntry<TOwner, TKey>
+  >({
+    debounceMs,
+    buildKey: (entry) => buildDebounceKey(entry.inbound),
+    shouldDebounce: (entry) => shouldDebounceMessage(entry.inbound),
+    onFlush: async (entries) => {
+      const activeEntries = entries.filter(
+        (entry) => entry.generation === generation,
+      );
+      if (activeEntries.length === 0) return;
+      await deliver(activeEntries);
+    },
+    onError: (error, entries) => {
+      reportDeliveryError(error, entries);
+    },
+  });
+
+  return {
+    async dispatch(entries) {
+      if (entries.length === 0) return;
+      const entryGeneration = generation;
+      startReadReceipts(entries);
+      if (debounceMs === 0) {
+        for (const entry of entries) {
+          if (entryGeneration !== generation) return;
+          try {
+            await deliver([entry]);
+          } catch (error) {
+            reportDeliveryError(error, [entry]);
+          }
+        }
+        return;
+      }
+      await Promise.all(
+        entries.map((entry) =>
+          debouncer.enqueue({ ...entry, generation: entryGeneration }),
+        ),
+      );
+    },
+    async flushAll() {
+      await debouncer.flushAll();
+    },
+    cancelPending() {
+      generation += 1;
+      debouncer.cancelAll();
+    },
+  };
+}

--- a/src/channels/whatsapp/inbound-debounce.ts
+++ b/src/channels/whatsapp/inbound-debounce.ts
@@ -242,9 +242,12 @@ export function createWhatsAppInboundDebounceController<TOwner, TKey>(
         return;
       }
       await Promise.all(
-        entries.map((entry) =>
-          debouncer.enqueue({ ...entry, generation: entryGeneration }),
-        ),
+        entries.map((entry) => {
+          const pendingEntry = { ...entry, generation: entryGeneration };
+          pendingEntries.delete(entry);
+          pendingEntries.add(pendingEntry);
+          return debouncer.enqueue(pendingEntry);
+        }),
       );
     },
     async flushAll() {

--- a/src/channels/whatsapp/inbound-debounce.ts
+++ b/src/channels/whatsapp/inbound-debounce.ts
@@ -18,6 +18,8 @@ export interface WhatsAppInboundReadReceipt<TOwner, TKey> {
 export interface WhatsAppInboundDebounceEntry<TOwner, TKey> {
   inbound: InboundChannelMessage;
   receipt?: WhatsAppInboundReadReceipt<TOwner, TKey>;
+  onDeliveryStarted?: () => void;
+  onDiscarded?: () => void;
 }
 
 interface PendingWhatsAppInboundDebounceEntry<TOwner, TKey>
@@ -89,6 +91,33 @@ export function createWhatsAppInboundDebounceController<TOwner, TKey>(
 ): WhatsAppInboundDebounceController<TOwner, TKey> {
   const debounceMs = resolveWhatsAppInboundDebounceMs(params.account);
   let generation = 0;
+  const pendingEntries = new Set<WhatsAppInboundDebounceEntry<TOwner, TKey>>();
+
+  const startDelivery = (
+    entries: WhatsAppInboundDebounceEntry<TOwner, TKey>[],
+  ): void => {
+    for (const entry of entries) {
+      if (!pendingEntries.delete(entry)) continue;
+      try {
+        entry.onDeliveryStarted?.();
+      } catch {
+        // Claim bookkeeping must not block inbound delivery.
+      }
+    }
+  };
+
+  const discard = (
+    entries: WhatsAppInboundDebounceEntry<TOwner, TKey>[],
+  ): void => {
+    for (const entry of entries) {
+      if (!pendingEntries.delete(entry)) continue;
+      try {
+        entry.onDiscarded?.();
+      } catch {
+        // Claim bookkeeping must not break cancellation.
+      }
+    }
+  };
 
   const reportDeliveryError = (
     error: unknown,
@@ -149,9 +178,13 @@ export function createWhatsAppInboundDebounceController<TOwner, TKey>(
   ): Promise<boolean> => {
     const deliverMessage = params.getDeliver();
     const first = entries[0];
-    if (!deliverMessage || !first) return false;
+    if (!deliverMessage || !first) {
+      discard(entries);
+      return false;
+    }
     const inbound =
       entries.length === 1 ? first.inbound : mergeInboundMessages(entries);
+    startDelivery(entries);
     await deliverMessage(inbound);
     return true;
   };
@@ -166,6 +199,7 @@ export function createWhatsAppInboundDebounceController<TOwner, TKey>(
       const activeEntries = entries.filter(
         (entry) => entry.generation === generation,
       );
+      discard(entries.filter((entry) => entry.generation !== generation));
       if (activeEntries.length === 0) return;
       const delivered = await deliver(activeEntries);
       if (
@@ -176,6 +210,7 @@ export function createWhatsAppInboundDebounceController<TOwner, TKey>(
       }
     },
     onError: (error, entries) => {
+      discard(entries);
       reportDeliveryError(error, entries);
     },
   });
@@ -183,12 +218,16 @@ export function createWhatsAppInboundDebounceController<TOwner, TKey>(
   return {
     async dispatch(entries) {
       if (entries.length === 0) return;
+      for (const entry of entries) pendingEntries.add(entry);
       const entryGeneration = generation;
       if (debounceMs === 0) {
         const deliveredEntries: WhatsAppInboundDebounceEntry<TOwner, TKey>[] =
           [];
         for (const entry of entries) {
-          if (entryGeneration !== generation) return;
+          if (entryGeneration !== generation) {
+            discard(entries);
+            return;
+          }
           try {
             if (await deliver([entry])) {
               deliveredEntries.push(entry);
@@ -213,6 +252,7 @@ export function createWhatsAppInboundDebounceController<TOwner, TKey>(
     },
     cancelPending() {
       generation += 1;
+      discard(Array.from(pendingEntries));
       debouncer.cancelAll();
     },
   };

--- a/src/channels/whatsapp/inbound-debounce.ts
+++ b/src/channels/whatsapp/inbound-debounce.ts
@@ -146,13 +146,14 @@ export function createWhatsAppInboundDebounceController<TOwner, TKey>(
 
   const deliver = async (
     entries: WhatsAppInboundDebounceEntry<TOwner, TKey>[],
-  ): Promise<void> => {
+  ): Promise<boolean> => {
     const deliverMessage = params.getDeliver();
     const first = entries[0];
-    if (!deliverMessage || !first) return;
+    if (!deliverMessage || !first) return false;
     const inbound =
       entries.length === 1 ? first.inbound : mergeInboundMessages(entries);
     await deliverMessage(inbound);
+    return true;
   };
 
   const debouncer = createInboundDebouncer<
@@ -166,7 +167,13 @@ export function createWhatsAppInboundDebounceController<TOwner, TKey>(
         (entry) => entry.generation === generation,
       );
       if (activeEntries.length === 0) return;
-      await deliver(activeEntries);
+      const delivered = await deliver(activeEntries);
+      if (
+        delivered &&
+        activeEntries.every((entry) => entry.generation === generation)
+      ) {
+        startReadReceipts(activeEntries);
+      }
     },
     onError: (error, entries) => {
       reportDeliveryError(error, entries);
@@ -177,15 +184,21 @@ export function createWhatsAppInboundDebounceController<TOwner, TKey>(
     async dispatch(entries) {
       if (entries.length === 0) return;
       const entryGeneration = generation;
-      startReadReceipts(entries);
       if (debounceMs === 0) {
+        const deliveredEntries: WhatsAppInboundDebounceEntry<TOwner, TKey>[] =
+          [];
         for (const entry of entries) {
           if (entryGeneration !== generation) return;
           try {
-            await deliver([entry]);
+            if (await deliver([entry])) {
+              deliveredEntries.push(entry);
+            }
           } catch (error) {
             reportDeliveryError(error, [entry]);
           }
+        }
+        if (entryGeneration === generation) {
+          startReadReceipts(deliveredEntries);
         }
         return;
       }

--- a/src/channels/whatsapp/media.ts
+++ b/src/channels/whatsapp/media.ts
@@ -7,6 +7,7 @@ import type {
   ChannelMessageAttachment,
   OutboundChannelMessage,
 } from "@/channels/types";
+import { inferWhatsAppAttachmentMimeType } from "./attachment-policy";
 import { sanitizePathSegment } from "./jid";
 
 export const DEFAULT_WHATSAPP_MEDIA_MAX_BYTES = 50 * 1024 * 1024;
@@ -275,43 +276,48 @@ export function buildWhatsAppOutboundPayload(
     OutboundChannelMessage,
     "text" | "mediaPath" | "fileName" | "title"
   >,
+  resolvedMedia?: WhatsAppResolvedOutboundMedia,
 ): Record<string, unknown> {
   if (!msg.mediaPath) {
     return { text: msg.text };
   }
 
-  const fileName = msg.fileName || basename(msg.mediaPath);
-  const extension = getWhatsAppOutboundMediaExtension(msg);
+  const mediaPath = resolvedMedia?.mediaPath ?? msg.mediaPath;
+  const fileName = resolvedMedia
+    ? basename(mediaPath)
+    : msg.fileName || basename(mediaPath);
+  const extension = resolvedMedia
+    ? extname(mediaPath).toLowerCase()
+    : getWhatsAppOutboundMediaExtension(msg);
   const caption = msg.text?.trim() || msg.title?.trim() || undefined;
 
-  const validationError = getWhatsAppOutboundMediaValidationError(msg);
-  if (validationError) {
-    throw new Error(validationError);
-  }
-
   if (WHATSAPP_IMAGE_EXTENSIONS.has(extension)) {
-    return { image: { url: msg.mediaPath }, ...(caption ? { caption } : {}) };
+    return { image: { url: mediaPath }, ...(caption ? { caption } : {}) };
   }
   if (WHATSAPP_VIDEO_EXTENSIONS.has(extension)) {
-    return { video: { url: msg.mediaPath }, ...(caption ? { caption } : {}) };
+    return { video: { url: mediaPath }, ...(caption ? { caption } : {}) };
   }
   if (WHATSAPP_VOICE_MEMO_EXTENSIONS.has(extension)) {
     return {
-      audio: { url: msg.mediaPath },
+      audio: { url: mediaPath },
       mimetype: "audio/ogg; codecs=opus",
       ptt: true,
     };
   }
   return {
-    document: { url: msg.mediaPath },
+    document: { url: mediaPath },
     fileName,
-    mimetype: "application/octet-stream",
+    mimetype:
+      resolvedMedia?.mimeType ??
+      inferWhatsAppAttachmentMimeType(msg.fileName || mediaPath),
     ...(caption ? { caption } : {}),
   };
 }
 
-export const WHATSAPP_VOICE_MEMO_REQUIREMENT =
-  "WhatsApp voice memos require an Ogg/Opus file (.ogg, .oga, or .opus). Convert MP3/M4A/WAV audio to Ogg Opus before upload.";
+export type WhatsAppResolvedOutboundMedia = {
+  mediaPath: string;
+  mimeType: string;
+};
 
 const WHATSAPP_IMAGE_EXTENSIONS = new Set([
   ".png",
@@ -322,12 +328,6 @@ const WHATSAPP_IMAGE_EXTENSIONS = new Set([
 ]);
 const WHATSAPP_VIDEO_EXTENSIONS = new Set([".mp4", ".mov", ".m4v", ".webm"]);
 const WHATSAPP_VOICE_MEMO_EXTENSIONS = new Set([".ogg", ".oga", ".opus"]);
-const WHATSAPP_AUDIO_EXTENSIONS = new Set([
-  ...WHATSAPP_VOICE_MEMO_EXTENSIONS,
-  ".mp3",
-  ".m4a",
-  ".wav",
-]);
 
 function getWhatsAppOutboundMediaExtension(
   msg: Pick<OutboundChannelMessage, "mediaPath" | "fileName">,
@@ -335,17 +335,4 @@ function getWhatsAppOutboundMediaExtension(
   const fileNameExtension = extname(msg.fileName ?? "");
   const mediaPathExtension = extname(msg.mediaPath ?? "");
   return (fileNameExtension || mediaPathExtension).toLowerCase();
-}
-
-export function getWhatsAppOutboundMediaValidationError(
-  msg: Pick<OutboundChannelMessage, "mediaPath" | "fileName">,
-): string | null {
-  const extension = getWhatsAppOutboundMediaExtension(msg);
-  if (
-    WHATSAPP_AUDIO_EXTENSIONS.has(extension) &&
-    !WHATSAPP_VOICE_MEMO_EXTENSIONS.has(extension)
-  ) {
-    return WHATSAPP_VOICE_MEMO_REQUIREMENT;
-  }
-  return null;
 }

--- a/src/channels/whatsapp/message-actions.ts
+++ b/src/channels/whatsapp/message-actions.ts
@@ -2,7 +2,6 @@ import type {
   ChannelMessageActionAdapter,
   ChannelMessageActionContext,
 } from "@/channels/plugin-types";
-import { getWhatsAppOutboundMediaValidationError } from "./media";
 
 async function sendWhatsAppMessage(
   ctx: ChannelMessageActionContext,
@@ -12,14 +11,6 @@ async function sendWhatsAppMessage(
 
   if (text.trim().length === 0 && !request.mediaPath) {
     return "Error: WhatsApp send requires message or media.";
-  }
-
-  const mediaValidationError = getWhatsAppOutboundMediaValidationError({
-    mediaPath: request.mediaPath,
-    fileName: request.filename,
-  });
-  if (mediaValidationError) {
-    return `Error: ${mediaValidationError}`;
   }
 
   const formatted = formatText(text);
@@ -76,7 +67,7 @@ export const whatsappMessageActions: ChannelMessageActionAdapter = {
           media: {
             type: "string",
             description:
-              "Absolute local file path to upload. For WhatsApp voice memos/audio uploads, provide Ogg/Opus only (.ogg, .oga, or .opus); MP3/M4A/WAV files are rejected because they do not render as WhatsApp push-to-talk voice notes.",
+              "Absolute local file path to upload. WhatsApp sends Ogg/Opus audio (.ogg, .oga, .opus) as push-to-talk voice memos; MP3/M4A/WAV and other files are sent as regular document attachments.",
           },
         },
       },

--- a/src/channels/whatsapp/message-prefix-adapter.test.ts
+++ b/src/channels/whatsapp/message-prefix-adapter.test.ts
@@ -1,0 +1,190 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { OutboundChannelMessage } from "@/channels/types";
+import {
+  createWhatsAppAdapter,
+  type WhatsAppAdapterDependencies,
+} from "./adapter";
+import { createLidStore } from "./lid-store";
+
+const account = {
+  channel: "whatsapp" as const,
+  accountId: "prefix-adapter",
+  displayName: "WhatsApp",
+  enabled: true,
+  dmPolicy: "pairing" as const,
+  allowedUsers: [],
+  agentId: "agent-1",
+  selfChatMode: false,
+  groupMode: "open" as const,
+  createdAt: new Date(0).toISOString(),
+  updatedAt: new Date(0).toISOString(),
+};
+
+const temporaryDirectories: string[] = [];
+const adapters: Array<Awaited<ReturnType<typeof createWhatsAppAdapter>>> = [];
+
+function temporaryDirectory(): string {
+  const directory = mkdtempSync(join(tmpdir(), "whatsapp-prefix-test-"));
+  temporaryDirectories.push(directory);
+  return directory;
+}
+
+function makeHarness(messagePrefix?: string) {
+  const payloads: Record<string, unknown>[] = [];
+  const presence: Array<{ presence: string; jid?: string }> = [];
+  const socket = {
+    ev: { on() {} },
+    ws: { close() {} },
+    async sendMessage(_jid: string, payload: Record<string, unknown>) {
+      payloads.push(payload);
+      return { key: { id: `sent-${payloads.length}` } };
+    },
+    async sendPresenceUpdate(presenceName: string, jid?: string) {
+      presence.push({ presence: presenceName, jid });
+    },
+  };
+  const createSocket: NonNullable<
+    WhatsAppAdapterDependencies["createSocket"]
+  > = async () => ({
+    sock: socket,
+    saveCreds: async () => undefined,
+    DisconnectReason: {},
+    release: () => undefined,
+  });
+  const adapter = createWhatsAppAdapter(
+    { ...account, messagePrefix },
+    {
+      createSocket,
+      loadRuntimeModule: async () => ({}),
+      lidStore: createLidStore(join(temporaryDirectory(), "lid-mappings.json")),
+    },
+  );
+  adapters.push(adapter);
+  return { adapter, payloads, presence };
+}
+
+afterEach(async () => {
+  try {
+    for (const adapter of adapters) await adapter.stop().catch(() => undefined);
+  } finally {
+    adapters.length = 0;
+    for (const directory of temporaryDirectories) {
+      rmSync(directory, { recursive: true, force: true });
+    }
+    temporaryDirectories.length = 0;
+  }
+});
+
+async function send(
+  adapter: Awaited<ReturnType<typeof createWhatsAppAdapter>>,
+  message: OutboundChannelMessage,
+) {
+  await adapter.start();
+  await adapter.sendMessage(message);
+}
+
+describe("WhatsApp message prefix adapter behavior", () => {
+  test("prefixes text exactly without mutating the caller object", async () => {
+    const harness = makeHarness("[bot] ");
+    const message: OutboundChannelMessage = {
+      channel: "whatsapp",
+      accountId: account.accountId,
+      chatId: "15550000001@s.whatsapp.net",
+      text: "hello",
+    };
+    await send(harness.adapter, message);
+    expect(harness.payloads).toEqual([{ text: "[bot] hello" }]);
+    expect(message).toEqual({
+      channel: "whatsapp",
+      accountId: account.accountId,
+      chatId: "15550000001@s.whatsapp.net",
+      text: "hello",
+    });
+  });
+
+  test("prefixes non-empty media captions and leaves empty captions absent", async () => {
+    const captioned = makeHarness("[bot] ");
+    await send(captioned.adapter, {
+      channel: "whatsapp",
+      accountId: account.accountId,
+      chatId: "15550000001@s.whatsapp.net",
+      text: "caption",
+      mediaPath: "/tmp/photo.png",
+    });
+    expect(captioned.payloads[0]).toEqual({
+      image: { url: "/tmp/photo.png" },
+      caption: "[bot] caption",
+    });
+
+    for (const text of ["", "   "]) {
+      const emptyCaption = makeHarness("[bot] ");
+      await send(emptyCaption.adapter, {
+        channel: "whatsapp",
+        accountId: account.accountId,
+        chatId: "15550000001@s.whatsapp.net",
+        text,
+        mediaPath: "/tmp/photo.png",
+      });
+      expect(emptyCaption.payloads[0]).toEqual({
+        image: { url: "/tmp/photo.png" },
+      });
+    }
+  });
+
+  test("does not prefix reactions or removals and prefixes direct replies", async () => {
+    const harness = makeHarness("[bot] ");
+    await harness.adapter.start();
+    await harness.adapter.sendMessage({
+      channel: "whatsapp",
+      accountId: account.accountId,
+      chatId: "15550000001@s.whatsapp.net",
+      text: "ignored",
+      reaction: "👍",
+      targetMessageId: "target",
+    });
+    await harness.adapter.sendMessage({
+      channel: "whatsapp",
+      accountId: account.accountId,
+      chatId: "15550000001@s.whatsapp.net",
+      text: "ignored",
+      removeReaction: true,
+      targetMessageId: "target",
+    });
+    await harness.adapter.sendDirectReply(
+      "15550000001@s.whatsapp.net",
+      "reply",
+    );
+    expect(harness.payloads[0]).toEqual({
+      react: {
+        text: "👍",
+        key: { remoteJid: "15550000001@s.whatsapp.net", id: "target" },
+      },
+    });
+    expect(harness.payloads[1]).toEqual({
+      react: {
+        text: "",
+        key: { remoteJid: "15550000001@s.whatsapp.net", id: "target" },
+      },
+    });
+    expect(harness.payloads[2]).toEqual({ text: "[bot] reply" });
+  });
+
+  test("absent and empty prefixes preserve payloads and one-shot composing", async () => {
+    for (const prefix of [undefined, ""]) {
+      const harness = makeHarness(prefix);
+      await send(harness.adapter, {
+        channel: "whatsapp",
+        accountId: account.accountId,
+        chatId: "15550000001@s.whatsapp.net",
+        text: "hello",
+      });
+      expect(harness.payloads).toEqual([{ text: "hello" }]);
+      expect(harness.presence).toEqual([
+        { presence: "composing", jid: "15550000001@s.whatsapp.net" },
+      ]);
+    }
+  });
+});

--- a/src/channels/whatsapp/message-prefix-adapter.test.ts
+++ b/src/channels/whatsapp/message-prefix-adapter.test.ts
@@ -2,7 +2,12 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import type { OutboundChannelMessage } from "@/channels/types";
+import type {
+  ChannelControlRequestEvent,
+  ChannelTurnLifecycleEvent,
+  ChannelTurnSource,
+  OutboundChannelMessage,
+} from "@/channels/types";
 import {
   createWhatsAppAdapter,
   type WhatsAppAdapterDependencies,
@@ -22,6 +27,9 @@ const account = {
   createdAt: new Date(0).toISOString(),
   updatedAt: new Date(0).toISOString(),
 };
+
+const chatId = "15550000001@s.whatsapp.net";
+const prefix = "[bot] ";
 
 const temporaryDirectories: string[] = [];
 const adapters: Array<Awaited<ReturnType<typeof createWhatsAppAdapter>>> = [];
@@ -66,6 +74,22 @@ function makeHarness(messagePrefix?: string) {
   return { adapter, payloads, presence };
 }
 
+function directSource(
+  overrides: Partial<ChannelTurnSource> = {},
+): ChannelTurnSource {
+  return {
+    channel: "whatsapp",
+    accountId: account.accountId,
+    chatId,
+    chatType: "direct",
+    senderId: "15550000001",
+    messageId: "incoming-1",
+    agentId: "agent-1",
+    conversationId: "conv-1",
+    ...overrides,
+  };
+}
+
 afterEach(async () => {
   try {
     for (const adapter of adapters) await adapter.stop().catch(() => undefined);
@@ -86,104 +110,228 @@ async function send(
   await adapter.sendMessage(message);
 }
 
+function payloadText(payload: Record<string, unknown>): string {
+  if (typeof payload.text !== "string")
+    throw new Error("expected text payload");
+  return payload.text;
+}
+
 describe("WhatsApp message prefix adapter behavior", () => {
-  test("prefixes text exactly without mutating the caller object", async () => {
-    const harness = makeHarness("[bot] ");
+  test("prefixes text exactly once without mutating the caller object", async () => {
+    const harness = makeHarness(prefix);
     const message: OutboundChannelMessage = {
       channel: "whatsapp",
       accountId: account.accountId,
-      chatId: "15550000001@s.whatsapp.net",
+      chatId,
       text: "hello",
     };
     await send(harness.adapter, message);
-    expect(harness.payloads).toEqual([{ text: "[bot] hello" }]);
+    await harness.adapter.sendMessage(message);
+    expect(harness.payloads).toEqual([
+      { text: "[bot] hello" },
+      { text: "[bot] hello" },
+    ]);
     expect(message).toEqual({
       channel: "whatsapp",
       accountId: account.accountId,
-      chatId: "15550000001@s.whatsapp.net",
+      chatId,
       text: "hello",
     });
   });
 
-  test("prefixes non-empty media captions and leaves empty captions absent", async () => {
-    const captioned = makeHarness("[bot] ");
-    await send(captioned.adapter, {
-      channel: "whatsapp",
-      accountId: account.accountId,
-      chatId: "15550000001@s.whatsapp.net",
-      text: "caption",
-      mediaPath: "/tmp/photo.png",
-    });
-    expect(captioned.payloads[0]).toEqual({
-      image: { url: "/tmp/photo.png" },
-      caption: "[bot] caption",
-    });
+  test("prefixes final media captions exactly once after text/title selection", async () => {
+    const cases: Array<{
+      name: string;
+      message: OutboundChannelMessage;
+      payload: Record<string, unknown>;
+    }> = [
+      {
+        name: "image text caption",
+        message: {
+          channel: "whatsapp",
+          accountId: account.accountId,
+          chatId,
+          text: "caption",
+          mediaPath: "/tmp/photo.png",
+        },
+        payload: {
+          image: { url: "/tmp/photo.png" },
+          caption: "[bot] caption",
+        },
+      },
+      {
+        name: "video title caption",
+        message: {
+          channel: "whatsapp",
+          accountId: account.accountId,
+          chatId,
+          text: "",
+          title: "clip title",
+          mediaPath: "/tmp/clip.mp4",
+        },
+        payload: {
+          video: { url: "/tmp/clip.mp4" },
+          caption: "[bot] clip title",
+        },
+      },
+      {
+        name: "text beats title",
+        message: {
+          channel: "whatsapp",
+          accountId: account.accountId,
+          chatId,
+          text: "caption",
+          title: "ignored title",
+          mediaPath: "/tmp/second.jpg",
+        },
+        payload: {
+          image: { url: "/tmp/second.jpg" },
+          caption: "[bot] caption",
+        },
+      },
+      {
+        name: "document title caption",
+        message: {
+          channel: "whatsapp",
+          accountId: account.accountId,
+          chatId,
+          text: "",
+          title: "document title",
+          mediaPath: "/tmp/report.pdf",
+        },
+        payload: {
+          document: { url: "/tmp/report.pdf" },
+          fileName: "report.pdf",
+          mimetype: "application/pdf",
+          caption: "[bot] document title",
+        },
+      },
+    ];
 
-    for (const text of ["", "   "]) {
-      const emptyCaption = makeHarness("[bot] ");
-      await send(emptyCaption.adapter, {
-        channel: "whatsapp",
-        accountId: account.accountId,
-        chatId: "15550000001@s.whatsapp.net",
-        text,
-        mediaPath: "/tmp/photo.png",
-      });
-      expect(emptyCaption.payloads[0]).toEqual({
-        image: { url: "/tmp/photo.png" },
-      });
+    for (const testCase of cases) {
+      const harness = makeHarness(prefix);
+      await send(harness.adapter, testCase.message);
+      expect(harness.payloads[0]).toEqual(testCase.payload);
     }
   });
 
-  test("does not prefix reactions or removals and prefixes direct replies", async () => {
-    const harness = makeHarness("[bot] ");
+  test("leaves empty media captions absent and voice memos captionless", async () => {
+    for (const mediaPath of ["/tmp/photo.png", "/tmp/report.pdf"]) {
+      const emptyCaption = makeHarness(prefix);
+      await send(emptyCaption.adapter, {
+        channel: "whatsapp",
+        accountId: account.accountId,
+        chatId,
+        text: "   ",
+        title: "   ",
+        mediaPath,
+      });
+      expect(emptyCaption.payloads[0]).not.toHaveProperty("caption");
+    }
+
+    const voiceMemo = makeHarness(prefix);
+    await send(voiceMemo.adapter, {
+      channel: "whatsapp",
+      accountId: account.accountId,
+      chatId,
+      text: "voice caption",
+      title: "voice title",
+      mediaPath: "/tmp/voice.ogg",
+    });
+    expect(voiceMemo.payloads[0]).toEqual({
+      audio: { url: "/tmp/voice.ogg" },
+      mimetype: "audio/ogg; codecs=opus",
+      ptt: true,
+    });
+  });
+
+  test("does not prefix reactions or removals and only prefixes opt-in direct replies", async () => {
+    const harness = makeHarness(prefix);
     await harness.adapter.start();
     await harness.adapter.sendMessage({
       channel: "whatsapp",
       accountId: account.accountId,
-      chatId: "15550000001@s.whatsapp.net",
+      chatId,
       text: "ignored",
-      reaction: "👍",
+      reaction: "ok",
       targetMessageId: "target",
     });
     await harness.adapter.sendMessage({
       channel: "whatsapp",
       accountId: account.accountId,
-      chatId: "15550000001@s.whatsapp.net",
+      chatId,
       text: "ignored",
       removeReaction: true,
       targetMessageId: "target",
     });
-    await harness.adapter.sendDirectReply(
-      "15550000001@s.whatsapp.net",
-      "reply",
-    );
+    await harness.adapter.sendDirectReply(chatId, "system reply");
+    await harness.adapter.sendDirectReply(chatId, "ordinary reply", {
+      applyMessagePrefix: true,
+    });
+
     expect(harness.payloads[0]).toEqual({
       react: {
-        text: "👍",
-        key: { remoteJid: "15550000001@s.whatsapp.net", id: "target" },
+        text: "ok",
+        key: { remoteJid: chatId, id: "target" },
       },
     });
     expect(harness.payloads[1]).toEqual({
       react: {
         text: "",
-        key: { remoteJid: "15550000001@s.whatsapp.net", id: "target" },
+        key: { remoteJid: chatId, id: "target" },
       },
     });
-    expect(harness.payloads[2]).toEqual({ text: "[bot] reply" });
+    expect(harness.payloads[2]).toEqual({ text: "system reply" });
+    expect(harness.payloads[3]).toEqual({ text: "[bot] ordinary reply" });
+  });
+
+  test("approval control prompts and lifecycle error replies are unprefixed", async () => {
+    const harness = makeHarness(prefix);
+    await harness.adapter.start();
+
+    await harness.adapter.handleControlRequestEvent?.({
+      requestId: "approval-1",
+      kind: "generic_tool_approval",
+      source: directSource(),
+      toolName: "Bash",
+      input: { command: "pwd" },
+    } satisfies ChannelControlRequestEvent);
+
+    await harness.adapter.handleTurnLifecycleEvent?.({
+      type: "finished",
+      outcome: "error",
+      batchId: "batch-1",
+      runId: "run-1",
+      stopReason: "error",
+      error: "boom",
+      sources: [directSource({ messageId: "incoming-2" })],
+    } satisfies ChannelTurnLifecycleEvent);
+
+    expect(harness.payloads).toHaveLength(2);
+    const [controlPayload, lifecyclePayload] = harness.payloads;
+    if (!controlPayload || !lifecyclePayload) {
+      throw new Error("expected control and lifecycle payloads");
+    }
+    const controlText = payloadText(controlPayload);
+    const lifecycleText = payloadText(lifecyclePayload);
+    expect(controlText).toStartWith("The agent wants approval");
+    expect(controlText).not.toStartWith(prefix);
+    expect(lifecycleText).toStartWith("Turn failed:");
+    expect(lifecycleText).not.toStartWith(prefix);
   });
 
   test("absent and empty prefixes preserve payloads and one-shot composing", async () => {
-    for (const prefix of [undefined, ""]) {
-      const harness = makeHarness(prefix);
+    for (const emptyPrefix of [undefined, ""]) {
+      const harness = makeHarness(emptyPrefix);
       await send(harness.adapter, {
         channel: "whatsapp",
         accountId: account.accountId,
-        chatId: "15550000001@s.whatsapp.net",
+        chatId,
         text: "hello",
       });
       expect(harness.payloads).toEqual([{ text: "hello" }]);
       expect(harness.presence).toEqual([
-        { presence: "composing", jid: "15550000001@s.whatsapp.net" },
+        { presence: "composing", jid: chatId },
       ]);
     }
   });

--- a/src/channels/whatsapp/message-prefix-config-types.ts
+++ b/src/channels/whatsapp/message-prefix-config-types.ts
@@ -1,0 +1,4 @@
+export interface WhatsAppMessagePrefixConfig {
+  /** Optional exact text prepended to outbound WhatsApp messages. */
+  messagePrefix?: string;
+}

--- a/src/channels/whatsapp/message-prefix-config.test.ts
+++ b/src/channels/whatsapp/message-prefix-config.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from "bun:test";
+import type { WhatsAppChannelAccount } from "@/channels/types";
+import { whatsappAccountConfigAdapter } from "./account-config";
+
+function account(
+  overrides: Partial<WhatsAppChannelAccount> = {},
+): WhatsAppChannelAccount {
+  return {
+    channel: "whatsapp",
+    accountId: "wa-test",
+    displayName: "WhatsApp",
+    enabled: true,
+    dmPolicy: "pairing",
+    allowedUsers: [],
+    agentId: null,
+    selfChatMode: true,
+    groupMode: "disabled",
+    createdAt: new Date(0).toISOString(),
+    updatedAt: new Date(0).toISOString(),
+    ...overrides,
+  };
+}
+
+describe("WhatsApp message prefix config", () => {
+  test("accepts empty and non-empty strings and round-trips them", () => {
+    expect(
+      whatsappAccountConfigAdapter.isValidConfig({ message_prefix: "" }),
+    ).toBe(true);
+    expect(
+      whatsappAccountConfigAdapter.isValidConfig({ message_prefix: "[bot] " }),
+    ).toBe(true);
+    expect(
+      whatsappAccountConfigAdapter.toAccountPatch({ message_prefix: "[bot] " }),
+    ).toEqual({ messagePrefix: "[bot] " });
+    expect(
+      whatsappAccountConfigAdapter.toAccountConfig(
+        account({ messagePrefix: "[bot] " }),
+      ).message_prefix,
+    ).toBe("[bot] ");
+    expect(
+      whatsappAccountConfigAdapter.toConfigSnapshotConfig(
+        account({ messagePrefix: "" }),
+      ).message_prefix,
+    ).toBe("");
+  });
+
+  test("rejects non-strings and unknown nested fields", () => {
+    expect(
+      whatsappAccountConfigAdapter.isValidConfig({ message_prefix: true }),
+    ).toBe(false);
+    expect(
+      whatsappAccountConfigAdapter.isValidConfig({ message_prefix: 1 }),
+    ).toBe(false);
+    expect(
+      whatsappAccountConfigAdapter.isValidConfig({ unexpected: true }),
+    ).toBe(false);
+  });
+});

--- a/src/channels/whatsapp/message-store.ts
+++ b/src/channels/whatsapp/message-store.ts
@@ -1,0 +1,136 @@
+import { isGroupJid, stripDeviceSuffix } from "./jid";
+
+const MESSAGE_STORE_MAX_SIZE = 5000;
+const MESSAGE_STORE_TTL_MS = 24 * 60 * 60 * 1000;
+
+type WhatsAppMessageStore = {
+  messages: Map<string, unknown>;
+  isSent: (messageId: string) => boolean;
+  forgetSent: (messageId: string) => void;
+  rememberStored: (messageId: string, message: unknown) => void;
+  rememberSent: (messageId: string, message?: unknown) => void;
+  clear: () => void;
+  isKnownOutbound: (messageId: string) => boolean;
+  buildReactionTargetKey: (
+    targetJid: string,
+    messageId: string,
+  ) => Record<string, unknown>;
+};
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object"
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function unrefTimeout(timer: ReturnType<typeof setTimeout>): void {
+  const unref = (timer as { unref?: () => void }).unref;
+  if (typeof unref === "function") unref.call(timer);
+}
+
+export function createWhatsAppMessageStore(): WhatsAppMessageStore {
+  const messages = new Map<string, unknown>();
+  const sentMessageIds = new Set<string>();
+  const timers = new Map<string, ReturnType<typeof setTimeout>>();
+
+  function clearTimer(messageId: string): void {
+    const timer = timers.get(messageId);
+    if (timer) clearTimeout(timer);
+    timers.delete(messageId);
+  }
+
+  function drop(messageId: string): void {
+    sentMessageIds.delete(messageId);
+    messages.delete(messageId);
+    clearTimer(messageId);
+  }
+
+  function scheduleExpiry(messageId: string): void {
+    clearTimer(messageId);
+    const timer = setTimeout(() => {
+      sentMessageIds.delete(messageId);
+      messages.delete(messageId);
+      timers.delete(messageId);
+    }, MESSAGE_STORE_TTL_MS);
+    unrefTimeout(timer);
+    timers.set(messageId, timer);
+  }
+
+  function cap(): void {
+    while (messages.size > MESSAGE_STORE_MAX_SIZE) {
+      const first = messages.keys().next().value;
+      if (typeof first !== "string") break;
+      drop(first);
+    }
+    while (sentMessageIds.size > MESSAGE_STORE_MAX_SIZE) {
+      const first = sentMessageIds.values().next().value;
+      if (typeof first !== "string") break;
+      drop(first);
+    }
+  }
+
+  function rememberStored(messageId: string, message: unknown): void {
+    if (!messageId) return;
+    messages.set(messageId, message);
+    scheduleExpiry(messageId);
+    cap();
+  }
+
+  function rememberSent(messageId: string, message?: unknown): void {
+    if (!messageId) return;
+    sentMessageIds.add(messageId);
+    if (message !== undefined) messages.set(messageId, message);
+    scheduleExpiry(messageId);
+    cap();
+  }
+
+  function clear(): void {
+    for (const timer of timers.values()) clearTimeout(timer);
+    timers.clear();
+    messages.clear();
+    sentMessageIds.clear();
+  }
+
+  function isKnownOutbound(messageId: string): boolean {
+    if (sentMessageIds.has(messageId)) return true;
+    const stored = messages.get(messageId);
+    if (!stored) return false;
+    return asRecord(asRecord(stored).key).fromMe === true;
+  }
+
+  function getStoredTargetKey(
+    messageId: string,
+  ): Record<string, unknown> | null {
+    const key = asRecord(asRecord(messages.get(messageId)).key);
+    if (typeof key.id !== "string" || key.id !== messageId) return null;
+    const remoteJid =
+      typeof key.remoteJid === "string" ? stripDeviceSuffix(key.remoteJid) : "";
+    if (!remoteJid) return null;
+    return { ...key, remoteJid, id: messageId };
+  }
+
+  function buildReactionTargetKey(
+    targetJid: string,
+    messageId: string,
+  ): Record<string, unknown> {
+    const storedKey = getStoredTargetKey(messageId);
+    if (storedKey) return storedKey;
+    if (isGroupJid(targetJid)) {
+      throw new Error(
+        "WhatsApp group reactions require the original target message key from the current adapter process; after restart, react only after the target message is observed again.",
+      );
+    }
+    return { remoteJid: targetJid, id: messageId };
+  }
+
+  return {
+    messages,
+    isSent: (messageId) => sentMessageIds.has(messageId),
+    forgetSent: (messageId) => sentMessageIds.delete(messageId),
+    rememberStored,
+    rememberSent,
+    clear,
+    isKnownOutbound,
+    buildReactionTargetKey,
+  };
+}

--- a/src/channels/whatsapp/message-store.ts
+++ b/src/channels/whatsapp/message-store.ts
@@ -28,7 +28,9 @@ function unrefTimeout(timer: ReturnType<typeof setTimeout>): void {
   if (typeof unref === "function") unref.call(timer);
 }
 
-export function createWhatsAppMessageStore(): WhatsAppMessageStore {
+export function createWhatsAppMessageStore(
+  canonicalizeChatId: (chatId: string) => string | null,
+): WhatsAppMessageStore {
   const messages = new Map<string, unknown>();
   const sentMessageIds = new Set<string>();
   const timers = new Map<string, ReturnType<typeof setTimeout>>();
@@ -99,6 +101,7 @@ export function createWhatsAppMessageStore(): WhatsAppMessageStore {
   }
 
   function getStoredTargetKey(
+    targetJid: string,
     messageId: string,
   ): Record<string, unknown> | null {
     const key = asRecord(asRecord(messages.get(messageId)).key);
@@ -106,6 +109,13 @@ export function createWhatsAppMessageStore(): WhatsAppMessageStore {
     const remoteJid =
       typeof key.remoteJid === "string" ? stripDeviceSuffix(key.remoteJid) : "";
     if (!remoteJid) return null;
+    const storedChatId = canonicalizeChatId(remoteJid);
+    const requestedChatId = canonicalizeChatId(targetJid);
+    if (!storedChatId || !requestedChatId || storedChatId !== requestedChatId) {
+      throw new Error(
+        "WhatsApp reaction target belongs to a different chat in the current adapter process.",
+      );
+    }
     return { ...key, remoteJid, id: messageId };
   }
 
@@ -113,7 +123,7 @@ export function createWhatsAppMessageStore(): WhatsAppMessageStore {
     targetJid: string,
     messageId: string,
   ): Record<string, unknown> {
-    const storedKey = getStoredTargetKey(messageId);
+    const storedKey = getStoredTargetKey(targetJid, messageId);
     if (storedKey) return storedKey;
     if (isGroupJid(targetJid)) {
       throw new Error(

--- a/src/channels/whatsapp/reactions-adapter.test.ts
+++ b/src/channels/whatsapp/reactions-adapter.test.ts
@@ -44,6 +44,10 @@ function reactionEntry(
     targetFromMe?: boolean;
     reactionFromMe?: boolean;
     participant?: string;
+    senderPn?: string;
+    senderLid?: string;
+    participantPn?: string;
+    participantLid?: string;
     text?: unknown;
     senderTimestampMs?: unknown;
   } = {},
@@ -60,7 +64,21 @@ function reactionEntry(
         remoteJid: chatId,
         id: overrides.reactionId ?? "reaction-event",
         fromMe: overrides.reactionFromMe ?? false,
-        participant: overrides.participant ?? REACTOR,
+        ...(overrides.participant === undefined
+          ? {}
+          : { participant: overrides.participant }),
+        ...(overrides.senderPn === undefined
+          ? {}
+          : { senderPn: overrides.senderPn }),
+        ...(overrides.senderLid === undefined
+          ? {}
+          : { senderLid: overrides.senderLid }),
+        ...(overrides.participantPn === undefined
+          ? {}
+          : { participantPn: overrides.participantPn }),
+        ...(overrides.participantLid === undefined
+          ? {}
+          : { participantLid: overrides.participantLid }),
       },
       text: overrides.text === undefined ? "👍" : overrides.text,
       senderTimestampMs:
@@ -89,6 +107,11 @@ function makeHarness(
   }
   const delivered: InboundChannelMessage[] = [];
   const eventNames: string[] = [];
+  const sentMessages: Array<{
+    jid: string;
+    payload: Record<string, unknown>;
+    options?: Record<string, unknown>;
+  }> = [];
   const handlers = new Map<string, (payload: unknown) => unknown>();
   let connectionUpdate: ((update: unknown) => void) | undefined;
   let readCalls = 0;
@@ -106,8 +129,13 @@ function makeHarness(
       readCalls += 1;
       return Promise.resolve();
     },
-    async sendMessage() {
-      return { key: { id: outboundId, fromMe: true, remoteJid: REACTOR } };
+    async sendMessage(
+      jid: string,
+      payload: Record<string, unknown>,
+      options?: Record<string, unknown>,
+    ) {
+      sentMessages.push({ jid, payload, options });
+      return { key: { id: outboundId, fromMe: true, remoteJid: jid } };
     },
     async sendPresenceUpdate() {},
   };
@@ -142,6 +170,7 @@ function makeHarness(
     adapter,
     delivered,
     eventNames,
+    sentMessages,
     readCalls: () => readCalls,
     async start() {
       await adapter.start();
@@ -270,6 +299,144 @@ describe("WhatsApp reaction adapter integration", () => {
       }),
     ]);
     expect(conflicting.delivered).toHaveLength(0);
+  });
+
+  test("resolves first LID reactions from Baileys key identity fields", async () => {
+    const directLid = "707070@lid";
+    const direct = makeHarness();
+    await direct.start();
+    await direct.emit([
+      reactionEntry({
+        chatId: directLid,
+        reactionId: "direct-lid-first-reaction",
+        senderPn: REACTOR,
+        senderLid: directLid,
+      }),
+    ]);
+    expect(direct.delivered[0]?.chatId).toBe(REACTOR);
+    expect(direct.delivered[0]?.senderId).toBe("15550000002");
+
+    const groupLid = "808080@lid";
+    const group = makeHarness();
+    await group.start();
+    await group.emit([
+      reactionEntry({
+        chatId: GROUP,
+        reactionId: "group-lid-first-reaction",
+        participant: groupLid,
+        participantPn: REACTOR,
+      }),
+    ]);
+    expect(group.delivered[0]?.chatId).toBe(GROUP);
+    expect(group.delivered[0]?.senderId).toBe("15550000002");
+  });
+
+  test("ignores synthetic reaction messages on messages.upsert", async () => {
+    const harness = makeHarness();
+    await harness.start();
+    await harness.emitUpsert([
+      {
+        key: { remoteJid: REACTOR, id: "synthetic-reaction", fromMe: false },
+        message: {
+          reactionMessage: {
+            key: { remoteJid: REACTOR, id: "target-message", fromMe: true },
+            text: "👍",
+          },
+        },
+        messageTimestamp: Math.floor(Date.now() / 1000),
+      },
+      {
+        key: { remoteJid: REACTOR, id: "ordinary", fromMe: false },
+        message: { conversation: "ordinary" },
+        messageTimestamp: Math.floor(Date.now() / 1000),
+      },
+    ]);
+    expect(harness.delivered.map((message) => message.messageId)).toEqual([
+      "ordinary",
+    ]);
+  });
+
+  test("uses stored group target keys for outbound add and removal reactions", async () => {
+    const harness = makeHarness();
+    await harness.start();
+    await harness.emitUpsert([
+      {
+        key: {
+          remoteJid: GROUP,
+          id: "group-target",
+          fromMe: false,
+          participant: REACTOR,
+        },
+        message: { conversation: "group message" },
+        messageTimestamp: Math.floor(Date.now() / 1000),
+      },
+    ]);
+
+    await harness.adapter.sendMessage({
+      channel: "whatsapp",
+      accountId: account.accountId,
+      chatId: GROUP,
+      text: "",
+      reaction: "👍",
+      targetMessageId: "group-target",
+    });
+    await harness.adapter.sendMessage({
+      channel: "whatsapp",
+      accountId: account.accountId,
+      chatId: GROUP,
+      text: "",
+      removeReaction: true,
+      targetMessageId: "group-target",
+    });
+
+    expect(harness.sentMessages.at(-2)).toEqual(
+      expect.objectContaining({
+        jid: GROUP,
+        payload: {
+          react: {
+            text: "👍",
+            key: expect.objectContaining({
+              remoteJid: GROUP,
+              id: "group-target",
+              fromMe: false,
+              participant: REACTOR,
+            }),
+          },
+        },
+      }),
+    );
+    expect(harness.sentMessages.at(-1)).toEqual(
+      expect.objectContaining({
+        jid: GROUP,
+        payload: {
+          react: {
+            text: "",
+            key: expect.objectContaining({
+              remoteJid: GROUP,
+              id: "group-target",
+              fromMe: false,
+              participant: REACTOR,
+            }),
+          },
+        },
+      }),
+    );
+  });
+
+  test("rejects group outbound reactions after target-key state is gone", async () => {
+    const harness = makeHarness();
+    await harness.start();
+    await expect(
+      harness.adapter.sendMessage({
+        channel: "whatsapp",
+        accountId: account.accountId,
+        chatId: GROUP,
+        text: "",
+        reaction: "👍",
+        targetMessageId: "missing-group-target",
+      }),
+    ).rejects.toThrow(/current adapter process/);
+    expect(harness.sentMessages).toHaveLength(0);
   });
 
   test("enforces group policy and preserves mention semantics", async () => {

--- a/src/channels/whatsapp/reactions-adapter.test.ts
+++ b/src/channels/whatsapp/reactions-adapter.test.ts
@@ -439,6 +439,81 @@ describe("WhatsApp reaction adapter integration", () => {
     expect(harness.sentMessages).toHaveLength(0);
   });
 
+  test("unrefs and clears message-store TTL timers", async () => {
+    const originalSetTimeout = globalThis.setTimeout;
+    const originalClearTimeout = globalThis.clearTimeout;
+    const timers: Array<
+      ReturnType<typeof setTimeout> & { unrefCalled: boolean }
+    > = [];
+    const cleared: unknown[] = [];
+    globalThis.setTimeout = ((callback: unknown, timeout?: number) => {
+      void callback;
+      void timeout;
+      const timer = {
+        unrefCalled: false,
+        unref() {
+          timer.unrefCalled = true;
+        },
+      } as ReturnType<typeof setTimeout> & { unrefCalled: boolean };
+      timers.push(timer);
+      return timer;
+    }) as unknown as typeof setTimeout;
+    globalThis.clearTimeout = ((timer?: unknown) => {
+      if (timer !== undefined) cleared.push(timer);
+    }) as unknown as typeof clearTimeout;
+    try {
+      const harness = makeHarness();
+      await harness.start();
+      await harness.emitUpsert([
+        {
+          key: { remoteJid: REACTOR, id: "timer-target", fromMe: false },
+          message: { conversation: "timer target" },
+          messageTimestamp: Math.floor(Date.now() / 1000),
+        },
+      ]);
+      expect(timers).toHaveLength(1);
+      expect(timers[0]?.unrefCalled).toBe(true);
+      await harness.adapter.stop();
+      expect(cleared).toContain(timers[0]);
+    } finally {
+      globalThis.setTimeout = originalSetTimeout;
+      globalThis.clearTimeout = originalClearTimeout;
+    }
+  });
+
+  test("caps outbound ownership cache", async () => {
+    const harness = makeHarness();
+    await harness.start();
+    const timestamp = Math.floor(Date.now() / 1000);
+    await harness.emitUpsert(
+      Array.from({ length: 5001 }, (_, index) => ({
+        key: {
+          remoteJid: REACTOR,
+          id: `cached-outbound-${index}`,
+          fromMe: true,
+        },
+        message: { conversation: `cached outbound ${index}` },
+        messageTimestamp: timestamp,
+      })),
+    );
+
+    await harness.emit([
+      reactionEntry({
+        targetId: "cached-outbound-0",
+        targetFromMe: false,
+        reactionId: "evicted-cache-target",
+      }),
+      reactionEntry({
+        targetId: "cached-outbound-5000",
+        targetFromMe: false,
+        reactionId: "retained-cache-target",
+      }),
+    ]);
+    expect(harness.delivered.map((message) => message.messageId)).toEqual([
+      "retained-cache-target",
+    ]);
+  });
+
   test("enforces group policy and preserves mention semantics", async () => {
     const cases: Array<{
       groupMode: "disabled" | "mention" | "open";

--- a/src/channels/whatsapp/reactions-adapter.test.ts
+++ b/src/channels/whatsapp/reactions-adapter.test.ts
@@ -464,6 +464,7 @@ describe("WhatsApp reaction adapter integration", () => {
     try {
       const harness = makeHarness();
       await harness.start();
+      const timersAfterStart = timers.length;
       await harness.emitUpsert([
         {
           key: { remoteJid: REACTOR, id: "timer-target", fromMe: false },
@@ -471,10 +472,11 @@ describe("WhatsApp reaction adapter integration", () => {
           messageTimestamp: Math.floor(Date.now() / 1000),
         },
       ]);
-      expect(timers).toHaveLength(1);
-      expect(timers[0]?.unrefCalled).toBe(true);
+      expect(timers).toHaveLength(timersAfterStart + 1);
+      const messageStoreTimer = timers.at(-1);
+      expect(messageStoreTimer?.unrefCalled).toBe(true);
       await harness.adapter.stop();
-      expect(cleared).toContain(timers[0]);
+      expect(cleared).toContain(messageStoreTimer);
     } finally {
       globalThis.setTimeout = originalSetTimeout;
       globalThis.clearTimeout = originalClearTimeout;

--- a/src/channels/whatsapp/reactions-adapter.test.ts
+++ b/src/channels/whatsapp/reactions-adapter.test.ts
@@ -423,6 +423,76 @@ describe("WhatsApp reaction adapter integration", () => {
     );
   });
 
+  test("rejects an outbound reaction target stored for another chat", async () => {
+    const harness = makeHarness();
+    await harness.start();
+    await harness.emitUpsert([
+      {
+        key: {
+          remoteJid: REACTOR,
+          id: "cross-chat-target",
+          fromMe: false,
+        },
+        message: { conversation: "direct message" },
+        messageTimestamp: Math.floor(Date.now() / 1000),
+      },
+    ]);
+
+    await expect(
+      harness.adapter.sendMessage({
+        channel: "whatsapp",
+        accountId: account.accountId,
+        chatId: "15550000003@s.whatsapp.net",
+        text: "",
+        reaction: "👍",
+        targetMessageId: "cross-chat-target",
+      }),
+    ).rejects.toThrow(/different chat/);
+    expect(harness.sentMessages).toHaveLength(0);
+  });
+
+  test("accepts a stored LID target for its canonical phone chat", async () => {
+    const targetLid = "210565536456917@lid";
+    const harness = makeHarness({
+      lidEntries: [{ lid: targetLid, phone: REACTOR }],
+    });
+    await harness.start();
+    await harness.emitUpsert([
+      {
+        key: {
+          remoteJid: targetLid,
+          id: "lid-chat-target",
+          fromMe: false,
+        },
+        message: { conversation: "LID direct message" },
+        messageTimestamp: Math.floor(Date.now() / 1000),
+      },
+    ]);
+
+    await harness.adapter.sendMessage({
+      channel: "whatsapp",
+      accountId: account.accountId,
+      chatId: REACTOR,
+      text: "",
+      reaction: "👍",
+      targetMessageId: "lid-chat-target",
+    });
+    expect(harness.sentMessages.at(-1)).toEqual(
+      expect.objectContaining({
+        jid: REACTOR,
+        payload: {
+          react: {
+            text: "👍",
+            key: expect.objectContaining({
+              remoteJid: targetLid,
+              id: "lid-chat-target",
+            }),
+          },
+        },
+      }),
+    );
+  });
+
   test("rejects group outbound reactions after target-key state is gone", async () => {
     const harness = makeHarness();
     await harness.start();
@@ -617,6 +687,26 @@ describe("WhatsApp reaction adapter integration", () => {
     expect(harness.delivered.map((message) => message.chatId)).toEqual([
       REACTOR,
       "15550000003@s.whatsapp.net",
+    ]);
+  });
+
+  test("replays a reaction claimed by a stale socket generation", async () => {
+    const harness = makeHarness();
+    await harness.start();
+    const reaction = reactionEntry({
+      chatId: GROUP,
+      reactionId: "replayed-reaction",
+      participant: REACTOR,
+    });
+
+    const staleDelivery = harness.emit([reaction]);
+    await harness.adapter.stop();
+    await harness.start();
+    await staleDelivery;
+    await harness.emit([reaction]);
+
+    expect(harness.delivered.map((message) => message.messageId)).toEqual([
+      "replayed-reaction",
     ]);
   });
 

--- a/src/channels/whatsapp/reactions-adapter.test.ts
+++ b/src/channels/whatsapp/reactions-adapter.test.ts
@@ -78,6 +78,8 @@ function makeHarness(
     };
     lidEntries?: Array<{ lid: string; phone: string }>;
     deliver?: (message: InboundChannelMessage) => Promise<void> | void;
+    /** When set, sendMessage returns this as the outbound message ID. */
+    outboundMessageId?: string;
   } = {},
 ) {
   const directory = temporaryDirectory();
@@ -90,6 +92,7 @@ function makeHarness(
   const handlers = new Map<string, (payload: unknown) => unknown>();
   let connectionUpdate: ((update: unknown) => void) | undefined;
   let readCalls = 0;
+  const outboundId = options.outboundMessageId ?? "sent-echo";
   const socket = {
     ev: {
       on(event: string, handler: (payload: unknown) => unknown) {
@@ -104,7 +107,7 @@ function makeHarness(
       return Promise.resolve();
     },
     async sendMessage() {
-      return { key: { id: "sent-echo" } };
+      return { key: { id: outboundId, fromMe: true, remoteJid: REACTOR } };
     },
     async sendPresenceUpdate() {},
   };
@@ -146,6 +149,9 @@ function makeHarness(
     },
     async emit(entries: unknown[]) {
       await handlers.get("messages.reaction")?.(entries);
+    },
+    async emitUpsert(messages: unknown[], type: string = "notify") {
+      await handlers.get("messages.upsert")?.({ type, messages });
     },
   };
 }
@@ -388,5 +394,107 @@ describe("WhatsApp reaction adapter integration", () => {
       "reject-me",
       "after-rejection",
     ]);
+  });
+
+  test("LID reaction against own outbound with target.fromMe:false is recognized", async () => {
+    // Exact live-evidence shape: Baileys delivers the reaction via a LID chat
+    // where it cannot equate Samantha's PN identity, so target.fromMe is false
+    // even though we sent the message.
+    const LID = "210565536456917@lid";
+    const harness = makeHarness({
+      lidEntries: [{ lid: LID, phone: REACTOR }],
+      outboundMessageId: "outbound-1",
+    });
+    await harness.start();
+
+    // Step 1: send outbound text — populates sentMessageIds + messageStore.
+    await harness.adapter.sendMessage({
+      channel: "whatsapp",
+      accountId: account.accountId,
+      chatId: REACTOR,
+      text: "hello",
+    });
+
+    // Step 2: emit outbound upsert echo — sentMessageIds entry consumed,
+    // but messageStore entry survives with key.fromMe: true.
+    await harness.emitUpsert([
+      {
+        key: {
+          remoteJid: LID,
+          id: "outbound-1",
+          fromMe: true,
+        },
+        message: { conversation: "hello" },
+        messageTimestamp: Math.floor(Date.now() / 1000),
+      },
+    ]);
+
+    // Step 3: emit real-shape LID reaction with target.fromMe: false.
+    await harness.emit([
+      reactionEntry({
+        chatId: LID,
+        targetId: "outbound-1",
+        targetFromMe: false,
+        reactionId: "lid-reaction-1",
+        participant: LID,
+      }),
+    ]);
+
+    expect(harness.delivered).toHaveLength(1);
+    expect(harness.delivered[0]?.reaction).toEqual({
+      action: "added",
+      emoji: "👍",
+      targetMessageId: "outbound-1",
+      targetSenderId: "15550000001",
+    });
+  });
+
+  test("unknown targetFromMe:false target remains dropped", async () => {
+    const harness = makeHarness();
+    await harness.start();
+
+    await harness.emit([
+      reactionEntry({
+        targetId: "not-in-any-store",
+        targetFromMe: false,
+        reactionId: "unknown-target",
+      }),
+    ]);
+    expect(harness.delivered).toHaveLength(0);
+  });
+
+  test("target stored from inbound message with key.fromMe:false remains dropped", async () => {
+    // An inbound message (fromMe: false) is stored in messageStore by the
+    // upsert handler. A reaction to it must NOT be treated as "ours."
+    const harness = makeHarness();
+    await harness.start();
+
+    // Simulate an inbound message arriving via upsert.
+    await harness.emitUpsert([
+      {
+        key: {
+          remoteJid: REACTOR,
+          id: "inbound-msg-1",
+          fromMe: false,
+        },
+        message: { conversation: "hi from user" },
+        messageTimestamp: Math.floor(Date.now() / 1000),
+        pushName: "User",
+      },
+    ]);
+    // The upsert handler should have delivered it as a normal inbound.
+    expect(harness.delivered).toHaveLength(1);
+
+    // Now react to that inbound message — target.fromMe is false and the
+    // messageStore entry has fromMe: false. Must be dropped.
+    await harness.emit([
+      reactionEntry({
+        targetId: "inbound-msg-1",
+        targetFromMe: false,
+        reactionId: "react-to-inbound",
+      }),
+    ]);
+    // Still just the original inbound, no reaction delivered.
+    expect(harness.delivered).toHaveLength(1);
   });
 });

--- a/src/channels/whatsapp/reactions-adapter.test.ts
+++ b/src/channels/whatsapp/reactions-adapter.test.ts
@@ -1,0 +1,392 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { InboundChannelMessage } from "@/channels/types";
+import {
+  createWhatsAppAdapter,
+  type WhatsAppAdapterDependencies,
+} from "./adapter";
+import { createLidStore } from "./lid-store";
+
+const PHONE = "15550000001@s.whatsapp.net";
+const REACTOR = "15550000002@s.whatsapp.net";
+const GROUP = "120363-987@g.us";
+
+const temporaryDirectories: string[] = [];
+const trackedAdapters: Array<ReturnType<typeof createWhatsAppAdapter>> = [];
+
+const account = {
+  channel: "whatsapp" as const,
+  accountId: "reaction-adapter",
+  displayName: "WhatsApp",
+  enabled: true,
+  dmPolicy: "pairing" as const,
+  allowedUsers: [],
+  agentId: "agent-1",
+  selfChatMode: false,
+  groupMode: "open" as const,
+  createdAt: new Date(0).toISOString(),
+  updatedAt: new Date(0).toISOString(),
+};
+
+function temporaryDirectory(): string {
+  const directory = mkdtempSync(join(tmpdir(), "whatsapp-reactions-test-"));
+  temporaryDirectories.push(directory);
+  return directory;
+}
+
+function reactionEntry(
+  overrides: {
+    chatId?: string;
+    targetId?: string;
+    reactionId?: string;
+    targetFromMe?: boolean;
+    reactionFromMe?: boolean;
+    participant?: string;
+    text?: unknown;
+    senderTimestampMs?: unknown;
+  } = {},
+): Record<string, unknown> {
+  const chatId = overrides.chatId ?? REACTOR;
+  return {
+    key: {
+      remoteJid: chatId,
+      id: overrides.targetId ?? "target-message",
+      fromMe: overrides.targetFromMe ?? true,
+    },
+    reaction: {
+      key: {
+        remoteJid: chatId,
+        id: overrides.reactionId ?? "reaction-event",
+        fromMe: overrides.reactionFromMe ?? false,
+        participant: overrides.participant ?? REACTOR,
+      },
+      text: overrides.text === undefined ? "👍" : overrides.text,
+      senderTimestampMs:
+        overrides.senderTimestampMs === undefined
+          ? Date.now()
+          : overrides.senderTimestampMs,
+    },
+  };
+}
+
+function makeHarness(
+  options: {
+    account?: Omit<Partial<typeof account>, "groupMode"> & {
+      groupMode?: "disabled" | "mention" | "open";
+    };
+    lidEntries?: Array<{ lid: string; phone: string }>;
+    deliver?: (message: InboundChannelMessage) => Promise<void> | void;
+  } = {},
+) {
+  const directory = temporaryDirectory();
+  const lidPath = join(directory, "lid-mappings.json");
+  if (options.lidEntries) {
+    writeFileSync(lidPath, JSON.stringify({ entries: options.lidEntries }));
+  }
+  const delivered: InboundChannelMessage[] = [];
+  const eventNames: string[] = [];
+  const handlers = new Map<string, (payload: unknown) => unknown>();
+  let connectionUpdate: ((update: unknown) => void) | undefined;
+  let readCalls = 0;
+  const socket = {
+    ev: {
+      on(event: string, handler: (payload: unknown) => unknown) {
+        eventNames.push(event);
+        handlers.set(event, handler);
+      },
+    },
+    user: { id: PHONE, lid: "999999@lid" },
+    ws: { close() {} },
+    readMessages() {
+      readCalls += 1;
+      return Promise.resolve();
+    },
+    async sendMessage() {
+      return { key: { id: "sent-echo" } };
+    },
+    async sendPresenceUpdate() {},
+  };
+  const createSocket: NonNullable<
+    WhatsAppAdapterDependencies["createSocket"]
+  > = async (params) => {
+    connectionUpdate = params.onConnectionUpdate as unknown as (
+      update: unknown,
+    ) => void;
+    return {
+      sock: socket,
+      saveCreds: async () => undefined,
+      DisconnectReason: {},
+      release: () => undefined,
+    };
+  };
+  const adapter = createWhatsAppAdapter(
+    { ...account, ...options.account },
+    {
+      createSocket,
+      loadRuntimeModule: async () => ({}),
+      lidStore: createLidStore(lidPath),
+    },
+  );
+  adapter.onMessage = async (message) => {
+    delivered.push(message);
+    await options.deliver?.(message);
+  };
+  trackedAdapters.push(adapter);
+
+  return {
+    adapter,
+    delivered,
+    eventNames,
+    readCalls: () => readCalls,
+    async start() {
+      await adapter.start();
+      connectionUpdate?.({ connection: "open" });
+    },
+    async emit(entries: unknown[]) {
+      await handlers.get("messages.reaction")?.(entries);
+    },
+  };
+}
+
+afterEach(async () => {
+  try {
+    for (const adapter of trackedAdapters) {
+      await adapter.stop().catch(() => undefined);
+    }
+  } finally {
+    trackedAdapters.length = 0;
+    for (const directory of temporaryDirectories) {
+      rmSync(directory, { recursive: true, force: true });
+    }
+    temporaryDirectories.length = 0;
+  }
+});
+
+describe("WhatsApp reaction adapter integration", () => {
+  test("registers messages.reaction and dispatches a direct reaction", async () => {
+    const harness = makeHarness();
+    await harness.start();
+    expect(harness.eventNames).toEqual([
+      "messages.upsert",
+      "messages.reaction",
+    ]);
+    await harness.emit([reactionEntry()]);
+    expect(harness.delivered).toHaveLength(1);
+    expect(harness.delivered[0]?.reaction).toEqual({
+      action: "added",
+      emoji: "👍",
+      targetMessageId: "target-message",
+      targetSenderId: "15550000001",
+    });
+  });
+
+  test("emits structured text and canonical target metadata", async () => {
+    const harness = makeHarness();
+    await harness.start();
+    const raw = reactionEntry({ reactionId: "reaction-1" });
+    await harness.emit([raw]);
+    const message = harness.delivered[0];
+    expect(message).toEqual(
+      expect.objectContaining({
+        chatId: REACTOR,
+        senderId: "15550000002",
+        text: "15550000002 reacted 👍",
+        messageId: "reaction-1",
+        chatType: "direct",
+        isMention: true,
+        raw,
+      }),
+    );
+    expect(harness.readCalls()).toBe(0);
+  });
+
+  test("dispatches empty and null reactions as removals", async () => {
+    const harness = makeHarness();
+    await harness.start();
+    await harness.emit([
+      reactionEntry({ reactionId: "removed-empty", text: "" }),
+      reactionEntry({ reactionId: "removed-null", text: null }),
+    ]);
+    expect(harness.delivered.map((message) => message.reaction)).toEqual([
+      {
+        action: "removed",
+        emoji: "",
+        targetMessageId: "target-message",
+        targetSenderId: "15550000001",
+      },
+      {
+        action: "removed",
+        emoji: "",
+        targetMessageId: "target-message",
+        targetSenderId: "15550000001",
+      },
+    ]);
+  });
+
+  test("resolves known direct LIDs and fails closed for unknown/conflicting LIDs", async () => {
+    const known = makeHarness({
+      lidEntries: [{ lid: "777777@lid", phone: REACTOR }],
+    });
+    await known.start();
+    await known.emit([
+      reactionEntry({
+        chatId: "777777@lid",
+        participant: "777777@lid",
+      }),
+    ]);
+    expect(known.delivered[0]?.chatId).toBe(REACTOR);
+    expect(known.delivered[0]?.senderId).toBe("15550000002");
+    expect(known.delivered[0]?.reaction?.targetSenderId).toBe("15550000001");
+
+    const unknown = makeHarness();
+    await unknown.start();
+    await unknown.emit([
+      reactionEntry({
+        chatId: "888888@lid",
+        participant: "888888@lid",
+      }),
+    ]);
+    expect(unknown.delivered).toHaveLength(0);
+
+    const conflicting = makeHarness({
+      lidEntries: [
+        { lid: "999888@lid", phone: REACTOR },
+        { lid: "999888@lid", phone: "15550000003@s.whatsapp.net" },
+      ],
+    });
+    await conflicting.start();
+    await conflicting.emit([
+      reactionEntry({
+        chatId: "999888@lid",
+        participant: "999888@lid",
+      }),
+    ]);
+    expect(conflicting.delivered).toHaveLength(0);
+  });
+
+  test("enforces group policy and preserves mention semantics", async () => {
+    const cases: Array<{
+      groupMode: "disabled" | "mention" | "open";
+      allowedGroups?: string[];
+      expected: boolean;
+      id: string;
+    }> = [
+      { groupMode: "disabled", expected: false, id: "group-disabled" },
+      { groupMode: "open", expected: true, id: "group-open" },
+      {
+        groupMode: "open",
+        allowedGroups: ["120363-other@g.us"],
+        expected: false,
+        id: "group-denied",
+      },
+      {
+        groupMode: "mention",
+        allowedGroups: [GROUP],
+        expected: true,
+        id: "group-mention",
+      },
+    ];
+    for (const policy of cases) {
+      const harness = makeHarness({ account: policy });
+      await harness.start();
+      await harness.emit([
+        reactionEntry({
+          chatId: GROUP,
+          reactionId: policy.id,
+          participant: REACTOR,
+        }),
+      ]);
+      expect(harness.delivered).toHaveLength(policy.expected ? 1 : 0);
+      if (policy.expected) {
+        expect(harness.delivered[0]?.chatType).toBe("channel");
+        expect(harness.delivered[0]?.isMention).toBe(
+          policy.groupMode === "mention",
+        );
+      }
+    }
+  });
+
+  test("drops non-owned targets and own reaction envelopes", async () => {
+    const harness = makeHarness();
+    await harness.start();
+    await harness.emit([
+      reactionEntry({ targetId: "not-ours", targetFromMe: false }),
+      reactionEntry({ reactionId: "own-reaction", reactionFromMe: true }),
+    ]);
+    expect(harness.delivered).toHaveLength(0);
+  });
+
+  test("drops old, sent-echo, and duplicate reaction events", async () => {
+    const harness = makeHarness();
+    await harness.start();
+    await harness.emit([
+      reactionEntry({
+        reactionId: "old",
+        senderTimestampMs: Date.now() - 10_000,
+      }),
+    ]);
+    await harness.emit([
+      reactionEntry({ reactionId: "duplicate" }),
+      reactionEntry({ reactionId: "duplicate" }),
+    ]);
+    await harness.adapter.sendMessage({
+      channel: "whatsapp",
+      accountId: account.accountId,
+      chatId: REACTOR,
+      text: "",
+      reaction: "👍",
+      targetMessageId: "target-message",
+    });
+    await harness.emit([reactionEntry({ reactionId: "sent-echo" })]);
+    expect(harness.delivered).toHaveLength(1);
+    expect(harness.delivered[0]?.messageId).toBe("duplicate");
+  });
+
+  test("deduplicates reaction IDs within a canonical chat only", async () => {
+    const harness = makeHarness();
+    await harness.start();
+    await harness.emit([
+      reactionEntry({
+        chatId: REACTOR,
+        reactionId: "shared-id",
+        participant: REACTOR,
+      }),
+      reactionEntry({
+        chatId: "15550000003@s.whatsapp.net",
+        reactionId: "shared-id",
+        participant: "15550000003@s.whatsapp.net",
+      }),
+      reactionEntry({
+        chatId: REACTOR,
+        reactionId: "shared-id",
+        participant: REACTOR,
+      }),
+    ]);
+    expect(harness.delivered.map((message) => message.chatId)).toEqual([
+      REACTOR,
+      "15550000003@s.whatsapp.net",
+    ]);
+  });
+
+  test("continues after malformed entries and rejected delivery", async () => {
+    const rejected = makeHarness({
+      deliver: async (message) => {
+        if (message.messageId === "reject-me") {
+          throw new Error("delivery failed");
+        }
+      },
+    });
+    await rejected.start();
+    await rejected.emit([
+      { malformed: true },
+      reactionEntry({ reactionId: "reject-me" }),
+      reactionEntry({ reactionId: "after-rejection" }),
+    ]);
+    expect(rejected.delivered.map((message) => message.messageId)).toEqual([
+      "reject-me",
+      "after-rejection",
+    ]);
+  });
+});

--- a/src/channels/whatsapp/reactions.test.ts
+++ b/src/channels/whatsapp/reactions.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, test } from "bun:test";
+import {
+  isWhatsAppReactionGroupEligible,
+  parseWhatsAppReactionEntry,
+} from "./reactions";
+
+function entry(overrides: Record<string, unknown> = {}) {
+  return {
+    key: {
+      remoteJid: "120363-987@g.us",
+      id: "target-message",
+      fromMe: true,
+      participant: "15550000002@s.whatsapp.net",
+    },
+    reaction: {
+      key: {
+        remoteJid: "120363-987:4@g.us",
+        id: "reaction-event",
+        participant: "15550000003@s.whatsapp.net",
+      },
+      text: "👍",
+      senderTimestampMs: 1710000000123,
+    },
+    ...overrides,
+  };
+}
+
+describe("WhatsApp reaction parser", () => {
+  test("parses an added emoji and preserves both keys", () => {
+    const parsed = parseWhatsAppReactionEntry(entry());
+    expect(parsed).toEqual({
+      targetKey: expect.objectContaining({
+        id: "target-message",
+        remoteJid: "120363-987@g.us",
+      }),
+      reactionKey: expect.objectContaining({
+        id: "reaction-event",
+        remoteJid: "120363-987@g.us",
+      }),
+      chatId: "120363-987@g.us",
+      reactionMessageId: "reaction-event",
+      targetMessageId: "target-message",
+      targetFromMe: true,
+      reactorParticipant: "15550000003@s.whatsapp.net",
+      action: "added",
+      emoji: "👍",
+      timestampMs: 1710000000123,
+    });
+  });
+
+  test("parses empty, null, and undefined text as removals", () => {
+    for (const text of ["", "   ", null, undefined]) {
+      const parsed = parseWhatsAppReactionEntry(
+        entry({ reaction: { ...entry().reaction, text } }),
+      );
+      expect(parsed?.action).toBe("removed");
+      expect(parsed?.emoji).toBe("");
+    }
+  });
+
+  test("preserves group participants and accepts numeric/toNumber timestamps", () => {
+    const numeric = parseWhatsAppReactionEntry(entry());
+    expect(numeric?.reactorParticipant).toBe("15550000003@s.whatsapp.net");
+    expect(numeric?.timestampMs).toBe(1710000000123);
+
+    const boxed = parseWhatsAppReactionEntry(
+      entry({
+        reaction: {
+          ...entry().reaction,
+          senderTimestampMs: { toNumber: () => 1710000000999 },
+        },
+      }),
+    );
+    expect(boxed?.timestampMs).toBe(1710000000999);
+  });
+
+  test("rejects malformed entries without throwing", () => {
+    const invalidEntries: unknown[] = [
+      entry({ key: { remoteJid: "120363-987@g.us" } }),
+      entry({ reaction: { key: { remoteJid: "120363-987@g.us" } } }),
+      entry({ key: "not-an-object" }),
+      entry({
+        reaction: {
+          ...entry().reaction,
+          key: { remoteJid: "120363-988@g.us", id: "reaction-event" },
+        },
+      }),
+      entry({
+        reaction: { ...entry().reaction, text: { emoji: "👍" } },
+      }),
+      entry({
+        reaction: { ...entry().reaction, text: "x".repeat(65) },
+      }),
+      entry({ key: { remoteJid: "malformed", id: "target-message" } }),
+    ];
+
+    for (const invalid of invalidEntries) {
+      expect(() => parseWhatsAppReactionEntry(invalid)).not.toThrow();
+      expect(parseWhatsAppReactionEntry(invalid)).toBeNull();
+    }
+  });
+});
+
+describe("WhatsApp reaction group policy", () => {
+  const groupJid = "120363-987@g.us";
+
+  test("enforces disabled, allowlist, open, and mention behavior", () => {
+    expect(
+      isWhatsAppReactionGroupEligible({
+        groupMode: "disabled",
+        groupJid,
+        targetFromMe: true,
+      }),
+    ).toBe(false);
+    expect(
+      isWhatsAppReactionGroupEligible({
+        groupMode: "open",
+        allowedGroups: ["120363-other@g.us"],
+        groupJid,
+        targetFromMe: true,
+      }),
+    ).toBe(false);
+    expect(
+      isWhatsAppReactionGroupEligible({
+        groupMode: "open",
+        allowedGroups: [groupJid],
+        groupJid: "120363-987:4@g.us",
+        targetFromMe: true,
+      }),
+    ).toBe(true);
+    expect(
+      isWhatsAppReactionGroupEligible({
+        groupMode: "mention",
+        groupJid,
+        targetFromMe: true,
+      }),
+    ).toBe(true);
+    expect(
+      isWhatsAppReactionGroupEligible({
+        groupMode: "mention",
+        groupJid,
+        targetFromMe: false,
+      }),
+    ).toBe(false);
+  });
+});

--- a/src/channels/whatsapp/reactions.test.ts
+++ b/src/channels/whatsapp/reactions.test.ts
@@ -58,6 +58,35 @@ describe("WhatsApp reaction parser", () => {
     }
   });
 
+  test("preserves Baileys PN/LID identity fields on reaction keys", () => {
+    const parsed = parseWhatsAppReactionEntry(
+      entry({
+        reaction: {
+          ...entry().reaction,
+          key: {
+            remoteJid: "120363-987@g.us",
+            id: "reaction-event",
+            participant: "200000@lid",
+            participantPn: "15550000003@s.whatsapp.net",
+            participantLid: "200000@lid",
+            senderPn: "15550000004@s.whatsapp.net",
+            senderLid: "300000@lid",
+          },
+        },
+      }),
+    );
+
+    expect(parsed?.reactionKey).toEqual(
+      expect.objectContaining({
+        participant: "200000@lid",
+        participantPn: "15550000003@s.whatsapp.net",
+        participantLid: "200000@lid",
+        senderPn: "15550000004@s.whatsapp.net",
+        senderLid: "300000@lid",
+      }),
+    );
+  });
+
   test("preserves group participants and accepts numeric/toNumber timestamps", () => {
     const numeric = parseWhatsAppReactionEntry(entry());
     expect(numeric?.reactorParticipant).toBe("15550000003@s.whatsapp.net");
@@ -90,6 +119,16 @@ describe("WhatsApp reaction parser", () => {
       }),
       entry({
         reaction: { ...entry().reaction, text: "x".repeat(65) },
+      }),
+      entry({
+        reaction: {
+          ...entry().reaction,
+          key: {
+            remoteJid: "120363-987@g.us",
+            id: "reaction-event",
+            senderPn: 123,
+          },
+        },
       }),
       entry({ key: { remoteJid: "malformed", id: "target-message" } }),
     ];

--- a/src/channels/whatsapp/reactions.ts
+++ b/src/channels/whatsapp/reactions.ts
@@ -6,6 +6,10 @@ export interface WhatsAppReactionKey {
   id: string;
   fromMe?: boolean;
   participant?: string;
+  senderPn?: string;
+  senderLid?: string;
+  participantPn?: string;
+  participantLid?: string;
   [key: string]: unknown;
 }
 
@@ -49,20 +53,28 @@ function parseKey(value: unknown): WhatsAppReactionKey | null {
   if (value.fromMe !== undefined && typeof value.fromMe !== "boolean") {
     return null;
   }
-  if (
-    value.participant !== undefined &&
-    typeof value.participant !== "string"
-  ) {
-    return null;
+  const optionalJidFields = [
+    "participant",
+    "senderPn",
+    "senderLid",
+    "participantPn",
+    "participantLid",
+  ] as const;
+  for (const field of optionalJidFields) {
+    if (value[field] !== undefined && typeof value[field] !== "string") {
+      return null;
+    }
   }
   return {
     ...value,
     id: value.id,
     remoteJid: typeof value.remoteJid === "string" ? value.remoteJid : "",
     ...(value.fromMe === undefined ? {} : { fromMe: value.fromMe }),
-    ...(value.participant === undefined
-      ? {}
-      : { participant: value.participant }),
+    ...Object.fromEntries(
+      optionalJidFields.flatMap((field) =>
+        value[field] === undefined ? [] : [[field, value[field]]],
+      ),
+    ),
   };
 }
 

--- a/src/channels/whatsapp/reactions.ts
+++ b/src/channels/whatsapp/reactions.ts
@@ -1,0 +1,153 @@
+import type { WhatsAppGroupMode } from "@/channels/types";
+import { isStrictLidJid, isStrictPhoneJid, stripDeviceSuffix } from "./jid";
+
+export interface WhatsAppReactionKey {
+  remoteJid: string;
+  id: string;
+  fromMe?: boolean;
+  participant?: string;
+  [key: string]: unknown;
+}
+
+export interface WhatsAppReaction {
+  targetKey: WhatsAppReactionKey;
+  reactionKey: WhatsAppReactionKey;
+  chatId: string;
+  reactionMessageId: string;
+  targetMessageId: string;
+  targetFromMe: boolean;
+  reactorParticipant?: string;
+  action: "added" | "removed";
+  emoji: string;
+  timestampMs?: number;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object";
+}
+
+function canonicalChatJid(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const normalized = stripDeviceSuffix(value.trim());
+  if (!normalized) return null;
+  const isGroup = /^\d[\d-]*@g\.us$/.test(normalized);
+  if (
+    !isGroup &&
+    !isStrictPhoneJid(normalized) &&
+    !isStrictLidJid(normalized)
+  ) {
+    return null;
+  }
+  return normalized;
+}
+
+function parseKey(value: unknown): WhatsAppReactionKey | null {
+  if (!isRecord(value)) return null;
+  if (typeof value.id !== "string" || value.id.trim().length === 0) {
+    return null;
+  }
+  if (value.fromMe !== undefined && typeof value.fromMe !== "boolean") {
+    return null;
+  }
+  if (
+    value.participant !== undefined &&
+    typeof value.participant !== "string"
+  ) {
+    return null;
+  }
+  return {
+    ...value,
+    id: value.id,
+    remoteJid: typeof value.remoteJid === "string" ? value.remoteJid : "",
+    ...(value.fromMe === undefined ? {} : { fromMe: value.fromMe }),
+    ...(value.participant === undefined
+      ? {}
+      : { participant: value.participant }),
+  };
+}
+
+function parseTimestamp(value: unknown): number | undefined {
+  if (typeof value === "number") {
+    return Number.isFinite(value) && value >= 0 ? value : undefined;
+  }
+  if (!isRecord(value) || typeof value.toNumber !== "function") {
+    return undefined;
+  }
+  try {
+    const numeric = value.toNumber();
+    return typeof numeric === "number" &&
+      Number.isFinite(numeric) &&
+      numeric >= 0
+      ? numeric
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/** Parse one Baileys `messages.reaction` entry without resolving identities. */
+export function parseWhatsAppReactionEntry(
+  entry: unknown,
+): WhatsAppReaction | null {
+  try {
+    if (!isRecord(entry) || !isRecord(entry.reaction)) return null;
+    const targetKey = parseKey(entry.key);
+    const reactionKey = parseKey(entry.reaction.key);
+    if (!targetKey || !reactionKey) return null;
+
+    const targetChatId = canonicalChatJid(targetKey.remoteJid);
+    const reactionChatId = canonicalChatJid(reactionKey.remoteJid);
+    if (!targetChatId || targetChatId !== reactionChatId) return null;
+
+    const text = entry.reaction.text;
+    if (text !== null && text !== undefined && typeof text !== "string") {
+      return null;
+    }
+    const emoji = typeof text === "string" ? text.trim() : "";
+    if (emoji.length > 64) return null;
+
+    return {
+      targetKey: {
+        ...targetKey,
+        remoteJid: targetChatId,
+        id: targetKey.id,
+      },
+      reactionKey: {
+        ...reactionKey,
+        remoteJid: targetChatId,
+        id: reactionKey.id,
+      },
+      chatId: targetChatId,
+      reactionMessageId: reactionKey.id,
+      targetMessageId: targetKey.id,
+      targetFromMe: targetKey.fromMe === true,
+      reactorParticipant:
+        typeof reactionKey.participant === "string"
+          ? reactionKey.participant
+          : undefined,
+      action: emoji ? "added" : "removed",
+      emoji: emoji || "",
+      timestampMs: parseTimestamp(entry.reaction.senderTimestampMs),
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function isWhatsAppReactionGroupEligible(params: {
+  groupMode: WhatsAppGroupMode;
+  allowedGroups?: string[];
+  groupJid: string;
+  targetFromMe: boolean;
+}): boolean {
+  const canonicalGroupJid = stripDeviceSuffix(params.groupJid);
+  if (params.groupMode === "disabled") return false;
+  if (
+    params.allowedGroups?.length &&
+    !params.allowedGroups.includes(canonicalGroupJid)
+  ) {
+    return false;
+  }
+  if (params.targetFromMe !== true) return false;
+  return params.groupMode === "open" || params.groupMode === "mention";
+}

--- a/src/channels/whatsapp/reconnect-scheduler.ts
+++ b/src/channels/whatsapp/reconnect-scheduler.ts
@@ -1,0 +1,26 @@
+export type WhatsAppReconnectScheduler = {
+  now(): number;
+  schedule(
+    delayMs: number,
+    callback: () => void,
+    options?: { unref?: boolean },
+  ): { cancel(): void };
+};
+
+export type WhatsAppReconnectTimer = {
+  generation: number;
+  task: { cancel(): void } | null;
+};
+
+export function createDefaultWhatsAppReconnectScheduler(): WhatsAppReconnectScheduler {
+  return {
+    now: () => Date.now(),
+    schedule(delayMs, callback, options) {
+      const timer = setTimeout(callback, delayMs) as ReturnType<
+        typeof setTimeout
+      > & { unref?: () => void };
+      if (options?.unref) timer.unref?.();
+      return { cancel: () => clearTimeout(timer) };
+    },
+  };
+}

--- a/src/channels/whatsapp/session.ts
+++ b/src/channels/whatsapp/session.ts
@@ -89,6 +89,10 @@ type WhatsAppConnectionUpdate = Record<string, unknown> & {
   };
 };
 
+export type WhatsAppConnectionUpdateResult = {
+  claimedConnectionState?: boolean;
+};
+
 type WhatsAppAuthState = {
   creds: unknown;
   keys: unknown;
@@ -265,7 +269,10 @@ export async function createWhatsAppSocket(params: {
   accountId: string;
   printQr?: boolean;
   messageStore?: Map<string, unknown>;
-  onConnectionUpdate?: (update: WhatsAppConnectionUpdate) => void;
+  loadRuntimeModule?: typeof loadWhatsAppModule;
+  onConnectionUpdate?: (
+    update: WhatsAppConnectionUpdate,
+  ) => WhatsAppConnectionUpdateResult | undefined;
 }): Promise<CreateSocketResult> {
   installWhatsAppConsoleFilters();
   const authDir = getWhatsAppAuthDir(params.accountId);
@@ -274,7 +281,7 @@ export async function createWhatsAppSocket(params: {
   setWhatsAppConnectionState(params.accountId, { status: "connecting" });
 
   try {
-    const mod = await loadWhatsAppModule();
+    const mod = await (params.loadRuntimeModule ?? loadWhatsAppModule)();
     const runtime = mod as WhatsAppRuntimeRecord;
     const makeWASocket = resolveMakeWASocket(runtime);
     const useMultiFileAuthState = runtime.useMultiFileAuthState;
@@ -333,8 +340,10 @@ export async function createWhatsAppSocket(params: {
 
     sock.ev?.on?.("connection.update", async (payload?: unknown) => {
       const update = (payload ?? {}) as WhatsAppConnectionUpdate;
-      params.onConnectionUpdate?.(update);
-      if (update.qr) {
+      const updateResult = params.onConnectionUpdate?.(update);
+      const claimedConnectionState =
+        updateResult?.claimedConnectionState === true;
+      if (update.qr && !claimedConnectionState) {
         const qrMod = await loadQrCodeTerminalModule().catch(() => null);
         const qrTerminal = renderQrTerminal(qrMod, update.qr);
         setWhatsAppConnectionState(params.accountId, {
@@ -353,7 +362,7 @@ export async function createWhatsAppSocket(params: {
           }
         }
       }
-      if (update.connection === "open") {
+      if (update.connection === "open" && !claimedConnectionState) {
         setWhatsAppConnectionState(params.accountId, {
           status: "connected",
           phoneJid: sock.user?.id,
@@ -362,6 +371,7 @@ export async function createWhatsAppSocket(params: {
       }
       if (update.connection === "close") {
         sessionLease.release();
+        if (claimedConnectionState) return;
         const statusCode = update.lastDisconnect?.error?.output?.statusCode;
         const disconnectReason = runtime.DisconnectReason as
           | Record<string, number>

--- a/src/channels/whatsapp/typing-adapter.test.ts
+++ b/src/channels/whatsapp/typing-adapter.test.ts
@@ -1,0 +1,313 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type {
+  ChannelAdapter,
+  ChannelTurnLifecycleEvent,
+  ChannelTurnSource,
+} from "@/channels/types";
+import {
+  createWhatsAppAdapter,
+  type WhatsAppAdapterDependencies,
+} from "./adapter";
+import { createLidStore } from "./lid-store";
+
+const account = {
+  channel: "whatsapp" as const,
+  accountId: "typing-adapter",
+  displayName: "WhatsApp",
+  enabled: true,
+  dmPolicy: "pairing" as const,
+  allowedUsers: [],
+  agentId: "agent-1",
+  selfChatMode: false,
+  groupMode: "open" as const,
+  waitingBehavior: "typing_indicator" as const,
+  createdAt: new Date(0).toISOString(),
+  updatedAt: new Date(0).toISOString(),
+};
+
+function source(overrides: Partial<ChannelTurnSource> = {}): ChannelTurnSource {
+  return {
+    channel: "whatsapp",
+    accountId: account.accountId,
+    chatId: "15550000001@s.whatsapp.net",
+    messageId: "message-1",
+    threadId: null,
+    agentId: "agent-1",
+    conversationId: "conversation-1",
+    ...overrides,
+  };
+}
+
+function lifecycle(
+  type: ChannelTurnLifecycleEvent["type"],
+  overrides: Record<string, unknown> = {},
+): ChannelTurnLifecycleEvent {
+  if (type === "queued") {
+    return {
+      type,
+      source: source(),
+      ...overrides,
+    } as ChannelTurnLifecycleEvent;
+  }
+  return {
+    type,
+    batchId: "batch-1",
+    sources: [source()],
+    ...(type === "finished"
+      ? { outcome: "completed" as const, stopReason: "end_turn" as const }
+      : {}),
+    ...overrides,
+  } as ChannelTurnLifecycleEvent;
+}
+
+type PresenceCall = { jid?: string; presence: string };
+
+const temporaryDirectories: string[] = [];
+const trackedAdapters: ChannelAdapter[] = [];
+
+function temporaryDirectory(): string {
+  const directory = mkdtempSync(join(tmpdir(), "whatsapp-typing-test-"));
+  temporaryDirectories.push(directory);
+  return directory;
+}
+
+function presenceNames(harness: { presence: PresenceCall[] }): string[] {
+  return harness.presence.map((call) => call.presence);
+}
+
+function wait(milliseconds: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+afterEach(async () => {
+  try {
+    for (const adapter of trackedAdapters) {
+      await adapter.stop().catch(() => undefined);
+    }
+  } finally {
+    trackedAdapters.length = 0;
+    for (const directory of temporaryDirectories) {
+      rmSync(directory, { recursive: true, force: true });
+    }
+    temporaryDirectories.length = 0;
+  }
+});
+
+function makeHarness(
+  directory: string,
+  options: {
+    sendPresence?: (presence: string, jid?: string) => Promise<void> | void;
+    waitingBehavior?: "off" | "typing_indicator";
+    lidMapping?: { lidJid: string; phoneJid: string };
+  } = {},
+) {
+  const presence: PresenceCall[] = [];
+  let connectionUpdate: ((update: Record<string, unknown>) => void) | undefined;
+  let socketClosed = false;
+  const socket = {
+    ev: {
+      on(_event: string, _handler: (payload: unknown) => void) {},
+    },
+    ws: {
+      close() {
+        socketClosed = true;
+      },
+    },
+    async sendMessage(_jid: string, _payload: Record<string, unknown>) {
+      return { key: { id: "sent" } };
+    },
+    sendPresenceUpdate(presenceName: string, jid?: string) {
+      presence.push({ jid, presence: presenceName });
+      return options.sendPresence?.(presenceName, jid);
+    },
+  };
+  const createSocket: NonNullable<
+    WhatsAppAdapterDependencies["createSocket"]
+  > = async (socketOptions) => {
+    connectionUpdate = socketOptions.onConnectionUpdate as unknown as (
+      update: Record<string, unknown>,
+    ) => void;
+    return {
+      sock: socket,
+      saveCreds: async () => undefined,
+      DisconnectReason: {},
+      release: () => undefined,
+    };
+  };
+  const lidStore = createLidStore(join(directory, "lid-mappings.json"));
+  if (options.lidMapping) {
+    lidStore.record(options.lidMapping.lidJid, options.lidMapping.phoneJid);
+  }
+  const adapter = createWhatsAppAdapter(
+    {
+      ...account,
+      waitingBehavior: options.waitingBehavior ?? account.waitingBehavior,
+    },
+    {
+      createSocket,
+      loadRuntimeModule: async () => ({}),
+      lidStore,
+    },
+  );
+  trackedAdapters.push(adapter);
+  return {
+    adapter,
+    presence,
+    get socketClosed() {
+      return socketClosed;
+    },
+    emitConnection(update: Record<string, unknown>) {
+      connectionUpdate?.(update);
+    },
+  };
+}
+
+describe("WhatsApp adapter typing lifecycle", () => {
+  test("queued is inert and processing-to-finished composes then pauses", async () => {
+    const harness = makeHarness(temporaryDirectory());
+    await harness.adapter.start();
+    const turn = source();
+    await harness.adapter.handleTurnLifecycleEvent?.(
+      lifecycle("queued", { source: turn }),
+    );
+    expect(presenceNames(harness)).toEqual([]);
+
+    await harness.adapter.handleTurnLifecycleEvent?.(
+      lifecycle("processing", { sources: [turn] }),
+    );
+    expect(presenceNames(harness)).toEqual(["composing"]);
+    await harness.adapter.handleTurnLifecycleEvent?.(
+      lifecycle("finished", { sources: [turn] }),
+    );
+    expect(presenceNames(harness)).toEqual(["composing", "paused"]);
+  });
+
+  test("off mode stays inert while normal sends preserve one-shot composing", async () => {
+    const harness = makeHarness(temporaryDirectory(), {
+      waitingBehavior: "off",
+    });
+    await harness.adapter.start();
+    await harness.adapter.handleTurnLifecycleEvent?.(lifecycle("processing"));
+    expect(presenceNames(harness)).toEqual([]);
+    await harness.adapter.sendMessage({
+      channel: "whatsapp",
+      accountId: account.accountId,
+      chatId: source().chatId,
+      text: "hello",
+    });
+    expect(presenceNames(harness)).toEqual(["composing"]);
+  });
+
+  test("normal send, reaction, and direct reply clear managed typing", async () => {
+    const harness = makeHarness(temporaryDirectory());
+    await harness.adapter.start();
+    const turn = source();
+    await harness.adapter.handleTurnLifecycleEvent?.(
+      lifecycle("processing", { sources: [turn] }),
+    );
+    await harness.adapter.sendMessage({
+      channel: "whatsapp",
+      accountId: account.accountId,
+      chatId: turn.chatId,
+      text: "hello",
+    });
+    expect(presenceNames(harness)).toEqual(["composing", "paused"]);
+
+    await harness.adapter.handleTurnLifecycleEvent?.(
+      lifecycle("processing", { sources: [turn] }),
+    );
+    await harness.adapter.sendMessage({
+      channel: "whatsapp",
+      accountId: account.accountId,
+      chatId: turn.chatId,
+      text: "",
+      reaction: "👍",
+      targetMessageId: "target",
+    });
+    await harness.adapter.handleTurnLifecycleEvent?.(
+      lifecycle("processing", { sources: [turn] }),
+    );
+    await harness.adapter.sendDirectReply(turn.chatId, "reply");
+    expect(
+      harness.presence.filter((call) => call.presence === "paused"),
+    ).toHaveLength(3);
+    expect(
+      harness.presence.filter((call) => call.presence === "composing"),
+    ).toHaveLength(3);
+  });
+
+  test("routes presence through canonical LID mappings", async () => {
+    const harness = makeHarness(temporaryDirectory(), {
+      lidMapping: {
+        lidJid: "123456@lid",
+        phoneJid: "15550000001@s.whatsapp.net",
+      },
+    });
+    await harness.adapter.start();
+    await harness.adapter.handleTurnLifecycleEvent?.(
+      lifecycle("processing", {
+        sources: [source({ chatId: "123456@lid" })],
+      }),
+    );
+    expect(harness.presence[0]).toEqual({
+      jid: "15550000001@s.whatsapp.net",
+      presence: "composing",
+    });
+  });
+
+  test("transient reconnect and conflict clear owned typing without stale finish", async () => {
+    const harness = makeHarness(temporaryDirectory());
+    await harness.adapter.start();
+    const turn = source();
+    await harness.adapter.handleTurnLifecycleEvent?.(
+      lifecycle("processing", { sources: [turn] }),
+    );
+    harness.emitConnection({
+      connection: "close",
+      lastDisconnect: { error: { message: "timed out" } },
+    });
+    await wait(2100);
+    expect(presenceNames(harness)).toEqual(["composing", "paused"]);
+    await harness.adapter.handleTurnLifecycleEvent?.(
+      lifecycle("finished", { sources: [turn] }),
+    );
+    expect(presenceNames(harness)).toEqual(["composing", "paused"]);
+    expect(harness.adapter.isRunning?.()).toBe(true);
+    await harness.adapter.stop();
+
+    const second = makeHarness(temporaryDirectory());
+    await second.adapter.start();
+    await second.adapter.handleTurnLifecycleEvent?.(
+      lifecycle("processing", { sources: [turn] }),
+    );
+    second.emitConnection({
+      connection: "close",
+      lastDisconnect: { error: { message: "Stream Errored (conflict)" } },
+    });
+    await wait(0);
+    expect(presenceNames(second)).toEqual(["composing", "paused"]);
+    expect(second.adapter.isRunning?.()).toBe(false);
+  });
+
+  test("stop awaits delayed paused presence before socket close", async () => {
+    let release!: () => void;
+    const paused = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const harness = makeHarness(temporaryDirectory(), {
+      sendPresence: (presenceName) =>
+        presenceName === "paused" ? paused : undefined,
+    });
+    await harness.adapter.start();
+    await harness.adapter.handleTurnLifecycleEvent?.(lifecycle("processing"));
+    const stopping = harness.adapter.stop?.();
+    await Promise.resolve();
+    expect(harness.socketClosed).toBe(false);
+    release();
+    await stopping;
+    expect(harness.socketClosed).toBe(true);
+  });
+});

--- a/src/channels/whatsapp/typing-controller.test.ts
+++ b/src/channels/whatsapp/typing-controller.test.ts
@@ -1,0 +1,245 @@
+import { describe, expect, test } from "bun:test";
+import type { ChannelTurnSource } from "@/channels/types";
+import {
+  createWhatsAppTypingController,
+  type WhatsAppTypingPresence,
+  type WhatsAppTypingTurn,
+} from "./typing-controller";
+
+const wait = (milliseconds: number) =>
+  new Promise<void>((resolve) => setTimeout(resolve, milliseconds));
+
+function source(overrides: Partial<ChannelTurnSource> = {}): ChannelTurnSource {
+  return {
+    channel: "whatsapp",
+    accountId: "wa-1",
+    chatId: "15550000001@s.whatsapp.net",
+    messageId: "message-1",
+    threadId: null,
+    agentId: "agent-1",
+    conversationId: "conversation-1",
+    ...overrides,
+  };
+}
+
+function turn(
+  overrides: { batchId?: string; source?: Partial<ChannelTurnSource> } = {},
+): WhatsAppTypingTurn {
+  return {
+    batchId: overrides.batchId ?? "batch-1",
+    source: source(overrides.source),
+  };
+}
+
+type Owner = { id: string };
+type PresenceCall = {
+  owner: Owner;
+  chatId: string;
+  presence: WhatsAppTypingPresence;
+};
+
+function makeController(
+  calls: PresenceCall[],
+  options: {
+    owner?: Owner | null;
+    refreshMs?: number;
+    maxLifetimeMs?: number;
+    sendPresence?: (
+      owner: Owner,
+      chatId: string,
+      presence: WhatsAppTypingPresence,
+    ) => unknown;
+  } = {},
+) {
+  let owner: Owner | null = options.owner ?? { id: "socket-1" };
+  return {
+    setOwner(next: Owner | null) {
+      owner = next;
+    },
+    owner() {
+      return owner;
+    },
+    controller: createWhatsAppTypingController<Owner>({
+      accountId: "wa-1",
+      canonicalizeChatId: (chatId) =>
+        chatId.endsWith("@lid") ? "15550000001@s.whatsapp.net" : chatId,
+      getOwner: () => owner,
+      sendPresence:
+        options.sendPresence ??
+        ((callOwner, chatId, presence) => {
+          calls.push({ owner: callOwner, chatId, presence });
+        }),
+      refreshMs: options.refreshMs,
+      maxLifetimeMs: options.maxLifetimeMs,
+    }),
+  };
+}
+
+describe("WhatsApp typing controller", () => {
+  test("accepts only matching WhatsApp account sources with an active owner", () => {
+    const calls: PresenceCall[] = [];
+    const harness = makeController(calls);
+    harness.controller.start(turn({ source: { channel: "telegram" } }));
+    harness.controller.start(turn({ source: { accountId: "wa-2" } }));
+    harness.setOwner(null);
+    harness.controller.start(turn());
+    expect(calls).toEqual([]);
+  });
+
+  test("deduplicates processing and pauses after the final stop", async () => {
+    const calls: PresenceCall[] = [];
+    const { controller } = makeController(calls);
+    const activeTurn = turn();
+    controller.start(activeTurn);
+    controller.start(activeTurn);
+    expect(calls.map(({ chatId, presence }) => ({ chatId, presence }))).toEqual(
+      [{ chatId: activeTurn.source.chatId, presence: "composing" }],
+    );
+    await controller.stop(activeTurn);
+    expect(calls.at(-1)?.presence).toBe("paused");
+    expect(controller.isActive(activeTurn.source.chatId)).toBe(false);
+  });
+
+  test("reference-counts multiple sources in one batch and chat", async () => {
+    const calls: PresenceCall[] = [];
+    const { controller } = makeController(calls);
+    const first = turn({ source: { messageId: "message-1" } });
+    const second = turn({ source: { messageId: "message-2" } });
+    controller.start(first);
+    controller.start(second);
+    await controller.stop(first);
+    expect(calls).toHaveLength(1);
+    expect(controller.isActive(first.source.chatId)).toBe(true);
+    await controller.stop(second);
+    expect(calls.at(-1)?.presence).toBe("paused");
+  });
+
+  test("supersedes an older batch without letting its finish pause the new owner", async () => {
+    const calls: PresenceCall[] = [];
+    const { controller } = makeController(calls);
+    const older = turn({ batchId: "batch-1" });
+    const newer = turn({
+      batchId: "batch-2",
+      source: { messageId: "message-2" },
+    });
+
+    controller.start(older);
+    controller.start(newer);
+    await controller.stop(older);
+    expect(calls.map((call) => call.presence)).toEqual([
+      "composing",
+      "composing",
+    ]);
+    expect(controller.isActive(newer.source.chatId)).toBe(true);
+
+    await controller.stop(newer);
+    expect(calls.map((call) => call.presence)).toEqual([
+      "composing",
+      "composing",
+      "paused",
+    ]);
+  });
+
+  test("refreshes and enforces max lifetime with short timings", async () => {
+    const calls: PresenceCall[] = [];
+    const { controller } = makeController(calls, {
+      refreshMs: 8,
+      maxLifetimeMs: 25,
+    });
+    controller.start(turn());
+    await wait(15);
+    expect(
+      calls.filter((call) => call.presence === "composing").length,
+    ).toBeGreaterThan(1);
+    await wait(20);
+    expect(controller.isActive(source().chatId)).toBe(false);
+    expect(calls.at(-1)?.presence).toBe("paused");
+  });
+
+  test("canonicalizes JIDs and contains sync/async presence failures", async () => {
+    const calls: string[] = [];
+    const controller = createWhatsAppTypingController<Owner>({
+      accountId: "wa-1",
+      canonicalizeChatId: () => "15550000001@s.whatsapp.net",
+      getOwner: () => ({ id: "socket-1" }),
+      refreshMs: 8,
+      maxLifetimeMs: 30,
+      sendPresence: (_owner, _chatId, presence) => {
+        calls.push(presence);
+        if (presence === "composing") throw new Error("sync failure");
+        return Promise.reject(new Error("async failure"));
+      },
+    });
+    expect(() =>
+      controller.start(turn({ source: { chatId: "123@lid" } })),
+    ).not.toThrow();
+    await wait(12);
+    await controller.clearChat("123@lid");
+    expect(calls).toContain("paused");
+  });
+
+  test("deletes timer state before awaiting paused presence", async () => {
+    let releasePaused!: () => void;
+    const paused = new Promise<void>((resolve) => {
+      releasePaused = resolve;
+    });
+    const calls: PresenceCall[] = [];
+    const { controller } = makeController(calls, {
+      sendPresence: (owner, chatId, presence) => {
+        calls.push({ owner, chatId, presence });
+        return presence === "paused" ? paused : undefined;
+      },
+    });
+    const activeTurn = turn();
+    controller.start(activeTurn);
+    const clearing = controller.clearChat(activeTurn.source.chatId);
+    expect(controller.isActive(activeTurn.source.chatId)).toBe(false);
+    releasePaused();
+    await clearing;
+  });
+
+  test("clearOwner uses the socket that owns typing and does not touch newer sockets", async () => {
+    const calls: PresenceCall[] = [];
+    const ownerA = { id: "socket-a" };
+    const ownerB = { id: "socket-b" };
+    const harness = makeController(calls, { owner: ownerA });
+    harness.controller.start(turn({ batchId: "batch-a" }));
+    harness.setOwner(ownerB);
+    harness.controller.start(turn({ batchId: "batch-b" }));
+
+    await harness.controller.clearOwner(ownerA);
+    expect(harness.controller.isActive(source().chatId)).toBe(true);
+    expect(calls.map((call) => [call.owner.id, call.presence])).toEqual([
+      ["socket-a", "composing"],
+      ["socket-b", "composing"],
+    ]);
+
+    await harness.controller.clearOwner(ownerB);
+    expect(harness.controller.isActive(source().chatId)).toBe(false);
+    expect(calls.map((call) => [call.owner.id, call.presence])).toEqual([
+      ["socket-a", "composing"],
+      ["socket-b", "composing"],
+      ["socket-b", "paused"],
+    ]);
+  });
+
+  test("clearChat and clearAll cancel active chats", async () => {
+    const calls: PresenceCall[] = [];
+    const { controller } = makeController(calls);
+    const first = turn();
+    const second = turn({
+      source: {
+        chatId: "15550000002@s.whatsapp.net",
+        messageId: "message-2",
+      },
+    });
+    controller.start(first);
+    controller.start(second);
+    await controller.clearChat(first.source.chatId);
+    expect(controller.isActive(first.source.chatId)).toBe(false);
+    expect(controller.isActive(second.source.chatId)).toBe(true);
+    await controller.clearAll();
+    expect(controller.isActive(second.source.chatId)).toBe(false);
+    expect(calls.filter((call) => call.presence === "paused")).toHaveLength(2);
+  });
+});

--- a/src/channels/whatsapp/typing-controller.ts
+++ b/src/channels/whatsapp/typing-controller.ts
@@ -1,0 +1,218 @@
+import type { ChannelTurnSource } from "@/channels/types";
+
+export type WhatsAppTypingPresence = "composing" | "paused";
+
+export interface WhatsAppTypingTurn {
+  batchId: string;
+  source: ChannelTurnSource;
+}
+
+export interface WhatsAppTypingControllerOptions<Owner> {
+  accountId: string;
+  canonicalizeChatId: (chatId: string) => string | null;
+  getOwner: () => Owner | null | undefined;
+  sendPresence: (
+    owner: Owner,
+    chatId: string,
+    presence: WhatsAppTypingPresence,
+  ) => unknown;
+  refreshMs?: number;
+  maxLifetimeMs?: number;
+}
+
+export interface WhatsAppTypingController<Owner = unknown> {
+  start(turn: WhatsAppTypingTurn): void;
+  stop(turn: WhatsAppTypingTurn): Promise<void>;
+  isActive(chatId: string): boolean;
+  clearChat(
+    chatId: string,
+    options?: WhatsAppTypingClearOptions<Owner>,
+  ): Promise<void>;
+  clearOwner(
+    owner: Owner,
+    options?: WhatsAppTypingClearOptions<Owner>,
+  ): Promise<void>;
+  clearAll(options?: WhatsAppTypingClearOptions<Owner>): Promise<void>;
+}
+
+export interface WhatsAppTypingClearOptions<Owner = unknown> {
+  sendPaused?: boolean;
+  owner?: Owner;
+}
+
+interface TypingEntry<Owner> {
+  batchId: string;
+  sourceKeys: Set<string>;
+  owner: Owner;
+  refreshTimer: ReturnType<typeof setInterval>;
+  maxTimer: ReturnType<typeof setTimeout>;
+}
+
+const DEFAULT_REFRESH_MS = 12_000;
+const DEFAULT_MAX_LIFETIME_MS = 5 * 60_000;
+
+function timing(value: number | undefined, fallback: number): number {
+  return typeof value === "number" && Number.isFinite(value) && value > 0
+    ? value
+    : fallback;
+}
+
+export function createWhatsAppTypingController<Owner>(
+  options: WhatsAppTypingControllerOptions<Owner>,
+): WhatsAppTypingController<Owner> {
+  const refreshMs = timing(options.refreshMs, DEFAULT_REFRESH_MS);
+  const maxLifetimeMs = timing(options.maxLifetimeMs, DEFAULT_MAX_LIFETIME_MS);
+  const typingByChatId = new Map<string, TypingEntry<Owner>>();
+
+  function canonicalChatId(chatId: string): string | null {
+    if (!chatId) return null;
+    try {
+      return options.canonicalizeChatId(chatId);
+    } catch {
+      return null;
+    }
+  }
+
+  function sourceChatId(source: ChannelTurnSource): string | null {
+    if (
+      source.channel !== "whatsapp" ||
+      source.accountId !== options.accountId
+    ) {
+      return null;
+    }
+    return canonicalChatId(source.chatId);
+  }
+
+  function sourceKey(turn: WhatsAppTypingTurn, chatId: string): string {
+    const { source } = turn;
+    return [
+      options.accountId,
+      chatId,
+      turn.batchId,
+      source.threadId ?? "",
+      source.messageId ?? "",
+      source.agentId,
+      source.conversationId,
+    ].join(":");
+  }
+
+  function reportPresenceError(error: unknown): void {
+    void error;
+  }
+
+  async function sendPresence(
+    owner: Owner,
+    chatId: string,
+    presence: WhatsAppTypingPresence,
+  ): Promise<void> {
+    try {
+      await Promise.resolve(options.sendPresence(owner, chatId, presence));
+    } catch (error) {
+      reportPresenceError(error);
+    }
+  }
+
+  function sendPresenceFireAndForget(
+    owner: Owner,
+    chatId: string,
+    presence: WhatsAppTypingPresence,
+  ): void {
+    void sendPresence(owner, chatId, presence);
+  }
+
+  async function clearChat(
+    chatId: string,
+    clearOptions: WhatsAppTypingClearOptions<Owner> = {},
+  ): Promise<void> {
+    const canonical = canonicalChatId(chatId);
+    if (!canonical) return;
+    const entry = typingByChatId.get(canonical);
+    if (!entry) return;
+    if (
+      clearOptions.owner !== undefined &&
+      entry.owner !== clearOptions.owner
+    ) {
+      return;
+    }
+    clearInterval(entry.refreshTimer);
+    clearTimeout(entry.maxTimer);
+    typingByChatId.delete(canonical);
+    if (clearOptions.sendPaused !== false) {
+      await sendPresence(entry.owner, canonical, "paused");
+    }
+  }
+
+  function start(turn: WhatsAppTypingTurn): void {
+    const chatId = sourceChatId(turn.source);
+    if (!chatId) return;
+    const owner = options.getOwner();
+    if (owner === null || owner === undefined) return;
+    const key = sourceKey(turn, chatId);
+    const existing = typingByChatId.get(chatId);
+    if (existing) {
+      if (existing.owner === owner && existing.batchId === turn.batchId) {
+        existing.sourceKeys.add(key);
+        return;
+      }
+      void clearChat(chatId, { owner: existing.owner, sendPaused: false });
+    }
+
+    const refreshTimer = setInterval(() => {
+      const entry = typingByChatId.get(chatId);
+      if (!entry || entry.owner !== owner || entry.batchId !== turn.batchId) {
+        return;
+      }
+      sendPresenceFireAndForget(owner, chatId, "composing");
+    }, refreshMs);
+    const maxTimer = setTimeout(() => {
+      void clearChat(chatId, { owner });
+    }, maxLifetimeMs);
+    refreshTimer.unref?.();
+    maxTimer.unref?.();
+    typingByChatId.set(chatId, {
+      batchId: turn.batchId,
+      sourceKeys: new Set([key]),
+      owner,
+      refreshTimer,
+      maxTimer,
+    });
+    sendPresenceFireAndForget(owner, chatId, "composing");
+  }
+
+  async function stop(turn: WhatsAppTypingTurn): Promise<void> {
+    const chatId = sourceChatId(turn.source);
+    if (!chatId) return;
+    const entry = typingByChatId.get(chatId);
+    if (!entry || entry.batchId !== turn.batchId) return;
+    entry.sourceKeys.delete(sourceKey(turn, chatId));
+    if (entry.sourceKeys.size === 0) {
+      await clearChat(chatId, { owner: entry.owner });
+    }
+  }
+
+  function isActive(chatId: string): boolean {
+    const canonical = canonicalChatId(chatId);
+    return canonical !== null && typingByChatId.has(canonical);
+  }
+
+  async function clearOwner(
+    owner: Owner,
+    clearOptions: WhatsAppTypingClearOptions<Owner> = {},
+  ): Promise<void> {
+    const chats = [...typingByChatId.entries()]
+      .filter(([, entry]) => entry.owner === owner)
+      .map(([chatId]) => chatId);
+    await Promise.all(
+      chats.map((chatId) => clearChat(chatId, { ...clearOptions, owner })),
+    );
+  }
+
+  async function clearAll(
+    clearOptions: WhatsAppTypingClearOptions<Owner> = {},
+  ): Promise<void> {
+    const chats = [...typingByChatId.keys()];
+    await Promise.all(chats.map((chatId) => clearChat(chatId, clearOptions)));
+  }
+
+  return { start, stop, isActive, clearChat, clearOwner, clearAll };
+}

--- a/src/channels/whatsapp/waiting-behavior-config-types.ts
+++ b/src/channels/whatsapp/waiting-behavior-config-types.ts
@@ -1,0 +1,6 @@
+export type WhatsAppWaitingBehavior = "off" | "typing_indicator";
+
+export interface WhatsAppWaitingBehaviorConfig {
+  /** Controls whether WhatsApp shows typing while a turn is processing. */
+  waitingBehavior?: WhatsAppWaitingBehavior;
+}

--- a/src/channels/whatsapp/waiting-behavior-config.test.ts
+++ b/src/channels/whatsapp/waiting-behavior-config.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, test } from "bun:test";
+import type { WhatsAppChannelAccount } from "@/channels/types";
+import { whatsappAccountConfigAdapter } from "./account-config";
+
+function account(
+  overrides: Partial<WhatsAppChannelAccount> = {},
+): WhatsAppChannelAccount {
+  return {
+    channel: "whatsapp",
+    accountId: "wa-test",
+    displayName: "WhatsApp",
+    enabled: true,
+    dmPolicy: "pairing",
+    allowedUsers: [],
+    agentId: null,
+    selfChatMode: true,
+    groupMode: "disabled",
+    createdAt: new Date(0).toISOString(),
+    updatedAt: new Date(0).toISOString(),
+    ...overrides,
+  };
+}
+
+describe("WhatsApp waiting behavior config", () => {
+  test("accepts and round-trips the supported values", () => {
+    expect(
+      whatsappAccountConfigAdapter.isValidConfig({
+        waiting_behavior: "off",
+      }),
+    ).toBe(true);
+    expect(
+      whatsappAccountConfigAdapter.isValidConfig({
+        waiting_behavior: "typing_indicator",
+      }),
+    ).toBe(true);
+    expect(
+      whatsappAccountConfigAdapter.toAccountPatch({
+        waiting_behavior: "typing_indicator",
+      }),
+    ).toEqual({ waitingBehavior: "typing_indicator" });
+    expect(
+      whatsappAccountConfigAdapter.toAccountPatch({ waiting_behavior: "off" }),
+    ).toEqual({ waitingBehavior: "off" });
+    expect(
+      whatsappAccountConfigAdapter.toAccountConfig(
+        account({ waitingBehavior: "typing_indicator" }),
+      ).waiting_behavior,
+    ).toBe("typing_indicator");
+  });
+
+  test("rejects unknown values and defaults absent values to off", () => {
+    expect(
+      whatsappAccountConfigAdapter.isValidConfig({
+        waiting_behavior: "always",
+      }),
+    ).toBe(false);
+    expect(
+      whatsappAccountConfigAdapter.isValidConfig({
+        waiting_behavior: true,
+      }),
+    ).toBe(false);
+    expect(
+      whatsappAccountConfigAdapter.isValidConfig({ unexpected: true }),
+    ).toBe(false);
+    expect(
+      whatsappAccountConfigAdapter.toConfigSnapshotConfig(account())
+        .waiting_behavior,
+    ).toBe("off");
+  });
+});


### PR DESCRIPTION
Overlord (agent-c2adbf5c-8419-4211-8cd8-3740db164974)

## Why

The maintained WhatsApp work was split across six PRs that all touched the same adapter and each required a separate owner review. This consolidates them into one review surface while preserving the feature boundaries as ordered commits.

## Included

- inbound reaction events, including PN/LID identity handling and bounded target ownership
- default-off outbound attachment policy for recipient, MIME, and canonical path controls
- configurable inbound debounce with read receipts only after successful delivery
- reconnect generation ownership, conflict handling, and unstable-loop circuit breaking
- opt-in lifecycle typing indicators with socket-owned cleanup
- optional outbound text/media-caption prefixes without prefixing control or error replies

## Integration hardening

The combined review also fixed interactions that were not visible in the isolated PRs:

- explicit session conflicts supersede earlier transient closes from the same socket generation
- canceled or stale inbound work releases provisional dedupe claims, while successful delivery remains deduplicated across reconnects
- stored reaction target keys are bound to the requested canonical chat while preserving PN/LID aliases
- message-store timer tests distinguish reconnect timers from reaction-target TTL timers

## Defaults and limits

Attachment filtering, inbound debounce, lifecycle typing, and message prefixes preserve existing behavior unless configured. Group reactions still require the original target key to be observed by the current adapter process. This is adapter-harness validated; no live linked-device smoke test was run.

## Validation

- `bun test src/channels/*whatsapp*.test.ts src/channels/whatsapp/*.test.ts` — 196 passed
- `bun run check` — all 12 checks passed
- full unit runner attempted twice; its only failures were 1–2 order-sensitive tests in the unrelated WebSocket recovery-lease suite, which passes 3/3 in isolation

## Replaces

- #3601
- #3602
- #3603
- #3604
- #3605
- #3606

## Test plan

- [x] reactions and reaction target ownership
- [x] attachment allow/deny and realpath containment
- [x] debounce, cancellation, replay, and read receipts
- [x] reconnect, conflict, stop/restart, and stale generations
- [x] typing lifecycle and socket replacement
- [x] text, media-caption, and control-reply prefix behavior
- [x] configuration migration and default-off behavior

👾 Generated with [Letta Code](https://letta.com)