### PR TITLE
fix(shell): force-kill timed-out process trees

### DIFF
--- a/src/tools/impl/shell-runner.test.ts
+++ b/src/tools/impl/shell-runner.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, test } from "bun:test";
+import { spawnWithLauncher } from "@/tools/impl/shell-runner";
+
+function stubbornProcessTreeLauncher(): string[] {
+  const descendantScript = [
+    'process.on("SIGTERM", () => {});',
+    "setTimeout(() => process.exit(0), 7000);",
+    "setInterval(() => {}, 1000);",
+  ].join("");
+  const launcherScript = [
+    'const { spawn } = require("node:child_process");',
+    'const descendant = spawn(process.execPath, ["-e", process.argv[1]], { stdio: "inherit" });',
+    'process.stdout.write("descendant:" + descendant.pid + "\\n");',
+    'process.on("SIGTERM", () => {});',
+    "setTimeout(() => process.exit(0), 7000);",
+    "setInterval(() => {}, 1000);",
+  ].join("");
+  return [process.execPath, "-e", launcherScript, descendantScript];
+}
+
+function expectProcessExited(pid: number): void {
+  expect(pid).toBeGreaterThan(0);
+  expect(() => process.kill(pid, 0)).toThrow();
+}
+
+describe("spawnWithLauncher", () => {
+  test("force-kills a timed-out process tree that ignores graceful termination", async () => {
+    let output = "";
+    const startedAt = Date.now();
+
+    let error: unknown;
+    try {
+      await spawnWithLauncher(stubbornProcessTreeLauncher(), {
+        cwd: process.cwd(),
+        env: process.env,
+        timeoutMs: 500,
+        onOutput: (chunk) => {
+          output += chunk;
+        },
+      });
+    } catch (caught) {
+      error = caught;
+    }
+
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toBe("Command timed out");
+    expect(Date.now() - startedAt).toBeLessThan(4000);
+
+    const descendantPid = Number(output.match(/descendant:(\d+)/)?.[1]);
+    expectProcessExited(descendantPid);
+  }, 10_000);
+
+  test("force-kills an aborted process tree that ignores graceful termination", async () => {
+    const controller = new AbortController();
+    let output = "";
+    const startedAt = Date.now();
+    const abortTimer = setTimeout(() => controller.abort(), 500);
+
+    let error: unknown;
+    try {
+      await spawnWithLauncher(stubbornProcessTreeLauncher(), {
+        cwd: process.cwd(),
+        env: process.env,
+        timeoutMs: 0,
+        signal: controller.signal,
+        onOutput: (chunk) => {
+          output += chunk;
+        },
+      });
+    } catch (caught) {
+      error = caught;
+    } finally {
+      clearTimeout(abortTimer);
+    }
+
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).name).toBe("AbortError");
+    expect(Date.now() - startedAt).toBeLessThan(4000);
+
+    const descendantPid = Number(output.match(/descendant:(\d+)/)?.[1]);
+    expectProcessExited(descendantPid);
+  }, 10_000);
+});

--- a/src/tools/impl/shell-runner.ts
+++ b/src/tools/impl/shell-runner.ts
@@ -18,7 +18,7 @@ export type ShellSpawnOptions = {
   onOutput?: (chunk: string, stream: "stdout" | "stderr") => void;
 };
 
-const ABORT_KILL_TIMEOUT_MS = 2000;
+const FORCE_KILL_GRACE_MS = 2000;
 
 function buildSpawnError(
   err: NodeJS.ErrnoException,
@@ -83,17 +83,42 @@ export function spawnWithLauncher(
       detached: process.platform !== "win32",
     });
 
