### PR TITLE
fix(updater): await startup update in smoke test

### DIFF
--- a/scripts/source-file-size-baseline.json
+++ b/scripts/source-file-size-baseline.json
@@ -24,7 +24,7 @@
   "src/cli/subcommands/skills.ts": 1264,
   "src/headless.ts": 5242,
   "src/hooks/integration.test.ts": 1147,
-  "src/index.ts": 2776,
+  "src/index.ts": 2773,
   "src/mods/learning-harness.ts": 2434,
   "src/mods/mod-engine.test.ts": 2153,
   "src/mods/mod-engine.ts": 1847,

--- a/src/index.ts
+++ b/src/index.ts
@@ -710,13 +710,10 @@ async function main(): Promise<void> {
   if (values.help) {
     printHelp();
 
-    // Test-only hook to keep process alive briefly so startup auto-update can run.
-    const helpDelayMs = Number.parseInt(
-      process.env.LETTA_TEST_HELP_EXIT_DELAY_MS ?? "",
-      10,
-    );
-    if (Number.isFinite(helpDelayMs) && helpDelayMs > 0) {
-      await new Promise((resolve) => setTimeout(resolve, helpDelayMs));
+    // Test-only hook for the end-to-end startup update smoke. Normal startup
+    // keeps the update check non-blocking.
+    if (process.env.LETTA_TEST_WAIT_FOR_STARTUP_AUTO_UPDATE === "1") {
+      await autoUpdatePromise;
     }
 
     process.exit(0);

--- a/src/test-utils/update-chain-smoke.ts
+++ b/src/test-utils/update-chain-smoke.ts
@@ -315,28 +315,20 @@ async function runStartupUpdateFlow(env: NodeJS.ProcessEnv) {
     );
   }
 
-  const maxAttempts = 15;
-  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-    await runCommand("letta", ["--help"], {
-      env: {
-        ...env,
-        LETTA_TEST_HELP_EXIT_DELAY_MS: "3000",
-      },
-      timeoutMs: 120000,
-    });
+  await runCommand("letta", ["--help"], {
+    env: {
+      ...env,
+      LETTA_TEST_WAIT_FOR_STARTUP_AUTO_UPDATE: "1",
+    },
+    timeoutMs: 120000,
+  });
 
-    const current = await getInstalledVersion(env);
-    if (current === NEW_VERSION) {
-      return;
-    }
-
-    await sleep(1500);
+  const versionAfter = await getInstalledVersion(env);
+  if (versionAfter !== NEW_VERSION) {
+    throw new Error(
+      `Expected post-startup version ${NEW_VERSION}, got ${versionAfter}`,
+    );
   }
-
-  const finalVersion = await getInstalledVersion(env);
-  throw new Error(
-    `Startup auto-update did not converge to ${NEW_VERSION}; final version ${finalVersion}`,
-  );
 }
 
 async function main() {


### PR DESCRIPTION
## Problem

The nightly startup update-chain smoke repeatedly exits `letta --help` while its non-blocking auto-update is still installing. The installed version therefore remains unchanged even though the updater started correctly.

## Cause

The test-only help path waits a fixed three seconds and then calls `process.exit(0)`. That terminates the in-flight package-manager process. Retrying the CLI repeats the same race rather than observing update completion.

## Before / after

- Before: invoke `letta --help` up to 15 times, sleep for guessed intervals, and poll the installed version.
- After: set an explicit test-only flag, await the existing startup auto-update promise once, and assert that the real installed version changed.
- Normal startup remains non-blocking because the promise is awaited only when the test-only flag is set on the help path.

## Risk

Low. The runtime change is confined to an explicit test-only environment flag used by the update-chain smoke. Ordinary help, TUI, and headless startup retain non-blocking update behavior.

## Validation

- `bun test src/startup-auto-update.test.ts src/updater/auto-update.test.ts` (42 passed)
- `bun run check` (12 checks passed)
- [Nightly Update Smoke run 30925749648](https://github.com/letta-ai/letta-code/actions/runs/30925749648) passed the real Ubuntu Verdaccio/package publish/global install/startup update chain
- Local Linux/Docker attempt was blocked before build or CLI execution because the smoke workspace `bun install` timed out after 240000ms with no stderr; it was not retried.