### PR TITLE
fix(listener): sanitize remaining terminal errors

### DIFF
--- a/src/cli/helpers/error-formatter.ts
+++ b/src/cli/helpers/error-formatter.ts
@@ -19,7 +19,10 @@ export type ErrorDisplaySurface = "plain" | "terminal";
 export interface FormatErrorDetailsOptions {
   automaticRetry?: boolean;
   surface?: ErrorDisplaySurface;
+  unclassifiedFallback?: "generic";
 }
+
+const GENERIC_ERROR_MESSAGE = "The request failed. Please try again.";
 
 function formatConversationBusyErrorForDisplay(
   errorText: string,
@@ -696,6 +699,8 @@ export function formatErrorDetails(
 ): string {
   let runId: string | undefined;
   const surface = options.surface ?? "terminal";
+  const fallback = (raw: string): string =>
+    options.unclassifiedFallback === "generic" ? GENERIC_ERROR_MESSAGE : raw;
 
   // Check for OpenAI encrypted content org mismatch before anything else
   const encryptedContentMsg = checkEncryptedContentError(e);
@@ -823,6 +828,8 @@ export function formatErrorDetails(
           options,
         );
         if (conversationBusyMessage) return conversationBusyMessage;
+        if (options.unclassifiedFallback === "generic")
+          return fallback(baseError);
         return runId && agentId
           ? `${baseError}\n${createAgentLink(runId, agentId, conversationId, surface)}`
           : baseError;
@@ -846,18 +853,20 @@ export function formatErrorDetails(
         options,
       );
       if (conversationBusyMessage) return conversationBusyMessage;
+      if (options.unclassifiedFallback === "generic")
+        return fallback(baseError);
       return runId && agentId
         ? `${baseError}\n${createAgentLink(runId, agentId, conversationId, surface)}`
         : baseError;
     }
 
     // Fallback for APIError with just message
-    return e.message;
+    return fallback(e.message);
   }
 
   // Handle regular Error objects
   if (e instanceof Error) {
-    return e.message;
+    return fallback(e.message);
   }
 
   // Fallback for any other type (e.g., plain objects thrown by SDK or other code)
@@ -866,24 +875,24 @@ export function formatErrorDetails(
 
     // Check common error-like properties
     if (typeof obj.message === "string") {
-      return obj.message;
+      return fallback(obj.message);
     }
     if (typeof obj.error === "string") {
-      return obj.error;
+      return fallback(obj.error);
     }
     if (typeof obj.detail === "string") {
-      return obj.detail;
+      return fallback(obj.detail);
     }
 
     // Last resort: JSON stringify
     try {
-      return JSON.stringify(e, null, 2);
+      return fallback(JSON.stringify(e, null, 2));
     } catch {
-      return "[Error: Unable to serialize error object]";
+      return fallback("[Error: Unable to serialize error object]");
     }
   }
 
-  return String(e);
+  return fallback(String(e));
 }
 
 const DEFAULT_RETRY_MESSAGE =

--- a/src/websocket/listen-client-concurrency.test.ts
+++ b/src/websocket/listen-client-concurrency.test.ts
@@ -2053,12 +2053,9 @@ describe("listen-client multi-worker concurrency", () => {
       ),
     ).toBe(true);
   });
