### PR TITLE
fix(app-server): execute tools without relay connection

### DIFF
--- a/src/websocket/app-server-openai-turn.ts
+++ b/src/websocket/app-server-openai-turn.ts
@@ -370,9 +370,9 @@ async function runTurnViaListenerRuntime(
       // would strand the second observer (only the first OTID survives a
       // merged batch) and answer the first with both prompts.
       noCoalesce: true,
-      // This request is owned by the in-process HTTP bridge. Local tools must
-      // not wait for a relay WebSocket connection that may never exist.
-      allowToolExecutionWithoutListenerConnection: true,
+      // This request's output is owned by the in-process HTTP bridge, so the
+      // turn must not block waiting for a relay WebSocket client to attach.
+      processOwnedTurn: true,
       // HTTP clients cannot surface Letta Code's interactive overlays. Keep
       // those tools out so the agent asks in ordinary assistant text.
       excludeInteractiveTools: true,

--- a/src/websocket/app-server-openai-turn.ts
+++ b/src/websocket/app-server-openai-turn.ts
@@ -370,6 +370,9 @@ async function runTurnViaListenerRuntime(
       // would strand the second observer (only the first OTID survives a
       // merged batch) and answer the first with both prompts.
       noCoalesce: true,
+      // This request is owned by the in-process HTTP bridge. Local tools must
+      // not wait for a relay WebSocket connection that may never exist.
+      allowToolExecutionWithoutListenerConnection: true,
       // HTTP clients cannot surface Letta Code's interactive overlays. Keep
       // those tools out so the agent asks in ordinary assistant text.
       excludeInteractiveTools: true,

--- a/src/websocket/listener/turn-approval.ts
+++ b/src/websocket/listener/turn-approval.ts
@@ -157,8 +157,8 @@ export async function handleApprovalStop(params: {
   pendingNormalizationInterruptedToolCallIds: string[];
   turnToolContextId: string | null;
   turnLease: TurnLease;
-  /** Process-owned turns can execute local tools without a relay connection. */
-  allowToolExecutionWithoutListenerConnection?: boolean;
+  /** This turn's output is owned by an in-process caller, not a relay client. */
+  processOwnedTurn?: boolean;
   buildSendOptions: () => Parameters<
     typeof sendApprovalContinuationWithRetry
   >[2];
@@ -185,7 +185,7 @@ export async function handleApprovalStop(params: {
     turnInput,
     turnToolContextId,
     turnLease,
-    allowToolExecutionWithoutListenerConnection = false,
+    processOwnedTurn = false,
     buildSendOptions,
     providerFallback,
     dependencies,
@@ -412,11 +412,12 @@ export async function handleApprovalStop(params: {
   const executionRunId =
     runId || runtime.activeRunId || msgRunIds[msgRunIds.length - 1];
 
-  // App Server turns own local tool execution even when no WebSocket client is
-  // attached. Relay-originated turns still wait through transient disconnects.
+  // A process-owned turn's results are consumed in-process, so there is no
+  // client whose reconnect is worth waiting for. Relay-originated turns still
+  // wait through transient disconnects so their output is not lost (#3522).
   if (
     approvedDecisions.length > 0 &&
-    !allowToolExecutionWithoutListenerConnection &&
+    !processOwnedTurn &&
     !isListenerTransportOpen(socket)
   ) {
     const transportOpenResult = await waitForTransportOpen(

--- a/src/websocket/listener/turn-approval.ts
+++ b/src/websocket/listener/turn-approval.ts
@@ -157,6 +157,8 @@ export async function handleApprovalStop(params: {
   pendingNormalizationInterruptedToolCallIds: string[];
   turnToolContextId: string | null;
   turnLease: TurnLease;
+  /** Process-owned turns can execute local tools without a relay connection. */
+  allowToolExecutionWithoutListenerConnection?: boolean;
   buildSendOptions: () => Parameters<
     typeof sendApprovalContinuationWithRetry
   >[2];
@@ -183,6 +185,7 @@ export async function handleApprovalStop(params: {
     turnInput,
     turnToolContextId,
     turnLease,
+    allowToolExecutionWithoutListenerConnection = false,
     buildSendOptions,
     providerFallback,
     dependencies,
@@ -409,7 +412,13 @@ export async function handleApprovalStop(params: {
   const executionRunId =
     runId || runtime.activeRunId || msgRunIds[msgRunIds.length - 1];
 
-  if (approvedDecisions.length > 0 && !isListenerTransportOpen(socket)) {
+  // App Server turns own local tool execution even when no WebSocket client is
+  // attached. Relay-originated turns still wait through transient disconnects.
+  if (
+    approvedDecisions.length > 0 &&
+    !allowToolExecutionWithoutListenerConnection &&
+    !isListenerTransportOpen(socket)
+  ) {
     const transportOpenResult = await waitForTransportOpen(
       socket,
       shouldInterrupt,

--- a/src/websocket/listener/turn-lifecycle-integration.test.ts
+++ b/src/websocket/listener/turn-lifecycle-integration.test.ts
@@ -153,6 +153,68 @@ describe("listener turn lifecycle integration", () => {
     expect(runtime.isProcessing).toBe(true);
   });
 
+  test("an explicitly process-owned tool executes without a remote listener connection", async () => {
+    const runtime = getOrCreateScopedRuntime(
+      createRuntime(),
+      "agent-1",
+      "conv-1",
+    );
+    const turnLease = runtime.turnLifecycle.begin({
+      origin: "message",
+      workingDirectory: process.cwd(),
+      initialStatus: "PROCESSING_API_RESPONSE",
+    });
+    const approval = {
+      toolCallId: "call-process",
+      toolName: "Bash",
+      toolArgs: '{"command":"pwd"}',
+    };
+    const executeApprovalBatch = mock(async () => [
+      {
+        type: "tool" as const,
+        tool_call_id: approval.toolCallId,
+        status: "success" as const,
+        tool_return: "/workspace",
+      },
+    ]);
+    const waitForApprovalTransportOpen = mock(async () => {
+      throw new Error("process transport should not wait for a remote client");
+    });
+
+    const result = await startQuestionApproval(runtime, turnLease, {
+      approvals: [approval],
+      socket: {
+        kind: "runtime",
+        bufferedAmount: 0,
+        isOpen: () => false,
+        send: () => {
+          throw new Error("process transport cannot send implicitly");
+        },
+      },
+      allowToolExecutionWithoutListenerConnection: true,
+      dependencies: {
+        classifyApprovals: async () => ({
+          autoAllowed: [
+            { approval, parsedArgs: { command: "pwd" }, context: null },
+          ],
+          autoDenied: [],
+          needsUserInput: [],
+        }),
+        executeApprovalBatch,
+        ensureSecretsHydrated: async () => {},
+        sendApprovalContinuation: async () => ({
+          kind: "terminal" as const,
+          drainResult: { stopReason: "end_turn" as const, apiDurationMs: 0 },
+        }),
+        waitForApprovalTransportOpen,
+      } as never,
+    });
+
+    expect(result.kind).toBe("terminal");
+    expect(waitForApprovalTransportOpen).toHaveBeenCalledTimes(0);
+    expect(executeApprovalBatch).toHaveBeenCalledTimes(1);
+  });
+
   test("a stale tool execution cannot emit results under a replacement run", async () => {
     const runtime = getOrCreateScopedRuntime(
       createRuntime(),

--- a/src/websocket/listener/turn-lifecycle-integration.test.ts
+++ b/src/websocket/listener/turn-lifecycle-integration.test.ts
@@ -191,7 +191,7 @@ describe("listener turn lifecycle integration", () => {
           throw new Error("process transport cannot send implicitly");
         },
       },
-      allowToolExecutionWithoutListenerConnection: true,
+      processOwnedTurn: true,
       dependencies: {
         classifyApprovals: async () => ({
           autoAllowed: [
@@ -212,6 +212,75 @@ describe("listener turn lifecycle integration", () => {
 
     expect(result.kind).toBe("terminal");
     expect(waitForApprovalTransportOpen).toHaveBeenCalledTimes(0);
+    expect(executeApprovalBatch).toHaveBeenCalledTimes(1);
+  });
+
+  // Guards the gate's polarity and its default. A relay turn's results must
+  // reach the client that asked for them, so a closed transport still waits for
+  // reconnect (#3522) — only an explicitly process-owned turn may skip it.
+  test("a relay-owned turn still waits for reconnect before executing tools", async () => {
+    const runtime = getOrCreateScopedRuntime(
+      createRuntime(),
+      "agent-1",
+      "conv-1",
+    );
+    const turnLease = runtime.turnLifecycle.begin({
+      origin: "message",
+      workingDirectory: process.cwd(),
+      initialStatus: "PROCESSING_API_RESPONSE",
+    });
+    const approval = {
+      toolCallId: "call-relay",
+      toolName: "Bash",
+      toolArgs: '{"command":"pwd"}',
+    };
+    const executeApprovalBatch = mock(async () => [
+      {
+        type: "tool" as const,
+        tool_call_id: approval.toolCallId,
+        status: "success" as const,
+        tool_return: "/workspace",
+      },
+    ]);
+    let waitedBeforeExecuting = false;
+    const waitForApprovalTransportOpen = mock(async () => {
+      waitedBeforeExecuting = executeApprovalBatch.mock.calls.length === 0;
+      return "open" as const;
+    });
+
+    // processOwnedTurn is intentionally omitted: the default must preserve the
+    // relay wait rather than opting every caller into the bypass.
+    const result = await startQuestionApproval(runtime, turnLease, {
+      approvals: [approval],
+      socket: {
+        kind: "runtime",
+        bufferedAmount: 0,
+        isOpen: () => false,
+        send: () => {
+          throw new Error("process transport cannot send implicitly");
+        },
+      },
+      dependencies: {
+        classifyApprovals: async () => ({
+          autoAllowed: [
+            { approval, parsedArgs: { command: "pwd" }, context: null },
+          ],
+          autoDenied: [],
+          needsUserInput: [],
+        }),
+        executeApprovalBatch,
+        ensureSecretsHydrated: async () => {},
+        sendApprovalContinuation: async () => ({
+          kind: "terminal" as const,
+          drainResult: { stopReason: "end_turn" as const, apiDurationMs: 0 },
+        }),
+        waitForApprovalTransportOpen,
+      } as never,
+    });
+
+    expect(result.kind).toBe("terminal");
+    expect(waitForApprovalTransportOpen).toHaveBeenCalledTimes(1);
+    expect(waitedBeforeExecuting).toBe(true);
     expect(executeApprovalBatch).toHaveBeenCalledTimes(1);
   });
 

--- a/src/websocket/listener/turn.ts
+++ b/src/websocket/listener/turn.ts
@@ -798,6 +798,8 @@ async function handleIncomingMessageInner(
         pendingNormalizationInterruptedToolCallIds,
         turnToolContextId,
         turnLease,
+        allowToolExecutionWithoutListenerConnection:
+          msg.allowToolExecutionWithoutListenerConnection === true,
         buildSendOptions,
         providerFallback,
       });

--- a/src/websocket/listener/turn.ts
+++ b/src/websocket/listener/turn.ts
@@ -798,8 +798,7 @@ async function handleIncomingMessageInner(
         pendingNormalizationInterruptedToolCallIds,
         turnToolContextId,
         turnLease,
-        allowToolExecutionWithoutListenerConnection:
-          msg.allowToolExecutionWithoutListenerConnection === true,
+        processOwnedTurn: msg.processOwnedTurn === true,
         buildSendOptions,
         providerFallback,
       });

--- a/src/websocket/listener/types.ts
+++ b/src/websocket/listener/types.ts
@@ -75,8 +75,17 @@ export interface IncomingMessage {
   conversationId?: string;
   /** Queue this message as its own turn; never merge with other messages. */
   noCoalesce?: boolean;
-  /** Execute local tools even when no relay WebSocket client is attached. */
-  allowToolExecutionWithoutListenerConnection?: boolean;
+  /**
+   * This turn's output is owned by an in-process caller (the OpenAI-compatible
+   * HTTP bridge), not by a relay WebSocket client. Such turns are consumed by
+   * in-process stream observers and returned in the HTTP response, so they must
+   * not block on a listener connection that may never attach.
+   *
+   * Ownership varies per turn, not per runtime: one app-server runtime serves
+   * both HTTP requests and real WebSocket clients, and relay-originated turns
+   * still need the reconnect wait that preserves their output.
+   */
+  processOwnedTurn?: boolean;
   imageFailureMode?: "strict" | "drop";
   clientToolAllowlist?: string[];
   clientToolset?: ClientToolsetConfig;

--- a/src/websocket/listener/types.ts
+++ b/src/websocket/listener/types.ts
@@ -75,6 +75,8 @@ export interface IncomingMessage {
   conversationId?: string;
   /** Queue this message as its own turn; never merge with other messages. */
   noCoalesce?: boolean;
+  /** Execute local tools even when no relay WebSocket client is attached. */
+  allowToolExecutionWithoutListenerConnection?: boolean;
   imageFailureMode?: "strict" | "drop";
   clientToolAllowlist?: string[];
   clientToolset?: ClientToolsetConfig;


### PR DESCRIPTION
Overlord (agent-c2adbf5c-8419-4211-8cd8-3740db164974)

## Problem

The OpenAI-compatible App Server uses a process runtime transport. With no WebSocket client attached, that transport intentionally reports closed. The listener interpreted that as a relay disconnect and waited for a connection before executing every auto-approved tool, so even an instant shell command emitted a function call and then stalled forever.

This reproduces with direct `curl` against both `/v1/responses` and `/v1/chat/completions`; OpenWebUI is not involved.

## Fix

- mark HTTP bridge messages as explicitly process-owned
- let only those turns execute local tools without an attached listener connection
- preserve the existing reconnect wait for relay-originated turns
- add a lifecycle regression that fails at the blocking transport wait on `main`

The bypass is internal listener metadata. Remote protocol input is still mapped through the explicit message router and cannot set it.

## Validation

- [x] regression fails without the source fix and passes with it
- [x] 45 App Server, process-transport, and relay-reconnect tests pass
- [x] `bun run check` — all 12 checks pass
- [x] direct Responses smoke: `function_call` → `function_call_output` → `response.completed`
- [x] direct Chat Completions smoke: tool output reported → `[DONE]`
- [x] text-only Responses control still completes
- [ ] complete `bun test`: 5,828 passed / 27 skipped / 21 environment failures; failures were outside this diff and predominantly exhausted Cloud credits, plus unrelated global-settings test interference

## Scope

This fixes the hard stall where tool execution never begins. It does not add SSE heartbeats for genuinely long, quiet tools, so the separate client-inactivity concern in #3647 remains relevant.

👾 Generated with [Letta Code](https://letta.com)