### PR TITLE
fix(cli): preserve OAuth provider identity in model selector

### DIFF
--- a/scripts/source-file-size-baseline.json
+++ b/scripts/source-file-size-baseline.json
@@ -13,7 +13,7 @@
   "src/cli/app/use-submit-handler.ts": 4077,
   "src/cli/components/AgentSelector.tsx": 1104,
   "src/cli/components/InputRich.tsx": 2225,
-  "src/cli/components/ModelSelector.tsx": 1262,
+  "src/cli/components/ModelSelector.tsx": 1259,
   "src/cli/components/ProviderSelector.tsx": 1692,
   "src/cli/components/ToolCallMessageRich.tsx": 1109,
   "src/cli/helpers/accumulator.ts": 1596,

--- a/src/cli/components/ModelSelector.tsx
+++ b/src/cli/components/ModelSelector.tsx
@@ -552,18 +552,14 @@ export function ModelSelector({
       .filter((handle) => !isByokHandle(handle))
       .map((handle) => {
         const staticModel = pickPreferredStaticModel(handle);
-        if (staticModel) {
-          return {
-            ...staticModel,
-            id: handle,
-            handle,
-          };
-        }
         return {
+          ...(staticModel ?? { label: handle, description: "" }),
           id: handle,
           handle,
-          label: handle,
-          description: "",
+          updateArgs: withProviderTypeMetadata(
+            handle,
+            staticModel?.updateArgs as Record<string, unknown> | undefined,
+          ),
         } satisfies UiModel;
       });
 
@@ -584,6 +580,7 @@ export function ModelSelector({
     isByokHandle,
     pickPreferredStaticModel,
     searchQuery,
+    withProviderTypeMetadata,
   ]);
 
   // Convert BYOK handle to base provider handle for models.json lookup

--- a/src/cli/components/ModelSelector.tsx
+++ b/src/cli/components/ModelSelector.tsx
@@ -544,7 +544,7 @@ export function ModelSelector({
     [byokProviderAliases],
   );
 
-  // Letta API (all): all non-BYOK handles from API, including recommended models.
+  // Letta API (all): preserve backend metadata when aliases are not yet classified as BYOK.
   const allLettaModels = useMemo(() => {
     if (availableHandles === undefined) return [];
 

--- a/src/cli/components/provider-mod-selector-refresh.test.tsx
+++ b/src/cli/components/provider-mod-selector-refresh.test.tsx
@@ -17,7 +17,8 @@ import {
   registerPiProvider,
 } from "@/backend/dev/pi-provider-mod-registry";
 import { settingsManager } from "@/settings-manager";
-import { ModelSelector } from "./ModelSelector";
+import { deriveToolsetFromModel } from "@/tools/toolset";
+import { ModelSelector, type ModelSelectorSelection } from "./ModelSelector";
 import { ProviderSelector } from "./ProviderSelector";
 
 class CaptureStream extends Writable {
@@ -162,6 +163,59 @@ describe("provider mod selector refresh", () => {
     await waitForOutput(stdout, "late-provider/late-model");
 
     expect(stdout.read()).toContain("late-provider/late-model");
+  });
+
+  test("preserves OAuth provider identity for custom aliases in the All category", async () => {
+    const handle = "chatgpt-cameron/gpt-5.6-sol";
+    const backend = new FakeHeadlessBackend();
+    backend.listModels = async () =>
+      [
+        {
+          handle,
+          display_name: "gpt-5.6-sol",
+          provider_type: "chatgpt_oauth",
+          provider_category: "byok",
+        },
+      ] as never;
+    __testSetBackend(backend);
+    clearAvailableModelsCache();
+
+    const stdout = new CaptureStream() as CaptureStream & NodeJS.WriteStream;
+    const stdin = createInputStream();
+    let resolveSelection: (selection: ModelSelectorSelection) => void =
+      () => {};
+    const selected = new Promise<ModelSelectorSelection>((resolve) => {
+      resolveSelection = resolve;
+    });
+    const instance = render(
+      <ModelSelector
+        onCancel={() => {}}
+        onSelect={(selection) => resolveSelection(selection)}
+      />,
+      {
+        stdout,
+        stdin,
+        debug: true,
+        patchConsole: false,
+        exitOnCtrlC: false,
+      },
+    );
+    renderedInstances.add(instance);
+
+    await waitForOutput(stdout, handle);
+    stdin.push("\r");
+    const selection = await selected;
+
+    expect(selection).toMatchObject({
+      handle,
+      updateArgs: { provider_type: "chatgpt_oauth" },
+    });
+    expect(
+      deriveToolsetFromModel(
+        selection.handle,
+        selection.updateArgs?.provider_type as string,
+      ),
+    ).toBe("codex");
   });
 
   test("refreshes an open provider selector when a provider registers", async () => {

--- a/src/cli/components/provider-mod-selector-refresh.test.tsx
+++ b/src/cli/components/provider-mod-selector-refresh.test.tsx
@@ -166,7 +166,7 @@ describe("provider mod selector refresh", () => {
   });
 
   test("preserves OAuth provider identity for custom aliases in the All category", async () => {
-    const handle = "chatgpt-cameron/gpt-5.6-sol";
+    const handle = "chatgpt-work/gpt-5.6-sol";
     const backend = new FakeHeadlessBackend();
     backend.listModels = async () =>
       [


### PR DESCRIPTION
## Summary

- preserve backend provider metadata on models projected into the TUI’s All category
- keep custom ChatGPT OAuth aliases on the Codex toolset instead of falling through to the Claude default
- add an Ink regression that selects a custom alias through the affected category and verifies provider identity and toolset derivation

## Why

The All-category projection rebuilt backend model rows without their `provider_type`. If a custom OAuth alias reached that path before provider-alias classification, model update fell back to generic OpenAI settings and automatic toolset selection could no longer recognize the alias as ChatGPT OAuth.

The fix carries the backend’s authoritative provider metadata through the same selector boundary instead of adding another handle-name heuristic.

## Test plan

- [x] New regression fails on `origin/main` with `updateArgs: undefined`
- [x] `bun test src/cli/components/provider-mod-selector-refresh.test.tsx`
- [x] `bun run check`

👾 Generated with [Letta Code](https://letta.com)