### PR TITLE
refactor(agent): centralize creation policy [LET-10557]

### DIFF
--- a/src/agent-presets.ts
+++ b/src/agent-presets.ts
@@ -19,7 +19,11 @@ export {
   ONBOARDING_ORIGIN_TAG,
 } from "./agent/agent-tags";
 export {
+  type BuildCreateAgentRequestOptions,
+  buildCreateAgentRequest,
   buildCreateAgentRequestForPersonality,
+  type CreateAgentMemoryBlock,
+  type CreateAgentRequest,
   type CreateAgentRequestForPersonality,
   DEFAULT_CREATED_AGENT_BASE_TOOLS,
   LETTA_CODE_AGENT_TYPE,

--- a/src/agent/create-agent-request.test.ts
+++ b/src/agent/create-agent-request.test.ts
@@ -5,6 +5,7 @@ import {
   ONBOARDING_ORIGIN_TAG,
 } from "@/agent/agent-tags";
 import {
+  buildCreateAgentRequest,
   buildCreateAgentRequestForPersonality,
   DEFAULT_CREATED_AGENT_BASE_TOOLS,
   LETTA_CODE_AGENT_TYPE,
@@ -17,6 +18,122 @@ import {
   getPersonalityOption,
 } from "@/agent/personality-presets";
 import { buildSystemPrompt } from "@/agent/prompt-assets";
+
+describe("buildCreateAgentRequest", () => {
+  test("owns the complete default creation policy without a personality", async () => {
+    const request = await buildCreateAgentRequest({
+      model: "openai/gpt-5.2",
+      memoryBlocks: [
+        { label: "persona", value: "You are Ezra." },
+        { label: "human", value: "The human reads the docs." },
+      ],
+    });
+
+    expect(request).toMatchObject({
+      agent_type: LETTA_CODE_AGENT_TYPE,
+      model: "openai/gpt-5.2",
+      system: buildSystemPrompt("default", "memfs"),
+      memory_blocks: [
+        { label: "persona", value: "You are Ezra." },
+        { label: "human", value: "The human reads the docs." },
+      ],
+      tags: [LETTA_CODE_ORIGIN_TAG, GIT_MEMORY_ENABLED_TAG],
+      tools: DEFAULT_CREATED_AGENT_BASE_TOOLS,
+      include_base_tools: false,
+      include_base_tool_rules: false,
+      initial_message_sequence: [],
+      parallel_tool_calls: true,
+      compaction_settings: { model: "letta/auto" },
+    });
+    expect(request).not.toHaveProperty("name");
+    expect(request).not.toHaveProperty("description");
+  });
+
+  test("merges caller identity into a personality by block label", async () => {
+    const request = await buildCreateAgentRequest({
+      personalityId: "memo",
+      memoryBlocks: [
+        { label: "persona", value: "Custom persona" },
+        { label: "project", value: "Custom project" },
+      ],
+    });
+
+    expect(request.memory_blocks?.map((block) => block.label)).toEqual([
+      "persona",
+      "human",
+      "project",
+    ]);
+    expect(
+      request.memory_blocks?.find((block) => block.label === "persona")?.value,
+    ).toBe("Custom persona");
+    expect(
+      request.memory_blocks?.find((block) => block.label === "project")?.value,
+    ).toBe("Custom project");
+  });
+
+  test("forces subagents onto hidden, stateless standard memory", async () => {
+    const request = await buildCreateAgentRequest({
+      isSubagent: true,
+      memoryPromptMode: "memfs",
+      enableMemfs: true,
+      memoryBlocks: [{ label: "persona", value: "Stateful" }],
+      blockIds: ["block-shared"],
+      hidden: false,
+    });
+
+    expect(request.system).toBe(buildSystemPrompt("default", "standard"));
+    expect(request.tags).toEqual([LETTA_CODE_ORIGIN_TAG, "role:subagent"]);
+    expect(request.tags).not.toContain(GIT_MEMORY_ENABLED_TAG);
+    expect(request.hidden).toBe(true);
+    expect(request).not.toHaveProperty("memory_blocks");
+    expect(request).not.toHaveProperty("block_ids");
+  });
+
+  test("keeps MemFS tags and prompts coherent", async () => {
+    const request = await buildCreateAgentRequest({ enableMemfs: false });
+    expect(request.system).toBe(buildSystemPrompt("default", "standard"));
+    expect(request.tags).not.toContain(GIT_MEMORY_ENABLED_TAG);
+
+    await expect(
+      buildCreateAgentRequest({
+        enableMemfs: false,
+        memoryPromptMode: "memfs",
+      }),
+    ).rejects.toThrow("must describe the same memory mode");
+  });
+
+  test("pins exact caller overrides without restoring server defaults", async () => {
+    const request = await buildCreateAgentRequest({
+      name: "Worker",
+      model: "custom/self-hosted-model",
+      system: "Custom prompt",
+      memoryPromptMode: "standard",
+      memoryBlocks: [],
+      blockIds: ["block-1"],
+      extraTags: ["role:worker"],
+      enableMemfs: false,
+      baseTools: [],
+      hidden: true,
+      parallelToolCalls: false,
+      compactionModel: "custom/summarizer",
+    });
+
+    expect(request).toMatchObject({
+      name: "Worker",
+      model: "custom/self-hosted-model",
+      system: "Custom prompt",
+      memory_blocks: [],
+      block_ids: ["block-1"],
+      tags: [LETTA_CODE_ORIGIN_TAG, "role:worker"],
+      tools: [],
+      include_base_tools: false,
+      include_base_tool_rules: false,
+      hidden: true,
+      parallel_tool_calls: false,
+      compaction_settings: { model: "custom/summarizer" },
+    });
+  });
+});
 
 describe("buildCreateAgentRequestForPersonality", () => {
   test("matches the CLI create path for every create-agent personality", async () => {

--- a/src/agent/create-agent-request.ts
+++ b/src/agent/create-agent-request.ts
@@ -1,19 +1,17 @@
 /**
- * Pure builder for the `POST /v1/agents` wire payload of a Letta Code
- * personality agent.
+ * Pure builder for the `POST /v1/agents` wire payload of a Letta Code agent.
  *
- * This is the shared source of truth between the CLI create path
- * (`createAgentForPersonality` → `createAgent`) and external surfaces that
- * create Letta Code agents directly through Core (e.g. the chat web app via
- * the `@letta-ai/letta-code/agent-presets` package export). It must stay free
- * of Node/backend imports so it can be bundled for the browser.
+ * This is the shared creation-policy choke point for the CLI and external
+ * harness surfaces. It owns the defaults that must not drift between callers:
+ * agent type, prompt mode, tags, server tools, initial messages, parallel tool
+ * calls, and compaction. Callers may supply either a Letta Code personality or
+ * their own identity blocks without rebuilding that policy.
  *
- * Intentional differences from the CLI's `createAgent`:
- * - `context_window_limit` is omitted (the CLI resolves it via the models
- *   API at runtime); Core applies the default for the model handle.
- * - `embedding` is omitted (CLI only sets it when explicitly configured).
+ * Everything reachable from this module must stay free of Node/backend imports
+ * so it can be bundled in the browser-safe `agent-presets` package export.
  */
 
+import type { CreateBlock } from "@letta-ai/letta-client/resources/blocks/blocks";
 import { DEFAULT_SUMMARIZATION_MODEL } from "@/constants";
 import { buildCreatedAgentTags } from "./agent-tags";
 import { getDefaultMemoryBlocks } from "./memory";
@@ -25,7 +23,7 @@ import {
   type PersonalityId,
   type PersonalityMemoryBlock,
 } from "./personality-presets";
-import { buildSystemPrompt } from "./prompt-assets";
+import { buildSystemPrompt, type MemoryPromptMode } from "./prompt-assets";
 
 /** Agent type used for all Letta Code agents. */
 export const LETTA_CODE_AGENT_TYPE = "letta_v1_agent";
@@ -36,40 +34,84 @@ export const LETTA_CODE_AGENT_TYPE = "letta_v1_agent";
  */
 export const DEFAULT_CREATED_AGENT_BASE_TOOLS = ["web_search", "fetch_webpage"];
 
-export interface CreateAgentRequestForPersonality {
-  agent_type: string;
-  name: string;
-  description: string;
+export type CreateAgentMemoryBlock = CreateBlock;
+
+export interface BuildCreateAgentRequestOptions {
+  personalityId?: PersonalityId;
+  name?: string;
+  description?: string;
+  /** Model ID or handle. Personality default, then catalog default, applies. */
+  model?: string;
+  /** Complete prompt override. Otherwise the standard prompt for prompt mode. */
+  system?: string;
+  memoryPromptMode?: MemoryPromptMode;
+  /**
+   * Caller-defined identity. With a personality, matching labels replace its
+   * blocks and new labels append after the personality blocks.
+   */
+  memoryBlocks?: CreateAgentMemoryBlock[];
+  blockIds?: string[];
+  /** Extra tags appended after canonical Letta Code and personality tags. */
+  extraTags?: string[];
+  enableMemfs?: boolean;
+  isSubagent?: boolean;
+  /** Exact server-side tools. Omission uses the Letta Code web-tool defaults. */
+  baseTools?: string[];
+  embedding?: string;
+  hidden?: boolean;
+  parallelToolCalls?: boolean;
+  compactionModel?: string;
+}
+
+export interface CreateAgentRequest {
+  agent_type: typeof LETTA_CODE_AGENT_TYPE;
+  name?: string;
+  description?: string;
   model: string;
   system: string;
-  memory_blocks: PersonalityMemoryBlock[];
+  memory_blocks?: CreateAgentMemoryBlock[];
+  block_ids?: string[];
   tags: string[];
   tools: string[];
-  include_base_tools: boolean;
-  include_base_tool_rules: boolean;
+  include_base_tools: false;
+  include_base_tool_rules: false;
   initial_message_sequence: never[];
   parallel_tool_calls: boolean;
   compaction_settings: { model: string };
+  embedding?: string;
+  hidden?: boolean;
 }
 
-/**
- * Build the Core create-agent request body for a Letta Code personality
- * agent with git-backed (MemFS) memory — byte-identical content to what the
- * CLI sends when creating the same personality against the Letta API.
- */
-export async function buildCreateAgentRequestForPersonality(params: {
-  personalityId: PersonalityId;
-  name?: string;
-  description?: string;
-  /** Model ID or handle; defaults to the personality's default model. */
-  model?: string;
-  /** Extra tags (e.g. a favorite tag) appended to the Letta Code tags. */
-  extraTags?: string[];
-}): Promise<CreateAgentRequestForPersonality> {
-  const { personalityId, name, description, model, extraTags } = params;
-  const personality = getPersonalityOption(personalityId);
+export type CreateAgentRequestForPersonality = CreateAgentRequest & {
+  name: string;
+  description: string;
+  memory_blocks: PersonalityMemoryBlock[];
+};
 
-  const modelIdentifier = model ?? personality.defaultModel;
+function mergeMemoryBlocks(
+  base: CreateAgentMemoryBlock[],
+  overrides: CreateAgentMemoryBlock[] | undefined,
+): CreateAgentMemoryBlock[] {
+  const blocks = base.map((block) => ({ ...block }));
+  for (const override of overrides ?? []) {
+    const index = blocks.findIndex((block) => block.label === override.label);
+    if (index >= 0) {
+      blocks[index] = { ...override };
+    } else {
+      blocks.push({ ...override });
+    }
+  }
+  return blocks;
+}
+
+/** Build the canonical Core create-agent request for a Letta Code agent. */
+export async function buildCreateAgentRequest(
+  options: BuildCreateAgentRequestOptions = {},
+): Promise<CreateAgentRequest> {
+  const personality = options.personalityId
+    ? getPersonalityOption(options.personalityId)
+    : undefined;
+  const modelIdentifier = options.model ?? personality?.defaultModel;
   const modelHandle = modelIdentifier
     ? resolveModel(modelIdentifier)
     : getDefaultModel();
@@ -77,30 +119,83 @@ export async function buildCreateAgentRequestForPersonality(params: {
     throw new Error(`Unknown model: ${modelIdentifier}`);
   }
 
-  const defaultMemoryBlocks = await getDefaultMemoryBlocks();
+  if (
+    !options.isSubagent &&
+    options.enableMemfs !== undefined &&
+    options.memoryPromptMode !== undefined &&
+    options.enableMemfs !== (options.memoryPromptMode !== "standard")
+  ) {
+    throw new Error(
+      "enableMemfs and memoryPromptMode must describe the same memory mode",
+    );
+  }
+  const enableMemfs = options.isSubagent
+    ? false
+    : (options.enableMemfs ?? options.memoryPromptMode !== "standard");
+  const memoryPromptMode = options.isSubagent
+    ? "standard"
+    : (options.memoryPromptMode ?? (enableMemfs ? "memfs" : "standard"));
+  const personalityTags = options.personalityId
+    ? getPersonalityCreationTags(options.personalityId)
+    : [];
+  const personalityBlocks = options.personalityId
+    ? buildPersonalityMemoryBlocks(
+        options.personalityId,
+        await getDefaultMemoryBlocks(),
+      )
+    : [];
+  const memoryBlocks = options.isSubagent
+    ? undefined
+    : options.personalityId || options.memoryBlocks !== undefined
+      ? mergeMemoryBlocks(personalityBlocks, options.memoryBlocks)
+      : undefined;
+  const blockIds = options.isSubagent ? undefined : options.blockIds;
 
   return {
     agent_type: LETTA_CODE_AGENT_TYPE,
-    name: name ?? personality.label,
-    description: description ?? personality.description,
+    ...(options.name !== undefined || personality
+      ? { name: options.name ?? personality?.label }
+      : {}),
+    ...(options.description !== undefined || personality
+      ? { description: options.description ?? personality?.description }
+      : {}),
     model: modelHandle,
-    system: buildSystemPrompt("default", "memfs"),
-    memory_blocks: buildPersonalityMemoryBlocks(
-      personalityId,
-      defaultMemoryBlocks,
-    ),
+    system: options.system ?? buildSystemPrompt("default", memoryPromptMode),
+    ...(memoryBlocks !== undefined ? { memory_blocks: memoryBlocks } : {}),
+    ...(blockIds && blockIds.length > 0 ? { block_ids: blockIds } : {}),
     tags: buildCreatedAgentTags({
-      enableMemfs: true,
-      tags: [
-        ...getPersonalityCreationTags(personalityId),
-        ...(extraTags ?? []),
-      ],
+      enableMemfs,
+      isSubagent: options.isSubagent,
+      tags: [...personalityTags, ...(options.extraTags ?? [])],
     }),
-    tools: [...DEFAULT_CREATED_AGENT_BASE_TOOLS],
+    tools: [...(options.baseTools ?? DEFAULT_CREATED_AGENT_BASE_TOOLS)],
     include_base_tools: false,
     include_base_tool_rules: false,
     initial_message_sequence: [],
-    parallel_tool_calls: true,
-    compaction_settings: { model: DEFAULT_SUMMARIZATION_MODEL },
+    parallel_tool_calls: options.parallelToolCalls ?? true,
+    compaction_settings: {
+      model: options.compactionModel ?? DEFAULT_SUMMARIZATION_MODEL,
+    },
+    ...(options.embedding !== undefined
+      ? { embedding: options.embedding }
+      : {}),
+    ...(options.isSubagent
+      ? { hidden: true }
+      : options.hidden !== undefined
+        ? { hidden: options.hidden }
+        : {}),
   };
+}
+
+/** Compatibility wrapper for callers that create a personality agent. */
+export async function buildCreateAgentRequestForPersonality(params: {
+  personalityId: PersonalityId;
+  name?: string;
+  description?: string;
+  model?: string;
+  extraTags?: string[];
+}): Promise<CreateAgentRequestForPersonality> {
+  return (await buildCreateAgentRequest(
+    params,
+  )) as CreateAgentRequestForPersonality;
 }

--- a/src/agent/create.ts
+++ b/src/agent/create.ts
@@ -2,20 +2,13 @@
  * Utilities for creating an agent on the Letta API backend
  **/
 
-import type {
-  AgentState,
-  AgentType,
-} from "@letta-ai/letta-client/resources/agents/agents";
+import type { AgentState } from "@letta-ai/letta-client/resources/agents/agents";
 import { type BackendCapabilities, getBackend } from "@/backend";
 import { apiRequest, getApiRequestConfig } from "@/backend/api/request";
-import { DEFAULT_AGENT_NAME, DEFAULT_SUMMARIZATION_MODEL } from "@/constants";
+import { DEFAULT_AGENT_NAME } from "@/constants";
 import { settingsManager } from "@/settings-manager";
-import { buildCreatedAgentTags } from "./agent-tags";
 import { getModelContextWindow } from "./available-models";
-import {
-  DEFAULT_CREATED_AGENT_BASE_TOOLS,
-  LETTA_CODE_AGENT_TYPE,
-} from "./create-agent-request";
+import { buildCreateAgentRequest } from "./create-agent-request";
 import { getDefaultMemoryBlocks } from "./memory";
 import {
   formatAvailableModels,
@@ -261,9 +254,7 @@ export async function createAgent(
   // Only attach server-side tools to the agent.
   // Client-side tools (Read, Write, Bash, etc.) are passed via client_tools at runtime,
   // NOT attached to the agent. This is the new pattern - no more stub tool registration.
-  const defaultBaseTools =
-    options.baseTools ?? DEFAULT_CREATED_AGENT_BASE_TOOLS;
-  const toolNames = [...defaultBaseTools];
+  const toolNames = options.baseTools;
 
   // Determine which memory blocks to use:
   // 1. If options.memoryBlocks is provided, use those (custom blocks and/or block references)
@@ -344,49 +335,38 @@ export async function createAgent(
   // Create agent with inline memory blocks (LET-7101: single API call instead of N+1)
   // - memory_blocks: new blocks to create inline
   // - block_ids: references to existing blocks (for shared memory)
-  const tags = buildCreatedAgentTags({
-    tags: options.tags,
-    isSubagent,
-    enableMemfs: memfsConfig.enableMemfs,
-  });
-
   const agentDescription =
     options.description ?? `Letta Code agent created in ${process.cwd()}`;
 
-  const createAgentRequestBase = {
-    agent_type: LETTA_CODE_AGENT_TYPE as AgentType,
-    system: systemPromptContent,
+  const createAgentRequestBase = await buildCreateAgentRequest({
     name,
     description: agentDescription,
-    embedding: embeddingModelVal || undefined,
     model: modelHandle,
-    ...(contextWindow && { context_window_limit: contextWindow }),
-    // New blocks created inline with agent (saves ~2s of sequential API calls)
-    memory_blocks:
+    system: systemPromptContent,
+    memoryPromptMode: memMode,
+    memoryBlocks:
       filteredMemoryBlocks.length > 0 ? filteredMemoryBlocks : undefined,
-    // Referenced block IDs (existing blocks to attach)
-    block_ids: referencedBlockIds.length > 0 ? referencedBlockIds : undefined,
-    tags,
-    ...(isSubagent && { hidden: true }),
-    // should be default off, but just in case
-    include_base_tools: false,
-    include_base_tool_rules: false,
-    initial_message_sequence: [],
-    parallel_tool_calls: parallelToolCallsVal,
-    compaction_settings: {
-      model: DEFAULT_SUMMARIZATION_MODEL,
-    },
-  };
+    blockIds: referencedBlockIds,
+    extraTags: options.tags,
+    enableMemfs: memfsConfig.enableMemfs,
+    isSubagent,
+    baseTools: toolNames,
+    embedding: embeddingModelVal || undefined,
+    hidden: isSubagent || undefined,
+    parallelToolCalls: parallelToolCallsVal,
+  });
 
   const createWithTools = (tools: string[]) =>
     backend.createAgent({
       ...createAgentRequestBase,
+      ...(contextWindow && { context_window_limit: contextWindow }),
       tools,
+      agent_type: createAgentRequestBase.agent_type,
     });
 
   const agent = await createAgentWithBaseToolsRecovery(
     createWithTools,
-    toolNames,
+    createAgentRequestBase.tools,
     addBaseToolsToServer,
   );
 

--- a/src/agent/create.ts
+++ b/src/agent/create.ts
@@ -352,7 +352,6 @@ export async function createAgent(
     isSubagent,
     baseTools: toolNames,
     embedding: embeddingModelVal || undefined,
-    hidden: isSubagent || undefined,
     parallelToolCalls: parallelToolCallsVal,
   });
 
@@ -361,7 +360,6 @@ export async function createAgent(
       ...createAgentRequestBase,
       ...(contextWindow && { context_window_limit: contextWindow }),
       tools,
-      agent_type: createAgentRequestBase.agent_type,
     });
 
   const agent = await createAgentWithBaseToolsRecovery(


### PR DESCRIPTION
## Summary

- add one browser-safe request builder for both personality and caller-defined Letta Code agents
- centralize model, prompt, MemFS, subagent, memory-block, server-tool, and compaction policy instead of letting downstream packages reconstruct or delete those fields
- route the CLI creation path through the same builder while preserving runtime-only context-window resolution and tool recovery
- keep the existing personality helper as a compatibility wrapper for web and desktop consumers

The canonical request always pins server-side tools explicitly and disables the API legacy base-tool union. This prevents omitted fields from silently attaching conversation and block-memory tools to harness-created agents.

This is the first PR in the LET-10557 fix sequence. letta-ai/letta-agent-sdk#253 is the narrow compatibility safeguard; after this builder ships in the next Letta Code package release, the SDK follow-up will consume it and delete its parallel generic builder and post-build creation-policy mutations.

Validated with 17 focused creation tests, all 12 repository checks, a package build, and browser-bundle smoke tests.

👾 Generated with [Letta Code](https://letta.com)
