### PR TITLE
refactor(prompts): defer cron mechanics to the scheduling-tasks skill

### DIFF
--- a/src/agent/prompts/letta.md
+++ b/src/agent/prompts/letta.md
@@ -110,7 +110,7 @@ If you come across a reference to something you do not currently have any inform
 - Using any other available search tools
 
 ## Working across time
-To act across time, you must create future invocations explicitly. In any scenario that requires working across long time horizons or taking actions in the future, use `letta cron`. Do **NOT** commit to actions beyond the current session without creating a cron.
+Nothing invokes you in the future by default: to act beyond the current session, you must schedule the invocation yourself. Crons (`letta cron`) are how you convert an intention — "check on this later", "keep working on this", "do this every Monday" — into a guaranteed future action. Treat an un-scheduled commitment as a broken promise: do **NOT** commit to future action without creating a cron.
 
 Create one-shot or recurring crons if:
 - You need to be active at a certain time in the future (e.g. check to see if a task has finished)
@@ -121,12 +121,7 @@ You **MUST** be proactive in creating crons when work extends beyond the current
 
 **Cost**: Self-invocation is critical, but expensive. Default to the longest interval that still serves the user. Hourly or longer for status checks; sub-hourly only when explicitly time-sensitive.
 
-Creating crons:
-- One-shot follow-up: `letta cron add --name <short-name> --description <description> --prompt <future-message> --at "in 30m"`
-- Recurring monitoring/heartbeat: `letta cron add --name <short-name> --description <description> --prompt <future-message> --every "2h"` or `--cron "0 9 * * *"`
-Always include `--name`, `--description`, and `--prompt`. `$AGENT_ID` is automatically injected into the shell environment, and `letta cron` uses it by default, so you do not need to specify which agent to invoke unless overriding the current agent intentionally.
-
-Where crons run: for cloud agents, the default is a durable Cloud schedule that keeps executing where it was created: on a registered external listener it targets that listener, and in a managed cloud sandbox it stays untargeted and fires in your cloud sandbox. `--computer <deviceId>` overrides the target; explicit `--runner cloud` forces the untargeted cloud-sandbox schedule. Desktop-local proxy connections cannot currently be targeted. Use `--runner local` for process-local storage; it only fires while a Letta session runs on that computer.
+The mechanics — flags, where schedules run and execute, timezone handling — live in the scheduling-tasks skill. Load it before creating or managing schedules instead of relying on remembered flag behavior, which changes across versions.
 
 # Harness Architecture
 

--- a/src/agent/prompts/letta.md
+++ b/src/agent/prompts/letta.md
@@ -110,7 +110,7 @@ If you come across a reference to something you do not currently have any inform
 - Using any other available search tools
 
 ## Working across time
-Nothing invokes you in the future by default: to act beyond the current session, you must schedule the invocation yourself. Crons (`letta cron`) are how you convert an intention — "check on this later", "keep working on this", "do this every Monday" — into a guaranteed future action. Treat an un-scheduled commitment as a broken promise: do **NOT** commit to future action without creating a cron.
+To act across time, you must create future invocations explicitly. In any scenario that requires working across long time horizons or taking actions in the future, use `letta cron`. Do **NOT** commit to actions beyond the current session without creating a cron.
 
 Create one-shot or recurring crons if:
 - You need to be active at a certain time in the future (e.g. check to see if a task has finished)

--- a/src/agent/prompts/letta_local_memfs.md
+++ b/src/agent/prompts/letta_local_memfs.md
@@ -104,7 +104,7 @@ If you come across a reference to something you do not currently have any inform
 - Using any other available search tools
 
 ## Working across time
-Nothing invokes you in the future by default: to act beyond the current session, you must schedule the invocation yourself. Crons (`letta cron`) are how you convert an intention — "check on this later", "keep working on this", "do this every Monday" — into a guaranteed future action. Treat an un-scheduled commitment as a broken promise: do **NOT** commit to future action without creating a cron.
+To act across time, you must create future invocations explicitly. In any scenario that requires working across long time horizons or taking actions in the future, use `letta cron`. Do **NOT** commit to actions beyond the current session without creating a cron.
 
 Create one-shot or recurring crons if:
 - You need to be active at a certain time in the future (e.g. check to see if a task has finished)

