### PR TITLE
feat(telemetry): track end_turn_no_assistant [LET-10690]

### DIFF
--- a/scripts/source-file-size-baseline.json
+++ b/scripts/source-file-size-baseline.json
@@ -21,7 +21,7 @@
   "src/cli/mods/local-mod-loader.test.ts": 1043,
   "src/cli/reflection-transcript.test.ts": 1084,
   "src/cli/subcommands/skills.ts": 1264,
-  "src/headless.ts": 5237,
+  "src/headless.ts": 5253,
   "src/hooks/integration.test.ts": 1147,
   "src/index.ts": 2773,
   "src/mods/learning-harness.ts": 2434,

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -11,7 +11,10 @@ import type {
 } from "@letta-ai/letta-client/resources/agents/messages";
 import type { StopReasonType } from "@letta-ai/letta-client/resources/runs/runs";
 import { getTerminalTelemetrySurface, telemetry } from "@/telemetry";
-import { trackBoundaryError } from "@/telemetry/error-reporting";
+import {
+  trackBoundaryError,
+  trackEndTurnNoAssistant,
+} from "@/telemetry/error-reporting";
 import { extractTelemetryInputText } from "@/telemetry/input";
 import { installHeadlessStdoutGuard } from "@/utils/headless-stdout-guard";
 import {
@@ -3546,6 +3549,19 @@ ${SYSTEM_REMINDER_CLOSE}
     lastReasoning?.text ||
     lastToolResult?.resultText ||
     "No assistant response found";
+
+  // end_turn with no assistant text → trajectory ended on reasoning or tool call (parse error)
+  if (!lastAssistant && (lastReasoning || lastToolResult)) {
+    trackEndTurnNoAssistant({
+      fallbackKind: lastReasoning ? "reasoning" : "tool_call",
+      modelHandle: agent.llm_config?.model ?? model,
+      runId: lastKnownRunId ?? undefined,
+      isSubagent,
+      subagentType:
+        systemPromptPreset ??
+        agent.tags?.find((t) => t.startsWith("type:"))?.slice(5),
+    });
+  }
 
   const stats = sessionStats.getSnapshot();
   const usage = {

--- a/src/telemetry/error-reporting.ts
+++ b/src/telemetry/error-reporting.ts
@@ -37,3 +37,25 @@ export function trackBoundaryError(options: BoundaryErrorOptions): void {
     },
   );
 }
+
+export function trackEndTurnNoAssistant(params: {
+  fallbackKind: "reasoning" | "tool_call";
+  modelHandle?: string;
+  runId?: string;
+  isSubagent: boolean;
+  subagentType?: string;
+}): void {
+  telemetry.trackError(
+    "end_turn_no_assistant",
+    `end_turn fell back to ${params.fallbackKind}`,
+    "headless_result_extraction",
+    {
+      modelId: params.modelHandle,
+      runId: params.runId,
+      isSubagent: params.isSubagent,
+      subagentType: params.subagentType,
+      modelHandle: params.modelHandle,
+      fallbackKind: params.fallbackKind,
+    },
+  );
+}

--- a/src/telemetry/index.ts
+++ b/src/telemetry/index.ts
@@ -84,6 +84,10 @@ export interface ErrorData {
   run_id?: string;
   recent_chunks?: Record<string, unknown>[];
   debug_log_tail?: string;
+  is_subagent?: boolean;
+  subagent_type?: string;
+  model_handle?: string;
+  fallback_kind?: string;
 }
 
 export interface UserInputData {
@@ -709,6 +713,10 @@ class TelemetryManager {
       modelId?: string;
       runId?: string;
       recentChunks?: Record<string, unknown>[];
+      isSubagent?: boolean;
+      subagentType?: string;
+      modelHandle?: string;
+      fallbackKind?: string;
     },
   ) {
     // Skip error telemetry for self-hosted users to avoid spamming cloud analytics
@@ -730,6 +738,10 @@ class TelemetryManager {
       run_id: options?.runId,
       recent_chunks: options?.recentChunks,
       debug_log_tail: debugLogFile.getTail(),
+      is_subagent: options?.isSubagent,
+      subagent_type: options?.subagentType,
+      model_handle: options?.modelHandle,
+      fallback_kind: options?.fallbackKind,
     };
     this.track("error", data);
   }

--- a/src/telemetry/index.ts
+++ b/src/telemetry/index.ts
@@ -88,6 +88,7 @@ export interface ErrorData {
   subagent_type?: string;
   model_handle?: string;
   fallback_kind?: string;
+  platform?: string;
 }
 
 export interface UserInputData {
@@ -742,6 +743,7 @@ class TelemetryManager {
       subagent_type: options?.subagentType,
       model_handle: options?.modelHandle,
       fallback_kind: options?.fallbackKind,
+      platform: process.platform,
     };
     this.track("error", data);
   }

--- a/src/telemetry/index.ts
+++ b/src/telemetry/index.ts
@@ -89,6 +89,7 @@ export interface ErrorData {
   model_handle?: string;
   fallback_kind?: string;
   platform?: string;
+  version?: string;
 }
 
 export interface UserInputData {
@@ -744,6 +745,7 @@ class TelemetryManager {
       model_handle: options?.modelHandle,
       fallback_kind: options?.fallbackKind,
       platform: process.platform,
+      version: getVersion(),
     };
     this.track("error", data);
   }


### PR DESCRIPTION
## Summary
- Add telemetry at headless result extraction point to detect when `end_turn` produces no assistant text and falls back to reasoning or tool_call output
- Tracks `is_subagent`, `subagent_type`, `model_handle`, and `fallback_kind` (reasoning|tool_call)
- Companion letta-cloud PR adds the new fields to the server-side Zod schema

## Test plan
- [x] `bun run check` passes (12/12)
- [ ] Verify telemetry event appears in PostHog when a trajectory ends on reasoning/tool_call

👾 Generated with [Letta Code](https://letta.com)