### PR TITLE
fix(tools): honor provider-aware auto toolsets

### DIFF
--- a/src/tools/client-toolset.test.ts
+++ b/src/tools/client-toolset.test.ts
@@ -43,6 +43,41 @@ describe("request-scoped client toolsets", () => {
     expect(prepared.preparedToolContext.loadedToolNames).toEqual(["Read"]);
   });
 
+  test("builds codex tools for custom OpenAI provider handles", async () => {
+    for (const providerType of ["chatgpt_oauth", "openai-codex"]) {
+      const prepared = await prepareToolExecutionContextForResolvedTarget({
+        modelIdentifier: "custom/gpt-5.6-sol",
+        providerType,
+        toolsetPreference: "auto",
+      });
+
+      expect(prepared.toolset).toBe("codex");
+      expect(prepared.preparedToolContext.loadedToolNames).toContain(
+        "ApplyPatch",
+      );
+      expect(prepared.preparedToolContext.loadedToolNames).toContain(
+        "exec_command",
+      );
+      expect(prepared.preparedToolContext.loadedToolNames).not.toContain(
+        "Edit",
+      );
+    }
+  });
+
+  test("keeps custom non-OpenAI provider handles on default tools", async () => {
+    const prepared = await prepareToolExecutionContextForResolvedTarget({
+      modelIdentifier: "custom/claude-sonnet-5",
+      providerType: "anthropic",
+      toolsetPreference: "auto",
+    });
+
+    expect(prepared.toolset).toBe("default");
+    expect(prepared.preparedToolContext.loadedToolNames).toContain("Edit");
+    expect(prepared.preparedToolContext.loadedToolNames).not.toContain(
+      "ApplyPatch",
+    );
+  });
+
   test("rejects unknown bundled tool names", async () => {
     expect(
       prepareToolExecutionContextForResolvedTarget({

--- a/src/tools/manager.ts
+++ b/src/tools/manager.ts
@@ -1166,12 +1166,16 @@ export async function prepareToolExecutionContextForSpecificTools(
   );
 }
 
+type ModelToolsetOptions = {
+  resolvedToolset?: "codex" | "default";
+  exclude?: ToolName[];
+  include?: ToolName[];
+  clientToolAllowlist?: string[];
+};
+
 export async function prepareToolExecutionContextForModel(
   modelIdentifier?: string,
-  options?: {
-    exclude?: ToolName[];
-    include?: ToolName[];
-    clientToolAllowlist?: string[];
+  options?: ModelToolsetOptions & {
     externalToolScopeIds?: string[];
     workingDirectory?: string;
     permissionModeState?: PermissionModeState;
@@ -1480,18 +1484,18 @@ async function buildSpecificToolRegistry(
 
 async function resolveBaseToolNamesForModel(
   modelIdentifier?: string,
-  options?: {
-    exclude?: ToolName[];
-    include?: ToolName[];
-    clientToolAllowlist?: string[];
-  },
+  options?: ModelToolsetOptions,
 ): Promise<ToolName[]> {
   const { toolFilter } = await import("@/tools/filter");
   let baseToolNames: ToolName[];
+  // Provider aliases can be classified by a caller that also has provider
+  // metadata. Prefer that result over re-inferring from the model handle.
   if (
     !toolFilter.isActive() &&
-    modelIdentifier &&
-    isOpenAIModel(modelIdentifier)
+    (options?.resolvedToolset === "codex" ||
+      (options?.resolvedToolset === undefined &&
+        modelIdentifier &&
+        isOpenAIModel(modelIdentifier)))
   ) {
     baseToolNames = OPENAI_PASCAL_TOOLS;
   } else if (!toolFilter.isActive()) {
@@ -1531,11 +1535,7 @@ async function resolveBaseToolNamesForModel(
 
 async function buildRegistryForModel(
   modelIdentifier?: string,
-  options?: {
-    exclude?: ToolName[];
-    include?: ToolName[];
-    clientToolAllowlist?: string[];
-  },
+  options?: ModelToolsetOptions,
 ): Promise<ToolRegistry> {
   const { toolFilter } = await import("@/tools/filter");
   const allSubagentConfigs = await getAllSubagentConfigs();

--- a/src/tools/toolset.ts
+++ b/src/tools/toolset.ts
@@ -259,6 +259,7 @@ export async function prepareToolExecutionContextForResolvedTarget(params: {
     const preparedToolContext = await prepareToolExecutionContextForModel(
       effectiveModel ?? undefined,
       {
+        resolvedToolset: derivedToolset,
         exclude,
         include: includedToolNames,
         clientToolAllowlist,


### PR DESCRIPTION
## Summary
- Use the provider-aware auto-toolset decision when building the request-scoped tool registry.
- Keep manual toolset selection and explicit `--tools` filtering unchanged.
- Add OpenAI alias regressions and a non-OpenAI control.

## Before / after
Before, a custom provider handle could report the Codex toolset while the registry loaded Claude-style tools such as `Edit`, `Read`, and `Bash`.

After, the reported auto toolset and loaded registry use the same provider-aware decision.

## Scope
This changes automatic toolset selection only. An explicit session tool filter remains higher priority.

## Test plan
- [x] Regression fails on current `main` and passes with this change.
- [x] Toolset and execution-context tests: 49 passed.
- [x] `bun run check`: 12 checks passed.
- [x] Complete unit run: 5,952 passed and 26 skipped. Fourteen unrelated tests failed; 13 reproduce on current `main`, and the remaining remote-settings test passes in isolation.
- [x] Independent adversarial review of the final behavior boundary.

Overlord (agent-c2adbf5c-8419-4211-8cd8-3740db164974)

👾 Generated with [Letta Code](https://letta.com)