### PR TITLE
fix(test): isolate user home state

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -4,3 +4,6 @@
 ".mdx" = "text"
 ".md" = "text"
 ".txt" = "text"
+
+[test]
+preload = ["./scripts/test-home-preload.ts"]

--- a/scripts/test-home-preload.ts
+++ b/scripts/test-home-preload.ts
@@ -1,7 +1,7 @@
 import { afterAll } from "bun:test";
 import { mkdtempSync, rmSync } from "node:fs";
 import { createRequire } from "node:module";
-import { isAbsolute, join, relative, resolve } from "node:path";
+import { basename, isAbsolute, join, relative, resolve } from "node:path";
 
 const require = createRequire(import.meta.url);
 const os = require("node:os") as typeof import("node:os");
@@ -47,6 +47,7 @@ for (const key of filesystemEnvKeys) {
 process.env.LETTA_TEST_HOME = testHome;
 process.env.HOME = testHome;
 process.env.USERPROFILE = testHome;
+process.env.LETTA_TEST_SECRETS_SERVICE_PREFIX = `letta-code-test-${process.pid}-${basename(testHome)}`;
 process.env.LETTA_CODE_TELEM ??= "0";
 
 // Bun resolves os.homedir() before preloads run. Patch the shared built-in

--- a/scripts/test-home-preload.ts
+++ b/scripts/test-home-preload.ts
@@ -1,0 +1,65 @@
+import { afterAll } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { createRequire } from "node:module";
+import { isAbsolute, join, relative, resolve } from "node:path";
+
+const require = createRequire(import.meta.url);
+const os = require("node:os") as typeof import("node:os");
+const originalHome = resolve(os.homedir());
+const configuredTestHome = process.env.LETTA_TEST_HOME?.trim();
+const testHome = configuredTestHome
+  ? resolve(configuredTestHome)
+  : mkdtempSync(join(os.tmpdir(), "letta-code-test-home-"));
+
+if (testHome === originalHome) {
+  throw new Error("LETTA_TEST_HOME must not be the operator home directory");
+}
+
+const filesystemEnvKeys = [
+  "LETTA_ARTIFACTS_DIR",
+  "LETTA_CODE_DEV_BACKEND_DIR",
+  "LETTA_DEBUG_FILE",
+  "LETTA_HOME",
+  "LETTA_LISTENER_PERF_FILE",
+  "LETTA_LOCAL_BACKEND_DIR",
+  "LETTA_MEMORY_DIR",
+  "LETTA_MODEL_CATALOG_CACHE_DIR",
+  "LETTA_TRANSCRIPT_ROOT",
+  "LETTA_TUI_PERF_FILE",
+  "MEMORY_DIR",
+  "WEZTERM_CONFIG_FILE",
+  "XDG_CONFIG_HOME",
+] as const;
+
+function isWithin(path: string, root: string): boolean {
+  const child = relative(root, path);
+  return child === "" || (!child.startsWith("..") && !isAbsolute(child));
+}
+
+for (const key of filesystemEnvKeys) {
+  const value = process.env[key]?.trim();
+  if (!value || !isAbsolute(value)) continue;
+  const absolute = resolve(value);
+  if (!isWithin(absolute, originalHome)) continue;
+  process.env[key] = join(testHome, relative(originalHome, absolute));
+}
+
+process.env.LETTA_TEST_HOME = testHome;
+process.env.HOME = testHome;
+process.env.USERPROFILE = testHome;
+process.env.LETTA_CODE_TELEM ??= "0";
+
+// Bun resolves os.homedir() before preloads run. Patch the shared built-in
+// module so both ESM and CommonJS consumers use the disposable home. This is a
+// direct module update rather than a Bun test mock, so mock.restore() in an
+// unrelated suite cannot remove the filesystem boundary. Child processes use
+// the redirected environment before their runtimes initialize.
+os.homedir = () => testHome;
+
+if (!configuredTestHome) {
+  const cleanup = () => {
+    rmSync(testHome, { recursive: true, force: true });
+  };
+  afterAll(cleanup);
+  process.once("exit", cleanup);
+}

--- a/src/permissions/sandbox-policy.test.ts
+++ b/src/permissions/sandbox-policy.test.ts
@@ -219,7 +219,10 @@ test("memory-subagent policy can write an exact reflection worktree and parent g
 
 test("deriveSelfAgentRootsForTrees keeps roots outside the tree as-is", () => {
   const tree = getDefaultAgentsTreeRoot();
-  const outside = canonicalizeRoot("/tmp");
+  // A tmpdir sibling is disjoint from the tree even when the isolated test
+  // home (and therefore the tree) lives under tmpdir, unlike tmpdir itself,
+  // which becomes an ancestor of the tree and is refused.
+  const outside = canonicalizeRoot(join(tmpdir(), "letta-outside-fixture"));
   expect(deriveSelfAgentRootsForTrees([outside], [tree])).toEqual([outside]);
 });
 

--- a/src/test-utils/test-home-isolation.test.ts
+++ b/src/test-utils/test-home-isolation.test.ts
@@ -1,0 +1,111 @@
+import { expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { homedir, tmpdir } from "node:os";
+import { isAbsolute, join, relative } from "node:path";
+import { getChannelRoutingPath } from "@/channels/config";
+import { addRoute } from "@/channels/routing";
+
+test("unit tests write home-relative state under a disposable home", () => {
+  const testHome = process.env.LETTA_TEST_HOME;
+  if (!testHome) throw new Error("Test home preload did not run");
+  expect(homedir()).toBe(testHome);
+  expect(process.env.HOME).toBe(testHome);
+  expect(process.env.USERPROFILE).toBe(testHome);
+
+  for (const key of [
+    "LETTA_HOME",
+    "LETTA_LOCAL_BACKEND_DIR",
+    "LETTA_MEMORY_DIR",
+    "MEMORY_DIR",
+    "XDG_CONFIG_HOME",
+  ]) {
+    const value = process.env[key];
+    if (!value || !isAbsolute(value)) continue;
+    const child = relative(testHome, value);
+    expect(
+      child === "" || (!child.startsWith("..") && !isAbsolute(child)),
+    ).toBe(true);
+  }
+
+  addRoute("slack", {
+    accountId: "test-account",
+    chatId: "test-chat",
+    chatType: "channel",
+    threadId: "test-thread",
+    agentId: "test-agent",
+    conversationId: "test-conversation",
+    enabled: true,
+    createdAt: "2026-01-01T00:00:00.000Z",
+  });
+
+  const routingPath = getChannelRoutingPath("slack");
+  expect(routingPath).toBe(
+    join(testHome, ".letta", "channels", "slack", "routing.yaml"),
+  );
+  expect(existsSync(routingPath)).toBe(true);
+  expect(readFileSync(routingPath, "utf-8")).toContain("test-conversation");
+});
+
+test("direct bun test preserves state outside its disposable home", () => {
+  const operatorHome = mkdtempSync(join(tmpdir(), "letta-operator-home-"));
+  const liveRoutePath = join(
+    operatorHome,
+    ".letta",
+    "channels",
+    "slack",
+    "routing.yaml",
+  );
+  const liveMemoryDir = join(
+    operatorHome,
+    ".letta",
+    "agents",
+    "operator-agent",
+    "memory",
+  );
+  const liveMemorySentinel = join(liveMemoryDir, "sentinel");
+  const routeSentinel = '{"routes":[{"conversationId":"operator-route"}]}\n';
+
+  try {
+    mkdirSync(join(operatorHome, ".letta", "channels", "slack"), {
+      recursive: true,
+    });
+    mkdirSync(liveMemoryDir, { recursive: true });
+    writeFileSync(liveRoutePath, routeSentinel, "utf-8");
+    writeFileSync(liveMemorySentinel, "operator-memory\n", "utf-8");
+
+    const env: NodeJS.ProcessEnv = {
+      ...process.env,
+      HOME: operatorHome,
+      USERPROFILE: operatorHome,
+      MEMORY_DIR: liveMemoryDir,
+    };
+    delete env.LETTA_TEST_HOME;
+
+    const fixturePath = join(
+      process.cwd(),
+      "src",
+      "test-utils",
+      "write-channel-route.test-fixture.ts",
+    );
+    const result = spawnSync(process.execPath, ["test", fixturePath], {
+      cwd: process.cwd(),
+      encoding: "utf-8",
+      env,
+    });
+
+    expect(result.status).toBe(0);
+    expect(readFileSync(liveRoutePath, "utf-8")).toBe(routeSentinel);
+    expect(readFileSync(liveMemorySentinel, "utf-8")).toBe("operator-memory\n");
+    expect(existsSync(join(liveMemoryDir, "fixture-write"))).toBe(false);
+  } finally {
+    rmSync(operatorHome, { recursive: true, force: true });
+  }
+});

--- a/src/test-utils/write-channel-route.test-fixture.ts
+++ b/src/test-utils/write-channel-route.test-fixture.ts
@@ -1,0 +1,27 @@
+import { expect, mock, test } from "bun:test";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { getChannelRoutingPath } from "@/channels/config";
+import { addRoute } from "@/channels/routing";
+
+test("writes fixture state through production path resolvers", () => {
+  const testHome = process.env.LETTA_TEST_HOME;
+  if (!testHome) throw new Error("Test home preload did not run");
+  mock.restore();
+  addRoute("slack", {
+    accountId: "fixture-account",
+    chatId: "fixture-chat",
+    chatType: "channel",
+    threadId: "fixture-thread",
+    agentId: "fixture-agent",
+    conversationId: "fixture-conversation",
+    enabled: true,
+    createdAt: "2026-01-01T00:00:00.000Z",
+  });
+  expect(getChannelRoutingPath("slack")).toStartWith(testHome);
+
+  const memoryDir = process.env.MEMORY_DIR;
+  if (!memoryDir) throw new Error("MEMORY_DIR was not redirected");
+  expect(memoryDir).toStartWith(testHome);
+  mkdirSync(memoryDir, { recursive: true });
+  writeFileSync(`${memoryDir}/fixture-write`, "isolated\n", "utf-8");
+});

--- a/src/utils/secrets.test.ts
+++ b/src/utils/secrets.test.ts
@@ -16,6 +16,7 @@ import {
   setApiKey,
   setRefreshToken,
   setSecureTokens,
+  setServiceName,
 } from "@/utils/secrets";
 
 const keychainAvailablePrecompute = await isKeychainAvailable();
@@ -44,6 +45,21 @@ describe("Secrets utilities", () => {
   test("isKeychainAvailable works", async () => {
     const available = await isKeychainAvailable();
     expect(typeof available).toBe("boolean");
+  });
+
+  test("uses a test-scoped keyring service", async () => {
+    const prefix = process.env.LETTA_TEST_SECRETS_SERVICE_PREFIX;
+    if (!prefix) throw new Error("Test keyring namespace was not configured");
+    let service: string | undefined;
+    __setSecretGetOverrideForTests(async (options) => {
+      service = options.service;
+      return null;
+    });
+
+    setServiceName("letta-code");
+    await getApiKey();
+
+    expect(service).toBe(`${prefix}:letta-code`);
   });
 
   test.skipIf(!keychainAvailablePrecompute)(

--- a/src/utils/secrets.ts
+++ b/src/utils/secrets.ts
@@ -16,7 +16,12 @@ try {
   secretsAvailable = false;
 }
 
-let SERVICE_NAME = "letta-code";
+function scopeServiceName(name: string): string {
+  const testPrefix = process.env.LETTA_TEST_SECRETS_SERVICE_PREFIX?.trim();
+  return testPrefix ? `${testPrefix}:${name}` : name;
+}
+
+let SERVICE_NAME = scopeServiceName("letta-code");
 const API_KEY_NAME = "letta-api-key";
 const REFRESH_TOKEN_NAME = "letta-refresh-token";
 
@@ -125,7 +130,7 @@ export async function deleteSecretValue(name: string): Promise<boolean> {
  * Override the keychain service name (useful for tests to avoid touching real credentials)
  */
 export function setServiceName(name: string): void {
-  SERVICE_NAME = name;
+  SERVICE_NAME = scopeServiceName(name);
 }
 
 // Note: When secrets API is unavailable (Node.js), tokens will be managed


### PR DESCRIPTION
## Summary
- Give every repository `bun test` process a disposable home directory before test modules load.
- Redirect `HOME`, `USERPROFILE`, `os.homedir()`, and inherited state paths rooted in the operator home.
- Namespace keyring access per test process, including tests that reset the service name.
- Remove the disposable home after the test process completes.
- Add subprocess regressions that restore Bun mocks, write through production route and memory path resolvers, and prove sentinel state outside the test home is unchanged.

## Before / after
Before, a unit test using production persistence or secret helpers could write fixture state into a developer’s normal configuration directory or keyring service. After this change, normal direct `bun test` commands and the unit runner use a per-process temporary home and keyring namespace.

## Limits
This boundary applies when tests use the repository Bun configuration and product persistence helpers. A command that explicitly bypasses `bunfig.toml`, test code that deliberately hard-codes an external absolute path, or direct low-level keyring access that bypasses the secret helper can bypass it.

## Validation
- `bun run check` — 12/12 passed
- Focused home, route, memory, credential, and keyring tests — 35 passed
- Full unit runner completed with protected settings, account, route, and production keyring entries unchanged and zero disposable-home directories left behind
- The full runner retains 12 unrelated baseline failures: five model-dependent hook E2E assertions and seven Bun WebSocket error-event tests. Both failing files reproduce without this preload using an empty Bun config.

👾 Generated with [Letta Code](https://letta.com)