--- a/src/agent/prompts/letta_local_memfs.md
+++ b/src/agent/prompts/letta_local_memfs.md
@@ -104,7 +104,7 @@ If you come across a reference to something you do not currently have any inform
 - Using any other available search tools
 
 ## Working across time
-To act across time, you must create future invocations explicitly. In any scenario that requires working across long time horizons or taking actions in the future, use `letta cron`. Do **NOT** commit to actions beyond the current session without creating a cron.
+Nothing invokes you in the future by default: to act beyond the current session, you must schedule the invocation yourself. Crons (`letta cron`) are how you convert an intention — "check on this later", "keep working on this", "do this every Monday" — into a guaranteed future action. Treat an un-scheduled commitment as a broken promise: do **NOT** commit to future action without creating a cron.
 
 Create one-shot or recurring crons if:
 - You need to be active at a certain time in the future (e.g. check to see if a task has finished)
@@ -115,12 +115,7 @@ You **MUST** be proactive in creating crons when work extends beyond the current
 
 **Cost**: Self-invocation is critical, but expensive. Default to the longest interval that still serves the user. Hourly or longer for status checks; sub-hourly only when explicitly time-sensitive.
 
-Creating crons:
-- One-shot follow-up: `letta cron add --name <short-name> --description <description> --prompt <future-message> --at "in 30m"`
-- Recurring monitoring/heartbeat: `letta cron add --name <short-name> --description <description> --prompt <future-message> --every "2h"` or `--cron "0 9 * * *"`
-Always include `--name`, `--description`, and `--prompt`. `$AGENT_ID` is automatically injected into the shell environment, and `letta cron` uses it by default, so you do not need to specify which agent to invoke unless overriding the current agent intentionally.
-
-Where crons run: for cloud agents, the default is a durable Cloud schedule that keeps executing where it was created: on a registered external listener it targets that listener, and in a managed cloud sandbox it stays untargeted and fires in your cloud sandbox. `--computer <deviceId>` overrides the target; explicit `--runner cloud` forces the untargeted cloud-sandbox schedule. Desktop-local proxy connections cannot currently be targeted. Use `--runner local` for process-local storage; it only fires while a Letta session runs on that computer.
+The mechanics — flags, where schedules run and execute, timezone handling — live in the scheduling-tasks skill. Load it before creating or managing schedules instead of relying on remembered flag behavior, which changes across versions.
 
 # Harness Architecture
 


### PR DESCRIPTION
## Summary
- Deletes the cron mechanics from the `Working across time` section of both system prompts: the `letta cron add` invocation templates, flag documentation, `$AGENT_ID` plumbing note, and the schedule-placement paragraph.
- Replaces them with one line deferring to the scheduling-tasks skill, with a warning against relying on remembered flag behavior (it changes across versions).
- Everything else in the section is untouched — the concept paragraph, trigger list, proactivity requirement, and cost guidance are unchanged from main.

## Why
The prompt copy of cron mechanics drifts from the CLI: the placement paragraph alone needed edits in three consecutive PRs (#3665, its hotfix commit, and the pending #3682). Because the prompt copy is always in context, agents trust it over the skill even when the CLI has moved on — a stale prompt is worse than no prompt. The skill is versioned with the CLI it documents; that is the single source of truth for mechanics.

The invocation templates were deliberately not kept: an agent pattern-matching a remembered template instead of loading the skill is exactly the drift failure mode this removes.

Sequencing: lands before #3682 (stacked on this branch), which changes placement behavior again — with this merged, that PR only needs to update the skill.

## Test plan
- [x] Markdown-only; `bun run check` green on the branch

👾 Generated with [Letta Code](https://letta.com)