### PR TITLE
fix(reflection): isolate child processes from mods

### DIFF
--- a/src/agent/subagent-env-composition.test.ts
+++ b/src/agent/subagent-env-composition.test.ts
@@ -5,12 +5,45 @@ import {
   composeSubagentChildEnv,
   resolveSubagentInheritedPrimaryRoot,
 } from "@/agent/subagents/subagent-launcher";
+import { LETTA_DISABLE_MODS_ENV } from "@/mods/disable";
 import { LETTA_INHERITED_CHANNEL_CONTEXT_ENV } from "@/runtime-context";
 
 const PARENT_ID = "agent-226cd814-09bf-4436-940e-aea9d91d14cb";
 const PARENT_MEMORY_DIR = `/Users/someone/.letta/agents/${PARENT_ID}/memory`;
 
 describe("composeSubagentChildEnv", () => {
+  test("reflection subagents disable mods in the child process only", () => {
+    const parentProcessEnv: NodeJS.ProcessEnv = {
+      HOME: "/home/user",
+      [LETTA_DISABLE_MODS_ENV]: "0",
+    };
+    const originalProcessValue = process.env[LETTA_DISABLE_MODS_ENV];
+
+    const env = composeSubagentChildEnv({
+      parentProcessEnv,
+      parentAgentId: PARENT_ID,
+      subagentType: "reflection",
+      launchProfile: "memory-subagent",
+      inheritedPrimaryRoot: PARENT_MEMORY_DIR,
+    });
+
+    expect(env[LETTA_DISABLE_MODS_ENV]).toBe("1");
+    expect(parentProcessEnv[LETTA_DISABLE_MODS_ENV]).toBe("0");
+    expect(process.env[LETTA_DISABLE_MODS_ENV]).toBe(originalProcessValue);
+  });
+
+  test("non-reflection subagents do not disable mods by default", () => {
+    const env = composeSubagentChildEnv({
+      parentProcessEnv: { HOME: "/home/user" },
+      parentAgentId: PARENT_ID,
+      subagentType: "general-purpose",
+      launchProfile: "default",
+      inheritedPrimaryRoot: PARENT_MEMORY_DIR,
+    });
+
+    expect(env[LETTA_DISABLE_MODS_ENV]).toBeUndefined();
+  });
+
   test("normal subagent records parent identity without overriding memory dir", () => {
     const env = composeSubagentChildEnv({
       parentProcessEnv: { HOME: "/home/user" },

--- a/src/agent/subagents/manager.ts
+++ b/src/agent/subagents/manager.ts
@@ -455,6 +455,7 @@ async function executeSubagent(
       backendMode,
       localBackendStorageDir,
       parentAgentId,
+      subagentType: type,
       launchProfile: effectiveLaunchProfile,
       inheritedPrimaryRoot,
       memoryScope,

--- a/src/agent/subagents/subagent-launcher.ts
+++ b/src/agent/subagents/subagent-launcher.ts
@@ -8,6 +8,7 @@
 
 import { type BackendMode, getLocalBackendStorageDir } from "@/backend";
 import { getLocalBackendMemoryFilesystemRoot } from "@/backend/local/paths";
+import { LETTA_DISABLE_MODS_ENV } from "@/mods/disable";
 import {
   getCurrentWorkingDirectory,
   type InheritedChannelContextPayload,
@@ -132,6 +133,8 @@ export interface ComposeSubagentChildEnvOptions {
   /** Parent agent ID. When present, sets LETTA_PARENT_AGENT_ID so prompts,
    * scripts, and the cross-agent guard can identify the immediate parent. */
   parentAgentId: string | undefined;
+  /** Subagent config type, used for type-specific child process isolation. */
+  subagentType?: string;
   /** The subagent config's declared launch profile. Subagents with the memory-subagent profile
    * operate on the parent's memory filesystem. */
   launchProfile: SubagentLaunchProfile | undefined;
@@ -197,6 +200,7 @@ export function composeSubagentChildEnv(
     backendMode,
     localBackendStorageDir,
     parentAgentId,
+    subagentType,
     launchProfile,
     inheritedPrimaryRoot,
     memoryScope,
@@ -211,6 +215,7 @@ export function composeSubagentChildEnv(
     ...(inheritedApiKey && { LETTA_API_KEY: inheritedApiKey }),
     ...(inheritedBaseUrl && { LETTA_BASE_URL: inheritedBaseUrl }),
     LETTA_CODE_AGENT_ROLE: "subagent",
+    ...(subagentType === "reflection" && { [LETTA_DISABLE_MODS_ENV]: "1" }),
     ...(parentAgentId && { LETTA_PARENT_AGENT_ID: parentAgentId }),
     ...(transcriptPath && { TRANSCRIPT_PATH: transcriptPath }),
     ...(inheritedChannelContext && {


### PR DESCRIPTION
## Summary
- disable global and memory-local mods only inside reflection child processes
- preserve primary-process and non-reflection subagent mod behavior
- prevent mod hooks from injecting additional system messages into reflection provider requests
- cover inherited environment overrides and process isolation in child-env tests

## Test plan
- [x] `bun test src/agent/subagent-env-composition.test.ts`
- [x] `bun run check`
- [x] Verify a live `/reflect` child has `LETTA_DISABLE_MODS=1`

👾 Generated with [Letta Code](https://letta.com)