### PR TITLE
fix(local): wire OpenAI-compatible provider into local backend

### DIFF
--- a/src/backend/dev/pi-local-endpoint-provider.ts
+++ b/src/backend/dev/pi-local-endpoint-provider.ts
@@ -221,7 +221,13 @@ export function createLocalEndpointPiProvider(
         resolve: async ({ credential }) => {
           const apiKey = credential?.key ?? options.apiKey;
           return apiKey
-            ? { auth: { apiKey }, source: "local provider record" }
+            ? {
+                auth:
+                  apiKey === "not-needed"
+                    ? { apiKey, headers: { Authorization: null } }
+                    : { apiKey },
+                source: "local provider record",
+              }
             : undefined;
         },
       },

--- a/src/backend/dev/pi-model-factory.ts
+++ b/src/backend/dev/pi-model-factory.ts
@@ -3,6 +3,7 @@ import type { OAuthCredentials } from "@earendil-works/pi-ai/oauth";
 import { localNamesForProviderId } from "@/backend/local/local-pi-credential-store";
 import {
   getLocalProviderRecordByName,
+  LOCAL_PROVIDER_NO_API_KEY,
   type LocalProviderRecord,
   localProviderApiKeyFromRecord,
 } from "@/backend/local/local-provider-auth-store";