-
-  test("pre-stream failures expose only transcript-safe terminal errors", async () => {
-    const agentId = "agent-402-terminal-error";
-    const conversationId = "conv-402-terminal-error";
-    const { runtime } = createRuntime(agentId, conversationId);
-    const socket = new MockSocket();
+  test("pre-stream and approval failures expose safe terminal errors", async () => {
+    const credit = createRuntime("agent-402", "conv-402");
+    const creditSocket = new MockSocket();
     sendMessageStreamMock.mockRejectedValueOnce(
       new APIError(
         402,
@@ -2070,34 +2067,38 @@ describe("listen-client multi-worker concurrency", () => {
         new Headers(),
       ),
     );
-
     await __listenClientTestUtils.handleIncomingMessage(
-      makeIncomingMessage(agentId, conversationId, "hello"),
-      socket as unknown as WebSocket,
-      runtime,
+      makeIncomingMessage("agent-402", "conv-402", "hello"),
+      creditSocket as unknown as WebSocket,
+      credit.runtime,
     );
-
-    const terminalEvents = socket.sentPayloads
-      .map((payload) => JSON.parse(payload) as Record<string, unknown>)
-      .filter((payload) => payload.type === "turn_finished");
-    expect(terminalEvents).toHaveLength(1);
-    expect(terminalEvents[0]).toMatchObject({
-      type: "turn_finished",
-      runtime: { agent_id: agentId, conversation_id: conversationId },
-      stop_reason: "error",
-      error:
-        "Your account does not have credits for this model. Add your own API keys or upgrade your plan to purchase credits.",
-    });
-    expect(JSON.stringify(terminalEvents[0])).not.toContain("Rate limited");
-    expect(JSON.stringify(terminalEvents[0])).not.toContain(
-      "not-enough-credits",
+    const creditTerminal = JSON.parse(creditSocket.sentPayloads[0] as string);
+    expect(creditTerminal.error).toBe(
+      "Your account does not have credits for this model. Add your own API keys or upgrade your plan to purchase credits.",
     );
+    expect(JSON.stringify(creditTerminal)).not.toContain("Rate limited");
+    const approval = createRuntime("agent-approval", "conv-approval");
+    const approvalSocket = new MockSocket();
+    drainHandlers.set("conv-approval", async () => ({
+      stopReason: "requires_approval",
+      approvals: [],
+      apiDurationMs: 0,
+    }));
+    await __listenClientTestUtils.handleIncomingMessage(
+      makeIncomingMessage("agent-approval", "conv-approval", "hello"),
+      approvalSocket as unknown as WebSocket,
+      approval.runtime,
+    );
+    const [approvalPayload] = approvalSocket.sentPayloads;
+    const approvalTerminal = JSON.parse(approvalPayload as string);
+    expect(approvalTerminal.error).toBe(
+      "The request failed. Please try again.",
+    );
+    expect(JSON.stringify(approvalTerminal)).not.toContain("requires_approval");
   });
-
   test("pre-stream 409 resumes via conversations stream with message otid", async () => {
     const { runtime } = createRuntime("agent-409-otid", "conv-409-otid");
     const socket = new MockSocket();
-
     sendMessageStreamMock.mockRejectedValueOnce(
       new APIError(
         409,
@@ -2111,7 +2112,6 @@ describe("listen-client multi-worker concurrency", () => {
         new Headers(),
       ),
     );
-
     const turnPromise = __listenClientTestUtils.handleIncomingMessage(
       {
         type: "message",

--- a/src/websocket/listener/recoverable-notices.ts
+++ b/src/websocket/listener/recoverable-notices.ts
@@ -5,6 +5,7 @@ import { extractConflictDetail } from "@/agent/turn-recovery-policy";
 import {
   checkCloudflareEdgeError,
   type ErrorDisplaySurface,
+  type FormatErrorDetailsOptions,
   formatErrorDetails,
 } from "@/cli/helpers/error-formatter";
 import type { ErrorInfo } from "@/cli/helpers/stream-processor";
@@ -186,6 +187,7 @@ export function getLoopErrorNoticeDecision(params: {
   cancelRequested?: boolean;
   abortSignal?: AbortSignal;
   surface?: ErrorDisplaySurface;
+  unclassifiedFallback?: FormatErrorDetailsOptions["unclassifiedFallback"];
 }): LoopErrorNoticeDecision {
   const apiError =
     params.apiError ??
@@ -236,7 +238,10 @@ export function getLoopErrorNoticeDecision(params: {
       : (params.error ?? params.message),
     params.agentId ?? undefined,
     params.conversationId ?? undefined,
-    { surface: params.surface },
+    {
+      surface: params.surface,
+      unclassifiedFallback: params.unclassifiedFallback,
+    },
   );
 
   return {
@@ -249,7 +254,11 @@ export function getLoopErrorNoticeDecision(params: {
 export function getTranscriptLoopErrorMessage(
   params: Parameters<typeof getLoopErrorNoticeDecision>[0],
 ): string | undefined {
-  const decision = getLoopErrorNoticeDecision({ ...params, surface: "plain" });
+  const decision = getLoopErrorNoticeDecision({
+    ...params,
+    surface: "plain",
+    unclassifiedFallback: "generic",
+  });
   return decision.visibility === "transcript" ? decision.message : undefined;
 }
 

--- a/src/websocket/listener/recovery-lease.test.ts
+++ b/src/websocket/listener/recovery-lease.test.ts
@@ -257,4 +257,41 @@ describe("recovered approval lease boundaries", () => {
     expect(ends.map((delta) => delta.tool_call_id)).toEqual(["call-1"]);
     expect(ends[0].status).toBe("error");
   });
+
+  test("terminated recovered execution omits terminal error details", async () => {
+    const runtime = getOrCreateScopedRuntime(
+      createRuntime(),
+      "agent-1",
+      "conv-1",
+    );
+    runtime.recoveredApprovalState = createRecoveredState();
+    const sentPayloads: string[] = [];
+    const handled = resolveRecoveredApprovalResponse(
+      runtime,
+      createTransport(sentPayloads),
+      { request_id: "perm-1", decision: { behavior: "allow" } },
+      mock(async () => {}),
+      {
+        dependencies: {
+          applySuggestedPermissions: async () => false,
+          ensureSecretsHydrated: async () => {},
+          prepareToolExecutionContext: async () => createPreparedToolContext(),
+          executeApprovalBatch: async () => {
+            throw new Error("terminated");
+          },
+        },
+      },
+    );
+
+    await handled.catch(() => {});
+
+    const terminal = sentPayloads
+      .map((payload) => JSON.parse(payload))
+      .find((frame) => frame.type === "turn_finished");
+    expect(terminal).toMatchObject({
+      type: "turn_finished",
+      stop_reason: "error",
+    });
+    expect(terminal).not.toHaveProperty("error");
+  });
 });

--- a/src/websocket/listener/recovery.ts
+++ b/src/websocket/listener/recovery.ts
@@ -57,7 +57,10 @@ import {
   emitRuntimeStateUpdates,
 } from "./protocol-outbound";
 import { consumeQueuedTurn } from "./queue";
-import { emitLoopErrorNotice } from "./recoverable-notices";
+import {
+  emitLoopErrorNotice,
+  getTranscriptLoopErrorMessage,
+} from "./recoverable-notices";
 import {
   clearRecoveredApprovalState,
   hasInterruptedCacheForScope,
@@ -285,23 +288,27 @@ export function finalizeHandledRecoveryTurn(
   const terminalStopReason =
     (params.drainResult.stopReason as StopReasonType) || "error";
   const runId = runtime.activeRunId;
+  const noticeParams = {
+    message: `Recovery continuation ended unexpectedly: ${terminalStopReason}`,
+    agentId: params.agentId,
+    conversationId: params.conversationId,
+  };
   const transition = finishListenerTurn(runtime, turnLease, {
     stopReason: terminalStopReason,
     socket,
     agentId: params.agentId,
     conversationId: params.conversationId,
     turnId: params.turnId,
+    error: getTranscriptLoopErrorMessage(noticeParams),
   });
   if (!transition.finished) {
     return transition;
   }
   emitLoopErrorNotice(socket, runtime, {
-    message: `Recovery continuation ended unexpectedly: ${terminalStopReason}`,
+    ...noticeParams,
     stopReason: terminalStopReason,
     isTerminal: true,
     runId: runId || undefined,
-    agentId: params.agentId ?? undefined,
-    conversationId: params.conversationId,
   });
   return transition;
 }
@@ -877,13 +884,17 @@ export async function resolveRecoveredApprovalResponse(
       );
       recovered.responsesByRequestId.clear();
     }
+    const stopReason = recoveryLease.signal.aborted ? "cancelled" : "error";
     finishListenerTurn(runtime, recoveryLease, {
-      stopReason: recoveryLease.signal.aborted ? "cancelled" : "error",
+      stopReason,
       socket,
       agentId: recovered.agentId,
       conversationId: recovered.conversationId,
       turnId: `batch-recovered-${requestId}`,
-      error: error instanceof Error ? error.message : String(error),
+      error:
+        stopReason === "error"
+          ? getTranscriptLoopErrorMessage({ error, message: String(error) })
+          : undefined,
     });
     throw error;
   }

--- a/src/websocket/listener/recovery.ts
+++ b/src/websocket/listener/recovery.ts
@@ -893,7 +893,10 @@ export async function resolveRecoveredApprovalResponse(
       turnId: `batch-recovered-${requestId}`,
       error:
         stopReason === "error"
-          ? getTranscriptLoopErrorMessage({ error, message: String(error) })
+          ? getTranscriptLoopErrorMessage({
+              error,
+              message: error instanceof Error ? error.message : String(error),
+            })
           : undefined,
     });
     throw error;

--- a/src/websocket/listener/turn-lifecycle-integration.test.ts
+++ b/src/websocket/listener/turn-lifecycle-integration.test.ts
@@ -363,6 +363,46 @@ describe("listener turn lifecycle integration", () => {
     expect(sentPayloads).toEqual([]);
   });
 
+  test("recovery errors finish with safe detail before loop diagnostics", () => {
+    const runtime = getOrCreateScopedRuntime(
+      createRuntime(),
+      "agent-1",
+      "conv-1",
+    );
+    const lease = runtime.turnLifecycle.begin({
+      origin: "approval_recovery",
+      workingDirectory: process.cwd(),
+    });
+    const sentPayloads: string[] = [];
+
+    const transition = finalizeHandledRecoveryTurn(
+      runtime,
+      createOpenTransport(sentPayloads),
+      lease,
+      {
+        drainResult: { stopReason: "error" } as never,
+        agentId: "agent-1",
+        conversationId: "conv-1",
+        turnId: "test-turn-1",
+      },
+    );
+    const payloads = sentPayloads.map((payload) => JSON.parse(payload));
+
+    expect(transition.finished).toBe(true);
+    expect(payloads.map(({ type }) => type)).toEqual([
+      "turn_finished",
+      "stream_delta",
+    ]);
+    expect(payloads[0]).toMatchObject({
+      type: "turn_finished",
+      stop_reason: "error",
+      error: "The request failed. Please try again.",
+    });
+    expect(JSON.stringify(payloads[0])).not.toContain(
+      "Recovery continuation ended unexpectedly",
+    );
+  });
+
   test("a stale recovery owner cannot finish or report errors for its replacement", () => {
     const listener = createRuntime();
     const runtime = getOrCreateScopedRuntime(listener, "agent-1", "conv-1");

--- a/src/websocket/listener/turn-terminal-protocol.test.ts
+++ b/src/websocket/listener/turn-terminal-protocol.test.ts
@@ -1,6 +1,11 @@
 import { expect, test } from "bun:test";
+import { APIError } from "@letta-ai/letta-client/error";
 import { getOrCreateScopedRuntime } from "./conversation-runtime";
 import { createRuntime } from "./lifecycle";
+import {
+  getLoopErrorNoticeDecision,
+  getTranscriptLoopErrorMessage,
+} from "./recoverable-notices";
 import type { ListenerTransport } from "./transport";
 import { finishListenerTurn } from "./turn-terminal";
 
@@ -52,4 +57,37 @@ test("finishListenerTurn emits exactly one correlated terminal event", () => {
       stop_reason: "end_turn",
     }),
   ]);
+});
+
+test("terminal error formatting preserves classifications and rejects raw fallbacks", () => {
+  const unknownApiError = new APIError(
+    500,
+    { detail: "upstream credential leaked" },
+    undefined,
+    new Headers(),
+  );
+  const safeMessages = [
+    getTranscriptLoopErrorMessage({
+      message: unknownApiError.message,
+      error: unknownApiError,
+    }),
+    getTranscriptLoopErrorMessage({
+      message: "unknown object",
+      error: { detail: "private object detail", token: "secret-value" },
+    }),
+  ];
+
+  expect(safeMessages).toEqual([
+    "The request failed. Please try again.",
+    "The request failed. Please try again.",
+  ]);
+  expect(JSON.stringify(safeMessages)).not.toContain("credential leaked");
+  expect(JSON.stringify(safeMessages)).not.toContain("private object detail");
+  expect(JSON.stringify(safeMessages)).not.toContain("secret-value");
+  expect(
+    getTranscriptLoopErrorMessage({ message: "terminated" }),
+  ).toBeUndefined();
+  expect(getLoopErrorNoticeDecision({ message: "terminated" }).visibility).toBe(
+    "debug_only",
+  );
 });

--- a/src/websocket/listener/turn.ts
+++ b/src/websocket/listener/turn.ts
@@ -53,7 +53,7 @@ import {
   emitLoopErrorNotice,
   emitRecoverableRetryNotice,
   emitRecoverableStatusNotice,
-  getTranscriptLoopErrorMessage,
+  getTranscriptLoopErrorMessage as getSafeTerminalError,
 } from "./recoverable-notices";
 import {
   finalizeHandledRecoveryTurn,
@@ -203,7 +203,6 @@ async function handleIncomingMessageInner(
     });
     return true;
   };
-
   try {
     runtime.lastTerminalLoopErrorMessage = null;
     runtime.lastTerminalLoopErrorRunId = null;
@@ -220,15 +219,14 @@ async function handleIncomingMessageInner(
       conversation_id: conversationId,
     });
     telemetry.setCurrentAgentId(agentId ?? null);
-
     if (!agentId) {
       finishTurn({
         stopReason: "error",
         conversationId,
+        error: getSafeTerminalError({ message: "Missing agent ID" }),
       });
       return;
     }
-
     let turnToolContextId: string | null = null;
     const setup = await prepareListenerTurn({
       msg,
@@ -478,10 +476,8 @@ async function handleIncomingMessageInner(
           agentId,
           conversationId,
         });
-
         break;
       }
-
       if (stopReason === "cancelled") {
         finishTurn({
           stopReason: "cancelled",
@@ -766,7 +762,7 @@ async function handleIncomingMessageInner(
           cancelRequested: turnAbortSignal.aborted,
           abortSignal: turnAbortSignal,
         };
-        const terminalError = getTranscriptLoopErrorMessage(noticeParams);
+        const terminalError = getSafeTerminalError(noticeParams);
         const transition = finishTurn({
           stopReason: effectiveStopReason,
           agentId,
@@ -806,13 +802,16 @@ async function handleIncomingMessageInner(
         buildSendOptions,
         providerFallback,
       });
-
       if (approvalResult.kind === "error") {
         const terminalRunId = runId || runtime.activeRunId;
+        const terminalError = getSafeTerminalError({
+          message: approvalResult.message,
+        });
         const transition = finishTurn({
           stopReason: "error",
           agentId,
           conversationId,
+          error: terminalError,
         });
         if (!transition.finished) {
           return;
@@ -939,7 +938,7 @@ async function handleIncomingMessageInner(
       cancelRequested: turnAbortSignal.aborted,
       abortSignal: turnAbortSignal,
     };
-    const terminalError = getTranscriptLoopErrorMessage(noticeParams);
+    const terminalError = getSafeTerminalError(noticeParams);
     const transition = finishTurn({
       stopReason: "error",
       agentId: agentId || null,
@@ -974,9 +973,11 @@ async function handleIncomingMessageInner(
         runId: runtime.activeRunId || msgRunIds[msgRunIds.length - 1],
         agentId: agentId || null,
         conversationId,
+        error: turnAbortSignal.aborted
+          ? undefined
+          : getSafeTerminalError({ message: "Unexpected turn failure" }),
       });
     }
-
     if (runtime.activeConnectionId === connectionId) {
       runtime.activeConnectionId = null;
     }


### PR DESCRIPTION
## Summary
- Add safe terminal error details to approval and recovery failure paths that were not covered by #3678.
- Preserve recognized user-facing errors while replacing unclassified API, object, and string payloads with generic copy.
- Keep terminated process noise internal, including recovered Error objects.
- Keep detailed loop diagnostics, event order, cancellation handling, and stale-owner guards unchanged.

## Why
#3678 made pre-stream and streamed failures available to channel consumers. Final review found sibling approval and recovery paths that still finished without an error, plus unclassified formatter fallbacks that could expose raw provider payloads.

## Before / after
Before, these sibling paths either lost their error after the terminal event or could forward raw fallback text. After this change, each error terminal includes either a recognized user-safe message or The request failed. Please try again. Debug-only and cancelled paths still omit the field.

## Risk
The generic fallback is opt-in and used only by terminal/channel formatting. Existing terminal diagnostics keep their current detailed output. Stale turn owners still cannot emit terminal state.

## Validation
- Focused listener and terminal tests — 192 passed.
- Recovery noise regressions — 15 passed.
- Error formatter tests — 36 passed.
- bun run typecheck — passed.
- bun run check — 12 of 12 checks passed.
- git diff --check — passed.

👾 Generated with [Letta Code](https://letta.com)