-    // Helper to kill the entire process group
-    const killProcessGroup = (signal: "SIGTERM" | "SIGKILL") => {
+    // Helper to kill the entire process tree.
+    const killProcessTree = (signal: "SIGTERM" | "SIGKILL") => {
       if (childProcess.pid) {
+        if (process.platform === "win32") {
+          // Windows has no Unix-style process groups or graceful SIGTERM.
+          // taskkill is required so descendants cannot keep stdio open after
+          // the launcher exits.
+          const taskkill = spawn(
+            "taskkill.exe",
+            ["/pid", String(childProcess.pid), "/t", "/f"],
+            {
+              stdio: "ignore",
+              windowsHide: true,
+            },
+          );
+          taskkill.once("error", () => {
+            try {
+              childProcess.kill("SIGKILL");
+            } catch {
+              // Already dead, ignore.
+            }
+          });
+          taskkill.once("close", (code) => {
+            if (code === 0) return;
+            try {
+              childProcess.kill("SIGKILL");
+            } catch {
+              // Already dead, ignore.
+            }
+          });
+          return;
+        }
+
         try {
-          if (process.platform !== "win32") {
-            // Unix: kill the process group using negative PID
-            process.kill(-childProcess.pid, signal);
-          } else {
-            // Windows: process groups work differently, just kill the child
-            childProcess.kill(signal);
-          }
+          // Unix: kill the process group using negative PID.
+          process.kill(-childProcess.pid, signal);
         } catch {
           // Process may already be dead, try killing just the child
           try {
@@ -109,24 +134,34 @@ export function spawnWithLauncher(
     const stderrChunks: Buffer[] = [];
     let timedOut = false;
     let killTimer: ReturnType<typeof setTimeout> | null = null;
+    let completed = false;
+
+    const terminateProcess = () => {
+      if (process.platform === "win32") {
+        killProcessTree("SIGKILL");
+        return;
+      }
+
+      killProcessTree("SIGTERM");
+      if (!killTimer) {
+        killTimer = setTimeout(() => {
+          if (!completed) {
+            killProcessTree("SIGKILL");
+          }
+        }, FORCE_KILL_GRACE_MS);
+      }
+    };
 
     // Only set timeout if timeoutMs > 0 (0 means no timeout)
     const timeoutId = options.timeoutMs
       ? setTimeout(() => {
           timedOut = true;
-          killProcessGroup("SIGTERM");
+          terminateProcess();
         }, options.timeoutMs)
       : null;
 
     const abortHandler = () => {
-      killProcessGroup("SIGTERM");
-      if (!killTimer) {
-        killTimer = setTimeout(() => {
-          if (childProcess.exitCode === null && !childProcess.killed) {
-            killProcessGroup("SIGKILL");
-          }
-        }, ABORT_KILL_TIMEOUT_MS);
-      }
+      terminateProcess();
     };
     if (options.signal) {
       options.signal.addEventListener("abort", abortHandler, { once: true });
@@ -143,6 +178,7 @@ export function spawnWithLauncher(
     });
 
     childProcess.on("error", (err: NodeJS.ErrnoException) => {
+      completed = true;
       if (timeoutId) clearTimeout(timeoutId);
       if (killTimer) {
         clearTimeout(killTimer);
@@ -156,6 +192,7 @@ export function spawnWithLauncher(
     });
 
     childProcess.on("close", (code) => {
+      completed = true;
       if (timeoutId) clearTimeout(timeoutId);
       if (killTimer) {
         clearTimeout(killTimer);


### PR DESCRIPTION
## Summary

- escalate Unix shell timeout and abort handling from `SIGTERM` to `SIGKILL` after the existing two-second grace period
- terminate the full Windows process tree with `taskkill /T /F` so descendants cannot keep stdio open
- add regressions covering both timeout and abort with a parent and descendant that ignore graceful termination

## Why

A timed-out foreground Bash command could leave `spawnWithLauncher` waiting forever when the command or one of its descendants ignored `SIGTERM`. The abort path also checked `childProcess.killed`, which only means a signal was sent successfully—not that the process exited—so its intended escalation could be skipped.

## Validation

- `bun run check`
- `bun test src/tools/impl/shell-runner.test.ts src/tools/shell-command.test.ts src/tools/run-shell-command.test.ts src/tools/shell-launchers.test.ts` (27 passed)
- live Bash-tool smoke: a process tree ignoring `SIGTERM` returned the expected timeout in 2.5s and its descendant PID was no longer alive
- live control: a normal Bash command returned successfully