### PR TITLE
fix(listener): expose agent MemFS to mod callbacks

### DIFF
--- a/src/websocket/listener/commands/model-toolset.ts
+++ b/src/websocket/listener/commands/model-toolset.ts
@@ -36,6 +36,7 @@ import type {
 } from "@/types/protocol_v2";
 import { OPENAI_COMPATIBLE_PROXY_UPDATE_ARG } from "@/utils/openai-endpoint";
 import {
+  createListenerModContext,
   createListenerModEvents,
   ensureListenerModAdaptersForAgent,
 } from "@/websocket/listener/mod-adapter";
@@ -536,6 +537,10 @@ export async function applyModelUpdateForRuntime(params: {
         providerTypeFromModelSettings(modelSettings) ??
         inferProviderTypeFromRegistryHandle(model.handle) ??
         null,
+      modContext: createListenerModContext({
+        sessionId: conversationId,
+        agent: { id: agentId },
+      }),
       modAdapters,
       modEvents: createListenerModEvents(modAdapters),
     });
@@ -631,6 +636,10 @@ export async function applyToolsetUpdateForRuntime(params: {
     const preparedToolContext = await prepareToolExecutionContextForScope({
       agentId,
       conversationId,
+      modContext: createListenerModContext({
+        sessionId: conversationId,
+        agent: { id: agentId },
+      }),
       modAdapters,
       modEvents: createListenerModEvents(modAdapters),
     });

--- a/src/websocket/listener/commands/model-toolset.ts
+++ b/src/websocket/listener/commands/model-toolset.ts
@@ -36,7 +36,7 @@ import type {
 } from "@/types/protocol_v2";
 import { OPENAI_COMPATIBLE_PROXY_UPDATE_ARG } from "@/utils/openai-endpoint";
 import {
-  createListenerModContext,
+  createListenerAgentModContext,
   createListenerModEvents,
   ensureListenerModAdaptersForAgent,
 } from "@/websocket/listener/mod-adapter";
@@ -537,10 +537,7 @@ export async function applyModelUpdateForRuntime(params: {
         providerTypeFromModelSettings(modelSettings) ??
         inferProviderTypeFromRegistryHandle(model.handle) ??
         null,
-      modContext: createListenerModContext({
-        sessionId: conversationId,
-        agent: { id: agentId },
-      }),
+      modContext: createListenerAgentModContext(agentId),
       modAdapters,
       modEvents: createListenerModEvents(modAdapters),
     });
@@ -636,10 +633,7 @@ export async function applyToolsetUpdateForRuntime(params: {
     const preparedToolContext = await prepareToolExecutionContextForScope({
       agentId,
       conversationId,
-      modContext: createListenerModContext({
-        sessionId: conversationId,
-        agent: { id: agentId },
-      }),
+      modContext: createListenerAgentModContext(agentId),
       modAdapters,
       modEvents: createListenerModEvents(modAdapters),
     });

--- a/src/websocket/listener/mod-adapter.test.ts
+++ b/src/websocket/listener/mod-adapter.test.ts
@@ -21,13 +21,10 @@ import {
 } from "@/tools/manager";
 import { prepareToolExecutionContextForScope } from "@/tools/toolset";
 import {
-  __listenerModAdapterTestUtils,
   createListenerModAdapter,
   createListenerModContext,
   LISTENER_MOD_CAPABILITIES,
 } from "@/websocket/listener/mod-adapter";
-import { emitListenerTurnStart } from "@/websocket/listener/turn-events";
-import type { ListenerRuntime } from "@/websocket/listener/types";
 
 const tempRoots: string[] = [];
 const originalIsMemfsEnabled =
@@ -40,7 +37,6 @@ function createTempDir(): string {
 }
 
 afterEach(() => {
-  __listenerModAdapterTestUtils.resetForTests();
   settingsManager.isMemfsEnabled = originalIsMemfsEnabled;
   clearModTools();
   clearRegisteredPiProviders();
@@ -122,103 +118,34 @@ describe("listener mod adapter", () => {
     expect(context.toolset).toBe("default");
   });
 
-  test("passes isolated agent MemFS roots through listener callbacks", async () => {
-    const root = createTempDir();
-    const modsDir = join(root, "mods");
-    const cacheDir = join(root, "cache");
-    const agentARoot = getScopedMemoryFilesystemRoot("agent-a");
-    const agentBRoot = getScopedMemoryFilesystemRoot("agent-b");
-    mkdirSync(modsDir, { recursive: true });
-    writeFileSync(
-      join(modsDir, "memfs-context.ts"),
-      `export default function activate(letta) {
-        letta.events.on("turn_start", (event, ctx) => {
-          globalThis.__listenerMemfsContexts ??= [];
-          globalThis.__listenerMemfsContexts.push({
-            agentId: event.agentId,
-            contextAgentId: ctx.agent.id,
-            memfs: ctx.memfs,
-          });
-        });
-      }`,
-    );
-    const syncedAgents = new Set<string>();
-    __listenerModAdapterTestUtils.setEnsureMemfsSyncedForAgentForTests(
-      async (_runtime, agentId) => {
-        syncedAgents.add(agentId);
-        return true;
-      },
-    );
-    __listenerModAdapterTestUtils.setAgentModsDirectoryResolverForTests(
-      () => null,
-    );
-    (
-      settingsManager as unknown as {
-        isMemfsEnabled: (agentId: string) => boolean;
-      }
-    ).isMemfsEnabled = (agentId) => {
-      expect(syncedAgents.has(agentId)).toBe(true);
-      return agentId === "agent-a" || agentId === "agent-b";
-    };
+  test("builds isolated agent MemFS roots", () => {
+    settingsManager.isMemfsEnabled = (agentId) => agentId !== "agent-disabled";
 
-    const adapter = createListenerModAdapter({
-      cacheDirectory: cacheDir,
-      globalModsDirectory: modsDir,
+    const agentAContext = createListenerModContext({
+      agent: { id: "agent-a" },
     });
-    await adapter.reload();
-    const runtime = {
-      modAdapter: adapter,
-      agentModAdapters: new Map(),
-      agentModAdapterLoads: new Map(),
-      bootWorkingDirectory: root,
-      sessionId: "listener-memfs-context-test",
-    } as unknown as ListenerRuntime;
-    const emitForAgent = (agentId: string) =>
-      emitListenerTurnStart({
-        agentId,
-        conversationId: `conversation-${agentId}`,
-        input: [],
-        runtime,
-        workingDirectory: root,
-      });
+    const agentBContext = createListenerModContext({
+      agent: { id: "agent-b" },
+    });
 
-    await Promise.all([
-      emitForAgent("agent-a"),
-      emitForAgent("agent-b"),
-      emitForAgent("agent-disabled"),
-    ]);
+    expect(agentAContext.memfs).toEqual({
+      enabled: true,
+      memoryDir: getScopedMemoryFilesystemRoot("agent-a"),
+    });
+    expect(agentBContext.memfs).toEqual({
+      enabled: true,
+      memoryDir: getScopedMemoryFilesystemRoot("agent-b"),
+    });
+    expect(agentAContext.memfs.memoryDir).not.toBe(
+      agentBContext.memfs.memoryDir,
+    );
+    expect(
+      createListenerModContext({ agent: { id: "agent-disabled" } }).memfs,
+    ).toEqual({ enabled: false, memoryDir: null });
     expect(createListenerModContext().memfs).toEqual({
       enabled: false,
       memoryDir: null,
     });
-
-    expect(
-      (globalThis as { __listenerMemfsContexts?: unknown[] })
-        .__listenerMemfsContexts,
-    ).toEqual(
-      expect.arrayContaining([
-        {
-          agentId: "agent-a",
-          contextAgentId: "agent-a",
-          memfs: { enabled: true, memoryDir: agentARoot },
-        },
-        {
-          agentId: "agent-b",
-          contextAgentId: "agent-b",
-          memfs: { enabled: true, memoryDir: agentBRoot },
-        },
-        {
-          agentId: "agent-disabled",
-          contextAgentId: "agent-disabled",
-          memfs: { enabled: false, memoryDir: null },
-        },
-      ]),
-    );
-    expect(agentARoot).not.toBe(agentBRoot);
-
-    delete (globalThis as { __listenerMemfsContexts?: unknown[] })
-      .__listenerMemfsContexts;
-    adapter.dispose();
   });
 
   test("loads provider, tool, and command registrations without exposing events or panels", async () => {

--- a/src/websocket/listener/mod-adapter.test.ts
+++ b/src/websocket/listener/mod-adapter.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { getScopedMemoryFilesystemRoot } from "@/agent/memory-filesystem";
 import { __testSetBackend } from "@/backend";
 import { FakeHeadlessBackend } from "@/backend/dev/fake-headless-backend";
 import {
@@ -19,10 +20,13 @@ import {
 } from "@/tools/manager";
 import { prepareToolExecutionContextForScope } from "@/tools/toolset";
 import {
+  __listenerModAdapterTestUtils,
   createListenerModAdapter,
   createListenerModContext,
   LISTENER_MOD_CAPABILITIES,
 } from "@/websocket/listener/mod-adapter";
+import { emitListenerTurnStart } from "@/websocket/listener/turn-events";
+import type { ListenerRuntime } from "@/websocket/listener/types";
 
 const tempRoots: string[] = [];
 
@@ -33,6 +37,7 @@ function createTempDir(): string {
 }
 
 afterEach(() => {
+  __listenerModAdapterTestUtils.resetForTests();
   clearModTools();
   clearRegisteredPiProviders();
   clearCapturedToolExecutionContexts();
@@ -111,6 +116,101 @@ describe("listener mod adapter", () => {
     });
     expect(context.permissionMode).toBe("standard");
     expect(context.toolset).toBe("default");
+  });
+
+  test("passes isolated agent MemFS roots through listener callbacks", async () => {
+    const root = createTempDir();
+    const modsDir = join(root, "mods");
+    const cacheDir = join(root, "cache");
+    const agentARoot = getScopedMemoryFilesystemRoot("agent-a");
+    const agentBRoot = getScopedMemoryFilesystemRoot("agent-b");
+    mkdirSync(modsDir, { recursive: true });
+    writeFileSync(
+      join(modsDir, "memfs-context.ts"),
+      `export default function activate(letta) {
+        letta.events.on("turn_start", (event, ctx) => {
+          globalThis.__listenerMemfsContexts ??= [];
+          globalThis.__listenerMemfsContexts.push({
+            agentId: event.agentId,
+            contextAgentId: ctx.agent.id,
+            memfs: ctx.memfs,
+          });
+        });
+      }`,
+    );
+    const syncedAgents = new Set<string>();
+    __listenerModAdapterTestUtils.setEnsureMemfsSyncedForAgentForTests(
+      async (_runtime, agentId) => {
+        syncedAgents.add(agentId);
+        return true;
+      },
+    );
+    __listenerModAdapterTestUtils.setAgentModsDirectoryResolverForTests(
+      () => null,
+    );
+    __listenerModAdapterTestUtils.setIsMemfsEnabledForTests((agentId) => {
+      expect(syncedAgents.has(agentId)).toBe(true);
+      return agentId === "agent-a" || agentId === "agent-b";
+    });
+
+    const adapter = createListenerModAdapter({
+      cacheDirectory: cacheDir,
+      globalModsDirectory: modsDir,
+    });
+    await adapter.reload();
+    const runtime = {
+      modAdapter: adapter,
+      agentModAdapters: new Map(),
+      agentModAdapterLoads: new Map(),
+      bootWorkingDirectory: root,
+      sessionId: "listener-memfs-context-test",
+    } as unknown as ListenerRuntime;
+    const emitForAgent = (agentId: string) =>
+      emitListenerTurnStart({
+        agentId,
+        conversationId: `conversation-${agentId}`,
+        input: [],
+        runtime,
+        workingDirectory: root,
+      });
+
+    await Promise.all([
+      emitForAgent("agent-a"),
+      emitForAgent("agent-b"),
+      emitForAgent("agent-disabled"),
+    ]);
+    expect(createListenerModContext().memfs).toEqual({
+      enabled: false,
+      memoryDir: null,
+    });
+
+    expect(
+      (globalThis as { __listenerMemfsContexts?: unknown[] })
+        .__listenerMemfsContexts,
+    ).toEqual(
+      expect.arrayContaining([
+        {
+          agentId: "agent-a",
+          contextAgentId: "agent-a",
+          memfs: { enabled: true, memoryDir: agentARoot },
+        },
+        {
+          agentId: "agent-b",
+          contextAgentId: "agent-b",
+          memfs: { enabled: true, memoryDir: agentBRoot },
+        },
+        {
+          agentId: "agent-disabled",
+          contextAgentId: "agent-disabled",
+          memfs: { enabled: false, memoryDir: null },
+        },
+      ]),
+    );
+    expect(agentARoot).not.toBe(agentBRoot);
+
+    delete (globalThis as { __listenerMemfsContexts?: unknown[] })
+      .__listenerMemfsContexts;
+    adapter.dispose();
   });
 
   test("loads provider, tool, and command registrations without exposing events or panels", async () => {

--- a/src/websocket/listener/mod-adapter.test.ts
+++ b/src/websocket/listener/mod-adapter.test.ts
@@ -14,6 +14,7 @@ import {
   getModToolDefinition,
   registerModTool,
 } from "@/mods/tool-registry";
+import { settingsManager } from "@/settings-manager";
 import {
   clearCapturedToolExecutionContexts,
   executeTool,
@@ -29,6 +30,8 @@ import { emitListenerTurnStart } from "@/websocket/listener/turn-events";
 import type { ListenerRuntime } from "@/websocket/listener/types";
 
 const tempRoots: string[] = [];
+const originalIsMemfsEnabled =
+  settingsManager.isMemfsEnabled.bind(settingsManager);
 
 function createTempDir(): string {
   const dir = mkdtempSync(join(tmpdir(), "letta-listener-mod-"));
@@ -38,6 +41,7 @@ function createTempDir(): string {
 
 afterEach(() => {
   __listenerModAdapterTestUtils.resetForTests();
+  settingsManager.isMemfsEnabled = originalIsMemfsEnabled;
   clearModTools();
   clearRegisteredPiProviders();
   clearCapturedToolExecutionContexts();
@@ -148,10 +152,14 @@ describe("listener mod adapter", () => {
     __listenerModAdapterTestUtils.setAgentModsDirectoryResolverForTests(
       () => null,
     );
-    __listenerModAdapterTestUtils.setIsMemfsEnabledForTests((agentId) => {
+    (
+      settingsManager as unknown as {
+        isMemfsEnabled: (agentId: string) => boolean;
+      }
+    ).isMemfsEnabled = (agentId) => {
       expect(syncedAgents.has(agentId)).toBe(true);
       return agentId === "agent-a" || agentId === "agent-b";
-    });
+    };
 
     const adapter = createListenerModAdapter({
       cacheDirectory: cacheDir,

--- a/src/websocket/listener/mod-adapter.ts
+++ b/src/websocket/listener/mod-adapter.ts
@@ -60,15 +60,12 @@ async function getUnavailableListenerClient(): Promise<Letta> {
   throw new Error("letta.client is not available in listener mods");
 }
 
-let isAgentMemfsEnabled = (agentId: string): boolean =>
-  settingsManager.isMemfsEnabled(agentId);
-
 function resolveListenerAgentMemfsContext(
   agentId: string | null,
 ): ModContext["memfs"] {
   if (!agentId) return { enabled: false, memoryDir: null };
   try {
-    return isAgentMemfsEnabled(agentId)
+    return settingsManager.isMemfsEnabled(agentId)
       ? {
           enabled: true,
           memoryDir: getScopedMemoryFilesystemRoot(agentId),
@@ -313,13 +310,9 @@ export const __listenerModAdapterTestUtils = {
   ): void {
     ensureAgentMemfsSynced = ensureSynced;
   },
-  setIsMemfsEnabledForTests(isEnabled: (agentId: string) => boolean): void {
-    isAgentMemfsEnabled = isEnabled;
-  },
   resetForTests(): void {
     resolveAgentModsDirectory = resolveListenerAgentModsDirectory;
     resolveAgentModCacheDirectory = resolveListenerAgentModCacheDirectory;
-    isAgentMemfsEnabled = (agentId) => settingsManager.isMemfsEnabled(agentId);
     ensureAgentMemfsSynced = ensureMemfsSyncedForAgent;
   },
 };

--- a/src/websocket/listener/mod-adapter.ts
+++ b/src/websocket/listener/mod-adapter.ts
@@ -60,6 +60,25 @@ async function getUnavailableListenerClient(): Promise<Letta> {
   throw new Error("letta.client is not available in listener mods");
 }
 
+let isAgentMemfsEnabled = (agentId: string): boolean =>
+  settingsManager.isMemfsEnabled(agentId);
+
+function resolveListenerAgentMemfsContext(
+  agentId: string | null,
+): ModContext["memfs"] {
+  if (!agentId) return { enabled: false, memoryDir: null };
+  try {
+    return isAgentMemfsEnabled(agentId)
+      ? {
+          enabled: true,
+          memoryDir: getScopedMemoryFilesystemRoot(agentId),
+        }
+      : { enabled: false, memoryDir: null };
+  } catch {
+    return { enabled: false, memoryDir: null };
+  }
+}
+
 export function createListenerModContext(
   options: Pick<
     CreateListenerModAdapterOptions,
@@ -81,7 +100,7 @@ export function createListenerModContext(
   } = {},
 ): ModContext {
   const cwd = options.workingDirectory ?? getCurrentWorkingDirectory();
-  return buildModInvocationContext({
+  const context = buildModInvocationContext({
     agent: options.agent ?? null,
     conversationId: options.sessionId ?? null,
     modelIdentifier: options.modelIdentifier ?? null,
@@ -89,6 +108,10 @@ export function createListenerModContext(
     toolset: options.toolset ?? null,
     workingDirectory: cwd,
   });
+  return {
+    ...context,
+    memfs: resolveListenerAgentMemfsContext(context.agent.id),
+  };
 }
 
 export function createListenerModAdapter(
@@ -290,9 +313,13 @@ export const __listenerModAdapterTestUtils = {
   ): void {
     ensureAgentMemfsSynced = ensureSynced;
   },
+  setIsMemfsEnabledForTests(isEnabled: (agentId: string) => boolean): void {
+    isAgentMemfsEnabled = isEnabled;
+  },
   resetForTests(): void {
     resolveAgentModsDirectory = resolveListenerAgentModsDirectory;
     resolveAgentModCacheDirectory = resolveListenerAgentModCacheDirectory;
+    isAgentMemfsEnabled = (agentId) => settingsManager.isMemfsEnabled(agentId);
     ensureAgentMemfsSynced = ensureMemfsSyncedForAgent;
   },
 };

--- a/src/websocket/listener/mod-adapter.ts
+++ b/src/websocket/listener/mod-adapter.ts
@@ -111,6 +111,10 @@ export function createListenerModContext(
   };
 }
 
+export function createListenerAgentModContext(agentId: string): ModContext {
+  return createListenerModContext({ agent: { id: agentId } });
+}
+
 export function createListenerModAdapter(
   options: CreateListenerModAdapterOptions = {},
 ): ModAdapter {

--- a/src/websocket/listener/recovery.ts
+++ b/src/websocket/listener/recovery.ts
@@ -45,6 +45,7 @@ import {
   normalizeToolReturnWireMessage,
 } from "./interrupts";
 import {
+  createListenerModContext,
   createListenerModEvents,
   ensureListenerModAdaptersForAgent,
 } from "./mod-adapter";
@@ -730,15 +731,22 @@ export async function resolveRecoveredApprovalResponse(
       if (!runtime.turnLifecycle.isCurrent(recoveryLease)) {
         return true;
       }
+      const permissionModeState = getOrCreateConversationPermissionModeStateRef(
+        runtime.listener,
+        recovered.agentId,
+        recovered.conversationId,
+      );
       const preparedToolContext = await prepareToolExecutionContext({
         agentId: recovered.agentId,
         conversationId: recovered.conversationId,
         workingDirectory,
-        permissionModeState: getOrCreateConversationPermissionModeStateRef(
-          runtime.listener,
-          recovered.agentId,
-          recovered.conversationId,
-        ),
+        permissionModeState,
+        modContext: createListenerModContext({
+          sessionId: recovered.conversationId,
+          workingDirectory,
+          agent: { id: recovered.agentId },
+          permissionMode: permissionModeState.mode,
+        }),
         modAdapters,
         modEvents: createListenerModEvents(modAdapters),
       });

--- a/src/websocket/listener/recovery.ts
+++ b/src/websocket/listener/recovery.ts
@@ -45,7 +45,7 @@ import {
   normalizeToolReturnWireMessage,
 } from "./interrupts";
 import {
-  createListenerModContext,
+  createListenerAgentModContext,
   createListenerModEvents,
   ensureListenerModAdaptersForAgent,
 } from "./mod-adapter";
@@ -731,22 +731,16 @@ export async function resolveRecoveredApprovalResponse(
       if (!runtime.turnLifecycle.isCurrent(recoveryLease)) {
         return true;
       }
-      const permissionModeState = getOrCreateConversationPermissionModeStateRef(
-        runtime.listener,
-        recovered.agentId,
-        recovered.conversationId,
-      );
       const preparedToolContext = await prepareToolExecutionContext({
         agentId: recovered.agentId,
         conversationId: recovered.conversationId,
         workingDirectory,
-        permissionModeState,
-        modContext: createListenerModContext({
-          sessionId: recovered.conversationId,
-          workingDirectory,
-          agent: { id: recovered.agentId },
-          permissionMode: permissionModeState.mode,
-        }),
+        permissionModeState: getOrCreateConversationPermissionModeStateRef(
+          runtime.listener,
+          recovered.agentId,
+          recovered.conversationId,
+        ),
+        modContext: createListenerAgentModContext(recovered.agentId),
         modAdapters,
         modEvents: createListenerModEvents(modAdapters),
       });

--- a/src/websocket/listener/send.ts
+++ b/src/websocket/listener/send.ts
@@ -33,7 +33,7 @@ import {
 import { appendQueuedTurnToInput } from "./continuation-input";
 import { getConversationWorkingDirectory } from "./cwd";
 import {
-  createListenerModContext,
+  createListenerAgentModContext,
   createListenerModEvents,
   ensureListenerModAdaptersForAgent,
 } from "./mod-adapter";
@@ -357,22 +357,16 @@ export async function resolveStaleApprovals(
     runtime.listener,
     runtime.agentId,
   );
-  const permissionModeState = getOrCreateConversationPermissionModeStateRef(
-    runtime.listener,
-    runtime.agentId,
-    runtime.conversationId,
-  );
   const preparedToolContext = await prepareToolExecutionContext({
     agentId: runtime.agentId,
     conversationId: recoveryConversationId,
     workingDirectory: recoveryWorkingDirectory,
-    permissionModeState,
-    modContext: createListenerModContext({
-      sessionId: recoveryConversationId,
-      workingDirectory: recoveryWorkingDirectory,
-      agent: { id: runtime.agentId },
-      permissionMode: permissionModeState.mode,
-    }),
+    permissionModeState: getOrCreateConversationPermissionModeStateRef(
+      runtime.listener,
+      runtime.agentId,
+      runtime.conversationId,
+    ),
+    modContext: createListenerAgentModContext(runtime.agentId),
     modAdapters,
     modEvents: createListenerModEvents(modAdapters),
   });

--- a/src/websocket/listener/send.ts
+++ b/src/websocket/listener/send.ts
@@ -33,6 +33,7 @@ import {
 import { appendQueuedTurnToInput } from "./continuation-input";
 import { getConversationWorkingDirectory } from "./cwd";
 import {
+  createListenerModContext,
   createListenerModEvents,
   ensureListenerModAdaptersForAgent,
 } from "./mod-adapter";
@@ -356,15 +357,22 @@ export async function resolveStaleApprovals(
     runtime.listener,
     runtime.agentId,
   );
+  const permissionModeState = getOrCreateConversationPermissionModeStateRef(
+    runtime.listener,
+    runtime.agentId,
+    runtime.conversationId,
+  );
   const preparedToolContext = await prepareToolExecutionContext({
     agentId: runtime.agentId,
     conversationId: recoveryConversationId,
     workingDirectory: recoveryWorkingDirectory,
-    permissionModeState: getOrCreateConversationPermissionModeStateRef(
-      runtime.listener,
-      runtime.agentId,
-      runtime.conversationId,
-    ),
+    permissionModeState,
+    modContext: createListenerModContext({
+      sessionId: recoveryConversationId,
+      workingDirectory: recoveryWorkingDirectory,
+      agent: { id: runtime.agentId },
+      permissionMode: permissionModeState.mode,
+    }),
     modAdapters,
     modEvents: createListenerModEvents(modAdapters),
   });

--- a/src/websocket/listener/turn-events.ts
+++ b/src/websocket/listener/turn-events.ts
@@ -62,7 +62,7 @@ export async function emitListenerTurnStart(options: {
       sessionId: options.conversationId,
       workingDirectory: options.workingDirectory,
       permissionMode: options.permissionMode ?? null,
-      agent: options.cachedAgent ?? null,
+      agent: options.cachedAgent ?? { id: options.agentId },
     });
     const event = {
       agentId: options.agentId,
@@ -107,7 +107,7 @@ export async function emitListenerTurnEnd(options: {
       sessionId: options.conversationId,
       workingDirectory: options.workingDirectory,
       permissionMode: options.permissionMode ?? null,
-      agent: options.cachedAgent ?? null,
+      agent: options.cachedAgent ?? { id: options.agentId },
     });
     const event: {
       agentId: string;

--- a/src/websocket/listener/turn-setup.ts
+++ b/src/websocket/listener/turn-setup.ts
@@ -23,6 +23,7 @@ import { detectShellContext } from "@/utils/shell-context";
 import { getInboundImageFailureModes } from "./image-policy";
 import { consumeInterruptQueue } from "./interrupts";
 import {
+  createListenerModContext,
   createListenerModEvents,
   ensureListenerModAdaptersForAgent,
 } from "./mod-adapter";
@@ -271,6 +272,12 @@ export async function prepareListenerTurn(params: {
     permissionModeState,
     skillSources: runtime.skillSources,
     cachedAgent,
+    modContext: createListenerModContext({
+      sessionId: conversationId,
+      workingDirectory,
+      permissionMode: permissionModeState.mode,
+      agent: cachedAgent ?? { id: agentId },
+    }),
     modAdapters,
     modEvents: createListenerModEvents(modAdapters),
   });

--- a/src/websocket/listener/turn-setup.ts
+++ b/src/websocket/listener/turn-setup.ts
@@ -23,7 +23,7 @@ import { detectShellContext } from "@/utils/shell-context";
 import { getInboundImageFailureModes } from "./image-policy";
 import { consumeInterruptQueue } from "./interrupts";
 import {
-  createListenerModContext,
+  createListenerAgentModContext,
   createListenerModEvents,
   ensureListenerModAdaptersForAgent,
 } from "./mod-adapter";
@@ -272,12 +272,7 @@ export async function prepareListenerTurn(params: {
     permissionModeState,
     skillSources: runtime.skillSources,
     cachedAgent,
-    modContext: createListenerModContext({
-      sessionId: conversationId,
-      workingDirectory,
-      permissionMode: permissionModeState.mode,
-      agent: cachedAgent ?? { id: agentId },
-    }),
+    modContext: createListenerAgentModContext(agentId),
     modAdapters,
     modEvents: createListenerModEvents(modAdapters),
   });


### PR DESCRIPTION
## Summary

- give listener mod callbacks the active agent’s MemFS status and scoped memory root
- preserve that context across turn events, tools, permissions, commands, model/toolset updates, and approval recovery
- keep disabled agents and concurrent agents isolated without using process-global `MEMORY_DIR`

## Problem

The listener syncs an agent’s MemFS before loading mods, but callback context construction discarded that state. `buildModInvocationContext()` then supplied `{ enabled: false, memoryDir: null }`, so MemFS-aware mods used machine-local fallback storage.

Reported in #3669.

## Before / after

Before: a MemFS-enabled agent invoked through a listener gave global and package mods a disabled MemFS context.

After: each callback resolves the active agent’s current MemFS setting and exact scoped root. Disabled and no-agent contexts remain disabled.

## Scope and risk

This does not change MemFS sync, storage, or commit behavior. It adds synchronous context metadata after the existing agent sync step. Context stays agent-scoped when one listener serves several agents.

## Test plan

- [x] Direct listener-context regression for two enabled agents, one disabled agent, and no active agent
- [x] The same context test on the parent returns disabled/null for an enabled agent; it passes here with distinct scoped roots
- [x] `bun test src/websocket/listener/mod-adapter.test.ts src/websocket/listener/agent-mod-isolation.test.ts`
- [x] `bun run check`
- [x] `git diff --check`

Overlord (agent-c2adbf5c-8419-4211-8cd8-3740db164974)

👾 Generated with [Letta Code](https://letta.com)