### PR TITLE
fix(listener): bridge external tools on remote connections

### DIFF
--- a/src/websocket/listener/external-tools.test.ts
+++ b/src/websocket/listener/external-tools.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import type WebSocket from "ws";
 import {
   clearExternalTools,
@@ -6,6 +6,7 @@ import {
   prepareToolExecutionContextForModel,
 } from "@/tools/manager";
 import type { ExternalToolCallRequestMessage } from "@/types/protocol_v2";
+import { openListenerConnection } from "@/websocket/listener/connection";
 import {
   handleExternalToolCallResponseCommand,
   installExternalToolBridge,
@@ -13,7 +14,17 @@ import {
   rejectPendingExternalToolCalls,
   rejectPendingExternalToolCallsForConnection,
 } from "@/websocket/listener/external-tools";
-import type { ListenerRuntime } from "@/websocket/listener/types";
+import {
+  createRuntime,
+  startConnectedListenerRuntime,
+  stopRuntime,
+} from "@/websocket/listener/lifecycle";
+import { setActiveRuntime } from "@/websocket/listener/runtime";
+import type { LocalTransport } from "@/websocket/listener/transport";
+import type {
+  ListenerRuntime,
+  StartListenerOptions,
+} from "@/websocket/listener/types";
 
 function createMockRuntime(): {
   runtime: ListenerRuntime;
@@ -48,9 +59,104 @@ function createMockRuntime(): {
   return { runtime, sent };
 }
 
-describe("app-server runtime_start external tool bridge", () => {
+describe("listener runtime_start external tool bridge", () => {
+  beforeEach(() => {
+    clearExternalTools();
+  });
+
   afterEach(() => {
     clearExternalTools();
+    setActiveRuntime(null);
+  });
+
+  test("connected listener startup installs the executor for runtime-scoped tools", async () => {
+    const runtime = createRuntime();
+    const sent: ExternalToolCallRequestMessage[] = [];
+    const transport: LocalTransport = {
+      kind: "local",
+      bufferedAmount: 0,
+      isOpen: () => true,
+      send(data: string) {
+        const request = JSON.parse(data) as ExternalToolCallRequestMessage;
+        sent.push(request);
+        queueMicrotask(() => {
+          handleExternalToolCallResponseCommand(runtime, "remote-client", {
+            type: "external_tool_call_response",
+            request_id: request.request_id,
+            result: {
+              content: [{ type: "text", text: "delivered" }],
+            },
+          });
+        });
+      },
+    };
+    const options: StartListenerOptions = {
+      connectionId: "remote-client",
+      wsUrl: "wss://example.test/listener",
+      deviceId: "test-device",
+      connectionName: "remote-client",
+      onConnected: () => {},
+      onDisconnected: () => {},
+      onError: () => {},
+    };
+    openListenerConnection({
+      runtime,
+      connectionId: options.connectionId,
+      writer: transport,
+      options,
+    });
+    runtime.processServicesStarted = true;
+    setActiveRuntime(runtime);
+
+    try {
+      await startConnectedListenerRuntime(
+        runtime,
+        transport,
+        options,
+        async () => {},
+        { startHeartbeat: false, startCronScheduler: false },
+      );
+      registerRuntimeExternalTools(
+        runtime,
+        options.connectionId,
+        { agent_id: "agent-1", conversation_id: "conv-1" },
+        [
+          {
+            tools: [
+              {
+                name: "MessageChannel",
+                description: "Deliver a channel message",
+                parameters: { type: "object", properties: {} },
+              },
+            ],
+          },
+        ],
+      );
+      const prepared = await prepareToolExecutionContextForModel(
+        "anthropic/claude-sonnet-4",
+        {
+          clientToolAllowlist: ["MessageChannel"],
+          runtimeContext: {
+            connectionId: options.connectionId,
+            agentId: "agent-1",
+            conversationId: "conv-1",
+          },
+        },
+      );
+
+      const result = await executeTool(
+        "MessageChannel",
+        {},
+        { toolContextId: prepared.contextId, toolCallId: "call-1" },
+      );
+
+      expect(result.status).toBe("success");
+      expect(result.toolReturn).toBe("delivered");
+      expect(sent).toHaveLength(1);
+    } finally {
+      stopRuntime(runtime, true);
+      setActiveRuntime(null);
+    }
   });
 
   test("registers runtime-scoped tools and executes calls over the control socket", async () => {

--- a/src/websocket/listener/lifecycle.ts
+++ b/src/websocket/listener/lifecycle.ts
@@ -385,7 +385,7 @@ export async function startConnectedListenerRuntime(
   if (runtime !== getActiveRuntime() || runtime.intentionallyClosed) {
     return;
   }
-
+  installExternalToolBridge(runtime);
   const shouldStartHeartbeat = options.startHeartbeat !== false;
   // LETTA_DISABLE_CRON_SCHEDULER=1 lets users opt out entirely. Useful when
   // running multiple letta-code instances against the same agent dir, since


### PR DESCRIPTION
## Summary
- install the external-tool bridge at the shared connected-listener boundary
- let remote listeners return scoped tool calls to their controlling client
- add a regression test for the connected runtime and request/response path

## Before / after
Before, a remote listener could register a scoped tool but return `External tool executor not set` when the model called it. After, the call is sent to the controller that registered the tool and its response settles the turn.

## Risk and limits
The bridge was already installed for the local App Server socket path. This extends the same behavior to every connected listener runtime. The repository test covers the shared runtime boundary, but production verification still requires a release and managed sandbox rebuild.

## Test plan
- [x] `bun test src/websocket/listener/external-tools.test.ts src/websocket/listener/connection-state-sync.test.ts src/websocket/listener-reconnect-reminders.test.ts`
- [x] `bun run check`
- [x] remove the new bridge install and confirm the regression test fails

👾 Generated with [Letta Code](https://letta.com)