### PR TITLE
fix(memfs): reset inherited credential helpers

### DIFF
--- a/scripts/check-test-mock-isolation.js
+++ b/scripts/check-test-mock-isolation.js
@@ -91,7 +91,11 @@ function moduleMatches(moduleSpecifier, suffixes) {
 }
 
 function isRelativeInternalModule(moduleSpecifier) {
-  return moduleSpecifier.startsWith("../") || moduleSpecifier.startsWith("./");
+  return (
+    moduleSpecifier.startsWith("../") ||
+    moduleSpecifier.startsWith("./") ||
+    moduleSpecifier.startsWith("@/")
+  );
 }
 
 function lineAndColumn(sourceText, index) {

--- a/scripts/isolated-unit-tests.json
+++ b/scripts/isolated-unit-tests.json
@@ -1,7 +1,22 @@
 {
   "tests": [
     {
+      "path": "src/channels/discord-reconcile.test.ts",
+      "timeoutMs": 15000,
+      "reason": "Mocks the backend client module in beforeAll; the mock leaks into later files in the same process."
+    },
+    {
       "path": "src/channels/discord-registry.test.ts",
+      "timeoutMs": 15000,
+      "reason": "Uses a top-level Bun module mock for the backend client."
+    },
+    {
+      "path": "src/channels/slack-registry.test.ts",
+      "timeoutMs": 15000,
+      "reason": "Uses a top-level Bun module mock for the backend client."
+    },
+    {
+      "path": "src/channels/telegram-registry.test.ts",
       "timeoutMs": 15000,
       "reason": "Uses a top-level Bun module mock for the backend client."
     },

--- a/src/agent/memory-git.auth.test.ts
+++ b/src/agent/memory-git.auth.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { execSync } from "node:child_process";
+import { execFileSync, execSync } from "node:child_process";
 import {
   existsSync,
   mkdirSync,
@@ -648,9 +648,18 @@ describe("credential helper reset", () => {
     const { repo } = makeSyncedRepo();
     const key = "credential.https://api.letta.com.helper";
     git(repo, `config --local --add ${key} ""`);
-    git(
-      repo,
-      `config --local --add ${key} '!f() { echo username=stale; echo password=stale; }; f'`,
+    // Argv array instead of a shell string: cmd.exe on Windows does not strip
+    // single quotes, so a quoted helper value would split into extra args.
+    execFileSync(
+      "git",
+      [
+        "config",
+        "--local",
+        "--add",
+        key,
+        "!f() { echo username=stale; echo password=stale; }; f",
+      ],
+      { cwd: repo },
     );
 
     await refreshCredentialConfig(repo, { proxy: true });

--- a/src/agent/memory-git.auth.test.ts
+++ b/src/agent/memory-git.auth.test.ts
@@ -577,6 +577,88 @@ describe("pullMemory recovery", () => {
   });
 });
 
+describe("credential helper reset", () => {
+  async function refreshCredentialConfig(
+    repo: string,
+    options: { proxy?: boolean } = {},
+  ): Promise<void> {
+    process.env.LETTA_BASE_URL = "https://api.letta.com";
+    delete process.env.LETTA_MEMFS_BASE_URL;
+    delete process.env.LETTA_DESKTOP_MODE;
+    if (options.proxy) {
+      process.env.LETTA_MEMFS_GIT_PROXY_BASE_URL = "http://localhost:51338";
+    } else {
+      delete process.env.LETTA_MEMFS_GIT_PROXY_BASE_URL;
+    }
+    process.env.LETTA_API_KEY = "fresh-token";
+    __testOverrideGetClient(async () => ({
+      _options: { apiKey: "fresh-token" },
+    }));
+
+    await syncPendingMemoryCommitsAfterTurn("agent-123", {
+      memoryDir: repo,
+    });
+  }
+
+  test("resets inherited helpers before the repo-local Letta helper", async () => {
+    const { repo } = makeSyncedRepo();
+
+    // Run twice to prove the two-entry write is idempotent rather than
+    // accumulating another helper on every sync.
+    await refreshCredentialConfig(repo);
+    await refreshCredentialConfig(repo);
+
+    const key = "credential.https://api.letta.com.helper";
+    const helpers = git(repo, `config --local --get-all ${key}`)
+      .replaceAll("\r\n", "\n")
+      .replace(/\n$/, "")
+      .split("\n");
+    expect(helpers).toHaveLength(2);
+    expect(helpers[0]).toBe("");
+
+    // Model a system/global helper such as osxkeychain returning a stale Letta
+    // identity. Git must skip it after seeing the host-scoped empty reset.
+    const globalConfig = join(repo, "global.gitconfig");
+    const systemConfig = join(repo, "system.gitconfig");
+    writeFileSync(
+      globalConfig,
+      '[credential]\n\thelper = "!f() { echo username=stale; echo password=stale-keychain-token; }; f"\n',
+      "utf-8",
+    );
+    writeFileSync(systemConfig, "", "utf-8");
+
+    const filled = execSync("git credential fill", {
+      cwd: repo,
+      encoding: "utf-8",
+      input: "protocol=https\nhost=api.letta.com\n\n",
+      env: {
+        ...process.env,
+        GIT_CONFIG_GLOBAL: globalConfig,
+        GIT_CONFIG_SYSTEM: systemConfig,
+        GIT_TERMINAL_PROMPT: "0",
+      },
+    });
+
+    expect(filled).toContain("username=letta");
+    expect(filled).toContain("password=fresh-token");
+    expect(filled).not.toContain("stale-keychain-token");
+  });
+
+  test("desktop proxy mode clears both reset and helper entries", async () => {
+    const { repo } = makeSyncedRepo();
+    const key = "credential.https://api.letta.com.helper";
+    git(repo, `config --local --add ${key} ""`);
+    git(
+      repo,
+      `config --local --add ${key} '!f() { echo username=stale; echo password=stale; }; f'`,
+    );
+
+    await refreshCredentialConfig(repo, { proxy: true });
+
+    expect(gitOrEmpty(repo, `config --local --get-all ${key}`)).toBe("");
+  });
+});
+
 describe("assertMemoryRepoCleanForWrite", () => {
   test("allows clean local commits to wait for post-turn sync", async () => {
     const { repo, remote } = makeSyncedRepo();

--- a/src/agent/memory-git.ts
+++ b/src/agent/memory-git.ts
@@ -750,18 +750,18 @@ echo password=${token}
     helper = `!f() { echo "username=letta"; echo "password=${token}"; }; f`;
   }
 
+  // Reset inherited helpers (for example, a stale macOS osxkeychain entry)
+  // for this host before installing Letta's repo-local helper.
+  const writeHelperWithReset = async (key: string) => {
+    await gitConfig(dir, ["config", "--local", "--replace-all", key, ""]);
+    await gitConfig(dir, ["config", "--local", "--add", key, helper]);
+  };
   // Primary config: normalized origin key (most robust for git's credential lookup)
-  await gitConfig(dir, [
-    "config",
-    `credential.${normalizedBaseUrl}.helper`,
-    helper,
-  ]);
-
+  await writeHelperWithReset(`credential.${normalizedBaseUrl}.helper`);
   // Backcompat: also set raw configured URL key if it differs (older repos/configs)
   if (rawBaseUrl !== normalizedBaseUrl) {
-    await gitConfig(dir, ["config", `credential.${rawBaseUrl}.helper`, helper]);
+    await writeHelperWithReset(`credential.${rawBaseUrl}.helper`);
   }
-
   debugLog(
     "memfs-git",
     `Configured local credential helper for ${normalizedBaseUrl}${rawBaseUrl !== normalizedBaseUrl ? ` (and raw ${rawBaseUrl})` : ""}`,


### PR DESCRIPTION
## Summary

- Reset inherited Git credential helpers for the configured Letta host before installing the existing repo-local helper.
- Prevent stale system/global helpers such as macOS `osxkeychain` from answering first with the wrong Letta identity.
- Keep the current platform-specific static helper unchanged; this is the focused LET-10545 hotfix, not the dynamic-helper or OAuth redesign.
- Preserve Desktop proxy behavior by clearing both the reset and helper entries when persistent credentials are disabled.

The write is idempotent: every sync replaces the host-scoped helper list with exactly one empty reset entry followed by the existing Letta helper. Other hosts remain unaffected.

## Verification

- `bun test src/agent/memory-git.auth.test.ts` — 44 passed, 0 failed.
- `bun run check` — all 12 repository checks passed.
- Regression coverage executes `git credential fill` with a stale inherited helper and verifies Git returns the repo-local Letta credential instead.

## AI Disclosure

- [ ] This pull request was written entirely by a human
- [ ] This pull request was written with AI assistance and reviewed and edited by a human
- [ ] I have read the [AI Policy](https://github.com/letta-ai/letta-code/blob/main/AI_POLICY.md) and agree to its terms

## AI Tool(s) Used

OpenAI Codex implemented and tested the focused hotfix under human direction.

## Human Verification

Pending human review before this draft is marked ready.