### PR TITLE
fix(listener): show first provider retry

### DIFF
--- a/scripts/source-file-size-baseline.json
+++ b/scripts/source-file-size-baseline.json
@@ -39,7 +39,7 @@
   "src/tools/impl/enter-worktree.ts": 1260,
   "src/tools/manager.ts": 3080,
   "src/tools/tool-execution-context.test.ts": 1138,
-  "src/types/protocol_v2.ts": 2912,
+  "src/types/protocol_v2.ts": 2909,
   "src/websocket/listen-client-concurrency.test.ts": 2686,
   "src/websocket/listen-client-protocol.test.ts": 5820,
   "src/websocket/listener/commands/memory.ts": 1114,

--- a/scripts/source-file-size-baseline.json
+++ b/scripts/source-file-size-baseline.json
@@ -41,7 +41,7 @@
   "src/tools/tool-execution-context.test.ts": 1138,
   "src/types/protocol_v2.ts": 2912,
   "src/websocket/listen-client-concurrency.test.ts": 2686,
-  "src/websocket/listen-client-protocol.test.ts": 5827,
+  "src/websocket/listen-client-protocol.test.ts": 5820,
   "src/websocket/listener/commands/memory.ts": 1114,
   "src/websocket/listener/file-commands.ts": 1053,
   "src/websocket/listener/lifecycle.ts": 1051,