@@ -492,7 +493,13 @@ export async function resolvePiModelForAgent(
   // The runtime is the sole credential source (stored records, ambient env
   // via the runtime's AuthContext aliases, per-credential OAuth request
   // auth). The one named exception is zai's dual-record endpoint selection.
-  connection = { ...connection, apiKey: authResult?.auth.apiKey };
+  connection = {
+    ...connection,
+    apiKey:
+      authResult?.auth.apiKey === LOCAL_PROVIDER_NO_API_KEY
+        ? undefined
+        : authResult?.auth.apiKey,
+  };
   if (authResult?.auth.baseUrl) baseURL = authResult.auth.baseUrl;
   if (authResult?.auth.headers) {
     headers = mergeHeaders(headers, nonNullHeaders(authResult.auth.headers));

--- a/src/backend/dev/pi-models-runtime.test.ts
+++ b/src/backend/dev/pi-models-runtime.test.ts
@@ -721,9 +721,10 @@ describe("LocalPiModelsRuntime + Ollama provider", () => {
 
     await runtime.refreshAll();
 
-    // Auto-detectable local daemons may be probed; the remote Ollama Cloud
-    // endpoint must not be touched without a configured record/env key.
+    // Auto-detectable local daemons may be probed. Remote and user-defined
+    // endpoints must not be touched before the user configures them.
     expect(requested.some((url) => url.includes("ollama.com"))).toBe(false);
+    expect(requested).not.toContain("/v1/models");
   });
 
   test("endpoint change drops the stored catalog instead of restoring stale models", async () => {
@@ -785,5 +786,172 @@ describe("LocalPiModelsRuntime + Ollama provider", () => {
       { localProviderAuthStorageDir: storageDir, modelsRuntime: runtime },
     );
     expect(resolved.model.input).toEqual(["text", "image"]);
+  });
+
+  test("OpenAI-compatible discovery publishes arbitrary IDs and turns use the same Model", async () => {
+    const requests: Array<{ path: string; authorization: string | null }> = [];
+    const chatBodies: Array<Record<string, unknown>> = [];
+    const server = Bun.serve({
+      port: 0,
+      async fetch(request) {
+        const url = new URL(request.url);
+        requests.push({
+          path: url.pathname,
+          authorization: request.headers.get("authorization"),
+        });
+        if (url.pathname === "/v1/models") {
+          return Response.json({
+            data: [
+              { id: "vendor/model:latest", object: "model" },
+              { id: "plain-model", object: "model" },
+            ],
+          });
+        }
+        if (url.pathname === "/v1/chat/completions") {
+          const body = (await request.json()) as Record<string, unknown>;
+          chatBodies.push(body);
+          return sseChatResponse(String(body.model));
+        }
+        return new Response("not found", { status: 404 });
+      },
+    });
+    servers.push({ url: "", chatBodies: [], stop: () => server.stop(true) });
+    const storageDir = await mkdtemp(
+      join(tmpdir(), "pi-openai-compatible-runtime-"),
+    );
+    storageDirs.push(storageDir);
+    await createOrUpdateLocalProvider({
+      providerType: "openai-compatible",
+      providerName: "openai-compatible",
+      apiKey: "compatible-key",
+      baseURL: `http://localhost:${server.port}/v1/`,
+      storageDir,
+    });
+    const runtime = new LocalPiModelsRuntime({ storageDir });
+
+    const listed = await listLocalModels(storageDir, {
+      fetch: failingDiscoveryFetch,
+      modelsRuntime: runtime,
+    });
+    expect(listed.map((model) => model.handle)).toContain(
+      "openai-compatible/vendor/model:latest",
+    );
+    expect(listed.map((model) => model.handle)).toContain(
+      "openai-compatible/plain-model",
+    );
+
+    const published = runtime.getModel(
+      "openai-compatible",
+      "vendor/model:latest",
+    );
+    if (!published)
+      throw new Error("Expected discovered model to be published");
+    expect(published).toMatchObject({
+      provider: "openai-compatible",
+      id: "vendor/model:latest",
+      baseUrl: `http://localhost:${server.port}/v1`,
+      input: ["text"],
+      reasoning: false,
+    });
+    const resolved = await resolvePiModelForAgent(
+      "openai-compatible/vendor/model:latest",
+      { provider_type: "openai-compatible" },
+      { localProviderAuthStorageDir: storageDir, modelsRuntime: runtime },
+    );
+    expect(resolved.model).toBe(published);
+    expect(resolved.apiKey).toBe("compatible-key");
+
+    const result = await runtime
+      .streamSimple(
+        resolved.model,
+        {
+          messages: [{ role: "user", content: "hello", timestamp: Date.now() }],
+        },
+        { apiKey: resolved.apiKey, maxRetries: 0 },
+      )
+      .result();
+    expect(result.stopReason).toBe("stop");
+    expect(chatBodies).toEqual([
+      expect.objectContaining({ model: "vendor/model:latest" }),
+    ]);
+    expect(requests).toContainEqual({
+      path: "/v1/models",
+      authorization: "Bearer compatible-key",
+    });
+    expect(requests).toContainEqual({
+      path: "/v1/chat/completions",
+      authorization: "Bearer compatible-key",
+    });
+    expect(requests.some((request) => request.path === "/v1/v1/models")).toBe(
+      false,
+    );
+
+    server.stop(true);
+    await expect(runtime.refresh("openai-compatible")).rejects.toThrow();
+    const retained = runtime.getModel(
+      "openai-compatible",
+      "vendor/model:latest",
+    );
+    expect(retained).toEqual(published);
+    if (!retained) throw new Error("Expected last-known model to be retained");
+    const resolvedAfterFailure = await resolvePiModelForAgent(
+      "openai-compatible/vendor/model:latest",
+      { provider_type: "openai-compatible" },
+      { localProviderAuthStorageDir: storageDir, modelsRuntime: runtime },
+    );
+    expect(resolvedAfterFailure.model).toBe(retained);
+  });
+
+  test("keyless OpenAI-compatible discovery does not send the sentinel as Bearer auth", async () => {
+    const authorizations: Array<string | null> = [];
+    const server = Bun.serve({
+      port: 0,
+      fetch(request) {
+        authorizations.push(request.headers.get("authorization"));
+        const url = new URL(request.url);
+        if (url.pathname === "/v1/models") {
+          return Response.json({ data: [{ id: "keyless-model" }] });
+        }
+        if (url.pathname === "/v1/chat/completions") {
+          return sseChatResponse("keyless-model");
+        }
+        return new Response("not found", { status: 404 });
+      },
+    });
+    servers.push({ url: "", chatBodies: [], stop: () => server.stop(true) });
+    const storageDir = await mkdtemp(
+      join(tmpdir(), "pi-openai-compatible-keyless-"),
+    );
+    storageDirs.push(storageDir);
+    await createOrUpdateLocalProvider({
+      providerType: "openai-compatible",
+      providerName: "openai-compatible",
+      apiKey: "not-needed",
+      baseURL: `http://localhost:${server.port}`,
+      storageDir,
+    });
+    const runtime = new LocalPiModelsRuntime({ storageDir });
+
+    await runtime.refresh("openai-compatible");
+
+    const resolved = await resolvePiModelForAgent(
+      "openai-compatible/keyless-model",
+      { provider_type: "openai-compatible" },
+      { localProviderAuthStorageDir: storageDir, modelsRuntime: runtime },
+    );
+    const published = runtime.getModel("openai-compatible", "keyless-model");
+    if (!published) throw new Error("Expected keyless model to be published");
+    expect(resolved.model).toBe(published);
+    const result = await runtime
+      .streamSimple(
+        resolved.model,
+        {
+          messages: [{ role: "user", content: "hello", timestamp: Date.now() }],
+        },
+        { apiKey: resolved.apiKey, maxRetries: 0 },
+      )
+      .result();
+    expect(result.stopReason).toBe("stop");
+    expect(authorizations).toEqual([null, null]);
   });
 });

--- a/src/backend/dev/pi-models-runtime.ts
+++ b/src/backend/dev/pi-models-runtime.ts
@@ -36,12 +36,17 @@ import {
   OLLAMA_CLOUD_PI_PROVIDER_ID,
   OLLAMA_PI_PROVIDER_ID,
 } from "./pi-ollama-provider";
+import { createOpenAICompatiblePiProvider } from "./pi-openai-compatible-provider";
 import {
   getRegisteredPiProvider,
   getRegisteredPiProviderRevision,
   listRegisteredPiProviders,
 } from "./pi-provider-mod-registry";
-import { getPiProviderSpec, type PiProvider } from "./pi-provider-registry";
+import {
+  getPiProviderSpec,
+  OPENAI_COMPATIBLE_PI_PROVIDER_ID,
+  type PiProvider,
+} from "./pi-provider-registry";
 import { resolveRegisteredPiProviderRuntimeConnection } from "./registered-pi-provider-runtime";
 
 const CONFIGURED_DISCOVERY_TIMEOUT_MS = 2_000;
@@ -115,6 +120,10 @@ const MANAGED_ENDPOINT_PROVIDERS: ReadonlyMap<
   ],
   [LLAMA_CPP_PI_PROVIDER_ID, (input) => createLlamaCppPiProvider(input)],
   [LMSTUDIO_PI_PROVIDER_ID, (input) => createLmStudioPiProvider(input)],
