### PR TITLE
fix(channels): emit canonical notification envelopes

### DIFF
--- a/src/channels/processor.test.ts
+++ b/src/channels/processor.test.ts
@@ -78,13 +78,26 @@ describe("channel processor primitives", () => {
       },
     };
 
-    expect(formatInboundChannelMessageForAgent({ message })).toBe(
-      "--- Slack thread ---\n" +
-        "starter: [Alice:U456]<1>:starter\n" +
-        "[Bob:U789]<1.5>:history\n" +
-        "--- End Thread Context ---\n\n" +
-        "[slack:#eng][Shub:U123]<2026-01-01T00:00:00.000Z>:current message",
+    const formatted = formatInboundChannelMessageForAgent({ message });
+
+    expect(formatted).toStartWith(
+      '<channel-notification source="slack" chat_id="C123" sender_id="U123"',
     );
+    expect(formatted).toContain('account_id="integration-1"');
+    expect(formatted).toContain('sender_name="Shub"');
+    expect(formatted).toContain('message_id="2"');
+    expect(formatted).toContain('thread_id="1"');
+    expect(formatted).toContain('<thread-context label="Slack thread">');
+    expect(formatted).toContain(
+      '<thread-starter sender_id="U456" sender_name="Alice" message_id="1">',
+    );
+    expect(formatted).toContain(
+      '<thread-message sender_id="U789" sender_name="Bob" message_id="1.5">',
+    );
+    expect(formatted).toContain("current message");
+    expect(formatted).toEndWith("</channel-notification>");
+    expect(formatted).not.toContain("--- Slack thread ---");
+    expect(formatted).not.toContain("[slack:#eng]");
   });
 
   test("formats batched channel messages without adding duplicate sender wrappers", () => {

--- a/src/channels/processor.ts
+++ b/src/channels/processor.ts
@@ -1,11 +1,10 @@
 import type {
   ChannelRoute,
-  ChannelThreadContext,
-  ChannelThreadContextEntry,
   ChannelTurnSource,
   InboundChannelMessage,
   OutboundChannelMessage,
 } from "./types";
+import { buildChannelNotificationXml } from "./xml";
 
 export interface BuildChannelTurnSourceParams {
   message: InboundChannelMessage;
@@ -33,48 +32,6 @@ export interface BuildOutboundChannelMessageFromTurnSourceParams {
   text: string;
 }
 
-function formatSenderLabel(entry: ChannelThreadContextEntry): string {
-  const senderName = entry.senderName?.trim();
-  const senderId = entry.senderId?.trim();
-  if (senderName && senderId && senderName !== senderId) {
-    return `${senderName}:${senderId}`;
-  }
-  if (senderName) {
-    return senderName;
-  }
-  if (senderId) {
-    return senderId;
-  }
-  return "unknown";
-}
-
-function formatThreadContextEntry(entry: ChannelThreadContextEntry): string {
-  const messageId = entry.messageId ? `<${entry.messageId}>` : "";
-  return `[${formatSenderLabel(entry)}]${messageId}:${entry.text}`;
-}
-
-function formatThreadContext(context: ChannelThreadContext): string {
-  const lines: string[] = [];
-  const label = context.label?.trim();
-  lines.push(label ? `--- ${label} ---` : "--- Thread Context ---");
-  if (context.starter) {
-    lines.push(`starter: ${formatThreadContextEntry(context.starter)}`);
-  }
-  for (const entry of context.history ?? []) {
-    lines.push(formatThreadContextEntry(entry));
-  }
-  lines.push("--- End Thread Context ---");
-  return `${lines.join("\n")}\n\n`;
-}
-
-function formatInboundSender(message: InboundChannelMessage): string {
-  const senderName = message.senderName?.trim();
-  if (senderName && senderName !== message.senderId) {
-    return `${senderName}:${message.senderId}`;
-  }
-  return message.senderId;
-}
-
 export function buildChannelTurnSource(
   params: BuildChannelTurnSourceParams,
 ): ChannelTurnSource {
@@ -96,16 +53,7 @@ export function buildChannelTurnSource(
 export function formatInboundChannelMessageForAgent(
   params: FormatInboundChannelMessageParams,
 ): string {
-  const { message } = params;
-  const context = message.threadContext
-    ? formatThreadContext(message.threadContext)
-    : "";
-  const chatLabel = message.chatLabel?.trim() || message.chatId;
-  const timestamp = new Date(message.timestamp).toISOString();
-  const prefix = `[${message.channel}:${chatLabel}][${formatInboundSender(
-    message,
-  )}]<${timestamp}>:`;
-  return `${context}${prefix}${message.text}`;
+  return buildChannelNotificationXml(params.message);
 }
 
 function formatLegacyBatchedSender(message: ChannelBatchMessage): string {


### PR DESCRIPTION
## Summary
- Route the exported inbound channel formatter through the canonical XML producer.
- Preserve channel, sender, thread, reply, reaction, and attachment metadata in the same `<channel-notification>` structure used by built-in channel delivery.
- Remove the older plain-text sender and thread wrapper format.

## Before / after
External channel hosts that use `formatInboundChannelMessageForAgent` previously persisted plain text such as `[slack:...][sender:...]`. They now persist `<channel-notification ...>` XML that channel-aware chat surfaces can parse and render.

## Risk
This changes the output contract of one public formatting helper. Its purpose is channel input formatting, and the new output reuses the existing canonical formatter instead of maintaining a second representation.

## Test plan
- [x] `bun test src/channels/processor.test.ts src/channels/xml.test.ts`
- [x] `bun test src/channels` (1,069 pass, 1 live test skipped)
- [x] `bun run check`
- [x] `bun run typecheck`
- [x] `bun run build`
- [x] Smoke-test `formatInboundChannelMessageForAgent` from the built `dist/channels-public.js`

Overlord (agent-c2adbf5c-8419-4211-8cd8-3740db164974)

👾 Generated with [Letta Code](https://letta.com)