### PR TITLE
feat(mods): surface user-only notifications in desktop

### DIFF
--- a/scripts/source-file-size-baseline.json
+++ b/scripts/source-file-size-baseline.json
@@ -26,7 +26,7 @@
   "src/index.ts": 2773,
   "src/mods/learning-harness.ts": 2434,
   "src/mods/mod-engine.test.ts": 2153,
-  "src/mods/mod-engine.ts": 1841,
+  "src/mods/mod-engine.ts": 1840,
   "src/mods/package-installer.test.ts": 1248,
   "src/mods/package-installer.ts": 1201,
   "src/mods/package-registry.ts": 1033,

--- a/src/cli/mods/command-runtime.ts
+++ b/src/cli/mods/command-runtime.ts
@@ -1,5 +1,6 @@
 import { SYSTEM_REMINDER_CLOSE, SYSTEM_REMINDER_OPEN } from "@/constants";
 import { attachDeprecatedGetContextTrap } from "@/mods/deprecated-api";
+import { runWithModInvocationContext } from "@/mods/invocation-context";
 import type { ModCommand, ModCommandContext, ModCommandResult } from "./types";
 
 const MOD_COMMAND_TIMEOUT_MS = 30_000;
@@ -130,15 +131,16 @@ export async function runModCommandWithTimeout(
 ): Promise<ModCommandResult> {
   let timeout: ReturnType<typeof setTimeout> | null = null;
   try {
+    const invocationContext = attachDeprecatedGetContextTrap(
+      context,
+      command.recordDiagnostic,
+      "ctx.getContext",
+    );
     return normalizeModCommandResult(
       await Promise.race([
         Promise.resolve(
-          command.run(
-            attachDeprecatedGetContextTrap(
-              context,
-              command.recordDiagnostic,
-              "ctx.getContext",
-            ),
+          runWithModInvocationContext(invocationContext, () =>
+            command.run(invocationContext),
           ),
         ),
         new Promise<never>((_, reject) => {

--- a/src/mods/invocation-context.ts
+++ b/src/mods/invocation-context.ts
@@ -1,0 +1,35 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+import type { ModInvocationContext } from "@/mods/types";
+
+export type ModNotificationHandler = (
+  message: string,
+  context: ModInvocationContext | null,
+) => void;
+
+const modInvocationContext = new AsyncLocalStorage<ModInvocationContext>();
+
+export function notifyMod(
+  handler: ModNotificationHandler,
+  message: string,
+): void {
+  handler(message.trim(), modInvocationContext.getStore() ?? null);
+}
+
+export function runWithModInvocationContext<TResult>(
+  context: ModInvocationContext,
+  callback: () => TResult,
+): TResult {
+  return modInvocationContext.run(context, callback);
+}
+
+export function invoke<TEvent, TContext extends ModInvocationContext, TResult>(
+  context: TContext,
+  registration: {
+    handler: (event: TEvent, context: TContext) => TResult;
+  },
+  event: TEvent,
+): TResult {
+  return modInvocationContext.run(context, () =>
+    registration.handler(event, context),
+  );
+}

--- a/src/mods/mod-engine.ts
+++ b/src/mods/mod-engine.ts
@@ -32,6 +32,7 @@ import {
   recordDeprecatedContextApiSourceDiagnostics,
 } from "@/mods/deprecated-api";
 import { isTypeScriptModFileExtension } from "@/mods/file-extensions";
+import * as modInvocationContext from "@/mods/invocation-context";
 import {
   appendModDiagnostic,
   recordModDiagnostic,
@@ -94,6 +95,7 @@ import type {
   ModTurnStartCancelResult,
   ModTurnStartEvent,
 } from "@/mods/types";
+import { createNoopModPanelHandle } from "@/mods/ui-helpers";
 
 export type {
   LocalModSource,
@@ -220,7 +222,7 @@ export interface LoadLocalModsOptions extends ResolveLocalModSourcesOptions {
   generation?: number;
   onChange?: () => void;
   onDiagnostic?: (diagnostic: ModDiagnostic) => void;
-  onNotification?: (message: string) => void;
+  onNotification?: modInvocationContext.ModNotificationHandler;
   onRegistryCreated?: (registry: LocalModRegistry) => void;
   registerCapabilitiesGlobally?: boolean;
   reservedToolNames?: Iterable<string>;
@@ -882,13 +884,6 @@ function upsertModPanel(
   };
 }
 
-function createNoopModPanelHandle(): ModPanelHandle {
-  return {
-    close() {},
-    update() {},
-  };
-}
-
 function createLettaModApi(
   registry: LocalModRegistry,
   owner: ModOwner,
@@ -896,7 +891,7 @@ function createLettaModApi(
   getClient: () => Promise<Letta>,
   onChange: () => void,
   onDiagnostic: ((diagnostic: ModDiagnostic) => void) | undefined,
-  onNotification: ((message: string) => void) | undefined,
+  onNotification: modInvocationContext.ModNotificationHandler | undefined,
   builtinCommandIds: Set<string>,
   reservedToolNames: Set<string>,
   signal: AbortSignal,
@@ -1274,9 +1269,9 @@ function createLettaModApi(
     ui: {
       closePanel,
       notify(message) {
-        if (!capabilities.ui.panels || !message.trim()) return;
+        if (!onNotification || !message.trim()) return;
         if (!guardLive({ id: "notify", kind: "panel" })) return;
-        onNotification?.(message.trim());
+        modInvocationContext.notifyMod(onNotification, message);
       },
       openPanel(panel) {
         if (!capabilities.ui.panels) {
@@ -1588,7 +1583,11 @@ export async function emitLocalModEvent<TName extends ModEventName>(
         recordEventDiagnostic,
         "ctx.getContext",
       );
-      const result = await registration.handler(event, eventContext);
+      const result = await modInvocationContext.invoke(
+        eventContext,
+        registration,
+        event,
+      );
       if (isTurnStartResultWithInput(name, result)) {
         (event as ModTurnStartEvent).input = result.input;
       }

--- a/src/mods/tool-registry.ts
+++ b/src/mods/tool-registry.ts
@@ -9,6 +9,7 @@ import type {
 } from "@/mods/types";
 import { attachDeprecatedGetContextTrap } from "./deprecated-api";
 import { areModsDisabled } from "./disable";
+import { runWithModInvocationContext } from "./invocation-context";
 
 const MOD_TOOLS_KEY = Symbol.for("@letta/modTools");
 
@@ -140,5 +141,5 @@ export async function runModTool(
   if (tool.activationSignal.aborted) {
     throw new Error(`Mod tool '${tool.name}' is no longer available`);
   }
-  return tool.run(context);
+  return runWithModInvocationContext(context, () => tool.run(context));
 }

--- a/src/mods/ui-helpers.ts
+++ b/src/mods/ui-helpers.ts
@@ -1,0 +1,5 @@
+import type { ModPanelHandle } from "@/mods/types";
+
+export function createNoopModPanelHandle(): ModPanelHandle {
+  return { close() {}, update() {} };
+}

--- a/src/websocket/listener/mod-adapter.test.ts
+++ b/src/websocket/listener/mod-adapter.test.ts
@@ -118,6 +118,63 @@ describe("listener mod adapter", () => {
     expect(context.toolset).toBe("default");
   });
 
+  test("delivers UI notifications with the active invocation scope when panels are unavailable", async () => {
+    const root = createTempDir();
+    const modsDir = join(root, "mods");
+    const cacheDir = join(root, "cache");
+    mkdirSync(modsDir, { recursive: true });
+    writeFileSync(
+      join(modsDir, "notify.ts"),
+      `export default function activate(letta) {
+        letta.events.on("turn_start", (_event, ctx) => {
+          letta.ui.notify("Desktop-only message");
+        });
+      }`,
+    );
+
+    const notifications: Array<{
+      message: string;
+      agentId: string | null;
+      conversationId: string | null;
+    }> = [];
+    const adapter = createListenerModAdapter({
+      cacheDirectory: cacheDir,
+      globalModsDirectory: modsDir,
+      includeGlobalMods: true,
+      onNotification: (message, context) => {
+        notifications.push({
+          message,
+          agentId: context?.agent.id ?? null,
+          conversationId: context?.sessionId ?? null,
+        });
+      },
+    });
+    await adapter.reload();
+
+    const context = createListenerModContext({
+      agent: { id: "agent-123" },
+      sessionId: "conversation-456",
+    });
+    await adapter.events.emit(
+      "turn_start",
+      {
+        agentId: "agent-123",
+        conversationId: "conversation-456",
+        input: [],
+      },
+      context,
+    );
+
+    expect(notifications).toEqual([
+      {
+        message: "Desktop-only message",
+        agentId: "agent-123",
+        conversationId: "conversation-456",
+      },
+    ]);
+    adapter.dispose();
+  });
+
   test("builds isolated agent MemFS roots", () => {
     settingsManager.isMemfsEnabled = (agentId) => agentId !== "agent-disabled";
 

--- a/src/websocket/listener/mod-adapter.ts
+++ b/src/websocket/listener/mod-adapter.ts
@@ -18,6 +18,7 @@ import { getCurrentWorkingDirectory } from "@/runtime-context";
 import { settingsManager } from "@/settings-manager";
 import { getBootWorkingDirectory } from "./cwd";
 import { ensureMemfsSyncedForAgent } from "./memfs-sync";
+import { emitStatusDelta } from "./protocol-outbound";
 import type { ListenerRuntime } from "./types";
 
 export const LISTENER_MOD_CAPABILITIES: ModCapabilities = {
@@ -51,6 +52,7 @@ export interface CreateListenerModAdapterOptions {
   disabled?: boolean;
   globalModsDirectory?: string;
   includeGlobalMods?: boolean;
+  onNotification?: (message: string, context: ModContext | null) => void;
   registerCapabilitiesGlobally?: boolean;
   sessionId?: string | null;
   workingDirectory?: string | null;
@@ -138,6 +140,9 @@ export function createListenerModAdapter(
     ...(options.includeGlobalMods !== undefined
       ? { includeGlobalMods: options.includeGlobalMods }
       : {}),
+    ...(options.onNotification
+      ? { onNotification: options.onNotification }
+      : {}),
     ...(options.registerCapabilitiesGlobally !== undefined
       ? {
           registerCapabilitiesGlobally: options.registerCapabilitiesGlobally,
@@ -146,10 +151,35 @@ export function createListenerModAdapter(
   });
 }
 
+export function emitListenerModNotification(
+  runtime: ListenerRuntime,
+  message: string,
+  context: ModContext | null,
+): void {
+  const agentId = context?.agent.id;
+  const conversationId = context?.sessionId;
+  if (!agentId || !conversationId) return;
+
+  const origin =
+    runtime.transport ??
+    runtime.socket ??
+    runtime.connections.values().next().value?.writer;
+  if (!origin) return;
+
+  emitStatusDelta(origin, runtime, {
+    message,
+    level: "info",
+    agentId,
+    conversationId,
+  });
+}
+
 export function ensureListenerModAdapter(runtime: ListenerRuntime): ModAdapter {
   runtime.modAdapter ??= createListenerModAdapter({
     sessionId: runtime.sessionId,
     workingDirectory: getBootWorkingDirectory(runtime),
+    onNotification: (message, context) =>
+      emitListenerModNotification(runtime, message, context),
   });
   return runtime.modAdapter;
 }
@@ -205,6 +235,8 @@ export async function ensureListenerAgentModAdapter(
         cacheDirectory: resolveAgentModCacheDirectory(agentId),
         capabilities: LISTENER_AGENT_MOD_CAPABILITIES,
         includeGlobalMods: false,
+        onNotification: (message, context) =>
+          emitListenerModNotification(runtime, message, context),
         registerCapabilitiesGlobally: false,
         sessionId: runtime.sessionId,
         workingDirectory: runtime.bootWorkingDirectory,

--- a/src/websocket/listener/mod-command-registry.ts
+++ b/src/websocket/listener/mod-command-registry.ts
@@ -1,0 +1,45 @@
+import type { ModCommand } from "@/mods/types";
+import type { ModCommandInfo } from "@/types/protocol_v2";
+import type { ListenerRuntime } from "./types";
+
+function getLoadedModCommands(
+  runtime: ListenerRuntime,
+  agentId?: string | null,
+): Map<string, ModCommand> {
+  const commands = new Map<string, ModCommand>();
+  const adapters = runtime.modAdapter ? [runtime.modAdapter] : [];
+  const agentAdapter = agentId
+    ? runtime.agentModAdapters?.get(agentId)
+    : undefined;
+  if (agentAdapter) adapters.push(agentAdapter);
+
+  for (const adapter of adapters) {
+    for (const command of Object.values(
+      adapter.getSnapshot().registry.commands,
+    )) {
+      commands.set(command.id, command);
+    }
+  }
+  return commands;
+}
+
+export function listListenerModCommands(
+  runtime: ListenerRuntime,
+  agentId?: string | null,
+): ModCommandInfo[] {
+  return Array.from(getLoadedModCommands(runtime, agentId).values()).map(
+    (command) => ({
+      id: command.id,
+      description: command.description,
+      ...(command.args ? { args: command.args } : {}),
+    }),
+  );
+}
+
+export function getListenerModCommand(
+  runtime: ListenerRuntime,
+  commandId: string,
+  agentId?: string | null,
+): ModCommand | undefined {
+  return getLoadedModCommands(runtime, agentId).get(commandId);
+}

--- a/src/websocket/listener/mod-commands.ts
+++ b/src/websocket/listener/mod-commands.ts
@@ -10,51 +10,16 @@ import type {
   ModCommandContext,
   ModCommandResult,
 } from "@/mods/types";
-import type { ModCommandInfo } from "@/types/protocol_v2";
 import { getConversationWorkingDirectory } from "./cwd";
-import {
-  createListenerModContext,
-  getLoadedListenerModAdapters,
-} from "./mod-adapter";
+import { createListenerModContext } from "./mod-adapter";
+
+export {
+  getListenerModCommand,
+  listListenerModCommands,
+} from "./mod-command-registry";
+
 import { getConversationPermissionModeState } from "./permission-mode";
-import type { ConversationRuntime, ListenerRuntime } from "./types";
-
-/**
- * Registered mod commands as advertisable facts. Clients read these to surface
- * mod commands in their palette by their own policy (separate from the built-in
- * `supported_commands` allowlist).
- */
-export function listListenerModCommands(
-  runtime: ListenerRuntime,
-  agentId?: string | null,
-): ModCommandInfo[] {
-  const commands = new Map<string, ModCommand>();
-  for (const adapter of getLoadedListenerModAdapters(runtime, agentId)) {
-    for (const command of Object.values(
-      adapter.getSnapshot().registry.commands,
-    )) {
-      commands.set(command.id, command);
-    }
-  }
-  return Array.from(commands.values()).map((command) => ({
-    id: command.id,
-    description: command.description,
-    ...(command.args ? { args: command.args } : {}),
-  }));
-}
-
-/** Look up a registered mod command by id, if any. */
-export function getListenerModCommand(
-  runtime: ListenerRuntime,
-  commandId: string,
-  agentId?: string | null,
-): ModCommand | undefined {
-  let result: ModCommand | undefined;
-  for (const adapter of getLoadedListenerModAdapters(runtime, agentId)) {
-    result = adapter.getSnapshot().registry.commands[commandId] ?? result;
-  }
-  return result;
-}
+import type { ConversationRuntime } from "./types";
 
 /**
  * Run a mod command in the listener and return its result. Builds a

--- a/src/websocket/listener/protocol-outbound.test.ts
+++ b/src/websocket/listener/protocol-outbound.test.ts
@@ -18,6 +18,10 @@ import {
 } from "@/websocket/listener/connection";
 import { getOrCreateScopedRuntime } from "@/websocket/listener/conversation-runtime";
 import { createRuntime as createListenerRuntime } from "@/websocket/listener/lifecycle";
+import {
+  createListenerModContext,
+  emitListenerModNotification,
+} from "@/websocket/listener/mod-adapter";
 import { OUTBOUND_QUEUE_LIMITS } from "@/websocket/listener/outbound-wire";
 import {
   emitDequeuedUserMessage,
@@ -123,6 +127,46 @@ describe("emitProtocolV2Message backpressure", () => {
 });
 
 describe("emitProtocolV2Message connection routing", () => {
+  test("routes mod notifications as UI-only status deltas", () => {
+    const listener = createListenerRuntime();
+    const socket = new MockSocket();
+    const connectionId = "desktop-client";
+    const scope = { agent_id: "agent-1", conversation_id: "conv-1" };
+    openListenerConnection({
+      runtime: listener,
+      connectionId,
+      writer: socket as never,
+      options: {
+        connectionId,
+        wsUrl: "ws://test",
+        deviceId: "test",
+        connectionName: connectionId,
+        onConnected: () => {},
+        onDisconnected: () => {},
+        onError: () => {},
+      },
+    });
+    markListenerConnectionInitialized(listener, connectionId);
+    subscribeListenerConnection(listener, connectionId, scope);
+
+    emitListenerModNotification(
+      listener,
+      "Desktop-only message",
+      createListenerModContext({
+        agent: { id: scope.agent_id },
+        sessionId: scope.conversation_id,
+      }),
+    );
+
+    const message = parseOnlyStreamDelta(socket);
+    expect(message.runtime).toEqual(scope);
+    expect(message.delta).toMatchObject({
+      message_type: "status",
+      message: "Desktop-only message",
+      level: "info",
+    });
+  });
+
   test("fans notifications out to subscribers and honors an explicit target", () => {
     const listener = createListenerRuntime();
     const runtime = getOrCreateScopedRuntime(listener, "agent-1", "conv-1");

--- a/src/websocket/listener/protocol-outbound.ts
+++ b/src/websocket/listener/protocol-outbound.ts
@@ -43,7 +43,7 @@ import {
   shouldEmitDeviceStatus,
 } from "./device-status-cache";
 import { SUPPORTED_REMOTE_COMMANDS } from "./listener-constants";
-import { listListenerModCommands } from "./mod-commands";
+import { listListenerModCommands } from "./mod-command-registry";
 import { enqueueOutboundFrame, type OutboundFrameClass } from "./outbound-wire";
 import { getConversationPermissionModeState } from "./permission-mode";
 import {


### PR DESCRIPTION
## Summary
- route `letta.ui.notify()` calls from listener mods into conversation-scoped status deltas
- preserve the active invocation scope across event, command, and tool callbacks so concurrent Desktop conversations receive only their own notifications
- keep notifications UI-only: they are neither persisted as conversation messages nor sent to the agent

Validated with the full `bun run check` suite and focused listener/mod protocol tests (24 passing).

👾 Generated with [Letta Code](https://letta.com)