+  [
+    OPENAI_COMPATIBLE_PI_PROVIDER_ID,
+    (input) => createOpenAICompatiblePiProvider(input),
+  ],
 ]);
 
 function resolveLocalEndpointConnection(
@@ -132,7 +141,9 @@ function resolveLocalEndpointConnection(
   const apiKey =
     localProviderApiKeyFromRecord(record) ??
     spec.apiKeyEnv?.() ??
-    spec.fallbackApiKey;
+    (record !== null || spec.autoDetectLocalEndpoint === true
+      ? spec.fallbackApiKey
+      : undefined);
   return {
     baseURL,
     apiKey,

--- a/src/backend/dev/pi-openai-compatible-provider.ts
+++ b/src/backend/dev/pi-openai-compatible-provider.ts
@@ -1,0 +1,43 @@
+import type { Provider } from "@earendil-works/pi-ai";
+import {
+  createLocalEndpointPiProvider,
+  type LocalEndpointDiscover,
+  modelIdsFromOpenAICompatibleList,
+} from "./pi-local-endpoint-provider";
+import { OPENAI_COMPATIBLE_PI_PROVIDER_ID } from "./pi-provider-registry";
+
+export interface OpenAICompatiblePiProviderOptions {
+  baseURL: string;
+  apiKey?: string;
+  fetchImpl?: typeof fetch;
+  discoveryTimeoutMs?: number;
+}
+
+const openAICompatibleDiscover: LocalEndpointDiscover = async (context) => {
+  const list = await context.fetchJson(`${context.openAIBaseURL}/models`);
+  return modelIdsFromOpenAICompatibleList(list).map(
+    (modelId) =>
+      context.lastKnown.get(modelId) ?? context.buildModel({ id: modelId }),
+  );
+};
+
+/**
+ * Dynamic provider for an arbitrary OpenAI-compatible Chat Completions API.
+ * The endpoint's /v1/models response owns model identity; capabilities remain
+ * conservative because the OpenAI model-list schema does not report them.
+ */
+export function createOpenAICompatiblePiProvider(
+  options: OpenAICompatiblePiProviderOptions,
+): Provider<"openai-completions"> {
+  return createLocalEndpointPiProvider({
+    id: OPENAI_COMPATIBLE_PI_PROVIDER_ID,
+    name: "OpenAI-compatible API",
+    baseURL: options.baseURL,
+    ...(options.apiKey ? { apiKey: options.apiKey } : {}),
+    ...(options.fetchImpl ? { fetchImpl: options.fetchImpl } : {}),
+    ...(options.discoveryTimeoutMs
+      ? { discoveryTimeoutMs: options.discoveryTimeoutMs }
+      : {}),
+    discover: openAICompatibleDiscover,
+  });
+}

--- a/src/backend/dev/pi-provider-registry.ts
+++ b/src/backend/dev/pi-provider-registry.ts
@@ -9,6 +9,8 @@ import {
 
 export const LOCAL_CHATGPT_PROVIDER_NAME = "chatgpt-plus-pro";
 export const LOCAL_OPENAI_PROVIDER_NAME = "lc-openai";
+export const LOCAL_OPENAI_COMPATIBLE_PROVIDER_NAME = "lc-openai-compatible";
+export const OPENAI_COMPATIBLE_PI_PROVIDER_ID = "openai-compatible";
 export const LOCAL_ANTHROPIC_PROVIDER_NAME = "lc-anthropic";
 export const LOCAL_OPENROUTER_PROVIDER_NAME = "lc-openrouter";
 export const LOCAL_OLLAMA_PROVIDER_NAME = "lc-ollama";
@@ -28,6 +30,7 @@ export const LOCAL_BEDROCK_PROVIDER_NAME = "lc-bedrock";
 export type LocalEndpointProvider =
   | "ollama"
   | "ollama-cloud"
+  | "openai-compatible"
   | "lmstudio"
   | "llama-cpp";
 
@@ -308,6 +311,18 @@ const LOCAL_ENDPOINT_PROVIDER_SPECS: readonly PiProviderSpec[] = [
     baseUrlEnv: () => process.env.OLLAMA_CLOUD_BASE_URL,
     localModelDiscovery: "openai-compatible",
     envConfigured: () => hasEnvValue(process.env.OLLAMA_API_KEY),
+    createCustomModel: true,
+  },
+  {
+    id: OPENAI_COMPATIBLE_PI_PROVIDER_ID,
+    providerTypes: ["openai-compatible"],
+    handlePrefixes: ["openai-compatible/"],
+    localProviderNames: [
+      OPENAI_COMPATIBLE_PI_PROVIDER_ID,
+      LOCAL_OPENAI_COMPATIBLE_PROVIDER_NAME,
+    ],
+    fallbackApiKey: "not-needed",
+    localModelDiscovery: "openai-compatible",
     createCustomModel: true,
   },
   {

--- a/src/backend/local/local-provider-auth-store.test.ts
+++ b/src/backend/local/local-provider-auth-store.test.ts
@@ -19,6 +19,50 @@ describe("local OAuth provider storage", () => {
     );
   });
 
+  test("persists keyed and keyless OpenAI-compatible connections with their base URL", async () => {
+    const storageDir = await mkdtemp(
+      join(tmpdir(), "local-openai-compatible-routing-"),
+    );
+    storageDirs.push(storageDir);
+
+    await expect(
+      createOrUpdateLocalProvider({
+        storageDir,
+        providerType: "openai-compatible",
+        providerName: "openai-compatible",
+        apiKey: "not-needed",
+      }),
+    ).rejects.toThrow("requires a base URL");
+
+    await createOrUpdateLocalProvider({
+      storageDir,
+      providerType: "openai-compatible",
+      providerName: "openai-compatible",
+      apiKey: "not-needed",
+      baseURL: "http://localhost:8000/v1",
+    });
+    expect(
+      getLocalProviderRecordByName("openai-compatible", storageDir),
+    ).toMatchObject({
+      provider_type: "openai-compatible",
+      base_url: "http://localhost:8000/v1",
+      auth: { type: "api", key: "not-needed" },
+    });
+
+    await createOrUpdateLocalProvider({
+      storageDir,
+      providerType: "openai-compatible",
+      providerName: "openai-compatible",
+      apiKey: "secret-key",
+    });
+    expect(
+      getLocalProviderRecordByName("openai-compatible", storageDir),
+    ).toMatchObject({
+      base_url: "http://localhost:8000/v1",
+      auth: { type: "api", key: "secret-key" },
+    });
+  });
+
   test("preserves proxy routing when OAuth credentials refresh", async () => {
     const storageDir = await mkdtemp(join(tmpdir(), "local-oauth-routing-"));
     storageDirs.push(storageDir);

--- a/src/backend/local/local-provider-auth-store.ts
+++ b/src/backend/local/local-provider-auth-store.ts
@@ -12,6 +12,7 @@ import { getProviderOAuthAuth } from "@/backend/dev/pi-oauth";
 import { getRegisteredPiProvider } from "@/backend/dev/pi-provider-mod-registry";
 import {
   LOCAL_CHATGPT_PROVIDER_NAME,
+  OPENAI_COMPATIBLE_PI_PROVIDER_ID,
   SUPPORTED_LOCAL_PROVIDER_TYPES,
 } from "@/backend/dev/pi-provider-registry";
 import type { LocalProviderTimeout } from "./local-provider-timeout";
@@ -29,6 +30,7 @@ export {
   LOCAL_MOONSHOT_PROVIDER_NAME,
   LOCAL_OLLAMA_CLOUD_PROVIDER_NAME,
   LOCAL_OLLAMA_PROVIDER_NAME,
+  LOCAL_OPENAI_COMPATIBLE_PROVIDER_NAME,
   LOCAL_OPENAI_PROVIDER_NAME,
   LOCAL_OPENROUTER_PROVIDER_NAME,
   LOCAL_ZAI_CODING_PROVIDER_NAME,
@@ -202,6 +204,13 @@ export async function createOrUpdateLocalProvider(input: {
 
   const file = readAuthFile(input.storageDir);
   const existing = file.providers[input.providerName];
+  const baseURL = input.baseURL ?? existing?.base_url;
+  if (
+    input.providerType === OPENAI_COMPATIBLE_PI_PROVIDER_ID &&
+    !baseURL?.trim()
+  ) {
+    throw new Error("OpenAI-compatible API requires a base URL.");
+  }
   const now = new Date().toISOString();
   const auth: LocalProviderAuth =
     input.providerType === "chatgpt_oauth"
@@ -216,9 +225,7 @@ export async function createOrUpdateLocalProvider(input: {
     ...(input.accessKey ? { access_key: input.accessKey } : {}),
     ...(input.region ? { region: input.region } : {}),
     ...(input.profile ? { profile: input.profile } : {}),
-    ...((input.baseURL ?? existing?.base_url)
-      ? { base_url: input.baseURL ?? existing?.base_url }
-      : {}),
+    ...(baseURL ? { base_url: baseURL } : {}),
     ...(input.timeout !== undefined
       ? { timeout: input.timeout }
       : existing?.timeout !== undefined

--- a/src/cli/commands/connect-normalize.ts
+++ b/src/cli/commands/connect-normalize.ts
@@ -127,6 +127,16 @@ export function isConnectBedrockProvider(
   );
 }
 
+export function isConnectBaseURLRequired(
+  provider: ResolvedConnectProvider,
+): boolean {
+  return (
+    provider.byokProvider.fields?.some(
+      (field) => field.key === "baseUrl" && field.required !== false,
+    ) === true
+  );
+}
+
 export function isConnectApiKeyProvider(
   provider: ResolvedConnectProvider,
 ): boolean {

--- a/src/cli/commands/connect.ts
+++ b/src/cli/commands/connect.ts
@@ -26,6 +26,7 @@ import { runLocalOAuthConnectFlow } from "./connect-local-oauth";
 import {
   defaultConnectApiKey,
   isConnectApiKeyProvider,
+  isConnectBaseURLRequired,
   isConnectBedrockProvider,
   isConnectOAuthProvider,
   isConnectZaiBaseProvider,
@@ -129,6 +130,7 @@ function formatConnectUsage(): string {
     "  /connect codex",
     "  /connect anthropic <api_key>",
     "  /connect openai <api_key>",
+    "  /connect openai-compatible --base-url http://localhost:8000/v1 [--api-key <api_key>]",
     "  /connect lmstudio --base-url http://127.0.0.1:1234/v1 --timeout 600s",
     "  /connect bedrock iam --access-key <id> --secret-key <key> --region <region>",
     "  /connect bedrock profile --profile <name> --region <region>",
@@ -221,7 +223,9 @@ function formatApiKeyUsage(provider: ResolvedConnectProvider): string {
       `Usage: /connect ${provider.canonical} [api_key]`,
       "",
       `Connect to ${provider.byokProvider.displayName}. API key is optional for this local provider.`,
-      "Optional: --base-url <url> --timeout <ms|duration|false>",
+      isConnectBaseURLRequired(provider)
+        ? "Required: --base-url <url>. Optional: --timeout <ms|duration|false>"
+        : "Optional: --base-url <url> --timeout <ms|duration|false>",
     ].join("\n");
   }
   return [
@@ -828,6 +832,16 @@ export async function handleConnect(
         ctx.refreshDerived,
         msg,
         `${parsed.error}\n\n${formatApiKeyUsage(provider)}`,
+        false,
+      );
+      return;
+    }
+    if (isConnectBaseURLRequired(provider) && !parsed.baseURL?.trim()) {
+      addCommandResult(
+        ctx.buffersRef,
+        ctx.refreshDerived,
+        msg,
+        `Missing required field: --base-url <url>.\n\n${formatApiKeyUsage(provider)}`,
         false,
       );
       return;

--- a/src/cli/components/provider-selector.test.ts
+++ b/src/cli/components/provider-selector.test.ts
@@ -67,6 +67,18 @@ describe("ProviderSelector local provider API keys", () => {
     expect(isChatGPTUsageProvider(openai)).toBe(false);
   });
 
+  test("keeps OpenAI-compatible endpoints distinct from named local engines", () => {
+    const provider = providerById("openai-compatible");
+
+    expect(provider).toMatchObject({
+      providerType: "openai-compatible",
+      providerName: "openai-compatible",
+      requiresApiKey: false,
+      fields: [{ key: "apiKey", required: false }, { key: "baseUrl" }],
+    });
+    expect(defaultProviderApiKey(provider)).toBe("not-needed");
+  });
+
   test("keeps LM Studio UI identity while using server provider type", () => {
     const lmstudio = providerById("lmstudio");
 
@@ -108,6 +120,9 @@ describe("ProviderSelector local provider API keys", () => {
         expect(providerApiKeyFromInput(providerById("ollama"), "   ")).toBe(
           "not-needed",
         );
+        expect(
+          providerApiKeyFromInput(providerById("openai-compatible"), ""),
+        ).toBe("not-needed");
         expect(providerApiKeyFromInput(providerById("openai"), "")).toBe(
           undefined,
         );

--- a/src/cli/connect-normalize.test.ts
+++ b/src/cli/connect-normalize.test.ts
@@ -125,6 +125,21 @@ describe("connect provider normalization", () => {
         expect(lmstudio.byokProvider.providerType).toBe("lmstudio_openai");
         expect(defaultConnectApiKey(llamaCpp)).toBe("not-needed");
         expect(llamaCpp.canonical).toBe("llama-cpp");
+
+        const openAICompatible = resolveConnectProvider(
+          "openai-compatible",
+          "local",
+        );
+        if (!openAICompatible) {
+          throw new Error(
+            "Expected local openai-compatible provider to resolve",
+          );
+        }
+        expect(openAICompatible.canonical).toBe("openai-compatible");
+        expect(openAICompatible.byokProvider.providerType).toBe(
+          "openai-compatible",
+        );
+        expect(defaultConnectApiKey(openAICompatible)).toBe("not-needed");
       },
     );
   });

--- a/src/cli/subcommands/connect.test.ts
+++ b/src/cli/subcommands/connect.test.ts
@@ -286,6 +286,45 @@ describe("connect subcommand", () => {
     );
   });
 
+  test("requires a base URL for the local OpenAI-compatible provider", async () => {
+    const { stderr, deps } = createIoDeps();
+    setProviderTarget("local");
+
+    const exitCode = await runConnectSubcommand(["openai-compatible"], deps);
+
+    expect(exitCode).toBe(1);
+    expect(stderr.join("\n")).toContain("Missing base URL");
+    expect(deps.promptSecret).not.toHaveBeenCalled();
+    expect(deps.checkProviderApiKey).not.toHaveBeenCalled();
+    expect(deps.createOrUpdateProvider).not.toHaveBeenCalled();
+  });
+
+  test("connects a keyless local OpenAI-compatible provider", async () => {
+    const { deps } = createIoDeps();
+    setProviderTarget("local");
+
+    const exitCode = await runConnectSubcommand(
+      ["openai-compatible", "--base-url", "http://127.0.0.1:8000/v1/"],
+      deps,
+    );
+
+    expect(exitCode).toBe(0);
+    expect(deps.promptSecret).not.toHaveBeenCalled();
+    expect(deps.checkProviderApiKey).toHaveBeenCalledWith(
+      "openai-compatible",
+      "not-needed",
+    );
+    expect(deps.createOrUpdateProvider).toHaveBeenCalledWith(
+      "openai-compatible",
+      "openai-compatible",
+      "not-needed",
+      undefined,
+      undefined,
+      undefined,
+      { baseURL: "http://127.0.0.1:8000/v1/" },
+    );
+  });
+
   test("connects llama.cpp local provider alias", async () => {
     const { deps } = createIoDeps();
     setProviderTarget("local");

--- a/src/cli/subcommands/connect.ts
+++ b/src/cli/subcommands/connect.ts
@@ -9,6 +9,7 @@ import {
 import {
   defaultConnectApiKey,
   isConnectApiKeyProvider,
+  isConnectBaseURLRequired,
   isConnectBedrockProvider,
   isConnectOAuthProvider,
   isConnectZaiBaseProvider,
@@ -124,6 +125,7 @@ function formatUsage(): string {
     "  letta connect codex --method device-code",
     "  letta connect anthropic <api_key>",
     "  letta connect openai --api-key <api_key>",
+    "  letta connect openai-compatible --base-url http://localhost:8000/v1 [--api-key <api_key>]",
     "  letta connect ollama --base-url http://192.168.1.50:11434/v1",
     "  letta connect lmstudio --base-url http://127.0.0.1:1234/v1 --timeout 600s",
     "  letta connect llama-cpp --base-url http://localhost:8080/v1",
@@ -422,6 +424,15 @@ export async function runConnectSubcommand(
       connectionOptions = connectionOptionsFromArgs(parsed.values);
     } catch (error) {
       io.stderr(getErrorMessage(error));
+      return 1;
+    }
+    if (
+      isConnectBaseURLRequired(provider) &&
+      !connectionOptions.baseURL?.trim()
+    ) {
+      io.stderr(
+        `Missing base URL for ${provider.canonical}. Pass --base-url <url>.`,
+      );
       return 1;
     }
     apiKey ||= defaultConnectApiKey(provider) ?? "";

--- a/src/providers/byok-providers.ts
+++ b/src/providers/byok-providers.ts
@@ -285,6 +285,20 @@ const LOCAL_EXTRA_PROVIDER_CONFIGS: readonly ByokProvider[] = [
     providerNames: ["ollama-cloud", "lc-ollama-cloud"],
   },
   {
+    id: "openai-compatible",
+    displayName: "OpenAI-compatible API",
+    description: "Connect an OpenAI-compatible Chat Completions endpoint",
+    providerType: "openai-compatible",
+    providerName: "openai-compatible",
+    providerNames: ["openai-compatible", "lc-openai-compatible"],
+    requiresApiKey: false,
+    defaultApiKey: LOCAL_PROVIDER_NO_API_KEY,
+    fields: [
+      { key: "apiKey", label: "API Key", secret: true, required: false },
+      { key: "baseUrl", label: "Base URL" },
+    ],
+  },
+  {
     id: "lmstudio",
     displayName: "LM Studio (local)",
     description:

--- a/src/providers/local-pi-provider-catalog.test.ts
+++ b/src/providers/local-pi-provider-catalog.test.ts
@@ -44,6 +44,29 @@ describe("local pi provider catalog", () => {
     expect(apiProviderIds.has("llama-cpp")).toBe(false);
   });
 
+  test("local OpenAI-compatible config is distinct and requires only its base URL", () => {
+    const provider = getProviderConfigs("local").find(
+      (candidate) => candidate.id === "openai-compatible",
+    );
+
+    expect(provider).toMatchObject({
+      id: "openai-compatible",
+      displayName: "OpenAI-compatible API",
+      providerType: "openai-compatible",
+      providerName: "openai-compatible",
+      providerNames: ["openai-compatible", "lc-openai-compatible"],
+      requiresApiKey: false,
+      defaultApiKey: "not-needed",
+      fields: [
+        { key: "apiKey", secret: true, required: false },
+        { key: "baseUrl", label: "Base URL" },
+      ],
+    });
+    expect(provider?.providerType).not.toBe("openai");
+    expect(provider?.providerType).not.toBe("lmstudio_openai");
+    expect(provider?.providerType).not.toBe("llama_cpp");
+  });
+
   test("local /connect configs cover every upstream pi-ai provider", () => {
     const coveredProviders = new Set(
       getProviderConfigs("local")
@@ -120,6 +143,7 @@ describe("local pi provider catalog", () => {
     const endpointProviders = new Set([
       "ollama",
       "ollama-cloud",
+      "openai-compatible",
       "lmstudio",
       "llama-cpp",
     ]);


### PR DESCRIPTION
## Summary
- add a first-class local `openai-compatible` provider to the CLI, TUI, and provider selector
- discover arbitrary model IDs from the configured `/v1/models` endpoint and use the same published model for turns
- support keyed and keyless endpoints without sending the internal no-key sentinel as authorization

## Before and after

Before, `letta --backend local connect openai-compatible` returned `Unknown provider`, so users had to configure arbitrary endpoints as LM Studio or llama.cpp.

After, the local provider has its own identity and stable `openai-compatible/<model-id>` handles. The base URL is required. The API key is optional.

## Scope and risk
- local backend only; the existing cloud provider flow is unchanged
- model capabilities remain text-only and non-reasoning because the standard model-list response does not report them
- the provider keeps the last successful model list when a refresh fails
- unconfigured custom endpoints are not probed
- this adds one configured OpenAI-compatible connection, not multiple named profiles

## Validation
- [x] 93 focused provider, CLI, storage, selector, discovery, and turn tests
- [x] command-level smoke using the source CLI and a mock OpenAI-compatible server
- [x] keyed and keyless discovery and Chat Completions requests
- [x] `bun run check`
- [x] listener tests that failed in the full parallel unit run passed when rerun in isolation
- [ ] full integration suite could not create its required test agents in the current test environment; CI will run it independently

Overlord (agent-c2adbf5c-8419-4211-8cd8-3740db164974)

👾 Generated with [Letta Code](https://letta.com)
