### PR TITLE
feat(listener): propagate server retry events

### DIFF
--- a/scripts/source-file-size-baseline.json
+++ b/scripts/source-file-size-baseline.json
@@ -39,7 +39,7 @@
   "src/tools/impl/enter-worktree.ts": 1260,
   "src/tools/manager.ts": 3080,
   "src/tools/tool-execution-context.test.ts": 1138,
-  "src/types/protocol_v2.ts": 2912,
+  "src/types/protocol_v2.ts": 2909,
   "src/websocket/listen-client-concurrency.test.ts": 2686,
   "src/websocket/listen-client-protocol.test.ts": 5820,
   "src/websocket/listener/commands/memory.ts": 1114,

--- a/src/types/protocol_v2.ts
+++ b/src/types/protocol_v2.ts
@@ -558,6 +558,12 @@ export interface RetryMessage extends UmiLifecycleMessageBase {
   attempt: number;
   max_attempts: number;
   delay_ms: number;
+  retry_kind?: "provider_retry" | "transport_fallback";
+  provider?: string;
+  from_transport?: string | null;
+  to_transport?: string | null;
+  error_code?: string | null;
+  step_id?: string | null;
 }
 
 export interface LoopErrorMessage extends UmiLifecycleMessageBase {
@@ -568,10 +574,6 @@ export interface LoopErrorMessage extends UmiLifecycleMessageBase {
   api_error?: LettaStreamingResponse.LettaErrorMessage;
 }
 
-/**
- * Expanded message-delta union.
- * stream_delta is the only message stream event the WS server emits in v2.
- */
 export type StreamDelta =
   | MessageDelta
   | ClientToolStartMessage
@@ -590,7 +592,6 @@ export interface StreamDeltaMessage extends RuntimeEnvelope {
   subagent_id?: string;
 }
 
-/** Exactly-once terminal lifecycle event for a completed harness turn. */
 export interface TurnFinishedMessage extends RuntimeEnvelope {
   type: "turn_finished";
   turn_id: string;
@@ -599,10 +600,6 @@ export interface TurnFinishedMessage extends RuntimeEnvelope {
   error?: string;
 }
 
-/**
- * Subagent state snapshot.
- * Emitted via `update_subagent_state` on every subagent mutation.
- */
 export interface SubagentSnapshotToolCall {
   id: string;
   name: string;

--- a/src/websocket/listener/cloud-retry-message.test.ts
+++ b/src/websocket/listener/cloud-retry-message.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, test } from "bun:test";
+import {
+  normalizeCloudRetryWireMessage,
+  parseCloudRetryMessage,
+} from "./cloud-retry-message";
+
+describe("parseCloudRetryMessage", () => {
+  test("maps the server retry contract", () => {
+    expect(
+      parseCloudRetryMessage({
+        message_type: "retry_message",
+        message: "ChatGPT connection failed; trying another transport...",
+        retry_kind: "transport_fallback",
+        attempt: 1,
+        max_attempts: 2,
+        delay_ms: 0,
+        provider: "chatgpt_oauth",
+        from_transport: "ws_proxy",
+        to_transport: "direct_ws",
+        error_code: null,
+        run_id: "run-1",
+        step_id: "step-1",
+      }),
+    ).toEqual({
+      message: "ChatGPT connection failed; trying another transport...",
+      retryKind: "transport_fallback",
+      attempt: 1,
+      maxAttempts: 2,
+      delayMs: 0,
+      provider: "chatgpt_oauth",
+      fromTransport: "ws_proxy",
+      toTransport: "direct_ws",
+      errorCode: null,
+      runId: "run-1",
+      stepId: "step-1",
+    });
+  });
+
+  test("normalizes Cloud retry metadata into the listener protocol", () => {
+    expect(
+      normalizeCloudRetryWireMessage({
+        message_type: "retry_message",
+        message: "ChatGPT is overloaded; retrying...",
+        retry_kind: "provider_retry",
+        attempt: 1,
+        max_attempts: 2,
+        delay_ms: 1000,
+        provider: "chatgpt_oauth",
+        from_transport: "sse",
+        to_transport: "sse",
+        error_code: "server_is_overloaded",
+        run_id: "run-1",
+        step_id: "step-1",
+      }),
+    ).toMatchObject({
+      message_type: "retry",
+      message: "ChatGPT is overloaded; retrying...",
+      reason: "llm_api_error",
+      attempt: 1,
+      max_attempts: 2,
+      delay_ms: 1000,
+      retry_kind: "provider_retry",
+      provider: "chatgpt_oauth",
+      from_transport: "sse",
+      to_transport: "sse",
+      error_code: "server_is_overloaded",
+      run_id: "run-1",
+      step_id: "step-1",
+    });
+  });
+
+  test("rejects malformed retry messages", () => {
+    expect(parseCloudRetryMessage({ message_type: "assistant_message" })).toBe(
+      null,
+    );
+    expect(
+      parseCloudRetryMessage({
+        message_type: "retry_message",
+        message: "Retrying",
+        retry_kind: "provider_retry",
+        attempt: 2,
+        max_attempts: 1,
+        delay_ms: 1000,
+        provider: "chatgpt_oauth",
+      }),
+    ).toBe(null);
+  });
+});

--- a/src/websocket/listener/cloud-retry-message.ts
+++ b/src/websocket/listener/cloud-retry-message.ts
@@ -1,0 +1,93 @@
+import type { RetryMessage } from "@/types/protocol_v2";
+import { createLifecycleMessageBase } from "./protocol-outbound";
+
+export interface CloudRetryMessage {
+  message: string;
+  retryKind: "provider_retry" | "transport_fallback";
+  attempt: number;
+  maxAttempts: number;
+  delayMs: number;
+  provider: string;
+  fromTransport: string | null;
+  toTransport: string | null;
+  errorCode: string | null;
+  runId: string | null;
+  stepId: string | null;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function optionalString(value: unknown): string | null {
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+export function parseCloudRetryMessage(
+  value: unknown,
+): CloudRetryMessage | null {
+  if (!isRecord(value) || value.message_type !== "retry_message") {
+    return null;
+  }
+
+  const attempt = value.attempt;
+  const maxAttempts = value.max_attempts;
+  const delayMs = value.delay_ms;
+  const retryKind = value.retry_kind;
+  if (
+    typeof value.message !== "string" ||
+    value.message.length === 0 ||
+    (retryKind !== "provider_retry" && retryKind !== "transport_fallback") ||
+    typeof attempt !== "number" ||
+    !Number.isInteger(attempt) ||
+    attempt < 1 ||
+    typeof maxAttempts !== "number" ||
+    !Number.isInteger(maxAttempts) ||
+    maxAttempts < attempt ||
+    typeof delayMs !== "number" ||
+    !Number.isFinite(delayMs) ||
+    delayMs < 0 ||
+    typeof value.provider !== "string" ||
+    value.provider.length === 0
+  ) {
+    return null;
+  }
+
+  return {
+    message: value.message,
+    retryKind,
+    attempt,
+    maxAttempts,
+    delayMs,
+    provider: value.provider,
+    fromTransport: optionalString(value.from_transport),
+    toTransport: optionalString(value.to_transport),
+    errorCode: optionalString(value.error_code),
+    runId: optionalString(value.run_id),
+    stepId: optionalString(value.step_id),
+  };
+}
+
+export function normalizeCloudRetryWireMessage(
+  value: unknown,
+): RetryMessage | null {
+  const retry = parseCloudRetryMessage(value);
+  if (!retry) {
+    return null;
+  }
+
+  return {
+    ...createLifecycleMessageBase("retry", retry.runId),
+    message: retry.message,
+    reason: "llm_api_error",
+    attempt: retry.attempt,
+    max_attempts: retry.maxAttempts,
+    delay_ms: retry.delayMs,
+    retry_kind: retry.retryKind,
+    provider: retry.provider,
+    from_transport: retry.fromTransport,
+    to_transport: retry.toTransport,
+    error_code: retry.errorCode,
+    step_id: retry.stepId,
+  };
+}

--- a/src/websocket/listener/recovery.ts
+++ b/src/websocket/listener/recovery.ts
@@ -33,6 +33,7 @@ import {
   applySuggestedPermissionsForApproval,
   classifyApprovalsWithSuggestions,
 } from "./approval-suggestions";
+import { normalizeCloudRetryWireMessage } from "./cloud-retry-message";
 import { MAX_POST_STOP_APPROVAL_RECOVERY } from "./constants";
 import { appendQueuedTurnToInput } from "./continuation-input";
 import { getConversationWorkingDirectory } from "./cwd";
@@ -229,9 +230,11 @@ export async function drainRecoveryStreamWithEmission(
       }
 
       if (shouldOutput) {
-        const normalizedChunk = normalizeToolReturnWireMessage(
-          chunk as unknown as Record<string, unknown>,
-        );
+        const normalizedChunk =
+          normalizeCloudRetryWireMessage(chunk) ??
+          normalizeToolReturnWireMessage(
+            chunk as unknown as Record<string, unknown>,
+          );
         if (normalizedChunk) {
           emitCanonicalMessageDelta(
             socket,

--- a/src/websocket/listener/turn.ts
+++ b/src/websocket/listener/turn.ts
@@ -25,6 +25,7 @@ import { telemetry } from "@/telemetry";
 import { trackBoundaryError } from "@/telemetry/error-reporting";
 import type { StopReasonType, StreamDelta } from "@/types/protocol_v2";
 import { debugLog, isDebugEnabled } from "@/utils/debug";
+import { normalizeCloudRetryWireMessage } from "./cloud-retry-message";
 import {
   EMPTY_RESPONSE_MAX_RETRIES,
   LLM_API_ERROR_MAX_RETRIES,
@@ -100,8 +101,7 @@ export async function handleIncomingMessage(
   dequeuedBatchId: string = `batch-direct-${crypto.randomUUID()}`,
   existingTurnLease?: TurnLease,
 ): Promise<void> {
-  // Notify OTID-keyed turn observers (see turn-observers.ts) around the
-  // whole turn, regardless of which dispatch closure invoked it.
+  // Notify OTID-keyed observers around the complete turn.
   notifyTurnStarted(msg);
   try {
     await handleIncomingMessageInner(
@@ -414,9 +414,11 @@ async function handleIncomingMessageInner(
           }
 
           if (shouldOutput) {
-            const normalizedChunk = normalizeToolReturnWireMessage(
-              chunk as unknown as Record<string, unknown>,
-            );
+            const normalizedChunk =
+              normalizeCloudRetryWireMessage(chunk) ??
+              normalizeToolReturnWireMessage(
+                chunk as unknown as Record<string, unknown>,
+              );
             if (normalizedChunk) {
               emitCanonicalMessageDelta(
                 socket,


### PR DESCRIPTION
Overlord (agent-c2adbf5c-8419-4211-8cd8-3740db164974)

## Summary

Convert server retry_message chunks into the existing listener retry delta used by connected clients.

This PR is stacked on #3706 so the first retry is transcript-visible.

## Change

- Validate retry kind, count, delay, provider, transport transition, error code, run ID, and step ID.
- Create a canonical retry lifecycle message instead of forwarding retry_message as a normal transcript message.
- Preserve retry metadata for client rendering and diagnostics.
- Apply the normalization to initial turn streams and approval-recovery streams.

No Desktop change is needed. Desktop already renders listener retry deltas.

## Validation

- bun run check
- bun test src/websocket/listener/cloud-retry-message.test.ts
