### PR TITLE
fix(cron): preserve the invoking computer by default

### DIFF
--- a/scripts/isolated-unit-tests.json
+++ b/scripts/isolated-unit-tests.json
@@ -26,6 +26,11 @@
       "reason": "Uses a top-level Bun module mock for backend search."
     },
     {
+      "path": "src/cli/subcommands/cron.test.ts",
+      "timeoutMs": 15000,
+      "reason": "Runs a real HTTP server while mutating the settings singleton, console methods, process environment, and local cron storage."
+    },
+    {
       "path": "src/hooks/prompt-executor.test.ts",
       "timeoutMs": 15000,
       "reason": "Uses a top-level Bun module mock for backend generation."

--- a/src/agent/prompt-assets.test.ts
+++ b/src/agent/prompt-assets.test.ts
@@ -92,6 +92,32 @@ describe("buildSystemPrompt", () => {
     expect(result).not.toContain('--author="$AGENT_NAME');
   });
 
+  test("memfs prompt documents cron execution precedence", () => {
+    const result = buildSystemPrompt("letta", "memfs");
+
+    expect(result).toContain(
+      "no explicit choice creates a durable Cloud timer targeted to the verified computer that runs `letta cron add`",
+    );
+    expect(result).toContain(
+      "`--computer <id>` to select another connected computer",
+    );
+    expect(result).toContain(
+      "explicit `--runner cloud` to select the managed Cloud sandbox",
+    );
+    expect(result).toContain(
+      "`--runner local` to create an in-process schedule in the local file",
+    );
+    expect(result).toContain(
+      "If the current computer cannot be verified as Cloud-routable, creation fails",
+    );
+    expect(result).toContain(
+      "can fall back to the agent sandbox when its target is offline; it never substitutes another device",
+    );
+    expect(result).not.toContain(
+      "schedules default to durable Cloud schedules that fire from the cloud and execute in your cloud sandbox",
+    );
+  });
+
   test("memfs prompt explains shared-memory projections", () => {
     const result = buildSystemPrompt("letta", "memfs");
 

--- a/src/agent/prompts/letta.md
+++ b/src/agent/prompts/letta.md
@@ -126,7 +126,7 @@ Creating crons:
 - Recurring monitoring/heartbeat: `letta cron add --name <short-name> --description <description> --prompt <future-message> --every "2h"` or `--cron "0 9 * * *"`
 Always include `--name`, `--description`, and `--prompt`. `$AGENT_ID` is automatically injected into the shell environment, and `letta cron` uses it by default, so you do not need to specify which agent to invoke unless overriding the current agent intentionally.
 
-Where crons run: for cloud agents, schedules default to durable Cloud schedules that fire from the cloud and execute in your cloud sandbox — they survive local shutdown, so this is the right default. If the scheduled work must run on a specific computer (e.g. it needs that computer's filesystem or local services), add `--computer <deviceId>` (from `letta environments list`) to keep the durable Cloud schedule but execute on that computer, with sandbox fallback if it is offline. Use `--runner local` only when that fallback is unacceptable; local schedules only fire while a Letta session is running on that computer.
+Where crons run: for a Cloud agent, no explicit choice creates a durable Cloud timer targeted to the verified computer that runs `letta cron add`. Use `--computer <id>` to select another connected computer, explicit `--runner cloud` to select the managed Cloud sandbox, or `--runner local` to create an in-process schedule in the local file. If the current computer cannot be verified as Cloud-routable, creation fails and tells you to choose one of those three explicit options. A device-targeted schedule can fall back to the agent sandbox when its target is offline; it never substitutes another device.
 
 # Harness Architecture
 

--- a/src/agent/prompts/letta_local_memfs.md
+++ b/src/agent/prompts/letta_local_memfs.md
@@ -120,7 +120,7 @@ Creating crons:
 - Recurring monitoring/heartbeat: `letta cron add --name <short-name> --description <description> --prompt <future-message> --every "2h"` or `--cron "0 9 * * *"`
 Always include `--name`, `--description`, and `--prompt`. `$AGENT_ID` is automatically injected into the shell environment, and `letta cron` uses it by default, so you do not need to specify which agent to invoke unless overriding the current agent intentionally.
 
-Where crons run: for cloud agents, schedules default to durable Cloud schedules that fire from the cloud and execute in your cloud sandbox — they survive local shutdown, so this is the right default. If the scheduled work must run on a specific computer (e.g. it needs that computer's filesystem or local services), add `--computer <deviceId>` (from `letta environments list`) to keep the durable Cloud schedule but execute on that computer, with sandbox fallback if it is offline. Use `--runner local` only when that fallback is unacceptable; local schedules only fire while a Letta session is running on that computer.
+Where crons run: for a Cloud agent, no explicit choice creates a durable Cloud timer targeted to the verified computer that runs `letta cron add`. Use `--computer <id>` to select another connected computer, explicit `--runner cloud` to select the managed Cloud sandbox, or `--runner local` to create an in-process schedule in the local file. If the current computer cannot be verified as Cloud-routable, creation fails and tells you to choose one of those three explicit options. A device-targeted schedule can fall back to the agent sandbox when its target is offline; it never substitutes another device.
 
 # Harness Architecture
 

--- a/src/backend/api/client.ts
+++ b/src/backend/api/client.ts
@@ -145,7 +145,7 @@ function getNodeRoutingHeader(): Record<string, string> {
   return { "x-letta-node": enabled ? "1" : "0" };
 }
 
-function getRuntimeEnvironmentDeviceId(): string {
+export function getRuntimeEnvironmentDeviceId(): string {
   // A managed runtime may have an orchestrator-assigned execution identity
   // distinct from this installation's persisted device id. Keep the override
   // scoped to runtime attribution; registration and auth still use settings.

--- a/src/cli/subcommands/cron-runner.test.ts
+++ b/src/cli/subcommands/cron-runner.test.ts
@@ -53,13 +53,17 @@ describe("resolveCronRunner", () => {
     expect(result).toMatchObject({ runner: "local" });
   });
 
-  test("server without schedule routes defaults to local runner", () => {
+  test("cloud agent errors when the server lacks schedule routes", () => {
     const result = resolveCronRunner({
       agentId: "agent-123",
       backendMode: "api",
       cloudSchedulesSupported: false,
     });
-    expect(result).toMatchObject({ runner: "local" });
+    expect("error" in result).toBe(true);
+    if ("error" in result) {
+      expect(result.error).toContain("--runner local");
+      expect(result.error).toContain("supports durable Cloud schedules");
+    }
   });
 
   test("--runner cloud errors for local-backend agents", () => {
@@ -88,6 +92,9 @@ describe("resolveCronRunner", () => {
       cloudSchedulesSupported: false,
     });
     expect("error" in result).toBe(true);
+    if ("error" in result) {
+      expect(result.error).toContain("--runner local");
+    }
   });
 
   test("--runner cloud is honored for cloud agents", () => {
@@ -181,7 +188,7 @@ describe("buildCloudScheduleInput", () => {
     expect(built.notes).toContain(CLOUD_DEVICE_FALLBACK_NOTE);
   });
 
-  test("untargeted schedules omit target_device_id entirely", () => {
+  test("managed-sandbox schedules omit target_device_id entirely", () => {
     const built = buildCloudScheduleInput({
       ...base,
       cron: "*/5 * * * *",
@@ -211,9 +218,12 @@ describe("validateTargetDevice", () => {
     expect(result).toEqual({ ok: true });
   });
 
-  test("unknown device (no local entry) passes through to server validation", () => {
+  test("unknown device is rejected before schedule creation", () => {
     const result = validateTargetDevice("device-unknown", null);
-    expect(result).toEqual({ ok: true });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain("not registered");
+    }
   });
 
   test("synthetic Cloud row is rejected with omit guidance", () => {

--- a/src/cli/subcommands/cron-runner.ts
+++ b/src/cli/subcommands/cron-runner.ts
@@ -4,15 +4,15 @@
  * Two runners own scheduled tasks:
  * - "local": the runtime-local scheduler (~/.letta/crons.json), executed by
  *   the WS listener process on this device. Dies with the device/sandbox.
- * - "cloud": durable Cloud schedules (`/v1/agents/:id/schedule`), fired by a
- *   cloud worker into the agent's managed cloud sandbox.
+ * - "cloud": durable Cloud schedules (`/v1/agents/:id/schedule`), dispatched
+ *   by a cloud worker to a targeted listener or the managed Cloud sandbox.
  *
- * Default policy: cloud agents get the cloud runner everywhere (laptop, VPS,
- * managed sandbox) — durability is the default. `--runner local` is the
- * explicit opt-in for schedules that must execute on a specific machine
- * (e.g. they need that device's filesystem). Local-backend agents
- * (`agent-local-*`) always use the local runner, and servers that don't serve
- * the Cloud schedule routes (self-hosted OSS core) fall back to it.
+ * Default policy: cloud agents get durable Cloud schedules targeted to the
+ * invocation's verified execution computer. `--runner cloud` explicitly opts
+ * into the managed Cloud sandbox instead, while `--runner local` creates an
+ * in-process schedule owned by this device. Local-backend agents
+ * (`agent-local-*`) and local backend mode use the local runner. API/Cloud
+ * agents fail closed when the configured server lacks Cloud schedule routes.
  *
  * Cloud support is determined by probing the schedule route, not by
  * inspecting the base URL: managed sandboxes and Desktop sessions point
@@ -73,15 +73,9 @@ export function resolveCronRunner(
   }
 
   if (cloudSchedulesSupported === false) {
-    if (explicit === "cloud") {
-      return {
-        error:
-          "This Letta server does not serve Cloud schedule routes (self-hosted?). Use --runner local.",
-      };
-    }
     return {
-      runner: "local",
-      reason: "server does not support Cloud schedules",
+      error:
+        "This Letta server does not support durable Cloud schedules. Use --runner local deliberately, or use a server that supports durable Cloud schedules.",
     };
   }
 
@@ -117,9 +111,9 @@ export type TargetDeviceValidity = { ok: true } | { ok: false; error: string };
  * and a synthetic Cloud row. Targeting either would earn an unhelpful server
  * 404; fail earlier with an actionable message instead.
  *
- * `environment` is null when the device wasn't found locally — that case is
- * allowed through so the server's own registry check stays the backstop
- * (the local list may be unavailable or incomplete).
+ * `environment` is null when the device could not be verified through the
+ * configured server. Schedule creation must reject that case rather than
+ * silently creating a target the Cloud scheduler cannot route.
  */
 export function validateTargetDevice(
   deviceId: string,
@@ -141,7 +135,14 @@ export function validateTargetDevice(
     };
   }
 
-  if (environment?.organizationId === "local") {
+  if (!environment) {
+    return {
+      ok: false,
+      error: `Computer ${deviceId} is not registered with this Letta account. Run \`letta environments list\` to choose a connected computer.`,
+    };
+  }
+
+  if (environment.organizationId === "local") {
     return {
       ok: false,
       error: `Device ${deviceId} is this computer's local desktop connection, not a computer connected to your Letta account. Cloud schedules can only target connected computers — run \`letta server\` on that machine (or enable remote access in the desktop app) to connect it.`,

--- a/src/cli/subcommands/cron.test.ts
+++ b/src/cli/subcommands/cron.test.ts
@@ -1,0 +1,373 @@
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "bun:test";
+import { existsSync, mkdirSync, rmSync } from "node:fs";
+import { createServer, type Server } from "node:http";
+import { join } from "node:path";
+import { listTasks } from "@/cron";
+import { type Settings, settingsManager } from "@/settings-manager";
+import { runCronSubcommand } from "./cron";
+
+type RecordedRequest = {
+  method: string;
+  path: string;
+  body?: Record<string, unknown>;
+};
+
+const TEST_DIR = join(import.meta.dir, "__cron_command_test_tmp__");
+const originalInitialize = settingsManager.initialize;
+const originalGetSettingsWithSecureTokens =
+  settingsManager.getSettingsWithSecureTokens;
+const originalGetOrCreateDeviceId = settingsManager.getOrCreateDeviceId;
+const originalConsoleLog = console.log;
+const originalConsoleError = console.error;
+const originalEnvironment = {
+  baseUrl: process.env.LETTA_BASE_URL,
+  apiKey: process.env.LETTA_API_KEY,
+  runtimeDeviceId: process.env.LETTA_RUNTIME_ENVIRONMENT_DEVICE_ID,
+  lettaHome: process.env.LETTA_HOME,
+  localBackend: process.env.LETTA_LOCAL_BACKEND_EXPERIMENTAL,
+};
+
+let server: Server;
+let baseUrl = "";
+let persistedDeviceId = "device-persisted";
+let scheduleCapabilityStatus = 200;
+let environmentLookupStatus: number | null = null;
+let requests: RecordedRequest[] = [];
+let errors: string[] = [];
+const environments = new Map<string, { organizationId: string } | null>();
+
+function sendJson(
+  response: import("node:http").ServerResponse,
+  status: number,
+  body: Record<string, unknown>,
+): void {
+  response.statusCode = status;
+  response.setHeader("content-type", "application/json");
+  response.end(JSON.stringify(body));
+}
+
+function addArgs(...extra: string[]): string[] {
+  return [
+    "add",
+    "--name",
+    "integration-task",
+    "--description",
+    "integration schedule",
+    "--prompt",
+    "do the thing",
+    "--cron",
+    "*/5 * * * *",
+    "--agent",
+    "agent-test",
+    ...extra,
+  ];
+}
+
+function schedulePosts(): RecordedRequest[] {
+  return requests.filter(
+    (request) =>
+      request.method === "POST" &&
+      request.path === "/v1/agents/agent-test/schedule",
+  );
+}
+
+beforeAll(async () => {
+  server = createServer(async (request, response) => {
+    const url = new URL(request.url ?? "/", baseUrl);
+    let body: Record<string, unknown> | undefined;
+    if (request.method === "POST") {
+      const chunks: Buffer[] = [];
+      for await (const chunk of request) {
+        chunks.push(Buffer.from(chunk));
+      }
+      body = JSON.parse(Buffer.concat(chunks).toString("utf8")) as Record<
+        string,
+        unknown
+      >;
+    }
+    requests.push({
+      method: request.method ?? "GET",
+      path: `${url.pathname}${url.search}`,
+      ...(body && { body }),
+    });
+
+    if (
+      request.method === "GET" &&
+      url.pathname === "/v1/agents/agent-test/schedule"
+    ) {
+      if (scheduleCapabilityStatus !== 200) {
+        sendJson(response, scheduleCapabilityStatus, {
+          error: "schedule route unavailable",
+        });
+        return;
+      }
+      sendJson(response, 200, {
+        scheduled_messages: [],
+        has_next_page: false,
+      });
+      return;
+    }
+
+    if (
+      request.method === "GET" &&
+      url.pathname.startsWith("/v1/environments/")
+    ) {
+      if (environmentLookupStatus !== null) {
+        sendJson(response, environmentLookupStatus, {
+          error: "environment lookup failed",
+        });
+        return;
+      }
+      const deviceId = decodeURIComponent(
+        url.pathname.slice("/v1/environments/".length),
+      );
+      const environment = environments.get(deviceId);
+      if (!environment) {
+        sendJson(response, 404, { error: "environment not found" });
+        return;
+      }
+      sendJson(response, 200, {
+        id: `environment-${deviceId}`,
+        deviceId,
+        organizationId: environment.organizationId,
+      });
+      return;
+    }
+
+    if (
+      request.method === "POST" &&
+      url.pathname === "/v1/agents/agent-test/schedule" &&
+      body
+    ) {
+      sendJson(response, 200, {
+        id: "schedule-created",
+        use_sandbox: true,
+        target_device_id: body.target_device_id ?? null,
+      });
+      return;
+    }
+
+    sendJson(response, 404, { error: "unexpected request" });
+  });
+
+  baseUrl = await new Promise<string>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        reject(new Error("test server did not bind a TCP port"));
+        return;
+      }
+      resolve(`http://127.0.0.1:${address.port}`);
+    });
+  });
+
+  settingsManager.initialize = async () => {};
+  settingsManager.getSettingsWithSecureTokens = async () =>
+    ({ env: {} }) as Settings;
+  settingsManager.getOrCreateDeviceId = () => persistedDeviceId;
+  console.log = () => {};
+  console.error = (...args: unknown[]) => {
+    errors.push(args.map(String).join(" "));
+  };
+});
+
+beforeEach(() => {
+  rmSync(TEST_DIR, { recursive: true, force: true });
+  mkdirSync(TEST_DIR, { recursive: true });
+  process.env.LETTA_HOME = TEST_DIR;
+  process.env.LETTA_BASE_URL = baseUrl;
+  process.env.LETTA_API_KEY = "test-api-key";
+  delete process.env.LETTA_RUNTIME_ENVIRONMENT_DEVICE_ID;
+  delete process.env.LETTA_LOCAL_BACKEND_EXPERIMENTAL;
+  persistedDeviceId = "device-persisted";
+  scheduleCapabilityStatus = 200;
+  environmentLookupStatus = null;
+  requests = [];
+  errors = [];
+  environments.clear();
+});
+
+afterAll(async () => {
+  settingsManager.initialize = originalInitialize;
+  settingsManager.getSettingsWithSecureTokens =
+    originalGetSettingsWithSecureTokens;
+  settingsManager.getOrCreateDeviceId = originalGetOrCreateDeviceId;
+  console.log = originalConsoleLog;
+  console.error = originalConsoleError;
+
+  for (const [key, value] of Object.entries(originalEnvironment)) {
+    const environmentKey =
+      key === "baseUrl"
+        ? "LETTA_BASE_URL"
+        : key === "apiKey"
+          ? "LETTA_API_KEY"
+          : key === "runtimeDeviceId"
+            ? "LETTA_RUNTIME_ENVIRONMENT_DEVICE_ID"
+            : key === "lettaHome"
+              ? "LETTA_HOME"
+              : "LETTA_LOCAL_BACKEND_EXPERIMENTAL";
+    if (value === undefined) delete process.env[environmentKey];
+    else process.env[environmentKey] = value;
+  }
+  rmSync(TEST_DIR, { recursive: true, force: true });
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});
+
+describe("runCronSubcommand add schedule creation", () => {
+  test("targets the registered persisted listener by default", async () => {
+    environments.set("device-persisted", { organizationId: "org-test" });
+
+    expect(await runCronSubcommand(addArgs())).toBe(0);
+
+    expect(
+      requests.map((request) => `${request.method} ${request.path}`),
+    ).toEqual([
+      "GET /v1/agents/agent-test/schedule?limit=1",
+      "GET /v1/environments/device-persisted",
+      "POST /v1/agents/agent-test/schedule",
+    ]);
+    expect(schedulePosts()[0]?.body).toMatchObject({
+      use_sandbox: true,
+      target_device_id: "device-persisted",
+    });
+  });
+
+  test("prefers the runtime execution device override", async () => {
+    process.env.LETTA_RUNTIME_ENVIRONMENT_DEVICE_ID = "device-runtime";
+    environments.set("device-runtime", { organizationId: "org-test" });
+
+    expect(await runCronSubcommand(addArgs())).toBe(0);
+
+    expect(requests.map((request) => request.path)).toContain(
+      "/v1/environments/device-runtime",
+    );
+    expect(requests.map((request) => request.path)).not.toContain(
+      "/v1/environments/device-persisted",
+    );
+    expect(schedulePosts()[0]?.body).toMatchObject({
+      use_sandbox: true,
+      target_device_id: "device-runtime",
+    });
+  });
+
+  test("explicit cloud runner creates an untargeted managed-sandbox schedule", async () => {
+    expect(await runCronSubcommand(addArgs("--runner", "cloud"))).toBe(0);
+
+    expect(
+      requests.map((request) => `${request.method} ${request.path}`),
+    ).toEqual([
+      "GET /v1/agents/agent-test/schedule?limit=1",
+      "POST /v1/agents/agent-test/schedule",
+    ]);
+    expect(schedulePosts()[0]?.body).toMatchObject({ use_sandbox: true });
+    expect(schedulePosts()[0]?.body).not.toHaveProperty("target_device_id");
+  });
+
+  test("explicit computer is verified and targeted", async () => {
+    environments.set("device-explicit", { organizationId: "org-test" });
+
+    expect(
+      await runCronSubcommand(addArgs("--computer", "device-explicit")),
+    ).toBe(0);
+
+    expect(requests.map((request) => request.path)).toContain(
+      "/v1/environments/device-explicit",
+    );
+    expect(schedulePosts()[0]?.body).toMatchObject({
+      use_sandbox: true,
+      target_device_id: "device-explicit",
+    });
+  });
+
+  test("local runner creates only the local file schedule", async () => {
+    expect(await runCronSubcommand(addArgs("--runner", "local"))).toBe(0);
+
+    expect(requests).toEqual([]);
+    expect(listTasks()).toHaveLength(1);
+    expect(existsSync(join(TEST_DIR, "crons.json"))).toBe(true);
+  });
+
+  test("local runner rejects an explicit computer without inference", async () => {
+    expect(
+      await runCronSubcommand(
+        addArgs("--runner", "local", "--computer", "device-explicit"),
+      ),
+    ).toBe(1);
+
+    expect(requests).toEqual([]);
+    expect(listTasks()).toEqual([]);
+    expect(errors.join("\n")).toContain("--computer requires the cloud runner");
+  });
+
+  test("missing Cloud schedule routes fail without creating a local task", async () => {
+    scheduleCapabilityStatus = 404;
+
+    expect(await runCronSubcommand(addArgs())).toBe(1);
+
+    expect(
+      requests.map((request) => `${request.method} ${request.path}`),
+    ).toEqual(["GET /v1/agents/agent-test/schedule?limit=1"]);
+    expect(schedulePosts()).toEqual([]);
+    expect(listTasks()).toEqual([]);
+    expect(existsSync(join(TEST_DIR, "crons.json"))).toBe(false);
+    expect(errors.join("\n")).toContain("--runner local");
+    expect(errors.join("\n")).toContain("durable Cloud schedules");
+  });
+
+  test("unregistered default device fails before schedule creation", async () => {
+    expect(await runCronSubcommand(addArgs())).toBe(1);
+
+    expect(
+      requests.map((request) => `${request.method} ${request.path}`),
+    ).toEqual([
+      "GET /v1/agents/agent-test/schedule?limit=1",
+      "GET /v1/environments/device-persisted",
+    ]);
+    expect(schedulePosts()).toEqual([]);
+    expect(errors.join("\n")).toContain("--runner cloud");
+    expect(errors.join("\n")).toContain("--computer <id>");
+    expect(errors.join("\n")).toContain("--runner local");
+  });
+
+  test("non-404 computer verification failure is not called unregistered", async () => {
+    environmentLookupStatus = 500;
+
+    expect(await runCronSubcommand(addArgs())).toBe(1);
+
+    expect(
+      requests.map((request) => `${request.method} ${request.path}`),
+    ).toEqual([
+      "GET /v1/agents/agent-test/schedule?limit=1",
+      "GET /v1/environments/device-persisted",
+    ]);
+    expect(schedulePosts()).toEqual([]);
+    expect(errors.join("\n")).toContain("Could not verify computer");
+    expect(errors.join("\n")).toContain("server returned 500");
+    expect(errors.join("\n")).not.toContain("not registered");
+    expect(errors.join("\n")).toContain("--runner cloud");
+    expect(errors.join("\n")).toContain("--computer <id>");
+    expect(errors.join("\n")).toContain("--runner local");
+  });
+
+  test("desktop-local-only default device fails before schedule creation", async () => {
+    environments.set("device-persisted", { organizationId: "local" });
+
+    expect(await runCronSubcommand(addArgs())).toBe(1);
+
+    expect(requests.map((request) => request.path)).toContain(
+      "/v1/environments/device-persisted",
+    );
+    expect(schedulePosts()).toEqual([]);
+    expect(errors.join("\n")).toContain("local desktop connection");
+  });
+});

--- a/src/cli/subcommands/cron.ts
+++ b/src/cli/subcommands/cron.ts
@@ -12,15 +12,16 @@
  *   letta cron delete --all [--agent <id>] [--runner local|cloud]
  *
  * Runners (LET-9692):
- * - "cloud" (default for cloud agents): durable Cloud schedules stored by the
- *   Letta API and executed in the agent's managed cloud sandbox.
+ * - "cloud": durable Cloud schedules stored by the Letta API. Explicit
+ *   `--runner cloud` executes in the managed cloud sandbox; the default for a
+ *   cloud agent targets the verified computer running this invocation.
  * - "local": runtime-local tasks in ~/.letta/crons.json, executed by the WS
- *   listener on this device. Default for local-backend agents and self-hosted
- *   servers; explicit opt-in (--runner local) for schedules that must run on
- *   this specific machine.
+ *   listener on this device. Default for local-backend agents/mode; explicit
+ *   opt-in (--runner local) for schedules that must run on this machine.
  */
 
 import { parseArgs } from "node:util";
+import { getRuntimeEnvironmentDeviceId } from "@/backend/api/client";
 import { ApiRequestError } from "@/backend/api/request";
 import {
   type CloudSchedule,
@@ -80,12 +81,11 @@ Add options:
   --agent <id>           Agent ID (defaults to LETTA_AGENT_ID)
   --conversation <id>    Conversation ID (defaults to LETTA_CONVERSATION_ID or "default")
   --runner <runner>      Where the schedule lives and fires:
-                           cloud - durable Cloud schedule; executes in the
-                                   agent's managed cloud sandbox (default for
-                                   cloud agents)
+                           cloud - durable Cloud schedule; explicitly executes
+                                   in the agent's managed cloud sandbox
                            local - this device's scheduler (~/.letta/crons.json);
                                    only fires while a session runs here (default
-                                   for local-backend agents / self-hosted)
+                                   for local-backend agents / local mode)
   --computer <id>        (cloud runner only) Execute on one of your
                          connected computers (deviceId from
                          \`letta environments list\`) instead of the agent's
@@ -197,23 +197,36 @@ function isRunnerFlagValid(value: string | undefined): boolean {
   return value === undefined || value === "local" || value === "cloud";
 }
 
+type TargetEnvironmentLookup =
+  | { environment: { organizationId?: string } | null }
+  | { error: string };
+
 /**
- * Best-effort lookup of a --computer deviceId in the environments registry
- * (through the same base URL the schedule request will use, so Desktop's
- * merged local+cloud view is what gets validated). Returns null when the
- * lookup fails or the device is unknown — the server-side registry check on
- * schedule create remains the backstop for those cases.
+ * Look up a deviceId in the environments registry through the same base URL
+ * the schedule request will use. A 404 proves the device is absent; other
+ * failures remain distinct so they are not mislabeled as registration state.
  */
 async function lookupEnvironmentForTarget(
   deviceId: string,
-): Promise<{ organizationId?: string } | null> {
+): Promise<TargetEnvironmentLookup> {
   try {
     const { getEnvironmentConnection } = await import(
       "@/backend/api/environments"
     );
-    return await getEnvironmentConnection(deviceId);
-  } catch {
-    return null;
+    return { environment: await getEnvironmentConnection(deviceId) };
+  } catch (error) {
+    if (error instanceof ApiRequestError && error.status === 404) {
+      return { environment: null };
+    }
+    const detail =
+      error instanceof ApiRequestError
+        ? `server returned ${error.status}`
+        : error instanceof Error
+          ? error.message
+          : "unknown verification error";
+    return {
+      error: `Could not verify computer ${deviceId}: ${detail}. No schedule was created.`,
+    };
   }
 }
 
@@ -340,7 +353,7 @@ async function handleAdd(values: CronArgValues): Promise<number> {
     return 1;
   }
 
-  const targetDeviceId = values.computer?.trim() || undefined;
+  let targetDeviceId = values.computer?.trim() || undefined;
 
   const resolved = await getRunnerForAgent(values.runner, agentId);
   if ("error" in resolved) {
@@ -359,19 +372,41 @@ async function handleAdd(values: CronArgValues): Promise<number> {
     return 1;
   }
 
-  // Pre-validate the target against the environments list: it can contain
-  // entries that are not valid Cloud-schedule targets (synthetic Cloud row,
-  // desktop-local connections). Catch those with an actionable error before
-  // hitting the server's registry 404.
+  // Explicit computer targets and invocation-local defaults must both be
+  // proven Cloud-routable before schedule creation. Explicit --runner cloud
+  // deliberately stays untargeted so it retains managed-sandbox semantics.
   if (targetDeviceId) {
-    const validity = validateTargetDevice(
-      targetDeviceId,
-      await lookupEnvironmentForTarget(targetDeviceId),
-    );
+    const lookup = await lookupEnvironmentForTarget(targetDeviceId);
+    if ("error" in lookup) {
+      console.error(`Error: ${lookup.error}`);
+      return 1;
+    }
+    const validity = validateTargetDevice(targetDeviceId, lookup.environment);
     if (!validity.ok) {
       console.error(`Error: ${validity.error}`);
       return 1;
     }
+  } else if (resolved.runner === "cloud" && values.runner !== "cloud") {
+    const activeDeviceId = getRuntimeEnvironmentDeviceId();
+    const lookup = await lookupEnvironmentForTarget(activeDeviceId);
+    if ("error" in lookup) {
+      console.error(`Error: ${lookup.error}`);
+      console.error(
+        "Use --runner cloud for the managed Cloud sandbox, --computer <id> for a connected computer, or --runner local for an in-process schedule.",
+      );
+      return 1;
+    }
+    const validity = validateTargetDevice(activeDeviceId, lookup.environment);
+    if (!validity.ok) {
+      console.error(
+        `Error: cannot create a default schedule for this computer: ${validity.error}`,
+      );
+      console.error(
+        "Use --runner cloud for the managed Cloud sandbox, --computer <id> for a connected computer, or --runner local for an in-process schedule.",
+      );
+      return 1;
+    }
+    targetDeviceId = activeDeviceId;
   }
 
   if (resolved.runner === "cloud") {

--- a/src/skills/builtin/scheduling-tasks/SKILL.md
+++ b/src/skills/builtin/scheduling-tasks/SKILL.md
@@ -16,26 +16,22 @@ This skill lets you create, list, and manage scheduled tasks using the `letta cr
 
 ## Where Schedules Run (`--runner`)
 
-There are two schedule runners, selected with the optional `--runner local|cloud` flag:
+For a Cloud agent, the creation choices are:
 
-- **`cloud`** (default for cloud agents): a durable Cloud schedule stored by the Letta API. It fires from the cloud and executes in the agent's cloud sandbox, so it survives local shutdown — the computer, sandbox, or session that created it can disappear and the schedule still fires.
-- **`local`**: a task local to the current computer (`~/.letta/crons.json`), executed by the Letta session running there. It only fires while a session is running on that computer, and it dies with that computer's local state.
+- **No explicit choice**: create a durable Cloud timer targeted to the verified computer that runs `letta cron add`.
+- **`--computer <id>`**: select another connected computer from `letta environments list`.
+- **`--runner cloud`**: select the managed Cloud sandbox without targeting a computer.
+- **`--runner local`**: create an in-process schedule in `~/.letta/crons.json`. It only fires while a Letta session is running on that computer.
 
-You normally don't need the flag — the default does the right thing. Local-backend agents (`agent-local-*`) and self-hosted servers always use the local runner.
+If the current computer cannot be verified as Cloud-routable, default creation fails and tells you to choose `--runner cloud`, `--computer <id>`, or `--runner local`. Local-backend agents (`agent-local-*`) and local backend mode use the local runner. An API server without durable Cloud schedule routes fails creation instead of silently writing a local schedule; choose `--runner local` deliberately or use a server that supports durable Cloud schedules.
 
-If the scheduled work must run on a **specific computer** (it needs that computer's filesystem, local services, or credentials — e.g. a bring-your-own machine like a Railway/VPS box or a home workstation), prefer a Cloud schedule that executes on that computer:
+A device-targeted schedule remains durable in the cloud and can fall back to the agent sandbox when its target is offline. It never substitutes another device. Use `--runner local` when sandbox fallback is unacceptable.
 
-```bash
-letta cron add ... --computer <deviceId>
-```
+Notes for Cloud schedules:
 
-The deviceId comes from `letta environments list`. The computer must be connected to your Letta account (run `letta server` on it, or enable remote access in the desktop app). The schedule stays durable in the cloud; if the computer is offline when it fires, execution falls back to the agent's cloud sandbox. Use `--runner local` (run on the target computer itself) only when that sandbox fallback is unacceptable — a local task never runs anywhere but its own computer.
-
-Notes for the cloud runner:
-
-- Untargeted schedules execute in the agent's cloud sandbox, not on the computer where you created them; `--computer` executes on the named computer with sandbox fallback.
+- Explicit `--runner cloud` executes in the managed Cloud sandbox; `--computer` and the verified-computer default are device-targeted.
 - Recurring `--cron` expressions are currently interpreted in UTC (the CLI output includes a note about this). `--at` and `--every` are unaffected.
-- If creating a Cloud schedule fails, no schedule is created — there is no silent fallback to local storage. Retry, or pass `--runner local` deliberately.
+- If creating a Cloud schedule fails, no schedule is created — there is no silent fallback to local storage.
 
 ## CLI Usage
 
@@ -69,8 +65,8 @@ letta cron add --name <short-name> --description <text> --prompt <text> <schedul
 |------|-------------|
 | `--agent <id>` | Agent ID (defaults to `LETTA_AGENT_ID` from the current shell/session) |
 | `--conversation <id>` | Conversation ID (defaults to `LETTA_CONVERSATION_ID` from the current shell/session, otherwise `"default"`) |
-| `--runner <runner>` | `cloud` or `local` — see "Where Schedules Run" above (defaults to `cloud` for cloud agents) |
-| `--computer <id>` | (cloud runner only) Execute on a connected computer instead of the agent's sandbox; falls back to the sandbox if the computer is offline |
+| `--runner <runner>` | Explicitly select the managed Cloud sandbox (`cloud`) or the in-process local file schedule (`local`) |
+| `--computer <id>` | Select another connected computer; falls back only to the agent sandbox if that target is offline |
 
 ### Listing Tasks
 
@@ -200,7 +196,7 @@ Include context about what the user originally asked for, so you can give a help
 - **One-shot cleanup (local runner)**: One-shot local tasks are garbage-collected 24 hours after firing.
 - **Timezone**: Local-runner tasks use the user's local timezone. Cloud-runner recurring `--cron` expressions are currently interpreted in UTC.
 - **Default binding precedence**: `letta cron add` uses `--agent` / `--conversation` first, then falls back to `LETTA_AGENT_ID` / `LETTA_CONVERSATION_ID`, then finally uses `"default"` for the conversation if no env var is present.
-- **Local scheduler requirement**: Local-runner tasks only fire while a Letta session is running on that computer (a WS listener must be active). If no session is running, tasks will be marked as missed. Cloud-runner schedules fire from the cloud regardless.
+- **Local scheduler requirement**: Local-runner tasks only fire while a Letta session is running on that computer (a WS listener must be active). If no session is running, tasks will be marked as missed. Durable Cloud schedules fire from the cloud and may target a verified computer or the managed Cloud sandbox.
 - **`--at` for specific times**: `--at "3:00pm"` schedules a one-shot. If the time has already passed today, it schedules for tomorrow.
 - **`--every` for daily**: `--every 1d` fires daily at midnight. For a specific time of day, use `--cron` instead (e.g. `--cron "0 9 * * *"` for 9am daily).
 

--- a/src/skills/builtin/scheduling-tasks/scheduling-tasks.test.ts
+++ b/src/skills/builtin/scheduling-tasks/scheduling-tasks.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "bun:test";
+import schedulingTasksSkill from "./SKILL.md";
+
+describe("scheduling-tasks skill", () => {
+  test("documents Cloud schedule creation precedence", () => {
+    expect(schedulingTasksSkill).toContain(
+      "No explicit choice**: create a durable Cloud timer targeted to the verified computer that runs `letta cron add`",
+    );
+    expect(schedulingTasksSkill).toContain(
+      "**`--computer <id>`**: select another connected computer",
+    );
+    expect(schedulingTasksSkill).toContain(
+      "**`--runner cloud`**: select the managed Cloud sandbox",
+    );
+    expect(schedulingTasksSkill).toContain(
+      "**`--runner local`**: create an in-process schedule",
+    );
+    expect(schedulingTasksSkill).toContain(
+      "If the current computer cannot be verified as Cloud-routable, default creation fails",
+    );
+    expect(schedulingTasksSkill).toContain(
+      "An API server without durable Cloud schedule routes fails creation instead of silently writing a local schedule",
+    );
+    expect(schedulingTasksSkill).toContain(
+      "can fall back to the agent sandbox when its target is offline. It never substitutes another device",
+    );
+    expect(schedulingTasksSkill).not.toContain(
+      "**`cloud`** (default for cloud agents)",
+    );
+  });
+});


### PR DESCRIPTION
Overlord (agent-c2adbf5c-8419-4211-8cd8-3740db164974)

## Summary

- Restore invocation locality for durable Cloud schedules by resolving and verifying the computer that runs `letta cron add`, then persisting it as `target_device_id`.
- Keep the explicit precedence: `--runner local`, `--computer <id>`, `--runner cloud`, then the verified active computer.
- Fail without creating a schedule when the active computer or durable Cloud schedule route cannot be verified. The error names the three explicit choices.
- Update bundled scheduling guidance to match the runtime behavior.

## Behavior

Before, an untargeted Cloud-agent schedule ran in the managed Cloud sandbox even when it was created from a connected computer. After this change, the default durable schedule targets the verified invoking computer. Explicit `--runner cloud` remains the opt-in for an untargeted managed-sandbox schedule.

Existing targetless schedules keep their current behavior. This PR does not change server dispatch, offline fallback, or listener acknowledgement semantics.

## Test plan

- [x] `runCronSubcommand()` tests through a real local HTTP boundary for registered default, runtime override, explicit Cloud, explicit computer, local runner, missing schedule routes, unregistered computer, verification failure, and Desktop-local-only identity
- [x] runner and payload unit tests
- [x] prompt and bundled-skill contract tests
- [x] `bun run check`
- [x] independent adversarial review of the committed diff

👾 Generated with [Letta Code](https://letta.com)