### PR TITLE
fix(cron): fall back to a local schedule when Cloud cannot reach this computer

### DIFF
--- a/src/cli/subcommands/cron-runner.test.ts
+++ b/src/cli/subcommands/cron-runner.test.ts
@@ -304,17 +304,15 @@ describe("resolveInferredTargetDevice", () => {
     ["synthetic local", "local", null],
     ["synthetic Cloud", "__letta_cloud__", null],
   ])(
-    "rejects %s identities with runner guidance",
+    "resolves %s identities to the local-runner fallback",
     async (_label, deviceId, environment) => {
       const result = await resolveInferredTargetDevice(
         deviceId,
         async () => environment,
       );
-      expect(result.kind).toBe("error");
-      if (result.kind === "error") {
-        expect(result.error).toContain("--runner cloud");
-        expect(result.error).toContain("--computer <deviceId>");
-        expect(result.error).toContain("--runner local");
+      expect(result.kind).toBe("local-fallback");
+      if (result.kind === "local-fallback") {
+        expect(result.reason.length).toBeGreaterThan(0);
       }
     },
   );

--- a/src/cli/subcommands/cron-runner.ts
+++ b/src/cli/subcommands/cron-runner.ts
@@ -205,22 +205,21 @@ export async function resolveInferredTargetDevice(
   if (!basicValidity.ok) {
     return {
       kind: "local-fallback",
-      reason: "this computer is not a registered Cloud environment",
+      reason: "this computer is not connected to your Letta account",
     };
   }
 
   if (!environment) {
     return {
       kind: "local-fallback",
-      reason: "this computer is not registered with Cloud scheduling",
+      reason: "this computer is not connected to your Letta account",
     };
   }
 
   if (!isEnvironmentOnline(environment)) {
     return {
       kind: "local-fallback",
-      reason:
-        "this computer's Cloud environment registration is not currently online",
+      reason: "this computer's connection to Letta is not currently online",
     };
   }
 

--- a/src/cli/subcommands/cron-runner.ts
+++ b/src/cli/subcommands/cron-runner.ts
@@ -158,35 +158,39 @@ export function validateTargetDevice(
   return { ok: true };
 }
 
-const INFERRED_TARGET_GUIDANCE =
-  "Pass --runner cloud to use the Cloud sandbox, --computer <deviceId> to choose a connected computer, or --runner local to use this process.";
-
 /**
- * How a default (no --runner/--computer) Cloud schedule should execute:
- * - "device": target the current runtime's device so the schedule keeps
- *   executing where it was created.
- * - "cloud-sandbox": leave the schedule untargeted; it fires in the agent's
+ * How a default (no --runner/--computer) schedule should execute:
+ * - "device": Cloud schedule targeting the current runtime's device so it
+ *   keeps executing where it was created.
+ * - "cloud-sandbox": untargeted Cloud schedule; it fires in the agent's
  *   managed Cloud sandbox.
- * - "error": the current runtime is neither — refuse with guidance.
+ * - "local-fallback": the current runtime is not reachable by Cloud
+ *   scheduling, so the schedule should be stored locally instead — that is
+ *   the only way it can keep executing here.
  */
 export type InferredTargetResolution =
   | { kind: "device" }
   | { kind: "cloud-sandbox" }
-  | { kind: "error"; error: string };
+  | { kind: "local-fallback"; reason: string };
 
 /**
- * A default Cloud schedule preserves the current turn's execution locality.
+ * A default schedule preserves the current turn's execution locality: work
+ * scheduled from a runtime should keep running in that runtime, so a
+ * follow-up never races the active conversation from a second execution
+ * environment (the two don't share a turn queue).
  *
  * A managed-sandbox runtime (`sandbox-*` device id) resolves to
  * "cloud-sandbox": an untargeted schedule already executes in the agent's
- * managed sandbox, so the old untargeted default IS locality-preserving
- * there. The sandbox check must come first — sandbox rows are registered
- * and online in the environments registry, but individual sandboxes get
+ * managed sandbox, so the untargeted default IS locality-preserving there.
+ * The sandbox check must come first — sandbox rows are registered and
+ * online in the environments registry, but individual sandboxes get
  * retired and recreated, so pinning one as a device target would be wrong.
  *
- * Any other runtime must be proven to be a live external listener because,
- * unlike an explicit --computer, there is no user-supplied target for the
- * Cloud API to validate or correct.
+ * A runtime that is not a live registered external listener (desktop-local
+ * proxy connections, unregistered installations, offline rows) cannot be
+ * reached by the Cloud scheduler at all, so the locality-preserving answer
+ * is "local-fallback": store the schedule in this computer's local
+ * scheduler. The caller surfaces the durability tradeoff to the user.
  */
 export async function resolveInferredTargetDevice(
   deviceId: string,
@@ -200,22 +204,23 @@ export async function resolveInferredTargetDevice(
   const basicValidity = validateTargetDevice(deviceId, environment);
   if (!basicValidity.ok) {
     return {
-      kind: "error",
-      error: `Cannot target the current runtime (${basicValidity.error}) ${INFERRED_TARGET_GUIDANCE}`,
+      kind: "local-fallback",
+      reason: "this computer is not a registered Cloud environment",
     };
   }
 
   if (!environment) {
     return {
-      kind: "error",
-      error: `The current runtime (${deviceId}) is not registered as a Cloud environment. ${INFERRED_TARGET_GUIDANCE}`,
+      kind: "local-fallback",
+      reason: "this computer is not registered with Cloud scheduling",
     };
   }
 
   if (!isEnvironmentOnline(environment)) {
     return {
-      kind: "error",
-      error: `The current runtime (${deviceId}) is not online in the Cloud environments registry. ${INFERRED_TARGET_GUIDANCE}`,
+      kind: "local-fallback",
+      reason:
+        "this computer's Cloud environment registration is not currently online",
     };
   }
 

--- a/src/cli/subcommands/cron.test.ts
+++ b/src/cli/subcommands/cron.test.ts
@@ -276,10 +276,60 @@ describe("cron add execution targeting", () => {
     }
   });
 
-  test("default Cloud creation fails when the current listener is unregistered", async () => {
+  test("default creation on an unregistered runtime falls back to a local schedule with a warning", async () => {
+    const home = mkdtempSync(join(tmpdir(), "letta-cron-fallback-test-"));
+    process.env.LETTA_HOME = home;
     const requests = installScheduleApi({});
+    const logs: string[] = [];
+    console.log = mock((line: string) => {
+      logs.push(String(line));
+    });
 
-    expect(await runCronSubcommand(addArgs)).toBe(1);
-    expect(requests.some((request) => request.method === "POST")).toBe(false);
+    try {
+      expect(await runCronSubcommand(addArgs)).toBe(0);
+
+      // No Cloud schedule was created.
+      expect(requests.some((request) => request.method === "POST")).toBe(false);
+
+      const output = JSON.parse(logs.join("")) as Record<string, unknown>;
+      expect(output.runner).toBe("local");
+      // addArgs uses --every (recurring), so the warning carries both the
+      // fallback reason and the louder recurring durability caution.
+      expect(String(output.warning)).toContain(
+        "Cloud scheduling cannot reach this computer",
+      );
+      expect(String(output.warning)).toContain("Recurring schedules");
+      expect(String(output.warning)).toContain("--runner cloud");
+      expect(String(output.warning)).toContain("--computer <deviceId>");
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  test("one-shot fallback warning omits the recurring caution", async () => {
+    const home = mkdtempSync(join(tmpdir(), "letta-cron-fallback-once-"));
+    process.env.LETTA_HOME = home;
+    installScheduleApi({});
+    const logs: string[] = [];
+    console.log = mock((line: string) => {
+      logs.push(String(line));
+    });
+
+    const everyIndex = addArgs.indexOf("--every");
+    const oneShotArgs = [...addArgs];
+    oneShotArgs.splice(everyIndex, 2, "--at", "in 30m");
+
+    try {
+      expect(await runCronSubcommand(oneShotArgs)).toBe(0);
+
+      const output = JSON.parse(logs.join("")) as Record<string, unknown>;
+      expect(output.runner).toBe("local");
+      expect(String(output.warning)).toContain(
+        "Cloud scheduling cannot reach this computer",
+      );
+      expect(String(output.warning)).not.toContain("Recurring schedules");
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
   });
 });

--- a/src/cli/subcommands/cron.test.ts
+++ b/src/cli/subcommands/cron.test.ts
@@ -296,7 +296,7 @@ describe("cron add execution targeting", () => {
       // addArgs uses --every (recurring), so the warning carries both the
       // fallback reason and the louder recurring durability caution.
       expect(String(output.warning)).toContain(
-        "Cloud scheduling cannot reach this computer",
+        "This schedule is local to this computer",
       );
       expect(String(output.warning)).toContain("Recurring schedules");
       expect(String(output.warning)).toContain("--runner cloud");
@@ -325,7 +325,7 @@ describe("cron add execution targeting", () => {
       const output = JSON.parse(logs.join("")) as Record<string, unknown>;
       expect(output.runner).toBe("local");
       expect(String(output.warning)).toContain(
-        "Cloud scheduling cannot reach this computer",
+        "This schedule is local to this computer",
       );
       expect(String(output.warning)).not.toContain("Recurring schedules");
     } finally {

--- a/src/cli/subcommands/cron.ts
+++ b/src/cli/subcommands/cron.ts
@@ -16,6 +16,10 @@
  *   Letta API. The implicit default keeps executing where it was created
  *   (external listener target, or untargeted from a managed sandbox);
  *   explicit --runner cloud always executes in the agent's Cloud sandbox.
+ *   When the current runtime is unreachable by Cloud scheduling
+ *   (desktop-local, unregistered), the implicit default falls back to the
+ *   local runner with a warning — that is the only placement that preserves
+ *   execution locality there.
  * - "local": runtime-local tasks in ~/.letta/crons.json, executed by the WS
  *   listener on this device. Default for local-backend agents and self-hosted
  *   servers; explicit opt-in (--runner local) for schedules that must run on
@@ -84,15 +88,19 @@ Add options:
   --cron <expr>          Raw 5-field cron expression
   --agent <id>           Agent ID (defaults to LETTA_AGENT_ID)
   --conversation <id>    Conversation ID (defaults to LETTA_CONVERSATION_ID or "default")
-  --runner <runner>      Where the schedule lives and fires:
+  --runner <runner>      Where the schedule lives and fires (normally omit:
+                         the default keeps the schedule running where it was
+                         created):
                            cloud - durable Cloud schedule (default for cloud
-                                   agents); the implicit default keeps running
-                                   where it was created (external listener or
-                                   the agent's Cloud sandbox). Explicit
+                                   agents on Cloud-reachable runtimes:
+                                   external listeners are targeted, managed
+                                   sandboxes stay untargeted). Explicit
                                    --runner cloud always uses the Cloud sandbox
                            local - this device's scheduler (~/.letta/crons.json);
                                    only fires while a session runs here (default
-                                   for local-backend agents / self-hosted)
+                                   for local-backend agents / self-hosted, and
+                                   the fallback when Cloud scheduling cannot
+                                   reach this computer)
   --computer <id>        (cloud runner only) Override execution with a
                          connected external environment (deviceId from
                          \`letta environments list\`). Falls back to the Cloud
@@ -355,12 +363,14 @@ async function handleAdd(values: CronArgValues): Promise<number> {
     console.error(`Error: ${resolved.error}`);
     return 1;
   }
+  let runner = resolved.runner;
+  let localFallbackNote: string | undefined;
 
   // Device targets are a Cloud-schedule feature: the cloud worker delivers
   // to the named device's listener (sandbox fallback when offline). A local
   // task already runs on the device that owns it, so the flag is meaningless
   // (and likely a mistake) for the local runner.
-  if (targetDeviceId && resolved.runner !== "cloud") {
+  if (targetDeviceId && runner !== "cloud") {
     console.error(
       "Error: --computer requires the cloud runner. Run `letta cron add` on the target computer itself (with --runner local) to schedule there locally.",
     );
@@ -378,26 +388,27 @@ async function handleAdd(values: CronArgValues): Promise<number> {
       console.error(`Error: ${validity.error}`);
       return 1;
     }
-  } else if (resolved.runner === "cloud" && values.runner !== "cloud") {
+  } else if (runner === "cloud" && values.runner !== "cloud") {
     // The durable default preserves the locality of the current agent turn.
     // Infer only at create time: old targetless schedules deliberately remain
     // Cloud-sandbox schedules, and dispatch must never guess a target later.
     // Managed-sandbox runtimes resolve to an untargeted schedule (the
-    // sandbox IS the untargeted execution environment).
+    // sandbox IS the untargeted execution environment). Runtimes the Cloud
+    // scheduler cannot reach (desktop-local, unregistered) fall back to the
+    // local runner so the schedule still executes here.
     const inferredDeviceId = getRuntimeEnvironmentDeviceId();
     const resolution = await resolveInferredTargetDevice(inferredDeviceId, () =>
       lookupEnvironmentForTarget(inferredDeviceId),
     );
-    if (resolution.kind === "error") {
-      console.error(`Error: ${resolution.error}`);
-      return 1;
-    }
     if (resolution.kind === "device") {
       targetDeviceId = inferredDeviceId;
+    } else if (resolution.kind === "local-fallback") {
+      runner = "local";
+      localFallbackNote = `Cloud scheduling cannot reach this computer (${resolution.reason}), so this schedule was stored locally: it only fires while a Letta session is running here. For a durable schedule, pass --runner cloud (agent's Cloud sandbox) or --computer <deviceId> (a registered computer from \`letta environments list\`).`;
     }
   }
 
-  if (resolved.runner === "cloud") {
+  if (runner === "cloud") {
     return handleCloudAdd({
       agentId,
       conversationId,
@@ -444,8 +455,16 @@ async function handleAdd(values: CronArgValues): Promise<number> {
     if (note) {
       output.note = note;
     }
-    if (result.warning) {
-      output.warning = result.warning;
+    // Recurring jobs pinned to an unregistered computer are usually a
+    // mistake (the user expects "every Monday" to survive this session);
+    // one-shot follow-ups usually aren't (a dead session obviates them).
+    const fallbackWarning =
+      localFallbackNote && recurring
+        ? `${localFallbackNote} Recurring schedules on an unregistered computer stop firing whenever no session is running — strongly consider a durable alternative.`
+        : localFallbackNote;
+    const warnings = [fallbackWarning, result.warning].filter(Boolean);
+    if (warnings.length > 0) {
+      output.warning = warnings.join(" ");
     }
 
     console.log(JSON.stringify(output, null, 2));

--- a/src/cli/subcommands/cron.ts
+++ b/src/cli/subcommands/cron.ts
@@ -404,7 +404,7 @@ async function handleAdd(values: CronArgValues): Promise<number> {
       targetDeviceId = inferredDeviceId;
     } else if (resolution.kind === "local-fallback") {
       runner = "local";
-      localFallbackNote = `Cloud scheduling cannot reach this computer (${resolution.reason}), so this schedule was stored locally: it only fires while a Letta session is running here. For a durable schedule, pass --runner cloud (agent's Cloud sandbox) or --computer <deviceId> (a registered computer from \`letta environments list\`).`;
+      localFallbackNote = `This schedule is local to this computer (${resolution.reason}): it only fires while a Letta session is running here. For a schedule that fires regardless, pass --runner cloud (runs in the agent's cloud sandbox) or --computer <deviceId> (runs on a connected computer, from \`letta environments list\`).`;
     }
   }
 

--- a/src/skills/builtin/scheduling-tasks/SKILL.md
+++ b/src/skills/builtin/scheduling-tasks/SKILL.md
@@ -16,27 +16,22 @@ This skill lets you create, list, and manage scheduled tasks using the `letta cr
 
 ## Where Schedules Run — Omit the Flags
 
-**Default guidance: omit `--runner` and `--computer`.** The CLI picks where the schedule is stored and where it executes based on the runtime you're running in, and its default preserves execution locality: the scheduled work keeps running in the same environment as the conversation that created it. That matters because two execution environments don't share a turn queue — a follow-up that fires into a different environment can race the active conversation (busy/409 errors) while the user is still chatting.
+**Default guidance: omit `--runner` and `--computer`.** The CLI places the schedule so the work keeps running on the computer where it was created. Don't move scheduled work to a different computer than the active conversation without a reason: two computers working the same conversation can conflict.
 
-What the default resolves to:
+Pass a flag only when you have a requirement the default can't infer:
 
-- **Registered external listener** (a `letta server` on a VPS/Railway box, or a computer with remote access enabled): durable Cloud schedule targeted to this computer. Survives restarts; falls back to the agent's Cloud sandbox if this computer is offline at fire time.
-- **Managed cloud sandbox**: durable Cloud schedule that fires in the agent's Cloud sandbox. That is the same environment you're running in, so locality is preserved.
-- **This computer, not registered with Cloud** (e.g. a desktop-local session): local schedule in `~/.letta/crons.json`. Cloud scheduling has no way to reach this computer, so a local schedule is the only way the work can keep executing here. The CLI prints a warning with the durability tradeoff: local schedules only fire while a Letta session runs on this computer.
-- **Local-backend agents** (`agent-local-*`) and self-hosted servers always use the local scheduler.
+- **`--runner cloud`** — the schedule must fire no matter which computers are online; execute in the agent's cloud sandbox.
+- **`--computer <deviceId>`** — the work needs a specific connected computer (its filesystem, services, or credentials). Get the deviceId from `letta environments list`. If that computer is offline at fire time, execution falls back to the cloud sandbox.
+- **`--runner local`** — the work must only ever run on the current computer, even if that means missing fires while no session is running here.
 
-Pass a flag only when you have a constraint the default can't infer:
-
-- **`--runner cloud`** — the schedule must survive this computer/session no matter what; execute in the agent's Cloud sandbox. Use this for recurring jobs created from an unregistered computer (see below).
-- **`--computer <deviceId>`** — the work needs a specific always-on computer's filesystem, services, or credentials. The deviceId comes from `letta environments list`; the computer must be a registered external environment (managed sandboxes and desktop-local connections are not valid targets). Falls back to the Cloud sandbox if it's offline at fire time; that fallback cannot be disabled.
-- **`--runner local`** — the work must only ever run on this computer, even if that means missing fires while no session is running.
+The CLI reports its placement in the command output. If it warns that the schedule is local (this happens when the cloud scheduler cannot reach the current computer), the schedule only fires while a Letta session is running here — read the warning and decide whether that's acceptable.
 
 ### Fast Follow-ups vs Recurring Jobs
 
-Two patterns cover most schedules; they want different placement:
+Two patterns cover most schedules:
 
-- **Fast follow-ups** ("check on the PR in 5m", "poke the deploy in 30m"): the default is right. Same execution environment as the active conversation, no queue races. If the session dies before it fires, the follow-up usually died with the task anyway.
-- **Recurring jobs** ("every Monday 11am, start the lunch order"): prefer durability. If you're on a registered listener or in a sandbox, the default is already durable. If the CLI warns that it created a *local* schedule for a recurring job, that's usually wrong for the user's intent — recreate it with `--runner cloud` (or `--computer` for an always-on box), and consider whether the job should post into a dedicated conversation rather than this one (continuity in one thread vs a fresh context per topic).
+- **Fast follow-ups** ("check on the PR in 5m"): the default is right — same computer as the active conversation. If the session dies before it fires, the follow-up usually died with the task anyway.
+- **Recurring jobs** ("every Monday 11am, start the lunch order"): prefer durability. If the CLI warned that a recurring schedule is local, that's usually wrong for the user's intent — recreate it with `--runner cloud`, or `--computer` if the job needs a specific always-on computer. Also consider whether the job should post into a dedicated conversation rather than this one (continuity in one thread vs a fresh context per run).
 
 ## CLI Usage
 
@@ -71,7 +66,7 @@ letta cron add --name <short-name> --description <text> --prompt <text> <schedul
 | `--agent <id>` | Agent ID (defaults to `LETTA_AGENT_ID` from the current shell/session) |
 | `--conversation <id>` | Conversation ID (defaults to `LETTA_CONVERSATION_ID` from the current shell/session, otherwise `"default"`) |
 | `--runner <runner>` | `cloud` or `local` — normally omit; see "Where Schedules Run" above |
-| `--computer <id>` | Execute on a specific registered computer — normally omit |
+| `--computer <id>` | Execute on a specific connected computer — normally omit |
 | `--once` | Mark `--at` as one-shot (already the default for `--at`) |
 
 ### Listing Tasks
@@ -209,9 +204,9 @@ Include context about what the user originally asked for, so you can give a help
 - **Recurring tasks**: No longer auto-expire. They remain active until explicitly cancelled.
 - **One-shot cleanup (local runner)**: One-shot local tasks are garbage-collected 24 hours after firing.
 - **Default binding precedence**: `letta cron add` uses `--agent` / `--conversation` first, then falls back to `LETTA_AGENT_ID` / `LETTA_CONVERSATION_ID`, then finally uses `"default"` for the conversation if no env var is present.
-- **Local scheduler requirement**: Local-runner tasks only fire while a Letta session is running on that computer (a WS listener must be active). If no session is running, tasks will be marked as missed. Cloud schedules fire from the cloud regardless.
+- **Local scheduler requirement**: Local schedules only fire while a Letta session is running on their computer; fires while no session runs are marked as missed. Cloud schedules fire from the cloud regardless.
 - **`--at` for specific times**: `--at "3:00pm"` schedules a one-shot. If the time has already passed today, it schedules for tomorrow.
-- **Cloud schedule creation failures are loud**: if creating a Cloud schedule fails, no schedule is created — there is no silent fallback to local storage on error. (The local fallback for unregistered computers happens *before* creation and is reported in the output.)
+- **Cloud schedule creation failures are loud**: if creating a cloud schedule fails, no schedule is created — a failed create never silently becomes a local schedule. (The local placement for computers the cloud scheduler can't reach is decided before creation and reported in the output.)
 
 ## Cron Expression Reference
 

--- a/src/skills/builtin/scheduling-tasks/SKILL.md
+++ b/src/skills/builtin/scheduling-tasks/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: scheduling-tasks
-description: Schedules reminders and recurring tasks via the letta cron CLI. Use when the user asks to be reminded of something, wants periodic messages, or needs to manage scheduled tasks.
+description: Schedules reminders and recurring tasks via the letta cron CLI. Use when the user asks to be reminded of something, wants periodic work or check-ins, or needs to list, inspect, replace, or cancel scheduled tasks.
 ---
 
 # Scheduling Tasks
@@ -14,28 +14,29 @@ This skill lets you create, list, and manage scheduled tasks using the `letta cr
 - User wants a one-shot delayed message ("in 30 minutes, check on X")
 - User wants to see or cancel existing scheduled tasks
 
-## Where Schedules Run (`--runner`)
+## Where Schedules Run — Omit the Flags
 
-There are two schedule runners, selected with the optional `--runner local|cloud` flag:
+**Default guidance: omit `--runner` and `--computer`.** The CLI picks where the schedule is stored and where it executes based on the runtime you're running in, and its default preserves execution locality: the scheduled work keeps running in the same environment as the conversation that created it. That matters because two execution environments don't share a turn queue — a follow-up that fires into a different environment can race the active conversation (busy/409 errors) while the user is still chatting.
 
-- **`cloud`** (default for cloud agents): a durable Cloud schedule stored by the Letta API. With no runner or computer flag, it keeps executing where it was created: a registered external listener becomes the schedule's target, and a managed cloud sandbox gets an untargeted schedule that fires in the agent's cloud sandbox. Either way the schedule survives process restarts.
-- **`local`**: a task local to the current computer (`~/.letta/crons.json`), executed by the Letta session running there. It only fires while a session is running on that computer, and it dies with that computer's local state.
+What the default resolves to:
 
-You normally don't need the flag. Use explicit `--runner cloud` to run in the agent's Cloud sandbox instead of the current listener. Local-backend agents (`agent-local-*`) and self-hosted servers use the local runner.
+- **Registered external listener** (a `letta server` on a VPS/Railway box, or a computer with remote access enabled): durable Cloud schedule targeted to this computer. Survives restarts; falls back to the agent's Cloud sandbox if this computer is offline at fire time.
+- **Managed cloud sandbox**: durable Cloud schedule that fires in the agent's Cloud sandbox. That is the same environment you're running in, so locality is preserved.
+- **This computer, not registered with Cloud** (e.g. a desktop-local session): local schedule in `~/.letta/crons.json`. Cloud scheduling has no way to reach this computer, so a local schedule is the only way the work can keep executing here. The CLI prints a warning with the durability tradeoff: local schedules only fire while a Letta session runs on this computer.
+- **Local-backend agents** (`agent-local-*`) and self-hosted servers always use the local scheduler.
 
-If the scheduled work must run on a **specific computer** (it needs that computer's filesystem, local services, or credentials — e.g. a bring-your-own machine like a Railway/VPS box or a home workstation), prefer a Cloud schedule that executes on that computer:
+Pass a flag only when you have a constraint the default can't infer:
 
-```bash
-letta cron add ... --computer <deviceId>
-```
+- **`--runner cloud`** — the schedule must survive this computer/session no matter what; execute in the agent's Cloud sandbox. Use this for recurring jobs created from an unregistered computer (see below).
+- **`--computer <deviceId>`** — the work needs a specific always-on computer's filesystem, services, or credentials. The deviceId comes from `letta environments list`; the computer must be a registered external environment (managed sandboxes and desktop-local connections are not valid targets). Falls back to the Cloud sandbox if it's offline at fire time; that fallback cannot be disabled.
+- **`--runner local`** — the work must only ever run on this computer, even if that means missing fires while no session is running.
 
-The deviceId comes from `letta environments list`. The computer must be a registered external environment, such as a manual `letta server`, VPS, or Railway listener. Managed sandboxes and Desktop-local proxy connections are not currently valid targets. The schedule stays durable in the cloud; if the computer is offline when it fires, execution falls back to the agent's Cloud sandbox. Use `--runner local` on the target computer only when that fallback is unacceptable.
+### Fast Follow-ups vs Recurring Jobs
 
-Notes for the cloud runner:
+Two patterns cover most schedules; they want different placement:
 
-- The implicit default infers the current runtime: a registered external listener is targeted, a managed sandbox falls through to an untargeted schedule. `--computer` overrides it. Explicit `--runner cloud` always creates an untargeted Cloud-sandbox schedule.
-- Recurring `--cron` expressions are currently interpreted in UTC (the CLI output includes a note about this). `--at` and `--every` are unaffected.
-- If creating a Cloud schedule fails, no schedule is created — there is no silent fallback to local storage. Retry, or pass `--runner local` deliberately.
+- **Fast follow-ups** ("check on the PR in 5m", "poke the deploy in 30m"): the default is right. Same execution environment as the active conversation, no queue races. If the session dies before it fires, the follow-up usually died with the task anyway.
+- **Recurring jobs** ("every Monday 11am, start the lunch order"): prefer durability. If you're on a registered listener or in a sandbox, the default is already durable. If the CLI warns that it created a *local* schedule for a recurring job, that's usually wrong for the user's intent — recreate it with `--runner cloud` (or `--computer` for an always-on box), and consider whether the job should post into a dedicated conversation rather than this one (continuity in one thread vs a fresh context per topic).
 
 ## CLI Usage
 
@@ -59,7 +60,7 @@ letta cron add --name <short-name> --description <text> --prompt <text> <schedul
 
 | Flag | Type | Example |
 |------|------|---------|
-| `--every <interval>` | Recurring | `5m`, `2h`, `1d` |
+| `--every <interval>` | Recurring (cron shorthand) | `5m`, `2h`, `1d` |
 | `--at <time>` | One-shot | `"3:00pm"`, `"in 45m"` |
 | `--cron <expr>` | Raw cron (recurring) | `"0 9 * * 1-5"` |
 
@@ -69,8 +70,9 @@ letta cron add --name <short-name> --description <text> --prompt <text> <schedul
 |------|-------------|
 | `--agent <id>` | Agent ID (defaults to `LETTA_AGENT_ID` from the current shell/session) |
 | `--conversation <id>` | Conversation ID (defaults to `LETTA_CONVERSATION_ID` from the current shell/session, otherwise `"default"`) |
-| `--runner <runner>` | `cloud` or `local` — see "Where Schedules Run" above (defaults to `cloud` for cloud agents) |
-| `--computer <id>` | (cloud runner only) Override execution with a registered external environment; falls back to the Cloud sandbox if it is offline |
+| `--runner <runner>` | `cloud` or `local` — normally omit; see "Where Schedules Run" above |
+| `--computer <id>` | Execute on a specific registered computer — normally omit |
+| `--once` | Mark `--at` as one-shot (already the default for `--at`) |
 
 ### Listing Tasks
 
@@ -78,13 +80,23 @@ letta cron add --name <short-name> --description <text> --prompt <text> <schedul
 letta cron list
 ```
 
-Optional filters: `--agent <id>`, `--conversation <id>`
+Optional filters: `--agent <id>`, `--conversation <id>`, `--runner local|cloud`
 
 ### Getting a Single Task
 
+`get` accepts an ID or name:
+
 ```bash
-letta cron get <task-id>
+letta cron get <id-or-name> [--runner local|cloud] [--agent <id>]
 ```
+
+### Reading Run History
+
+```bash
+letta cron runs --id <task-id> [--limit <n>] [--runner local|cloud] [--agent <id>]
+```
+
+For local run history, `--run-id <id>` selects one run. Cloud history ignores that flag.
 
 ### Binding a Task to the Right Conversation
 
@@ -110,37 +122,37 @@ Then verify the binding explicitly:
 letta cron list --agent "$AGENT_ID" --conversation "$CONVERSATION_ID"
 ```
 
-### Deleting Tasks
+### Deleting or Replacing Tasks
+
+`delete` accepts an ID or name; `remove` is an alias.
 
 ```bash
 # Delete a specific task
-letta cron delete <task-id>
+letta cron delete <id-or-name> [--runner local|cloud] [--agent <id>]
 
-# Delete all tasks for the current agent
-letta cron delete --all
+# Delete all tasks for one agent
+letta cron delete --all --agent "$AGENT_ID"
 ```
+
+In-place editing is not available. To change a schedule, create and verify the replacement before deleting the old one.
+
+## Timezones — Convert Before Writing `--cron`
+
+Cloud-schedule recurring expressions (both `--cron` and the expression `--every` compiles to) are interpreted in **UTC**. Users say times in their local timezone, so convert before writing the expression: a user in PDT asking for "9am daily" needs `--cron "0 16 * * *"` (9am PDT = 16:00 UTC; 17:00 during PST). State the conversion in your reply so the user can catch a wrong assumption. Local-runner tasks use the computer's local timezone — no conversion. `--at` stores one absolute timestamp parsed in the current process timezone, so it needs no conversion either.
 
 ## Examples
 
-### "Remind me every morning at 9am to walk the dog"
+### "Remind me every morning at 9am to walk the dog" (user in UTC−7)
 
 ```bash
 letta cron add \
   --name "dog-walk-reminder" \
-  --description "Daily morning reminder to walk the dog" \
+  --description "Daily 9am (America/Los_Angeles) reminder to walk the dog" \
   --prompt "Hey! It's 9am — time to walk the dog." \
-  --every 1d
+  --cron "0 16 * * *"
 ```
 
-Note: `--every 1d` fires once daily at midnight. For a specific time like 9am, use a raw cron expression:
-
-```bash
-letta cron add \
-  --name "dog-walk-reminder" \
-  --description "Daily 9am reminder to walk the dog" \
-  --prompt "Hey! It's 9am — time to walk the dog." \
-  --cron "0 9 * * *"
-```
+Note: `--every 1d` fires daily at midnight (UTC on a Cloud schedule), so use `--cron` for a specific time of day, converting the user's local time to UTC first.
 
 ### "Check on the deploy in 30 minutes"
 
@@ -148,19 +160,21 @@ letta cron add \
 letta cron add \
   --name "deploy-check" \
   --description "One-time check on deployment status" \
-  --prompt "The user asked you to check on the deploy — ask them how it went." \
+  --prompt "Check the deployment status and report the result here." \
   --at "in 30m"
 ```
 
-### "Every weekday at 5pm, remind me to submit my timesheet"
+### "Every weekday at 5pm, remind me to submit my timesheet" (user in UTC−7)
 
 ```bash
 letta cron add \
   --name "timesheet-reminder" \
-  --description "Weekday 5pm timesheet reminder" \
+  --description "Weekday 5pm (America/Los_Angeles) timesheet reminder" \
   --prompt "Friendly reminder: don't forget to submit your timesheet before EOD!" \
-  --cron "0 17 * * 1-5"
+  --cron "0 0 * * 2-6"
 ```
+
+Note the day shift: 5pm UTC−7 is midnight UTC the *next* day, so weekdays Mon–Fri become `2-6`. Always re-derive both the hour and the day fields after converting.
 
 ### "What reminders do I have?"
 
@@ -176,12 +190,8 @@ letta cron list --agent "$AGENT_ID" --conversation "$CONVERSATION_ID"
 
 ### "Cancel the dog walk reminder"
 
-First list to find the task ID, then delete:
-
 ```bash
-letta cron list
-# Find the task ID from the output, then:
-letta cron delete <task-id>
+letta cron delete dog-walk-reminder
 ```
 
 ## Writing Good Prompts
@@ -198,15 +208,14 @@ Include context about what the user originally asked for, so you can give a help
 - **Minimum granularity**: 1 minute. Intervals under 60 seconds are rounded up.
 - **Recurring tasks**: No longer auto-expire. They remain active until explicitly cancelled.
 - **One-shot cleanup (local runner)**: One-shot local tasks are garbage-collected 24 hours after firing.
-- **Timezone**: Local-runner tasks use the user's local timezone. Cloud-runner recurring `--cron` expressions are currently interpreted in UTC.
 - **Default binding precedence**: `letta cron add` uses `--agent` / `--conversation` first, then falls back to `LETTA_AGENT_ID` / `LETTA_CONVERSATION_ID`, then finally uses `"default"` for the conversation if no env var is present.
-- **Local scheduler requirement**: Local-runner tasks only fire while a Letta session is running on that computer (a WS listener must be active). If no session is running, tasks will be marked as missed. Cloud-runner schedules fire from the cloud regardless.
+- **Local scheduler requirement**: Local-runner tasks only fire while a Letta session is running on that computer (a WS listener must be active). If no session is running, tasks will be marked as missed. Cloud schedules fire from the cloud regardless.
 - **`--at` for specific times**: `--at "3:00pm"` schedules a one-shot. If the time has already passed today, it schedules for tomorrow.
-- **`--every` for daily**: `--every 1d` fires daily at midnight. For a specific time of day, use `--cron` instead (e.g. `--cron "0 9 * * *"` for 9am daily).
+- **Cloud schedule creation failures are loud**: if creating a Cloud schedule fails, no schedule is created — there is no silent fallback to local storage on error. (The local fallback for unregistered computers happens *before* creation and is reported in the output.)
 
 ## Cron Expression Reference
 
-For `--cron`, use standard 5-field cron syntax:
+For `--cron`, use numeric 5-field cron syntax (named days/months, seconds, `?`, `L`, and `#` are not supported):
 
 ```
 ┌───────────── minute (0-59)
@@ -218,9 +227,9 @@ For `--cron`, use standard 5-field cron syntax:
 * * * * *
 ```
 
-Common patterns:
+Common patterns (UTC on Cloud schedules):
 - `*/5 * * * *` — every 5 minutes
 - `0 */2 * * *` — every 2 hours
-- `0 9 * * *` — daily at 9am
-- `0 9 * * 1-5` — weekdays at 9am
-- `30 8 1 * *` — 8:30am on the 1st of each month
+- `0 9 * * *` — daily at 9:00 UTC
+- `0 9 * * 1-5` — weekdays at 9:00 UTC
+- `30 8 1 * *` — 8:30 UTC on the 1st of each month


### PR DESCRIPTION
## Summary
- Bare `letta cron add` on a desktop-local or unregistered runtime now creates a **local** schedule with a warning, instead of erroring. After #3665, those runtimes had no working no-flags path: Cloud scheduling cannot deliver into a computer that is not in the environments registry, so the local scheduler is the only placement that keeps the work executing where the conversation lives.
- Recurring schedules that hit this fallback get a louder caution — "every Monday" pinned to a session that must stay open is usually not what the user meant — with the durable alternatives (`--runner cloud`, `--computer <deviceId>`) spelled out.
- Rewrites the `scheduling-tasks` skill around intention rather than the flag matrix: **omit `--runner`/`--computer`** and the CLI keeps the schedule on the computer that created it, so scheduled work never conflicts with the active conversation from a second computer. Adds fast-followup vs recurring-job guidance and UTC-conversion instructions for cloud cron expressions (agents were previously shown examples that would silently schedule 9am UTC for a user asking for 9am local).
- Folds in the verified CLI-reference corrections from #3675: `--once`, id-or-name for `get`/`delete` (+ `remove` alias), `runs` history, `--every` compiling to a UTC cron expression on cloud schedules, numeric-only cron fields, and no in-place editing. Cameron is co-authored for those.

**Stacked on #3683** (system prompts defer cron mechanics to the skill), so this PR touches only code and the skill — the skill is the single place placement behavior is documented.

## Resulting default (no flags, cloud agent)

| Runtime | Placement |
|---|---|
| Registered external listener | Cloud schedule targeting that listener (#3665) |
| Managed cloud sandbox | untargeted Cloud schedule → fires in the sandbox |
| Desktop-local / unregistered computer | **local schedule + warning** (was: error) |
| Local-backend agent / self-hosted | local schedule (unchanged) |

Explicit flags stay authoritative and unchanged: `--computer` picks a registered device, `--runner cloud` picks the sandbox, `--runner local` pins this computer.

## Implementation
`resolveInferredTargetDevice` now returns `device | cloud-sandbox | local-fallback` (the error arm is gone); `handleAdd` routes `local-fallback` to the local runner and threads the reason into the JSON output's `warning` field, merged with the existing no-scheduler-running warning when both apply. User-facing messages use plain wording ("not connected to your Letta account"), and guidance text avoids runtime taxonomy — the CLI reports its placement in output, and the skill teaches reading that instead of predicting it.

Follow-up (separate track): registering desktop-local listeners in the Cloud environments registry would let those runtimes get durable Cloud schedules targeting the desktop, at which point this fallback narrows naturally. Until then, local is the honest placement.

Supersedes #3675.

## Test plan
- [x] `bun test src/cli/subcommands/cron.test.ts src/cli/subcommands/cron-runner.test.ts src/tools/shell-env.test.ts` — includes new HTTP-boundary tests: unregistered runtime creates a local task (no schedule POST) with fallback + recurring warnings; one-shot fallback omits the recurring caution
- [x] `bun run check` (12/12)

👾 Generated with [Letta Code](https://letta.com)