### PR TITLE
fix(listener): forward safe terminal turn errors

### DIFF
--- a/src/websocket/listen-client-concurrency.test.ts
+++ b/src/websocket/listen-client-concurrency.test.ts
@@ -359,6 +359,20 @@ function makeIncomingMessage(
   };
 }
 
+// Keep listener/runtime setup consistent across tests without repeating the
+// full construction sequence at every handleIncomingMessage boundary.
+function createRuntime(agentId: string, conversationId: string) {
+  const listener = __listenClientTestUtils.createListenerRuntime();
+  return {
+    listener,
+    runtime: __listenClientTestUtils.getOrCreateConversationRuntime(
+      listener,
+      agentId,
+      conversationId,
+    ),
+  };
+}
+
 function makeRecoveredApprovalState(params: {
   agentId: string;
   conversationId: string;
@@ -534,12 +548,7 @@ describe("listen-client multi-worker concurrency", () => {
   });
 
   test("processes simultaneous turns for two named conversations under one agent", async () => {
-    const listener = __listenClientTestUtils.createListenerRuntime();
-    const runtimeA = __listenClientTestUtils.getOrCreateConversationRuntime(
-      listener,
-      "agent-1",
-      "conv-a",
-    );
+    const { listener, runtime: runtimeA } = createRuntime("agent-1", "conv-a");
     const runtimeB = __listenClientTestUtils.getOrCreateConversationRuntime(
       listener,
       "agent-1",
@@ -596,7 +605,10 @@ describe("listen-client multi-worker concurrency", () => {
           }));
         }`,
       );
-      const listener = __listenClientTestUtils.createListenerRuntime();
+      const { listener, runtime } = createRuntime(
+        "agent-cancel",
+        "conv-cancel",
+      );
       listener.modAdapter = createListenerModAdapter({
         cacheDirectory: cacheDir,
         globalModsDirectory: modsDir,
@@ -604,11 +616,6 @@ describe("listen-client multi-worker concurrency", () => {
         workingDirectory: modsDir,
       });
       await listener.modAdapter.reload();
-      const runtime = __listenClientTestUtils.getOrCreateConversationRuntime(
-        listener,
-        "agent-cancel",
-        "conv-cancel",
-      );
       const socket = new MockSocket();
 
       await __listenClientTestUtils.handleIncomingMessage(
@@ -628,12 +635,7 @@ describe("listen-client multi-worker concurrency", () => {
   });
 
   test("listener turns do not bypass send-boundary image normalization", async () => {
-    const listener = __listenClientTestUtils.createListenerRuntime();
-    const runtime = __listenClientTestUtils.getOrCreateConversationRuntime(
-      listener,
-      "agent-1",
-      "conv-image",
-    );
+    const { runtime } = createRuntime("agent-1", "conv-image");
     const socket = new MockSocket();
     const drain = createDeferredDrain();
     drainHandlers.set("conv-image", () => drain.promise);
@@ -675,12 +677,7 @@ describe("listen-client multi-worker concurrency", () => {
   });
 
   test("keeps default conversations separate for different agents during concurrent turns", async () => {
-    const listener = __listenClientTestUtils.createListenerRuntime();
-    const runtimeA = __listenClientTestUtils.getOrCreateConversationRuntime(
-      listener,
-      "agent-a",
-      "default",
-    );
+    const { listener, runtime: runtimeA } = createRuntime("agent-a", "default");
     const runtimeB = __listenClientTestUtils.getOrCreateConversationRuntime(
       listener,
       "agent-b",
@@ -727,13 +724,10 @@ describe("listen-client multi-worker concurrency", () => {
     agentModelById.set("agent-openai", "openai/gpt-5.3-codex");
     agentModelById.set("agent-anthropic", "anthropic/claude-sonnet-4");
 
-    const listener = __listenClientTestUtils.createListenerRuntime();
-    const runtimeOpenAI =
-      __listenClientTestUtils.getOrCreateConversationRuntime(
-        listener,
-        "agent-openai",
-        "conv-openai",
-      );
+    const { listener, runtime: runtimeOpenAI } = createRuntime(
+      "agent-openai",
+      "conv-openai",
+    );
     const runtimeAnthropic =
       __listenClientTestUtils.getOrCreateConversationRuntime(
         listener,
@@ -798,12 +792,7 @@ describe("listen-client multi-worker concurrency", () => {
   });
 
   test("cancelling one conversation runtime does not cancel another", async () => {
-    const listener = __listenClientTestUtils.createListenerRuntime();
-    const runtimeA = __listenClientTestUtils.getOrCreateConversationRuntime(
-      listener,
-      "agent-1",
-      "conv-a",
-    );
+    const { listener, runtime: runtimeA } = createRuntime("agent-1", "conv-a");
     const runtimeB = __listenClientTestUtils.getOrCreateConversationRuntime(
       listener,
       "agent-1",
@@ -820,12 +809,7 @@ describe("listen-client multi-worker concurrency", () => {
   });
 
   test("recovered approval state does not leak across conversation scopes", () => {
-    const listener = __listenClientTestUtils.createListenerRuntime();
-    const runtimeA = __listenClientTestUtils.getOrCreateConversationRuntime(
-      listener,
-      "agent-1",
-      "conv-a",
-    );
+    const { listener, runtime: runtimeA } = createRuntime("agent-1", "conv-a");
     __listenClientTestUtils.getOrCreateConversationRuntime(
       listener,
       "agent-1",
@@ -2072,13 +2056,46 @@ describe("listen-client multi-worker concurrency", () => {
     ).toBe(true);
   });
 
-  test("pre-stream 409 resumes via conversations stream with message otid", async () => {
-    const listener = __listenClientTestUtils.createListenerRuntime();
-    const runtime = __listenClientTestUtils.getOrCreateConversationRuntime(
-      listener,
-      "agent-409-otid",
-      "conv-409-otid",
+  // Channel consumers finalize immediately on turn_finished, so the terminal
+  // event itself must carry the failure detail. A later loop_error is too late.
+  // Exercise the send boundary rather than the terminal serializer in isolation.
+  test("pre-stream 402 includes API error detail in turn_finished", async () => {
+    const agentId = "agent-402-terminal-error";
+    const conversationId = "conv-402-terminal-error";
+    const { runtime } = createRuntime(agentId, conversationId);
+    const socket = new MockSocket();
+    sendMessageStreamMock.mockRejectedValueOnce(
+      new APIError(
+        402,
+        {
+          error: "Rate limited",
+          reasons: ["not-enough-credits", "requests", "tokens"],
+        },
+        undefined,
+        new Headers(),
+      ),
     );
+
+    await __listenClientTestUtils.handleIncomingMessage(
+      makeIncomingMessage(agentId, conversationId, "hello"),
+      socket as unknown as WebSocket,
+      runtime,
+    );
+
+    const terminalEvents = socket.sentPayloads
+      .map((payload) => JSON.parse(payload) as Record<string, unknown>)
+      .filter((payload) => payload.type === "turn_finished");
+    expect(terminalEvents).toHaveLength(1);
+    expect(terminalEvents[0]).toMatchObject({
+      type: "turn_finished",
+      runtime: { agent_id: agentId, conversation_id: conversationId },
+      stop_reason: "error",
+      error: expect.stringContaining("not-enough-credits"),
+    });
+  });
+
+  test("pre-stream 409 resumes via conversations stream with message otid", async () => {
+    const { runtime } = createRuntime("agent-409-otid", "conv-409-otid");
     const socket = new MockSocket();
 
     sendMessageStreamMock.mockRejectedValueOnce(
@@ -2126,9 +2143,7 @@ describe("listen-client multi-worker concurrency", () => {
   });
 
   test("handleIncomingMessage reuses client_message_id as the message otid", async () => {
-    const listener = __listenClientTestUtils.createListenerRuntime();
-    const runtime = __listenClientTestUtils.getOrCreateConversationRuntime(
-      listener,
+    const { runtime } = createRuntime(
       "agent-client-message-id",
       "conv-client-message-id",
     );
@@ -2164,12 +2179,7 @@ describe("listen-client multi-worker concurrency", () => {
   test("secret_apply refreshes the next user payload for the same conversation", async () => {
     const agentId = "agent-secret-payload";
     const conversationId = "conv-secret-payload";
-    const listener = __listenClientTestUtils.createListenerRuntime();
-    const runtime = __listenClientTestUtils.getOrCreateConversationRuntime(
-      listener,
-      agentId,
-      conversationId,
-    );
+    const { listener, runtime } = createRuntime(agentId, conversationId);
     const socket = new MockSocket();
     let serverSecrets: Record<string, string> = {};
     __testOverrideSecretsBackend({
@@ -2235,12 +2245,7 @@ describe("listen-client multi-worker concurrency", () => {
   test("handleIncomingMessage records direct websocket user turns in the reflection transcript", async () => {
     const agentId = "agent-websocket-transcript";
     const conversationId = "conv-websocket-transcript";
-    const listener = __listenClientTestUtils.createListenerRuntime();
-    const runtime = __listenClientTestUtils.getOrCreateConversationRuntime(
-      listener,
-      agentId,
-      conversationId,
-    );
+    const { runtime } = createRuntime(agentId, conversationId);
     const socket = new MockSocket();
 
     await __listenClientTestUtils.handleIncomingMessage(
@@ -2279,12 +2284,7 @@ describe("listen-client multi-worker concurrency", () => {
   });
 
   test("pre-stream 409 resume on default conversation includes agent_id", async () => {
-    const listener = __listenClientTestUtils.createListenerRuntime();
-    const runtime = __listenClientTestUtils.getOrCreateConversationRuntime(
-      listener,
-      "agent-409-default",
-      "default",
-    );
+    const { runtime } = createRuntime("agent-409-default", "default");
     const socket = new MockSocket();
 
     sendMessageStreamMock.mockRejectedValueOnce(

--- a/src/websocket/listen-client-concurrency.test.ts
+++ b/src/websocket/listen-client-concurrency.test.ts
@@ -361,16 +361,16 @@ function makeIncomingMessage(
 
 // Keep listener/runtime setup consistent across tests without repeating the
 // full construction sequence at every handleIncomingMessage boundary.
-function createRuntime(agentId: string, conversationId: string) {
+function createRuntime(
+  agentId: string,
+  conversationId: string,
+  scoped = false,
+) {
   const listener = __listenClientTestUtils.createListenerRuntime();
-  return {
-    listener,
-    runtime: __listenClientTestUtils.getOrCreateConversationRuntime(
-      listener,
-      agentId,
-      conversationId,
-    ),
-  };
+  const getRuntime = scoped
+    ? __listenClientTestUtils.getOrCreateScopedRuntime
+    : __listenClientTestUtils.getOrCreateConversationRuntime;
+  return { listener, runtime: getRuntime(listener, agentId, conversationId) };
 }
 
 function makeRecoveredApprovalState(params: {
@@ -1401,13 +1401,12 @@ describe("listen-client multi-worker concurrency", () => {
   });
 
   test("sync replay queues stale denials instead of restoring approval UI", async () => {
-    const listener = __listenClientTestUtils.createListenerRuntime();
-    __listenClientTestUtils.setActiveRuntime(listener);
-    const runtime = __listenClientTestUtils.getOrCreateScopedRuntime(
-      listener,
+    const { listener, runtime } = createRuntime(
       "agent-1",
       "conv-mixed-sync",
+      true,
     );
+    __listenClientTestUtils.setActiveRuntime(listener);
 
     const autoAllowedApproval = {
       toolCallId: "tool-auto-allow",
@@ -1493,13 +1492,12 @@ describe("listen-client multi-worker concurrency", () => {
   });
 
   test("recovered approval continuation executes hidden auto decisions together with manual responses", async () => {
-    const listener = __listenClientTestUtils.createListenerRuntime();
-    __listenClientTestUtils.setActiveRuntime(listener);
-    const runtime = __listenClientTestUtils.getOrCreateScopedRuntime(
-      listener,
+    const { listener, runtime } = createRuntime(
       "agent-1",
       "conv-mixed-recovered",
+      true,
     );
+    __listenClientTestUtils.setActiveRuntime(listener);
     const socket = new MockSocket();
 
     const autoAllowedApproval = {
@@ -2056,10 +2054,7 @@ describe("listen-client multi-worker concurrency", () => {
     ).toBe(true);
   });
 
-  // Channel consumers finalize immediately on turn_finished, so the terminal
-  // event itself must carry the failure detail. A later loop_error is too late.
-  // Exercise the send boundary rather than the terminal serializer in isolation.
-  test("pre-stream 402 includes API error detail in turn_finished", async () => {
+  test("pre-stream failures expose only transcript-safe terminal errors", async () => {
     const agentId = "agent-402-terminal-error";
     const conversationId = "conv-402-terminal-error";
     const { runtime } = createRuntime(agentId, conversationId);
@@ -2090,8 +2085,13 @@ describe("listen-client multi-worker concurrency", () => {
       type: "turn_finished",
       runtime: { agent_id: agentId, conversation_id: conversationId },
       stop_reason: "error",
-      error: expect.stringContaining("not-enough-credits"),
+      error:
+        "Your account does not have credits for this model. Add your own API keys or upgrade your plan to purchase credits.",
     });
+    expect(JSON.stringify(terminalEvents[0])).not.toContain("Rate limited");
+    expect(JSON.stringify(terminalEvents[0])).not.toContain(
+      "not-enough-credits",
+    );
   });
 
   test("pre-stream 409 resumes via conversations stream with message otid", async () => {

--- a/src/websocket/listen-client-protocol.test.ts
+++ b/src/websocket/listen-client-protocol.test.ts
@@ -59,6 +59,7 @@ import {
   getLoopErrorNoticeDecision,
   getRecoverableRetryNoticeVisibility,
   getRecoverableStatusNoticeVisibility,
+  getTranscriptLoopErrorMessage as getTerminalError,
 } from "@/websocket/listener/recoverable-notices";
 import type { ConversationRuntime } from "@/websocket/listener/types";
 
@@ -4899,6 +4900,7 @@ describe("listen-client loop error notices", () => {
       visibility: "debug_only",
       message: "terminated",
     });
+    expect(getTerminalError({ message: "terminated" })).toBeUndefined();
   });
 
   test("normalizes Cloudflare HTML errors to match TUI formatting", () => {
@@ -4914,7 +4916,6 @@ describe("listen-client loop error notices", () => {
         "Cloudflare 520: Web server is returning an unknown error for api.letta.com (Ray ID: abc123). This is usually a temporary edge/origin outage. Please retry in a moment.",
     });
   });
-
   test("normalizes proxy transport errors into a friendly transcript message", () => {
     const error = new APIError(
       504,
@@ -4937,7 +4938,6 @@ describe("listen-client loop error notices", () => {
       message: "Connection to Letta service failed. Please retry.",
     });
   });
-
   test("reuses TUI formatter for structured run errors", () => {
     const apiError = {
       message_type: "error_message" as const,

--- a/src/websocket/listener/recoverable-notices.ts
+++ b/src/websocket/listener/recoverable-notices.ts
@@ -4,6 +4,7 @@ import type { RunErrorInfo } from "@/agent/approval-recovery";
 import { extractConflictDetail } from "@/agent/turn-recovery-policy";
 import {
   checkCloudflareEdgeError,
+  type ErrorDisplaySurface,
   formatErrorDetails,
 } from "@/cli/helpers/error-formatter";
 import type { ErrorInfo } from "@/cli/helpers/stream-processor";
@@ -184,6 +185,7 @@ export function getLoopErrorNoticeDecision(params: {
   conversationId?: string | null;
   cancelRequested?: boolean;
   abortSignal?: AbortSignal;
+  surface?: ErrorDisplaySurface;
 }): LoopErrorNoticeDecision {
   const apiError =
     params.apiError ??
@@ -234,6 +236,7 @@ export function getLoopErrorNoticeDecision(params: {
       : (params.error ?? params.message),
     params.agentId ?? undefined,
     params.conversationId ?? undefined,
+    { surface: params.surface },
   );
 
   return {
@@ -241,6 +244,13 @@ export function getLoopErrorNoticeDecision(params: {
     message: formattedMessage,
     apiError,
   };
+}
+
+export function getTranscriptLoopErrorMessage(
+  params: Parameters<typeof getLoopErrorNoticeDecision>[0],
+): string | undefined {
+  const decision = getLoopErrorNoticeDecision({ ...params, surface: "plain" });
+  return decision.visibility === "transcript" ? decision.message : undefined;
 }
 
 export function emitLoopErrorNotice(

--- a/src/websocket/listener/turn.ts
+++ b/src/websocket/listener/turn.ts
@@ -53,6 +53,7 @@ import {
   emitLoopErrorNotice,
   emitRecoverableRetryNotice,
   emitRecoverableStatusNotice,
+  getTranscriptLoopErrorMessage,
 } from "./recoverable-notices";
 import {
   finalizeHandledRecoveryTurn,
@@ -753,31 +754,33 @@ async function handleIncomingMessageInner(
           });
           break;
         }
-
         const errorMessage =
           errorDetail || `Unexpected stop reason: ${stopReason}`;
-
         const terminalRunId =
           runId || runtime.activeRunId || runErrorInfo?.run_id;
-        const transition = finishTurn({
-          stopReason: effectiveStopReason,
-          agentId,
-          conversationId,
-          error: errorMessage,
-        });
-        if (!transition.finished) {
-          break;
-        }
-        const formattedError = emitLoopErrorNotice(socket, runtime, {
+        const noticeParams = {
           message: errorMessage,
-          stopReason: effectiveStopReason,
-          isTerminal: true,
-          runId: terminalRunId,
           agentId,
           conversationId,
           runErrorInfo: runErrorInfo ?? undefined,
           cancelRequested: turnAbortSignal.aborted,
           abortSignal: turnAbortSignal,
+        };
+        const terminalError = getTranscriptLoopErrorMessage(noticeParams);
+        const transition = finishTurn({
+          stopReason: effectiveStopReason,
+          agentId,
+          conversationId,
+          error: terminalError,
+        });
+        if (!transition.finished) {
+          break;
+        }
+        const formattedError = emitLoopErrorNotice(socket, runtime, {
+          ...noticeParams,
+          stopReason: effectiveStopReason,
+          isTerminal: true,
+          runId: terminalRunId,
         });
         runtime.lastTerminalLoopErrorMessage = formattedError ?? errorMessage;
         runtime.lastTerminalLoopErrorRunId = terminalRunId ?? null;
@@ -924,31 +927,33 @@ async function handleIncomingMessageInner(
         agentId: agentId || null,
         conversationId,
       });
-
       return;
     }
-
     const errorMessage = error instanceof Error ? error.message : String(error);
     const terminalRunId = runtime.activeRunId;
+    const noticeParams = {
+      message: errorMessage,
+      agentId,
+      conversationId,
+      error,
+      cancelRequested: turnAbortSignal.aborted,
+      abortSignal: turnAbortSignal,
+    };
+    const terminalError = getTranscriptLoopErrorMessage(noticeParams);
     const transition = finishTurn({
       stopReason: "error",
       agentId: agentId || null,
       conversationId,
-      error: errorMessage,
+      error: terminalError,
     });
     if (!transition.finished) {
       return;
     }
     const formattedError = emitLoopErrorNotice(socket, runtime, {
-      message: errorMessage,
+      ...noticeParams,
       stopReason: "error",
       isTerminal: true,
       runId: terminalRunId,
-      agentId: agentId || undefined,
-      conversationId,
-      error,
-      cancelRequested: turnAbortSignal.aborted,
-      abortSignal: turnAbortSignal,
     });
     runtime.lastTerminalLoopErrorMessage = formattedError ?? errorMessage;
     runtime.lastTerminalLoopErrorRunId = terminalRunId ?? null;

--- a/src/websocket/listener/turn.ts
+++ b/src/websocket/listener/turn.ts
@@ -763,6 +763,7 @@ async function handleIncomingMessageInner(
           stopReason: effectiveStopReason,
           agentId,
           conversationId,
+          error: errorMessage,
         });
         if (!transition.finished) {
           break;
@@ -933,6 +934,7 @@ async function handleIncomingMessageInner(
       stopReason: "error",
       agentId: agentId || null,
       conversationId,
+      error: errorMessage,
     });
     if (!transition.finished) {
       return;


### PR DESCRIPTION
## Summary
- Include transcript-safe failure details in terminal turn events.
- Omit debug-only process and cancellation noise so channel consumers can use a generic fallback.
- Use plain formatting for forwarded errors and cover the pre-stream HTTP failure boundary.

## Why
Channel gateways finalize a turn as soon as they receive turn_finished. The listener previously sent that event without error details, then sent loop_error after the consumer had already cleared the turn. Pre-stream failures therefore lost their useful cause.

## Before / after
Before, terminal consumers received only stop_reason: error for pre-stream failures. After this change, turn_finished carries the same user-safe message selected for the transcript. Internal-only errors remain absent.

## Risk
The event order and stale-turn lease checks are unchanged. The new field value comes from the existing loop-error visibility classifier rather than from raw API response text.

## Validation
- Focused listener, terminal protocol, and gateway tests — 55 passed.
- bun run typecheck — passed.
- bun run check — 12 of 12 checks passed.
- Biome and git diff --check — passed.

👾 Generated with [Letta Code](https://letta.com)