### PR TITLE
fix: use Luna for conversation titles

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -15,7 +15,7 @@ export const DEFAULT_SUMMARIZATION_MODEL = "letta/auto";
 /**
  * Default model handle for lightweight conversation title generation.
  */
-export const DEFAULT_TITLE_SUMMARIZATION_MODEL = "letta/auto-fast";
+export const DEFAULT_TITLE_SUMMARIZATION_MODEL = "openai/gpt-5.6-luna";
 
 /**
  * Default agent name when creating a new agent


### PR DESCRIPTION
## Summary
- route automatic conversation title generation through `openai/gpt-5.6-luna`
- keep conversation descriptions and compaction summaries on their existing `letta/auto` default

## Test plan
- [x] Run the full pre-commit validation suite, including TypeScript and Biome

👾 Generated with [Letta Code](https://letta.com)