### PR TITLE
fix(channels): batch gateway runtime tool registration

### DIFF
--- a/scripts/source-file-size-baseline.json
+++ b/scripts/source-file-size-baseline.json
@@ -40,12 +40,12 @@
   "src/tools/impl/enter-worktree.ts": 1260,
   "src/tools/manager.ts": 3080,
   "src/tools/tool-execution-context.test.ts": 1138,
-  "src/types/protocol_v2.ts": 2958,
+  "src/types/protocol_v2.ts": 2912,
   "src/websocket/listen-client-concurrency.test.ts": 2686,
   "src/websocket/listen-client-protocol.test.ts": 5827,
   "src/websocket/listener/commands/memory.ts": 1114,
   "src/websocket/listener/file-commands.ts": 1053,
   "src/websocket/listener/lifecycle.ts": 1051,
-  "src/websocket/listener/protocol-inbound.ts": 2302,
+  "src/websocket/listener/protocol-inbound.ts": 2262,
   "src/websocket/listener/protocol-outbound.ts": 1085
 }

--- a/src/app-server-client.test.ts
+++ b/src/app-server-client.test.ts
@@ -131,6 +131,7 @@ describe("app-server client", () => {
         conversation_management: true,
         memory_management: true,
         runtime_start: true,
+        runtime_external_tools_update: true,
         split_channels: false,
       },
     });