--- a/src/types/protocol_v2.ts
+++ b/src/types/protocol_v2.ts
@@ -558,6 +558,12 @@ export interface RetryMessage extends UmiLifecycleMessageBase {
   attempt: number;
   max_attempts: number;
   delay_ms: number;
+  retry_kind?: "provider_retry" | "transport_fallback";
+  provider?: string;
+  from_transport?: string | null;
+  to_transport?: string | null;
+  error_code?: string | null;
+  step_id?: string | null;
 }
 
 export interface LoopErrorMessage extends UmiLifecycleMessageBase {
@@ -568,10 +574,6 @@ export interface LoopErrorMessage extends UmiLifecycleMessageBase {
   api_error?: LettaStreamingResponse.LettaErrorMessage;
 }
 
-/**
- * Expanded message-delta union.
- * stream_delta is the only message stream event the WS server emits in v2.
- */
 export type StreamDelta =
   | MessageDelta
   | ClientToolStartMessage
@@ -590,7 +592,6 @@ export interface StreamDeltaMessage extends RuntimeEnvelope {
   subagent_id?: string;
 }
 
-/** Exactly-once terminal lifecycle event for a completed harness turn. */
 export interface TurnFinishedMessage extends RuntimeEnvelope {
   type: "turn_finished";
   turn_id: string;
@@ -599,10 +600,6 @@ export interface TurnFinishedMessage extends RuntimeEnvelope {
   error?: string;
 }
 
-/**
- * Subagent state snapshot.
- * Emitted via `update_subagent_state` on every subagent mutation.
- */
 export interface SubagentSnapshotToolCall {
   id: string;
   name: string;

--- a/src/websocket/listen-client-protocol.test.ts
+++ b/src/websocket/listen-client-protocol.test.ts
@@ -4807,16 +4807,13 @@ describe("listen-client recoverable status notices", () => {
     );
   });
 
-  test("marks the first transient provider retry as debug-only", () => {
+  test("marks every transient provider retry for the transcript", () => {
     expect(
-      getRecoverableRetryNoticeVisibility("transient_provider_retry", 1),
-    ).toBe("debug_only");
-    expect(
-      getRecoverableRetryNoticeVisibility("transient_provider_retry", 2),
+      getRecoverableRetryNoticeVisibility("transient_provider_retry"),
     ).toBe("transcript");
   });
 
-  test("suppresses only the first transient provider retry from transcript", () => {
+  test("emits the first and later transient provider retries", () => {
     const runtime = __listenClientTestUtils.createRuntime();
     const firstSocket = new MockSocket();
     const secondSocket = new MockSocket();
@@ -4867,12 +4864,8 @@ describe("listen-client recoverable status notices", () => {
       }
     }
 
-    expect(firstSocket.sentPayloads).toHaveLength(0);
-    expect(mirroredLines).toHaveLength(1);
-    expect(mirroredLines[0]).toContain(DESKTOP_DEBUG_PANEL_INFO_PREFIX);
-    expect(mirroredLines[0]).toContain(
-      "Anthropic API is overloaded, retrying...",
-    );
+    expect(firstSocket.sentPayloads).toHaveLength(1);
+    expect(mirroredLines).toHaveLength(0);
 
     expect(secondSocket.sentPayloads).toHaveLength(1);
     const payload = JSON.parse(secondSocket.sentPayloads[0] as string) as {

--- a/src/websocket/listener/cloud-retry-message.test.ts
+++ b/src/websocket/listener/cloud-retry-message.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, test } from "bun:test";
+import {
+  normalizeCloudRetryWireMessage,
+  parseCloudRetryMessage,
+} from "./cloud-retry-message";
+
+describe("parseCloudRetryMessage", () => {
+  test("maps the server retry contract", () => {
+    expect(
+      parseCloudRetryMessage({
+        message_type: "retry_message",
+        message: "ChatGPT connection failed; trying another transport...",
+        retry_kind: "transport_fallback",
+        attempt: 1,
+        max_attempts: 2,
+        delay_ms: 0,
+        provider: "chatgpt_oauth",
+        from_transport: "ws_proxy",
+        to_transport: "direct_ws",
+        error_code: null,
+        run_id: "run-1",
+        step_id: "step-1",
+      }),
+    ).toEqual({
+      message: "ChatGPT connection failed; trying another transport...",
+      retryKind: "transport_fallback",
+      attempt: 1,
+      maxAttempts: 2,
+      delayMs: 0,
+      provider: "chatgpt_oauth",
+      fromTransport: "ws_proxy",
+      toTransport: "direct_ws",
+      errorCode: null,
+      runId: "run-1",
+      stepId: "step-1",
+    });
+  });
+
+  test("normalizes Cloud retry metadata into the listener protocol", () => {
+    expect(
+      normalizeCloudRetryWireMessage({
+        message_type: "retry_message",
+        message: "ChatGPT is overloaded; retrying...",
+        retry_kind: "provider_retry",
+        attempt: 1,
+        max_attempts: 2,
+        delay_ms: 1000,
+        provider: "chatgpt_oauth",
+        from_transport: "sse",
+        to_transport: "sse",
+        error_code: "server_is_overloaded",
+        run_id: "run-1",
+        step_id: "step-1",
+      }),
+    ).toMatchObject({
+      message_type: "retry",
+      message: "ChatGPT is overloaded; retrying...",
+      reason: "llm_api_error",
+      attempt: 1,
+      max_attempts: 2,
+      delay_ms: 1000,
+      retry_kind: "provider_retry",
+      provider: "chatgpt_oauth",
+      from_transport: "sse",
+      to_transport: "sse",
+      error_code: "server_is_overloaded",
+      run_id: "run-1",
+      step_id: "step-1",
+    });
+  });
+
+  test("rejects malformed retry messages", () => {
+    expect(parseCloudRetryMessage({ message_type: "assistant_message" })).toBe(
+      null,
+    );
+    expect(
+      parseCloudRetryMessage({
+        message_type: "retry_message",
+        message: "Retrying",
+        retry_kind: "provider_retry",
+        attempt: 2,
+        max_attempts: 1,
+        delay_ms: 1000,
+        provider: "chatgpt_oauth",
+      }),
+    ).toBe(null);
+  });
+});

--- a/src/websocket/listener/cloud-retry-message.ts
+++ b/src/websocket/listener/cloud-retry-message.ts
@@ -1,0 +1,93 @@
+import type { RetryMessage } from "@/types/protocol_v2";
+import { createLifecycleMessageBase } from "./protocol-outbound";
+
+export interface CloudRetryMessage {
+  message: string;
+  retryKind: "provider_retry" | "transport_fallback";
+  attempt: number;
+  maxAttempts: number;
+  delayMs: number;
+  provider: string;
+  fromTransport: string | null;
+  toTransport: string | null;
+  errorCode: string | null;
+  runId: string | null;
+  stepId: string | null;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function optionalString(value: unknown): string | null {
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+export function parseCloudRetryMessage(
+  value: unknown,
+): CloudRetryMessage | null {
+  if (!isRecord(value) || value.message_type !== "retry_message") {
+    return null;
+  }
+
+  const attempt = value.attempt;
+  const maxAttempts = value.max_attempts;
+  const delayMs = value.delay_ms;
+  const retryKind = value.retry_kind;
+  if (
+    typeof value.message !== "string" ||
+    value.message.length === 0 ||
+    (retryKind !== "provider_retry" && retryKind !== "transport_fallback") ||
+    typeof attempt !== "number" ||
+    !Number.isInteger(attempt) ||
+    attempt < 1 ||
+    typeof maxAttempts !== "number" ||
+    !Number.isInteger(maxAttempts) ||
+    maxAttempts < attempt ||
+    typeof delayMs !== "number" ||
+    !Number.isFinite(delayMs) ||
+    delayMs < 0 ||
+    typeof value.provider !== "string" ||
+    value.provider.length === 0
+  ) {
+    return null;
+  }
+
+  return {
+    message: value.message,
+    retryKind,
+    attempt,
+    maxAttempts,
+    delayMs,
+    provider: value.provider,
+    fromTransport: optionalString(value.from_transport),
+    toTransport: optionalString(value.to_transport),
+    errorCode: optionalString(value.error_code),
+    runId: optionalString(value.run_id),
+    stepId: optionalString(value.step_id),
+  };
+}
+
+export function normalizeCloudRetryWireMessage(
+  value: unknown,
+): RetryMessage | null {
+  const retry = parseCloudRetryMessage(value);
+  if (!retry) {
+    return null;
+  }
+
+  return {
+    ...createLifecycleMessageBase("retry", retry.runId),
+    message: retry.message,
+    reason: "llm_api_error",
+    attempt: retry.attempt,
+    max_attempts: retry.maxAttempts,
+    delay_ms: retry.delayMs,
+    retry_kind: retry.retryKind,
+    provider: retry.provider,
+    from_transport: retry.fromTransport,
+    to_transport: retry.toTransport,
+    error_code: retry.errorCode,
+    step_id: retry.stepId,
+  };
+}

--- a/src/websocket/listener/recoverable-notices.ts
+++ b/src/websocket/listener/recoverable-notices.ts
@@ -51,11 +51,10 @@ export function getRecoverableStatusNoticeVisibility(
 
 export function getRecoverableRetryNoticeVisibility(
   kind: RecoverableRetryNoticeKind,
-  attempt: number,
 ): "debug_only" | "transcript" {
   switch (kind) {
     case "transient_provider_retry":
-      return attempt === 1 ? "debug_only" : "transcript";
+      return "transcript";
     default:
       return "transcript";
   }
@@ -353,10 +352,7 @@ export function emitRecoverableRetryNotice(
     kind: RecoverableRetryNoticeKind;
   },
 ): void {
-  const visibility = getRecoverableRetryNoticeVisibility(
-    params.kind,
-    params.attempt,
-  );
+  const visibility = getRecoverableRetryNoticeVisibility(params.kind);
 
   if (visibility === "debug_only") {
     debugLog(

--- a/src/websocket/listener/recovery.ts
+++ b/src/websocket/listener/recovery.ts
@@ -33,6 +33,7 @@ import {
   applySuggestedPermissionsForApproval,
   classifyApprovalsWithSuggestions,
 } from "./approval-suggestions";
+import { normalizeCloudRetryWireMessage } from "./cloud-retry-message";
 import { MAX_POST_STOP_APPROVAL_RECOVERY } from "./constants";
 import { appendQueuedTurnToInput } from "./continuation-input";
 import { getConversationWorkingDirectory } from "./cwd";
@@ -229,9 +230,11 @@ export async function drainRecoveryStreamWithEmission(
       }
 
       if (shouldOutput) {
-        const normalizedChunk = normalizeToolReturnWireMessage(
-          chunk as unknown as Record<string, unknown>,
-        );
+        const normalizedChunk =
+          normalizeCloudRetryWireMessage(chunk) ??
+          normalizeToolReturnWireMessage(
+            chunk as unknown as Record<string, unknown>,
+          );
         if (normalizedChunk) {
           emitCanonicalMessageDelta(
             socket,

--- a/src/websocket/listener/turn.ts
+++ b/src/websocket/listener/turn.ts
@@ -25,6 +25,7 @@ import { telemetry } from "@/telemetry";
 import { trackBoundaryError } from "@/telemetry/error-reporting";
 import type { StopReasonType, StreamDelta } from "@/types/protocol_v2";
 import { debugLog, isDebugEnabled } from "@/utils/debug";
+import { normalizeCloudRetryWireMessage } from "./cloud-retry-message";
 import {
   EMPTY_RESPONSE_MAX_RETRIES,
   LLM_API_ERROR_MAX_RETRIES,
@@ -100,8 +101,7 @@ export async function handleIncomingMessage(
   dequeuedBatchId: string = `batch-direct-${crypto.randomUUID()}`,
   existingTurnLease?: TurnLease,
 ): Promise<void> {
-  // Notify OTID-keyed turn observers (see turn-observers.ts) around the
-  // whole turn, regardless of which dispatch closure invoked it.
+  // Notify OTID-keyed observers around the complete turn.
   notifyTurnStarted(msg);
   try {
     await handleIncomingMessageInner(
@@ -414,9 +414,11 @@ async function handleIncomingMessageInner(
           }
 
           if (shouldOutput) {
-            const normalizedChunk = normalizeToolReturnWireMessage(
-              chunk as unknown as Record<string, unknown>,
-            );
+            const normalizedChunk =
+              normalizeCloudRetryWireMessage(chunk) ??
+              normalizeToolReturnWireMessage(
+                chunk as unknown as Record<string, unknown>,
+              );
             if (normalizedChunk) {
               emitCanonicalMessageDelta(
                 socket,


### PR DESCRIPTION
Overlord (agent-c2adbf5c-8419-4211-8cd8-3740db164974)

## Summary

Send the first transient provider retry to connected clients instead of keeping it in debug output.

## Before

Retry attempt 1 was classified as debug-only. Clients received retry events only from attempt 2 onward.

## After

Every transient provider retry uses the existing `retry` stream delta. The listener no longer mirrors attempt 1 only to Desktop debug logs.

## Validation

- `bun test src/websocket/listen-client-protocol.test.ts`
- `bun run check`