@@ -159,6 +160,18 @@ describe("app-server client", () => {
     };
 
     expect(isAppServerInfoResponseMessage(response)).toBe(true);
+    expect(
+      isAppServerInfoResponseMessage({
+        ...response,
+        capabilities: {
+          agent_management: true,
+          conversation_management: true,
+          memory_management: true,
+          runtime_start: true,
+          split_channels: false,
+        },
+      }),
+    ).toBe(true);
     expect(
       isAppServerInfoResponseMessage({
         ...response,
@@ -282,15 +295,45 @@ describe("app-server client", () => {
     });
     expect((await syncPromise).success).toBe(true);
 
-    const abortPromise = client.abort({ runtime });
+    const toolUpdatePromise = client.runtimeExternalToolsUpdate({
+      updates: [
+        {
+          runtimes: [runtime],
+          external_tools: [
+            {
+              tools: [
+                {
+                  name: "MessageChannel",
+                  description: "Deliver a channel message",
+                  parameters: { type: "object", properties: {} },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
     expect(JSON.parse(control.sent[1] ?? "{}")).toMatchObject({
+      type: "runtime_external_tools_update",
+      request_id: "runtime-external-tools-2",
+      updates: [{ runtimes: [runtime] }],
+    });
+    control.receive({
+      type: "runtime_external_tools_update_response",
+      request_id: "runtime-external-tools-2",
+      success: true,
+    });
+    expect((await toolUpdatePromise).success).toBe(true);
+
+    const abortPromise = client.abort({ runtime });
+    expect(JSON.parse(control.sent[2] ?? "{}")).toMatchObject({
       type: "abort_message",
-      request_id: "abort-2",
+      request_id: "abort-3",
       runtime,
     });
     control.receive({
       type: "abort_message_response",
-      request_id: "abort-2",
+      request_id: "abort-3",
       runtime,
       aborted: false,
       success: true,
@@ -304,12 +347,17 @@ describe("app-server client", () => {
         messages: [{ role: "user", content: "hello" }],
       },
     });
-    expect(JSON.parse(control.sent[2] ?? "{}")).toMatchObject({
+    expect(JSON.parse(control.sent[3] ?? "{}")).toMatchObject({
       type: "input",
       runtime,
       payload: { kind: "create_message" },
     });
-    expect(sent).toEqual(["sync", "abort_message", "input"]);
+    expect(sent).toEqual([
+      "sync",
+      "runtime_external_tools_update",
+      "abort_message",
+      "input",
+    ]);
   });
 
   test("wraps conversation list requests", async () => {

--- a/src/app-server-client.ts
+++ b/src/app-server-client.ts
@@ -13,6 +13,8 @@ import type {
   ExternalToolCallResult,
   InputAcceptedResponseMessage,
   InputCommand,
+  RuntimeExternalToolsUpdateCommand,
+  RuntimeExternalToolsUpdateResponseMessage,
   RuntimeStartCommand,
   RuntimeStartResponseMessage,
   SyncCommand,
@@ -481,6 +483,32 @@ export class AppServerClient {
         ...options,
         predicate: (message): message is RuntimeStartResponseMessage =>
           message.type === "runtime_start_response",
+      },
+    );
+  }
+
+  runtimeExternalToolsUpdate(
+    command: Omit<RuntimeExternalToolsUpdateCommand, "type" | "request_id"> & {
+      request_id?: string;
+    },
+    options: Omit<
+      AppServerRequestOptions<RuntimeExternalToolsUpdateResponseMessage>,
+      "predicate"
+    > = {},
+  ): Promise<RuntimeExternalToolsUpdateResponseMessage> {
+    return this.request(
+      {
+        type: "runtime_external_tools_update",
+        request_id:
+          command.request_id ?? this.nextRequestId("runtime-external-tools"),
+        ...command,
+      },
+      {
+        ...options,
+        predicate: (
+          message,
+        ): message is RuntimeExternalToolsUpdateResponseMessage =>
+          message.type === "runtime_external_tools_update_response",
       },
     );
   }

--- a/src/channels/gateway-core.test.ts
+++ b/src/channels/gateway-core.test.ts
@@ -30,6 +30,7 @@ import type {
 interface FakeClientOptions {
   startResponse?: Partial<RuntimeStartResponseMessage>;
   inputResponse?: Partial<InputAcceptedResponseMessage>;
+  toolUpdateWait?: Promise<void>;
 }
 
 class FakeClient implements ChannelGatewayClient {
@@ -48,6 +49,9 @@ class FakeClient implements ChannelGatewayClient {
     preserve_skill_sources?: boolean;
     external_tools?: unknown;
   }> = [];
+  readonly runtimeToolUpdates: Array<
+    import("@/types/app-server-protocol").RuntimeExternalToolsUpdateGroup
+  > = [];
   closeCalls = 0;
   // Mutable input response for per-test control
   inputResponse: { accepted: boolean; disposition: "started" | "queued" };
@@ -119,6 +123,20 @@ class FakeClient implements ChannelGatewayClient {
       ...(this.options.startResponse?.error
         ? { error: this.options.startResponse.error }
         : {}),
+    };
+  }
+
+  async runtimeExternalToolsUpdate(options: {
+    updates: readonly import("@/types/app-server-protocol").RuntimeExternalToolsUpdateGroup[];
+  }): Promise<
+    import("@/types/app-server-protocol").RuntimeExternalToolsUpdateResponseMessage
+  > {
+    this.runtimeToolUpdates.push(...options.updates);
+    await this.options.toolUpdateWait;
+    return {
+      type: "runtime_external_tools_update_response",
+      request_id: "runtime-external-tools-test",
+      success: true,
     };
   }
 
@@ -618,6 +636,89 @@ test("runtime registration happens before input submission", async () => {
     },
   ]);
 
+  gateway.close();
+});
+
+test("serializes routed tool publication with runtime registration", async () => {
+  let releaseToolUpdate!: () => void;
+  const toolUpdateWait = new Promise<void>((resolve) => {
+    releaseToolUpdate = resolve;
+  });
+  const client = new FakeClient({ toolUpdateWait });
+  const { hooks } = makeHooks();
+  const gateway = new ChannelGateway(client, hooks);
+  const source = makeSource();
+
+  const publication = gateway.updateRoutedRuntimeTools(
+    [
+      {
+        runtimes: [TEST_RUNTIME],
+        external_tools: [
+          {
+            tools: [
+              {
+                name: "MessageChannel",
+                description: "Send a message through a channel",
+                parameters: {},
+              },
+            ],
+          },
+        ],
+      },
+    ],
+    [{ runtime: TEST_RUNTIME, sources: [source] }],
+  );
+  const registration = gateway.registerRuntime(TEST_RUNTIME, [source]);
+
+  await Bun.sleep(0);
+  expect(client.runtimeToolUpdates).toHaveLength(1);
+  expect(client.startedRuntimes).toHaveLength(0);
+
+  releaseToolUpdate();
+  await Promise.all([publication, registration]);
+  expect(client.startedRuntimes).toHaveLength(1);
+  gateway.close();
+});
+
+test("publishes hundreds of routed runtime tools without runtime_start", async () => {
+  const client = new FakeClient();
+  const { hooks } = makeHooks();
+  const gateway = new ChannelGateway(client, hooks);
+  const runtimes = Array.from({ length: 350 }, (_, index) => ({
+    agent_id: "agent-1",
+    conversation_id: `conv-${index}`,
+  }));
+
+  await gateway.updateRoutedRuntimeTools(
+    [
+      {
+        runtimes,
+        external_tools: [
+          {
+            tools: [
+              {
+                name: "MessageChannel",
+                description: "Send a message through a channel",
+                parameters: {},
+              },
+            ],
+          },
+        ],
+      },
+    ],
+    runtimes.map((runtime) => ({
+      runtime,
+      sources: [
+        makeSource({
+          agentId: runtime.agent_id,
+          conversationId: runtime.conversation_id,
+        }),
+      ],
+    })),
+  );
+
+  expect(client.runtimeToolUpdates[0]?.runtimes).toHaveLength(350);
+  expect(client.startedRuntimes).toHaveLength(0);
   gateway.close();
 });
 

--- a/src/channels/gateway-core.ts
+++ b/src/channels/gateway-core.ts
@@ -9,6 +9,8 @@ import type {
   InputAcceptedResponseMessage,
   InputCommand,
   QueueUpdateMessage,
+  RuntimeExternalToolsUpdateGroup,
+  RuntimeExternalToolsUpdateResponseMessage,
   RuntimeScope,
   RuntimeStartCommand,
   RuntimeStartResponseMessage,
@@ -43,6 +45,9 @@ export interface ChannelGatewayClient {
       request_id?: string;
     },
   ): Promise<RuntimeStartResponseMessage>;
+  runtimeExternalToolsUpdate(options: {
+    updates: readonly RuntimeExternalToolsUpdateGroup[];
+  }): Promise<RuntimeExternalToolsUpdateResponseMessage>;
 }
 
 export interface ChannelGatewayDelivery {
@@ -105,7 +110,6 @@ type GatewayRuntimeState = {
   active: ActiveGatewayTurn | null;
   registrationSignature: string | null;
   registration: Promise<void> | null;
-  registrationQueue: Promise<void>;
   routedSources: ChannelTurnSource[];
   replayedControlRequestIds: Set<string>;
   submissionQueue: Promise<void>;
@@ -172,6 +176,10 @@ function errorFromDelta(message: StreamDeltaMessage): string | undefined {
 export class ChannelGateway {
   private readonly states = new Map<string, GatewayRuntimeState>();
   private readonly disposers: Array<() => void> = [];
+  // Tool publication and runtime_start both replace the same connection-owned
+  // registration. Keep them ordered so a late runtime_start cannot resurrect a
+  // route that an overlapping route-removal update just revoked.
+  private registrationQueue = Promise.resolve();
 
   constructor(
     private readonly client: ChannelGatewayClient,
@@ -220,13 +228,14 @@ export class ChannelGateway {
       sources: uniqueSources(delivery.sources),
       disposition: "submitting",
     });
-    state.routedSources = uniqueSources([
-      ...state.routedSources,
-      ...delivery.sources,
-    ]);
-
     try {
-      await this.ensureRuntimeRegistration(state, delivery);
+      await this.enqueueRegistration(async () => {
+        state.routedSources = uniqueSources([
+          ...state.routedSources,
+          ...delivery.sources,
+        ]);
+        await this.performRuntimeRegistration(state, delivery);
+      });
       const response = await this.client.submitInput({
         runtime: delivery.runtime,
         payload: {
@@ -312,13 +321,15 @@ export class ChannelGateway {
     defaultPermissionMode?: ChannelDefaultPermissionMode,
   ): Promise<void> {
     const state = this.getState(runtime);
-    state.routedSources = uniqueSources(sources);
-    await this.ensureRuntimeRegistration(state, {
-      runtime,
-      content: "",
-      sources,
-      clientMessageId: "recovered",
-      ...(defaultPermissionMode ? { defaultPermissionMode } : {}),
+    await this.enqueueRegistration(async () => {
+      this.setRoutedSources(runtime, sources);
+      await this.performRuntimeRegistration(state, {
+        runtime,
+        content: "",
+        sources,
+        clientMessageId: "recovered",
+        ...(defaultPermissionMode ? { defaultPermissionMode } : {}),
+      });
     });
   }
 
@@ -333,8 +344,36 @@ export class ChannelGateway {
     return result.accepted;
   }
 
+  setRoutedSources(runtime: RuntimeScope, sources: ChannelTurnSource[]): void {
+    this.getState(runtime).routedSources = uniqueSources(sources);
+  }
+
   getKnownRuntimes(): RuntimeScope[] {
     return [...this.states.values()].map((state) => state.runtime);
+  }
+
+  updateRoutedRuntimeTools(
+    updates: readonly RuntimeExternalToolsUpdateGroup[],
+    routedSources: Array<{
+      runtime: RuntimeScope;
+      sources: ChannelTurnSource[];
+    }>,
+  ): Promise<void> {
+    return this.enqueueRegistration(async () => {
+      if (updates.length > 0) {
+        const response = await this.client.runtimeExternalToolsUpdate({
+          updates,
+        });
+        if (!response.success) {
+          throw new Error(
+            response.error ?? "Failed to update routed runtime tools",
+          );
+        }
+      }
+      for (const update of routedSources) {
+        this.setRoutedSources(update.runtime, update.sources);
+      }
+    });
   }
 
   getModelStatus(runtime: RuntimeScope): ChannelGatewayModelStatus | null {
@@ -360,7 +399,6 @@ export class ChannelGateway {
         active: null,
         registrationSignature: null,
         registration: null,
-        registrationQueue: Promise.resolve(),
         routedSources: [],
         replayedControlRequestIds: new Set(),
         submissionQueue: Promise.resolve(),
@@ -398,15 +436,13 @@ export class ChannelGateway {
     return pending;
   }
 
-  private ensureRuntimeRegistration(
-    state: GatewayRuntimeState,
-    delivery: ChannelGatewayDelivery,
-  ): Promise<void> {
-    const registration = state.registrationQueue.then(() =>
-      this.performRuntimeRegistration(state, delivery),
+  private enqueueRegistration<T>(task: () => Promise<T>): Promise<T> {
+    const result = this.registrationQueue.then(task, task);
+    this.registrationQueue = result.then(
+      () => undefined,
+      () => undefined,
     );
-    state.registrationQueue = registration.catch(() => undefined);
-    return registration;
+    return result;
   }
 
   private async performRuntimeRegistration(

--- a/src/channels/gateway-local.ts
+++ b/src/channels/gateway-local.ts
@@ -177,6 +177,19 @@ export async function startLocalChannelGateway(
     WebSocket: WebSocket as never,
   });
   await client.connect();
+  let serverInfo: Awaited<ReturnType<typeof client.info>>;
+  try {
+    serverInfo = await client.info();
+  } catch (error) {
+    client.close();
+    throw error;
+  }
+  if (serverInfo.capabilities.runtime_external_tools_update !== true) {
+    client.close();
+    throw new Error(
+      "ChannelGateway requires App Server runtime external-tool updates",
+    );
+  }
   client.onDisconnect(() => {
     options.onDisconnect?.(
       new Error("Channel gateway lost App Server connection"),
@@ -247,12 +260,17 @@ export async function startLocalChannelGateway(
   });
 
   const routedRuntimeRegistrationRefresher =
-    createRoutedRuntimeRegistrationRefresher(
+    createRoutedRuntimeRegistrationRefresher({
       registry,
-      gateway,
-      options.channelNames,
-      options.logger,
-    );
+      channelNames: options.channelNames,
+      buildTool: buildGatewayMessageChannelTool,
+      publisher: {
+        getKnownRuntimes: () => gateway.getKnownRuntimes(),
+        publish: (updates, routedSources) =>
+          gateway.updateRoutedRuntimeTools(updates, routedSources),
+      },
+      logger: options.logger,
+    });
   registry.setMessageHandler((delivery) => {
     const sources = delivery.turnSources ?? [];
     const gatewayDelivery: ChannelGatewayDelivery = {

--- a/src/channels/routed-runtime-registration.test.ts
+++ b/src/channels/routed-runtime-registration.test.ts
@@ -1,13 +1,11 @@
 import { afterEach, expect, test } from "bun:test";
-import type { RuntimeScope } from "@/types/app-server-protocol";
-import { ChannelRegistry, getChannelRegistry } from "./registry";
+import type {
+  ExternalToolDefinitionPayload,
+  RuntimeExternalToolsUpdateGroup,
+  RuntimeScope,
+} from "@/types/app-server-protocol";
 import { createRoutedRuntimeRegistrationRefresher } from "./routed-runtime-registration";
-import {
-  __testOverrideLoadRoutes,
-  __testOverrideSaveRoutes,
-  clearAllRoutes,
-  setRouteInMemory,
-} from "./routing";
+import { __testOverrideLoadRoutes, clearAllRoutes } from "./routing";
 import type { ChannelTurnSource } from "./types";
 
 const runtime: RuntimeScope = {
@@ -15,134 +13,205 @@ const runtime: RuntimeScope = {
   conversation_id: "conv-1",
 };
 
-const source: ChannelTurnSource = {
-  channel: "slack",
-  accountId: "acct-1",
-  chatId: "C123",
-  chatType: "channel",
-  threadId: null,
-  agentId: runtime.agent_id,
-  conversationId: runtime.conversation_id,
-};
-
-afterEach(async () => {
-  await getChannelRegistry()?.stopAll();
-  clearAllRoutes();
-  __testOverrideLoadRoutes(null);
-  __testOverrideSaveRoutes(null);
-});
-
-test("registers routed conversations at gateway startup", async () => {
-  __testOverrideLoadRoutes(() => null);
-  __testOverrideSaveRoutes(() => {});
-  setRouteInMemory("slack", {
-    accountId: source.accountId,
-    chatId: source.chatId,
+function createSource(
+  nextRuntime: RuntimeScope = runtime,
+  accountId = "acct-1",
+): ChannelTurnSource {
+  return {
+    channel: "slack",
+    accountId,
+    chatId: `chat-${nextRuntime.conversation_id}`,
     chatType: "channel",
     threadId: null,
-    agentId: runtime.agent_id,
-    conversationId: runtime.conversation_id,
-    enabled: true,
-    outboundEnabled: true,
-    createdAt: "2026-08-05T00:00:00.000Z",
-    updatedAt: "2026-08-05T00:00:00.000Z",
-  });
-  const registry = new ChannelRegistry();
-  registry.registerAdapter({
-    id: "slack:acct-1",
-    channelId: "slack",
-    accountId: "acct-1",
-    name: "Slack",
-    start: async () => {},
-    stop: async () => {},
-    isRunning: () => true,
-    sendMessage: async () => ({ messageId: "msg-1" }),
-    sendDirectReply: async () => {},
-  });
+    agentId: nextRuntime.agent_id,
+    conversationId: nextRuntime.conversation_id,
+  };
+}
 
-  const registrations: Array<{
-    runtime: RuntimeScope;
-    sources: ChannelTurnSource[];
-  }> = [];
-  const refresher = createRoutedRuntimeRegistrationRefresher(
-    registry,
-    {
-      getKnownRuntimes: () => [],
-      registerRuntime: async (nextRuntime, sources = []) => {
-        registrations.push({ runtime: nextRuntime, sources });
+function createTool(
+  description = "Deliver a channel message",
+): ExternalToolDefinitionPayload {
+  return {
+    name: "MessageChannel",
+    description,
+    parameters: { type: "object", properties: {} },
+  };
+}
+
+afterEach(() => {
+  clearAllRoutes();
+  __testOverrideLoadRoutes(null);
+});
+
+test("publishes routed tools in one batch without starting runtimes", async () => {
+  __testOverrideLoadRoutes(() => null);
+  const updates: RuntimeExternalToolsUpdateGroup[][] = [];
+  const routedSources = new Map<string, ChannelTurnSource[]>();
+  const refresher = createRoutedRuntimeRegistrationRefresher({
+    registry: { resolveRoutedTurnSources: () => [createSource()] },
+    publisher: {
+      publish: async (nextUpdates, nextRoutedSources) => {
+        if (nextUpdates.length > 0) updates.push([...nextUpdates]);
+        for (const update of nextRoutedSources) {
+          routedSources.set(update.runtime.conversation_id, update.sources);
+        }
       },
     },
-    ["slack"],
-  );
+    channelNames: ["slack"],
+    buildTool: async () => createTool(),
+  });
 
   await refresher.refresh();
 
-  expect(registrations).toEqual([{ runtime, sources: [source] }]);
+  expect(updates).toEqual([
+    [
+      {
+        runtimes: [runtime],
+        external_tools: [{ tools: [createTool()] }],
+      },
+    ],
+  ]);
+  expect(routedSources.get(runtime.conversation_id)).toEqual([createSource()]);
   refresher.close();
 });
 
-test("removes the tool registration when a known runtime loses its routes", async () => {
+test("groups hundreds of identical routed tools into one update", async () => {
   __testOverrideLoadRoutes(() => null);
-
-  const registrations: ChannelTurnSource[][] = [];
-  const refresher = createRoutedRuntimeRegistrationRefresher(
-    {
-      resolveRoutedTurnSources: () => [],
+  const sources = Array.from({ length: 350 }, (_, index) =>
+    createSource({
+      agent_id: "agent-1",
+      conversation_id: `conv-${index}`,
+    }),
+  );
+  const updates: RuntimeExternalToolsUpdateGroup[][] = [];
+  let toolBuilds = 0;
+  const refresher = createRoutedRuntimeRegistrationRefresher({
+    registry: { resolveRoutedTurnSources: () => sources },
+    publisher: {
+      publish: async (nextUpdates) => {
+        updates.push([...nextUpdates]);
+      },
     },
-    {
+    channelNames: ["slack"],
+    buildTool: async () => {
+      toolBuilds++;
+      return createTool();
+    },
+  });
+
+  await refresher.refresh();
+
+  expect(updates).toHaveLength(1);
+  expect(updates[0]).toHaveLength(1);
+  expect(updates[0]?.[0]?.runtimes).toHaveLength(350);
+  expect(updates[0]?.[0]?.external_tools).toEqual([{ tools: [createTool()] }]);
+  expect(toolBuilds).toBe(1);
+  refresher.close();
+});
+
+test("publishes only changed schemas and removed runtime registrations", async () => {
+  __testOverrideLoadRoutes(() => null);
+  let sources = [createSource()];
+  let description = "Initial tool";
+  const updates: RuntimeExternalToolsUpdateGroup[][] = [];
+  const cleared: RuntimeScope[] = [];
+  const refresher = createRoutedRuntimeRegistrationRefresher({
+    registry: { resolveRoutedTurnSources: () => sources },
+    publisher: {
+      publish: async (nextUpdates, nextRoutedSources) => {
+        if (nextUpdates.length > 0) updates.push([...nextUpdates]);
+        for (const update of nextRoutedSources) {
+          if (update.sources.length === 0) cleared.push(update.runtime);
+        }
+      },
+    },
+    channelNames: ["slack"],
+    buildTool: async () => createTool(description),
+  });
+
+  await refresher.refresh();
+  await refresher.refresh();
+  description = "Updated tool";
+  await refresher.refresh();
+  sources = [];
+  await refresher.refresh();
+
+  expect(updates).toHaveLength(3);
+  expect(updates[1]?.[0]?.external_tools).toEqual([
+    { tools: [createTool("Updated tool")] },
+  ]);
+  expect(updates[2]).toEqual([{ runtimes: [runtime], external_tools: [] }]);
+  expect(cleared).toEqual([runtime]);
+  refresher.close();
+});
+
+test("revokes a known runtime that lost its route before publication", async () => {
+  __testOverrideLoadRoutes(() => null);
+  const updates: RuntimeExternalToolsUpdateGroup[][] = [];
+  const refresher = createRoutedRuntimeRegistrationRefresher({
+    registry: { resolveRoutedTurnSources: () => [] },
+    publisher: {
       getKnownRuntimes: () => [runtime],
-      registerRuntime: async (_runtime, sources = []) => {
-        registrations.push(sources);
+      publish: async (nextUpdates) => {
+        updates.push([...nextUpdates]);
       },
     },
-    ["slack"],
-  );
+    channelNames: ["slack"],
+    buildTool: async () => createTool(),
+  });
 
   await refresher.refresh();
 
-  expect(registrations).toEqual([[]]);
+  expect(updates).toEqual([[{ runtimes: [runtime], external_tools: [] }]]);
   refresher.close();
 });
 
-test("fails startup when initial MessageChannel registration fails", async () => {
+test("does not expose new route sources until tool publication succeeds", async () => {
   __testOverrideLoadRoutes(() => null);
-  const refresher = createRoutedRuntimeRegistrationRefresher(
-    { resolveRoutedTurnSources: () => [source] },
-    {
-      getKnownRuntimes: () => [],
-      registerRuntime: async () => {
-        throw new Error("listener unavailable");
+  let attempts = 0;
+  const routedSources: ChannelTurnSource[][] = [];
+  const refresher = createRoutedRuntimeRegistrationRefresher({
+    registry: { resolveRoutedTurnSources: () => [createSource()] },
+    publisher: {
+      publish: async (_updates, nextRoutedSources) => {
+        attempts++;
+        if (attempts === 1) throw new Error("listener unavailable");
+        routedSources.push(
+          ...nextRoutedSources.map((update) => update.sources),
+        );
       },
     },
-    ["slack"],
-  );
+    channelNames: ["slack"],
+    buildTool: async () => createTool(),
+  });
 
   await expect(refresher.refresh()).rejects.toThrow("listener unavailable");
+  expect(routedSources).toEqual([]);
+  await refresher.refresh();
+  expect(routedSources).toEqual([[createSource()]]);
   refresher.close();
 });
 
-test("retries a failed MessageChannel unregister until it succeeds", async () => {
+test("retries a failed background publication until it succeeds", async () => {
   __testOverrideLoadRoutes(() => null);
   let attempts = 0;
   let finish!: () => void;
   const finished = new Promise<void>((resolve) => {
     finish = resolve;
   });
-  const refresher = createRoutedRuntimeRegistrationRefresher(
-    { resolveRoutedTurnSources: () => [] },
-    {
-      getKnownRuntimes: () => [runtime],
-      registerRuntime: async (_runtime, sources = []) => {
+  const refresher = createRoutedRuntimeRegistrationRefresher({
+    registry: { resolveRoutedTurnSources: () => [createSource()] },
+    publisher: {
+      publish: async () => {
         attempts++;
-        expect(sources).toEqual([]);
         if (attempts === 1) throw new Error("temporary failure");
         finish();
       },
     },
-    ["slack"],
-    undefined,
-    0,
-  );
+    channelNames: ["slack"],
+    buildTool: async () => createTool(),
+    retryDelayMs: 0,
+  });
 
   refresher.requestRefresh();
   await Promise.race([
@@ -156,26 +225,31 @@ test("retries a failed MessageChannel unregister until it succeeds", async () =>
   refresher.close();
 });
 
-test("runs another pass when registration changes during a refresh", async () => {
+test("runs another publication pass when routes change during refresh", async () => {
   __testOverrideLoadRoutes(() => null);
+  let description = "Initial tool";
   let attempts = 0;
   let finish!: () => void;
   const finished = new Promise<void>((resolve) => {
     finish = resolve;
   });
   let refresher!: ReturnType<typeof createRoutedRuntimeRegistrationRefresher>;
-  refresher = createRoutedRuntimeRegistrationRefresher(
-    { resolveRoutedTurnSources: () => [source] },
-    {
-      getKnownRuntimes: () => [],
-      registerRuntime: async () => {
+  refresher = createRoutedRuntimeRegistrationRefresher({
+    registry: { resolveRoutedTurnSources: () => [createSource()] },
+    publisher: {
+      publish: async () => {
         attempts++;
-        if (attempts === 1) refresher.requestRefresh();
-        if (attempts === 2) finish();
+        if (attempts === 1) {
+          description = "Updated tool";
+          refresher.requestRefresh();
+        } else {
+          finish();
+        }
       },
     },
-    ["slack"],
-  );
+    channelNames: ["slack"],
+    buildTool: async () => createTool(description),
+  });
 
   refresher.requestRefresh();
   await Promise.race([

--- a/src/channels/routed-runtime-registration.ts
+++ b/src/channels/routed-runtime-registration.ts
@@ -1,4 +1,9 @@
-import type { RuntimeScope } from "@/types/app-server-protocol";
+import type {
+  ExternalToolDefinitionPayload,
+  RuntimeExternalToolsUpdateGroup,
+  RuntimeScope,
+  RuntimeStartExternalToolsGroup,
+} from "@/types/app-server-protocol";
 import { loadRoutes } from "./routing";
 import type { ChannelStartupLogger, ChannelTurnSource } from "./types";
 
@@ -6,62 +11,176 @@ interface RoutedRuntimeSourceResolver {
   resolveRoutedTurnSources(): ChannelTurnSource[];
 }
 
-interface RoutedRuntimeRegistrar {
-  getKnownRuntimes(): RuntimeScope[];
-  registerRuntime(
-    runtime: RuntimeScope,
-    sources?: ChannelTurnSource[],
+interface RoutedRuntimeToolPublisher {
+  getKnownRuntimes?(): RuntimeScope[];
+  publish(
+    updates: readonly RuntimeExternalToolsUpdateGroup[],
+    routedSources: Array<{
+      runtime: RuntimeScope;
+      sources: ChannelTurnSource[];
+    }>,
   ): Promise<void>;
 }
 
-async function refreshRoutedRuntimeRegistrations(
-  registry: RoutedRuntimeSourceResolver,
-  gateway: RoutedRuntimeRegistrar,
-  channelNames: string[],
-): Promise<void> {
+type RoutedRuntimeToolBuilder = (
+  sources: ChannelTurnSource[],
+) => Promise<ExternalToolDefinitionPayload | null>;
+
+type DesiredRuntimeRegistration = {
+  runtime: RuntimeScope;
+  sources: ChannelTurnSource[];
+  externalTools: RuntimeStartExternalToolsGroup[];
+  signature: string;
+};
+
+function runtimeKey(runtime: RuntimeScope): string {
+  return `${runtime.agent_id}:${runtime.conversation_id}`;
+}
+
+function groupSourcesByRuntime(
+  sources: ChannelTurnSource[],
+): Array<{ runtime: RuntimeScope; sources: ChannelTurnSource[] }> {
   const sourcesByRuntime = new Map<
     string,
     { runtime: RuntimeScope; sources: ChannelTurnSource[] }
   >();
-  for (const channel of channelNames) {
-    loadRoutes(channel);
-  }
-  for (const source of registry.resolveRoutedTurnSources()) {
+  for (const source of sources) {
     const runtime = {
       agent_id: source.agentId,
       conversation_id: source.conversationId,
     };
-    const key = `${runtime.agent_id}:${runtime.conversation_id}`;
+    const key = runtimeKey(runtime);
     const existing = sourcesByRuntime.get(key);
-    if (existing) {
-      existing.sources.push(source);
-    } else {
-      sourcesByRuntime.set(key, { runtime, sources: [source] });
-    }
+    if (existing) existing.sources.push(source);
+    else sourcesByRuntime.set(key, { runtime, sources: [source] });
   }
-  for (const runtime of gateway.getKnownRuntimes()) {
-    const key = `${runtime.agent_id}:${runtime.conversation_id}`;
-    if (!sourcesByRuntime.has(key)) {
-      sourcesByRuntime.set(key, { runtime, sources: [] });
-    }
-  }
-
-  for (const { runtime, sources } of sourcesByRuntime.values()) {
-    await gateway.registerRuntime(runtime, sources);
-  }
+  return [...sourcesByRuntime.values()];
 }
 
-export function createRoutedRuntimeRegistrationRefresher(
+function toolScopeKey(sources: ChannelTurnSource[]): string {
+  return JSON.stringify(
+    [
+      ...new Set(
+        sources.map((source) => `${source.channel}:${source.accountId ?? ""}`),
+      ),
+    ].sort(),
+  );
+}
+
+async function buildDesiredRegistrations(
   registry: RoutedRuntimeSourceResolver,
-  gateway: RoutedRuntimeRegistrar,
   channelNames: string[],
-  logger?: ChannelStartupLogger,
-  retryDelayMs = 1000,
-): {
+  buildTool: RoutedRuntimeToolBuilder,
+  knownRuntimes: RuntimeScope[],
+): Promise<Map<string, DesiredRuntimeRegistration>> {
+  for (const channel of channelNames) loadRoutes(channel);
+  const groupedSources = groupSourcesByRuntime(
+    registry.resolveRoutedTurnSources(),
+  );
+  const desired = new Map<string, DesiredRuntimeRegistration>();
+  // Hundreds of conversations commonly share one channel/account capability
+  // set. Resolve and serialize that schema once, then fan it out by runtime.
+  const toolsByScope = new Map<
+    string,
+    Promise<ExternalToolDefinitionPayload | null>
+  >();
+  await Promise.all(
+    groupedSources.map(async ({ runtime, sources }) => {
+      const scopeKey = toolScopeKey(sources);
+      let toolPromise = toolsByScope.get(scopeKey);
+      if (!toolPromise) {
+        toolPromise = buildTool(sources);
+        toolsByScope.set(scopeKey, toolPromise);
+      }
+      const tool = await toolPromise;
+      const externalTools: RuntimeStartExternalToolsGroup[] = tool
+        ? [{ tools: [tool] }]
+        : [];
+      desired.set(runtimeKey(runtime), {
+        runtime,
+        sources,
+        externalTools,
+        signature: JSON.stringify(externalTools),
+      });
+    }),
+  );
+  for (const runtime of knownRuntimes) {
+    const key = runtimeKey(runtime);
+    if (desired.has(key)) continue;
+    const externalTools: RuntimeStartExternalToolsGroup[] = [];
+    desired.set(key, {
+      runtime,
+      sources: [],
+      externalTools,
+      signature: JSON.stringify(externalTools),
+    });
+  }
+  return desired;
+}
+
+function buildUpdateGroups(
+  desired: Map<string, DesiredRuntimeRegistration>,
+  publishedSignatures: Map<
+    string,
+    { runtime: RuntimeScope; signature: string }
+  >,
+): RuntimeExternalToolsUpdateGroup[] {
+  const groupsBySignature = new Map<
+    string,
+    {
+      runtimes: RuntimeScope[];
+      external_tools: RuntimeStartExternalToolsGroup[];
+    }
+  >();
+  const append = (
+    runtime: RuntimeScope,
+    externalTools: RuntimeStartExternalToolsGroup[],
+    signature: string,
+  ): void => {
+    const existing = groupsBySignature.get(signature);
+    if (existing) existing.runtimes.push(runtime);
+    else {
+      groupsBySignature.set(signature, {
+        runtimes: [runtime],
+        external_tools: externalTools,
+      });
+    }
+  };
+
+  for (const [key, registration] of desired) {
+    if (publishedSignatures.get(key)?.signature === registration.signature) {
+      continue;
+    }
+    append(
+      registration.runtime,
+      registration.externalTools,
+      registration.signature,
+    );
+  }
+  const emptySignature = JSON.stringify([]);
+  for (const [key, published] of publishedSignatures) {
+    if (!desired.has(key)) append(published.runtime, [], emptySignature);
+  }
+  return [...groupsBySignature.values()];
+}
+
+export function createRoutedRuntimeRegistrationRefresher(options: {
+  registry: RoutedRuntimeSourceResolver;
+  publisher: RoutedRuntimeToolPublisher;
+  channelNames: string[];
+  buildTool: RoutedRuntimeToolBuilder;
+  logger?: ChannelStartupLogger;
+  retryDelayMs?: number;
+}): {
   refresh: () => Promise<void>;
   requestRefresh: () => void;
   close: () => void;
 } {
+  const retryDelayMs = options.retryDelayMs ?? 1000;
+  let publishedSignatures = new Map<
+    string,
+    { runtime: RuntimeScope; signature: string }
+  >();
   let pending = Promise.resolve();
   let backgroundRefresh: Promise<void> | null = null;
   let requestedVersion = 0;
@@ -70,11 +189,35 @@ export function createRoutedRuntimeRegistrationRefresher(
   let retryTimer: NodeJS.Timeout | null = null;
   let resolveRetry: (() => void) | null = null;
 
+  const runRefresh = async (): Promise<void> => {
+    const desired = await buildDesiredRegistrations(
+      options.registry,
+      options.channelNames,
+      options.buildTool,
+      options.publisher.getKnownRuntimes?.() ?? [],
+    );
+    const updates = buildUpdateGroups(desired, publishedSignatures);
+    const routedSources = [...desired.values()].map((registration) => ({
+      runtime: registration.runtime,
+      sources: registration.sources,
+    }));
+    for (const [key, published] of publishedSignatures) {
+      if (!desired.has(key)) {
+        routedSources.push({ runtime: published.runtime, sources: [] });
+      }
+    }
+    await options.publisher.publish(updates, routedSources);
+    publishedSignatures = new Map(
+      [...desired].map(([key, registration]) => [
+        key,
+        { runtime: registration.runtime, signature: registration.signature },
+      ]),
+    );
+  };
   const refresh = (): Promise<void> => {
-    const run = () =>
-      refreshRoutedRuntimeRegistrations(registry, gateway, channelNames);
-    pending = pending.then(run, run);
-    return pending;
+    const run = pending.then(runRefresh, runRefresh);
+    pending = run.catch(() => undefined);
+    return run;
   };
   const waitForRetry = (): Promise<void> =>
     new Promise((resolve) => {
@@ -96,7 +239,7 @@ export function createRoutedRuntimeRegistrationRefresher(
           completedVersion = version;
           if (version === requestedVersion) return;
         } catch (error) {
-          logger?.(
+          options.logger?.(
             `[ChannelGateway] Failed to refresh routed runtimes; retrying: ${error instanceof Error ? error.message : String(error)}`,
           );
           await waitForRetry();

--- a/src/types/app-server-info.ts
+++ b/src/types/app-server-info.ts
@@ -20,6 +20,7 @@ export interface AppServerInfoResponseMessage {
     conversation_management: boolean;
     memory_management: boolean;
     runtime_start: boolean;
+    runtime_external_tools_update?: boolean;
     split_channels: boolean;
   };
 }
@@ -55,6 +56,8 @@ export function isAppServerInfoResponseMessage(
     typeof capabilityRecord.conversation_management === "boolean" &&
     typeof capabilityRecord.memory_management === "boolean" &&
     typeof capabilityRecord.runtime_start === "boolean" &&
+    (capabilityRecord.runtime_external_tools_update === undefined ||
+      typeof capabilityRecord.runtime_external_tools_update === "boolean") &&
     typeof capabilityRecord.split_channels === "boolean"
   );
 }

--- a/src/types/external-tool-protocol.ts
+++ b/src/types/external-tool-protocol.ts
@@ -1,0 +1,69 @@
+import type { RuntimeScope } from "./runtime-scope";
+
+export interface ExternalToolDefinitionPayload {
+  name: string;
+  label?: string;
+  description: string;
+  parameters: Record<string, unknown>;
+}
+
+export interface RuntimeStartExternalToolsGroup {
+  /** Hidden controller-defined scope used to select these tools on input turns. */
+  scope_id?: string;
+  tools: readonly ExternalToolDefinitionPayload[];
+}
+
+/**
+ * Applies one external-tool definition set to one or more exact runtimes.
+ * Empty external_tools removes the controller's tools for those runtimes.
+ */
+export interface RuntimeExternalToolsUpdateGroup {
+  runtimes: readonly RuntimeScope[];
+  external_tools: readonly RuntimeStartExternalToolsGroup[];
+}
+
+/**
+ * Publishes runtime-owned external tools without starting or subscribing to
+ * each runtime. Registrations remain owned by the sending connection.
+ */
+export interface RuntimeExternalToolsUpdateCommand {
+  type: "runtime_external_tools_update";
+  request_id: string;
+  updates: readonly RuntimeExternalToolsUpdateGroup[];
+}
+
+export interface RuntimeExternalToolsUpdateResponseMessage {
+  type: "runtime_external_tools_update_response";
+  request_id: string;
+  success: boolean;
+  error?: string;
+}
+
+export interface ExternalToolCallRequestMessage {
+  type: "external_tool_call_request";
+  request_id: string;
+  runtime?: RuntimeScope;
+  scope_id?: string;
+  tool_call_id: string;
+  tool_name: string;
+  input: Record<string, unknown>;
+}
+
+export interface ExternalToolCallResultContent {
+  type: string;
+  text?: string;
+  data?: string;
+  mimeType?: string;
+}
+
+export interface ExternalToolCallResult {
+  content: readonly ExternalToolCallResultContent[];
+  is_error?: boolean;
+}
+
+export interface ExternalToolCallResponseCommand {
+  type: "external_tool_call_response";
+  request_id: string;
+  result?: ExternalToolCallResult;
+  error?: string;
+}

--- a/src/types/protocol_v2.ts
+++ b/src/types/protocol_v2.ts
@@ -35,8 +35,18 @@ import type {
   AppServerInfoResponseMessage,
 } from "./app-server-info";
 import type { ConversationForkBody } from "./conversation-fork-protocol";
+import type {
+  ExternalToolCallRequestMessage,
+  ExternalToolCallResponseCommand,
+  RuntimeExternalToolsUpdateCommand,
+  RuntimeExternalToolsUpdateResponseMessage,
+  RuntimeStartExternalToolsGroup,
+} from "./external-tool-protocol";
+import type { RuntimeScope } from "./runtime-scope";
 import type { CronRunLogPage, CronTask } from "./schedule-protocol";
 
+export type * from "./external-tool-protocol";
+export type * from "./runtime-scope";
 export type * from "./schedule-protocol";
 
 export type DmPolicy = "pairing" | "allowlist" | "open";
@@ -59,24 +69,6 @@ export interface ExperimentSnapshot {
   enabled: boolean;
   source: ExperimentSource;
   override: boolean | null;
-}
-
-/**
- * Runtime identity for all state and delta events.
- *
- * `acting_user_id` is set by cloud-api on inbound `input`
- * create_message frames (the WS subscriber's authenticated cloud
- * user id). The listener echoes it back as the
- * `X-Letta-Acting-User-Id` HTTP header on the outbound
- * createMessage call so cloud can attribute credits + rate limits
- * to the actual sender — not the user whose API key happens to
- * spawn the sandbox / desktop runtime. Other event types (state,
- * delta, control) ignore this field.
- */
-export interface RuntimeScope {
-  agent_id: string;
-  conversation_id: string;
-  acting_user_id?: string;
 }
 
 /**
@@ -801,17 +793,6 @@ export interface RuntimeStartClientInfo {
   version?: string;
 }
 
-export interface ExternalToolDefinitionPayload {
-  name: string;
-  label?: string;
-  description: string;
-  parameters: Record<string, unknown>;
-}
-export interface RuntimeStartExternalToolsGroup {
-  /** Hidden controller-defined scope used to select these tools on input turns. */
-  scope_id?: string;
-  tools: readonly ExternalToolDefinitionPayload[];
-}
 export interface RuntimeStartCommand {
   type: "runtime_start";
   /** Echoed back in the response for request correlation. */
@@ -840,35 +821,6 @@ export interface RuntimeStartCommand {
   wait_for_replay?: boolean;
   /** Controller-owned tools registered atomically with the resolved runtime. */
   external_tools?: readonly RuntimeStartExternalToolsGroup[];
-}
-
-export interface ExternalToolCallRequestMessage {
-  type: "external_tool_call_request";
-  request_id: string;
-  runtime?: RuntimeScope;
-  scope_id?: string;
-  tool_call_id: string;
-  tool_name: string;
-  input: Record<string, unknown>;
-}
-
-export interface ExternalToolCallResultContent {
-  type: string;
-  text?: string;
-  data?: string;
-  mimeType?: string;
-}
-
-export interface ExternalToolCallResult {
-  content: readonly ExternalToolCallResultContent[];
-  is_error?: boolean;
-}
-
-export interface ExternalToolCallResponseCommand {
-  type: "external_tool_call_response";
-  request_id: string;
-  result?: ExternalToolCallResult;
-  error?: string;
 }
 
 export interface TerminalSpawnCommand {
@@ -2759,6 +2711,7 @@ export type WsProtocolCommand =
   | AbortMessageCommand
   | SyncCommand
   | RuntimeStartCommand
+  | RuntimeExternalToolsUpdateCommand
   | ExternalToolCallResponseCommand
   | TerminalSpawnCommand
   | TerminalInputCommand
@@ -2861,6 +2814,7 @@ export type WsProtocolMessage =
   | ExternalToolCallRequestMessage
   | AbortMessageResponseMessage
   | SyncResponseMessage
+  | RuntimeExternalToolsUpdateResponseMessage
   | TerminalOutputMessage
   | TerminalSpawnedMessage
   | TerminalExitedMessage

--- a/src/types/runtime-scope.ts
+++ b/src/types/runtime-scope.ts
@@ -1,0 +1,17 @@
+/**
+ * Runtime identity for all state and delta events.
+ *
+ * `acting_user_id` is set by cloud-api on inbound `input`
+ * create_message frames (the WS subscriber's authenticated cloud
+ * user id). The listener echoes it back as the
+ * `X-Letta-Acting-User-Id` HTTP header on the outbound
+ * createMessage call so cloud can attribute credits + rate limits
+ * to the actual sender — not the user whose API key happens to
+ * spawn the sandbox / desktop runtime. Other event types (state,
+ * delta, control) ignore this field.
+ */
+export interface RuntimeScope {
+  agent_id: string;
+  conversation_id: string;
+  acting_user_id?: string;
+}

--- a/src/websocket/listener/commands/app-server-info.test.ts
+++ b/src/websocket/listener/commands/app-server-info.test.ts
@@ -46,6 +46,7 @@ describe("app-server info protocol", () => {
         conversation_management: true,
         memory_management: true,
         runtime_start: true,
+        runtime_external_tools_update: true,
         split_channels: false,
       },
     });

--- a/src/websocket/listener/commands/app-server-info.ts
+++ b/src/websocket/listener/commands/app-server-info.ts
@@ -33,6 +33,7 @@ export function buildAppServerInfoResponse(
       conversation_management: true,
       memory_management: true,
       runtime_start: true,
+      runtime_external_tools_update: true,
       split_channels: false,
     },
   };

--- a/src/websocket/listener/external-tool-protocol.ts
+++ b/src/websocket/listener/external-tool-protocol.ts
@@ -1,0 +1,97 @@
+import type {
+  ExternalToolCallResponseCommand,
+  RuntimeExternalToolsUpdateCommand,
+} from "@/types/protocol_v2";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function isRuntimeScope(value: unknown): value is {
+  agent_id: string;
+  conversation_id: string;
+} {
+  if (!isRecord(value)) return false;
+  return (
+    typeof value.agent_id === "string" &&
+    value.agent_id.length > 0 &&
+    typeof value.conversation_id === "string" &&
+    value.conversation_id.length > 0
+  );
+}
+
+function isExternalToolDefinitionPayload(value: unknown): boolean {
+  if (!isRecord(value)) return false;
+  return (
+    typeof value.name === "string" &&
+    (value.label === undefined || typeof value.label === "string") &&
+    typeof value.description === "string" &&
+    isRecord(value.parameters)
+  );
+}
+
+export function isRuntimeStartExternalToolsGroup(value: unknown): boolean {
+  if (!isRecord(value)) return false;
+  return (
+    (value.scope_id === undefined || typeof value.scope_id === "string") &&
+    Array.isArray(value.tools) &&
+    value.tools.every(isExternalToolDefinitionPayload)
+  );
+}
+
+export function isRuntimeExternalToolsUpdateCommand(
+  value: unknown,
+): value is RuntimeExternalToolsUpdateCommand {
+  if (!isRecord(value)) return false;
+  if (
+    value.type !== "runtime_external_tools_update" ||
+    typeof value.request_id !== "string" ||
+    !Array.isArray(value.updates)
+  ) {
+    return false;
+  }
+  const runtimeKeys = new Set<string>();
+  for (const update of value.updates) {
+    if (
+      !isRecord(update) ||
+      !Array.isArray(update.runtimes) ||
+      update.runtimes.length === 0 ||
+      !update.runtimes.every(isRuntimeScope) ||
+      !Array.isArray(update.external_tools) ||
+      !update.external_tools.every(isRuntimeStartExternalToolsGroup)
+    ) {
+      return false;
+    }
+    for (const runtime of update.runtimes) {
+      const key = `${runtime.agent_id}:${runtime.conversation_id}`;
+      if (runtimeKeys.has(key)) return false;
+      runtimeKeys.add(key);
+    }
+  }
+  return true;
+}
+
+export function isExternalToolCallResponseCommand(
+  value: unknown,
+): value is ExternalToolCallResponseCommand {
+  if (!isRecord(value)) return false;
+  if (
+    value.type !== "external_tool_call_response" ||
+    typeof value.request_id !== "string"
+  ) {
+    return false;
+  }
+  if (value.error !== undefined && typeof value.error !== "string") {
+    return false;
+  }
+  if (value.result === undefined) {
+    return typeof value.error === "string";
+  }
+  if (!isRecord(value.result)) return false;
+  return (
+    Array.isArray(value.result.content) &&
+    value.result.content.every(isRecord) &&
+    (value.result.is_error === undefined ||
+      typeof value.result.is_error === "boolean")
+  );
+}

--- a/src/websocket/listener/external-tools.test.ts
+++ b/src/websocket/listener/external-tools.test.ts
@@ -13,6 +13,7 @@ import {
   registerRuntimeExternalTools,
   rejectPendingExternalToolCalls,
   rejectPendingExternalToolCallsForConnection,
+  updateRuntimeExternalTools,
 } from "@/websocket/listener/external-tools";
 import {
   createRuntime,
@@ -289,6 +290,101 @@ describe("listener runtime_start external tool bridge", () => {
         description: "Lookup ticket for conversation B",
       }),
     ]);
+  });
+
+  test("applies batched runtime tool registrations without starting runtimes", async () => {
+    const { runtime, sent } = createMockRuntime();
+    installExternalToolBridge(runtime);
+    const runtimes = Array.from({ length: 350 }, (_, index) => ({
+      agent_id: "agent-1",
+      conversation_id: `conv-${index}`,
+    }));
+    updateRuntimeExternalTools(runtime, "client-1", [
+      {
+        runtimes,
+        external_tools: [
+          {
+            tools: [
+              {
+                name: "MessageChannel",
+                description: "Deliver through the channel gateway",
+                parameters: { type: "object", properties: {} },
+              },
+            ],
+          },
+        ],
+      },
+    ]);
+
+    const routed = await prepareToolExecutionContextForModel(
+      "anthropic/claude-sonnet-4",
+      {
+        clientToolAllowlist: ["MessageChannel"],
+        runtimeContext: {
+          agentId: "agent-1",
+          conversationId: "conv-349",
+        },
+      },
+    );
+    const unrouted = await prepareToolExecutionContextForModel(
+      "anthropic/claude-sonnet-4",
+      {
+        clientToolAllowlist: ["MessageChannel"],
+        runtimeContext: {
+          agentId: "agent-1",
+          conversationId: "conv-missing",
+        },
+      },
+    );
+
+    expect(routed.clientTools.map((tool) => tool.name)).toEqual([
+      "MessageChannel",
+    ]);
+    expect(unrouted.clientTools).toEqual([]);
+    const delivered = await executeTool(
+      "MessageChannel",
+      {},
+      { toolContextId: routed.contextId, toolCallId: "call-batched" },
+    );
+    expect(delivered.status).toBe("success");
+    expect(sent[0]).toMatchObject({
+      runtime: { agent_id: "agent-1", conversation_id: "conv-349" },
+      tool_name: "MessageChannel",
+    });
+
+    const removedRuntime = runtimes.at(-1);
+    if (!removedRuntime) throw new Error("expected a routed runtime");
+    updateRuntimeExternalTools(runtime, "client-1", [
+      { runtimes: [removedRuntime], external_tools: [] },
+    ]);
+    const removed = await prepareToolExecutionContextForModel(
+      "anthropic/claude-sonnet-4",
+      {
+        clientToolAllowlist: ["MessageChannel"],
+        runtimeContext: {
+          agentId: "agent-1",
+          conversationId: "conv-349",
+        },
+      },
+    );
+    expect(removed.clientTools).toEqual([]);
+
+    rejectPendingExternalToolCallsForConnection(
+      runtime,
+      "client-1",
+      "gateway disconnected",
+    );
+    const afterDisconnect = await prepareToolExecutionContextForModel(
+      "anthropic/claude-sonnet-4",
+      {
+        clientToolAllowlist: ["MessageChannel"],
+        runtimeContext: {
+          agentId: "agent-1",
+          conversationId: "conv-348",
+        },
+      },
+    );
+    expect(afterDisconnect.clientTools).toEqual([]);
   });
 
   test("keeps same runtime tool registrations isolated by connection", async () => {

--- a/src/websocket/listener/external-tools.ts
+++ b/src/websocket/listener/external-tools.ts
@@ -8,6 +8,7 @@ import type {
   ExternalToolCallRequestMessage,
   ExternalToolCallResponseCommand,
   ExternalToolDefinitionPayload,
+  RuntimeExternalToolsUpdateGroup,
   RuntimeScope,
   RuntimeStartExternalToolsGroup,
 } from "@/types/protocol_v2";
@@ -216,6 +217,23 @@ export function registerRuntimeExternalTools(
     registeredTools.set(runtimeKey, tools);
   } else {
     registeredTools.delete(runtimeKey);
+  }
+}
+
+export function updateRuntimeExternalTools(
+  runtime: ListenerRuntime,
+  connectionId: ListenerConnectionId,
+  updates: readonly RuntimeExternalToolsUpdateGroup[],
+): void {
+  for (const update of updates) {
+    for (const runtimeScope of update.runtimes) {
+      registerRuntimeExternalTools(
+        runtime,
+        connectionId,
+        runtimeScope,
+        update.external_tools,
+      );
+    }
   }
 }
 

--- a/src/websocket/listener/message-router.test.ts
+++ b/src/websocket/listener/message-router.test.ts
@@ -1,5 +1,9 @@
 import { afterEach, describe, expect, mock, test } from "bun:test";
 import WebSocket from "ws";
+import {
+  clearExternalTools,
+  prepareToolExecutionContextForModel,
+} from "@/tools/manager";
 import { CHANNEL_SERVICE_COMMAND_TYPES } from "@/types/service-protocol";
 import { getOrCreateScopedRuntime } from "./conversation-runtime";
 import { createRuntime } from "./lifecycle";
@@ -40,7 +44,85 @@ async function waitFor(predicate: () => boolean): Promise<void> {
 }
 
 describe("listener message router ownership handoff", () => {
-  afterEach(() => setActiveRuntime(null));
+  afterEach(() => {
+    clearExternalTools();
+    setActiveRuntime(null);
+  });
+
+  test("acknowledges batched external-tool registration without runtime startup", async () => {
+    const listener = createRuntime();
+    const runtime = getOrCreateScopedRuntime(listener, "agent-1", "conv-1");
+    const socket = new MockSocket();
+    const sent: unknown[] = [];
+    setActiveRuntime(listener);
+    const handleMessage = createListenerMessageHandler({
+      runtime: listener,
+      socket: socket as unknown as WebSocket,
+      opts: makeListenerOptions(),
+      processQueuedTurn: async () => {},
+      fileCommandSession: { handle: () => false },
+      getParsedRuntimeScope: () => null,
+      replaySyncStateForRuntime: async () => {},
+      getOrCreateScopedRuntime: () => runtime,
+      handleApprovalResponseInput: async () => false,
+      handleChangeDeviceStateInput: async () => false,
+      handleAbortMessageInput: async () => false,
+      stampInboundUserMessageOtids: (incoming) => incoming,
+      safeSocketSend: (_target, payload) => {
+        sent.push(payload);
+        return true;
+      },
+      runDetachedListenerTask: () => {},
+      trackListenerError: () => {},
+      processIncomingMessage: async () => {},
+    });
+
+    await handleMessage(
+      Buffer.from(
+        JSON.stringify({
+          type: "runtime_external_tools_update",
+          request_id: "tools-1",
+          updates: [
+            {
+              runtimes: [{ agent_id: "agent-1", conversation_id: "conv-1" }],
+              external_tools: [
+                {
+                  tools: [
+                    {
+                      name: "MessageChannel",
+                      description: "Deliver a channel message",
+                      parameters: { type: "object", properties: {} },
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        }),
+      ),
+    );
+
+    expect(sent).toEqual([
+      {
+        type: "runtime_external_tools_update_response",
+        request_id: "tools-1",
+        success: true,
+      },
+    ]);
+    const prepared = await prepareToolExecutionContextForModel(
+      "anthropic/claude-sonnet-4",
+      {
+        clientToolAllowlist: ["MessageChannel"],
+        runtimeContext: {
+          agentId: "agent-1",
+          conversationId: "conv-1",
+        },
+      },
+    );
+    expect(prepared.clientTools.map((tool) => tool.name)).toEqual([
+      "MessageChannel",
+    ]);
+  });
 
   test("a direct message that loses the idle race is queued and later drained", async () => {
     const listener = createRuntime();

--- a/src/websocket/listener/message-router.ts
+++ b/src/websocket/listener/message-router.ts
@@ -33,7 +33,10 @@ import { handleSettingsProtocolCommand } from "./commands/settings";
 import { handleSkillAgentProtocolCommand } from "./commands/skills-agents";
 import { subscribeListenerConnection } from "./connection";
 import { getBootWorkingDirectory, getExportedCwdMap } from "./cwd";
-import { handleExternalToolCallResponseCommand } from "./external-tools";
+import {
+  handleExternalToolCallResponseCommand,
+  updateRuntimeExternalTools,
+} from "./external-tools";
 import {
   dispatchInboundMessageWhenReady,
   getAcceptedInputDisposition,
@@ -268,6 +271,29 @@ export function createListenerMessageHandler(
 
       if (parsed.type === "external_tool_call_response") {
         handleExternalToolCallResponseCommand(runtime, connectionId, parsed);
+        return;
+      }
+
+      if (parsed.type === "runtime_external_tools_update") {
+        const respond = (success: boolean, error?: string): void => {
+          safeSocketSend(
+            socket,
+            {
+              type: "runtime_external_tools_update_response",
+              request_id: parsed.request_id,
+              success,
+              ...(error ? { error } : {}),
+            },
+            "runtime_external_tools_update_response",
+            "runtime_external_tools_update",
+          );
+        };
+        if (runtime !== getActiveRuntime() || runtime.intentionallyClosed) {
+          respond(false, "Runtime is no longer active");
+          return;
+        }
+        updateRuntimeExternalTools(runtime, connectionId, parsed.updates);
+        respond(true);
         return;
       }
 

--- a/src/websocket/listener/protocol-inbound.test.ts
+++ b/src/websocket/listener/protocol-inbound.test.ts
@@ -130,6 +130,29 @@ describe("agent/conversation management protocol-inbound validators", () => {
       result: { content: [{ type: "text", text: "ok" }] },
     },
     {
+      type: "runtime_external_tools_update",
+      request_id: "tools-1",
+      updates: [
+        {
+          runtimes: [
+            { agent_id: "agent-1", conversation_id: "conv-1" },
+            { agent_id: "agent-1", conversation_id: "conv-2" },
+          ],
+          external_tools: [
+            {
+              tools: [
+                {
+                  name: "MessageChannel",
+                  description: "Deliver a channel message",
+                  parameters: { type: "object", properties: {} },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+    {
       type: "create_agent",
       request_id: "create-1",
       personality: "tutorial",
@@ -237,6 +260,35 @@ describe("agent/conversation management protocol-inbound validators", () => {
       type: "external_tool_call_response",
       request_id: "ext-1",
       result: { content: "not-array" },
+    },
+    {
+      type: "runtime_external_tools_update",
+      request_id: "tools-empty-runtime-list",
+      updates: [{ runtimes: [], external_tools: [] }],
+    },
+    {
+      type: "runtime_external_tools_update",
+      request_id: "tools-duplicate-runtime",
+      updates: [
+        {
+          runtimes: [{ agent_id: "agent-1", conversation_id: "conv-1" }],
+          external_tools: [],
+        },
+        {
+          runtimes: [{ agent_id: "agent-1", conversation_id: "conv-1" }],
+          external_tools: [],
+        },
+      ],
+    },
+    {
+      type: "runtime_external_tools_update",
+      request_id: "tools-invalid-definition",
+      updates: [
+        {
+          runtimes: [{ agent_id: "agent-1", conversation_id: "conv-1" }],
+          external_tools: [{ tools: [{ name: "missing schema" }] }],
+        },
+      ],
     },
     {
       type: "create_agent",

--- a/src/websocket/listener/protocol-inbound.ts
+++ b/src/websocket/listener/protocol-inbound.ts
@@ -62,7 +62,6 @@ import type {
   EditFileCommand,
   EnableMemfsCommand,
   ExecuteCommandCommand,
-  ExternalToolCallResponseCommand,
   FileOpsCommand,
   GetCwdMapCommand,
   GetExperimentsCommand,
@@ -116,6 +115,11 @@ function isExperimentId(value: unknown): value is ExperimentId {
 }
 
 import { isValidApprovalResponseBody } from "./approval";
+import {
+  isExternalToolCallResponseCommand,
+  isRuntimeExternalToolsUpdateCommand,
+  isRuntimeStartExternalToolsGroup,
+} from "./external-tool-protocol";
 import {
   isAppServerInfoCommand,
   isConversationForkCommand,
@@ -519,24 +523,6 @@ function isRuntimeStartClientInfo(value: unknown): boolean {
   );
 }
 
-function isExternalToolDefinitionPayload(value: unknown): boolean {
-  if (!isObjectRecord(value)) return false;
-  return (
-    typeof value.name === "string" &&
-    (value.label === undefined || typeof value.label === "string") &&
-    typeof value.description === "string" &&
-    isObjectRecord(value.parameters)
-  );
-}
-
-function isRuntimeStartExternalToolsGroup(value: unknown): boolean {
-  if (!isObjectRecord(value)) return false;
-  return (
-    (value.scope_id === undefined || typeof value.scope_id === "string") &&
-    Array.isArray(value.tools) &&
-    value.tools.every(isExternalToolDefinitionPayload)
-  );
-}
 export function isRuntimeStartCommand(
   value: unknown,
 ): value is RuntimeStartCommand {
@@ -567,33 +553,6 @@ export function isRuntimeStartCommand(
     (c.external_tools === undefined ||
       (Array.isArray(c.external_tools) &&
         c.external_tools.every(isRuntimeStartExternalToolsGroup)))
-  );
-}
-
-export function isExternalToolCallResponseCommand(
-  value: unknown,
-): value is ExternalToolCallResponseCommand {
-  if (!isObjectRecord(value)) return false;
-  if (
-    value.type !== "external_tool_call_response" ||
-    typeof value.request_id !== "string"
-  ) {
-    return false;
-  }
-  if (value.error !== undefined && typeof value.error !== "string") {
-    return false;
-  }
-  if (value.result === undefined) {
-    return typeof value.error === "string";
-  }
-  if (!isObjectRecord(value.result)) {
-    return false;
-  }
-  return (
-    Array.isArray(value.result.content) &&
-    value.result.content.every(isObjectRecord) &&
-    (value.result.is_error === undefined ||
-      typeof value.result.is_error === "boolean")
   );
 }
 
@@ -2197,6 +2156,7 @@ export function parseServerMessage(
       isAbortMessageCommand(parsed) ||
       isSyncCommand(parsed) ||
       isRuntimeStartCommand(parsed) ||
+      isRuntimeExternalToolsUpdateCommand(parsed) ||
       isExternalToolCallResponseCommand(parsed) ||
       isTerminalSpawnCommand(parsed) ||
       isTerminalInputCommand(parsed) ||

--- a/src/websocket/listener/protocol-logging.ts
+++ b/src/websocket/listener/protocol-logging.ts
@@ -101,6 +101,21 @@ export function summarizeV2Command(parsed: unknown): string {
     pushField(fields, "conversation_id", parsed.payload.conversation_id);
   } else if (parsed.type === "runtime_start") {
     fields.push(...summarizeRuntimeStartCommand(parsed));
+  } else if (
+    parsed.type === "runtime_external_tools_update" &&
+    Array.isArray(parsed.updates)
+  ) {
+    fields.push(`updates=${parsed.updates.length}`);
+    fields.push(
+      `runtimes=${parsed.updates.reduce((count, update) => {
+        return (
+          count +
+          (isRecord(update) && Array.isArray(update.runtimes)
+            ? update.runtimes.length
+            : 0)
+        );
+      }, 0)}`,
+    );
   } else {
     for (const key of [
       "agent_id",


### PR DESCRIPTION
## Summary
- add a generic App Server command for updating exact runtime-owned external tools without starting or subscribing to those runtimes
- publish persisted ChannelGateway route tools in one schema-deduplicated batch before readiness, then apply ordered incremental updates/removals
- keep `MessageChannel` gateway-owned while preserving exact runtime isolation, process-turn availability, controller execution routing, and disconnect cleanup

## Before / after

Before, gateway startup called full `runtime_start` sequentially for every persisted routed conversation. A listener with 350 routes completed only 22–27 registrations before the 30-second readiness timeout and restarted indefinitely.

After, the same 350 runtime registrations collapse into one acknowledged external-tool update and zero `runtime_start` calls. Real runtime startup remains lazy for inbound turns, approval recovery, and model operations.

## Safety and compatibility
- the listener remains channel-agnostic; the protocol operation is generic to external tools
- tool updates and `runtime_start` are serialized so a late registration cannot resurrect a removed route
- the gateway checks the advertised App Server capability and fails clearly instead of timing out against an older server
- unrouted, disabled, outbound-disabled, and stopped routes remain ineligible
- no channel persistence, adapter, queue, or Cloud execution-target behavior changes

## Validation
- `bun run check` (12/12)
- `bun run build`
- focused gateway/protocol/listener regression suite: 120 passed
- complete Channels suite: 1,065 passed, 1 skipped
- full isolated unit runner: 952 passed, 1 skipped; 7 pre-existing Bun 1.3.13 native WebSocket `ErrorEvent` failures reproduced unchanged on current main
- independent adversarial review completed; capability negotiation, registration/source ordering, known-runtime revocation, and 350-runtime no-start proof were addressed before push
