### PR TITLE
fix(connect): validate API keys against the supplied base URL

### DIFF
--- a/src/cli/subcommands/connect.test.ts
+++ b/src/cli/subcommands/connect.test.ts
@@ -271,6 +271,15 @@ describe("connect subcommand", () => {
     expect(deps.checkProviderApiKey).toHaveBeenCalledWith(
       "lmstudio_openai",
       "not-needed",
+      undefined,
+      undefined,
+      undefined,
+      {
+        connection: {
+          baseURL: "http://127.0.0.1:1234/v1",
+          timeout: 600_000,
+        },
+      },
     );
     expect(deps.createOrUpdateProvider).toHaveBeenCalledWith(
       "lmstudio_openai",
@@ -283,6 +292,35 @@ describe("connect subcommand", () => {
         baseURL: "http://127.0.0.1:1234/v1",
         timeout: 600_000,
       },
+    );
+  });
+
+  // Regression for #3381: the API key was validated against the provider's
+  // default endpoint because --base-url never reached checkProviderApiKey, so
+  // any third-party key failed with a 401 from api.openai.com.
+  test("validates the API key against the supplied base URL", async () => {
+    const { deps } = createIoDeps();
+    setProviderTarget("api");
+
+    const exitCode = await runConnectSubcommand(
+      [
+        "openai-compatible",
+        "--base-url",
+        "http://localhost:8080/v1",
+        "--api-key",
+        "third-party-key",
+      ],
+      deps,
+    );
+
+    expect(exitCode).toBe(0);
+    expect(deps.checkProviderApiKey).toHaveBeenCalledWith(
+      "openai",
+      "third-party-key",
+      undefined,
+      undefined,
+      undefined,
+      { connection: { baseURL: "http://localhost:8080/v1" } },
     );
   });
 
@@ -313,6 +351,10 @@ describe("connect subcommand", () => {
     expect(deps.checkProviderApiKey).toHaveBeenCalledWith(
       "openai-compatible",
       "not-needed",
+      undefined,
+      undefined,
+      undefined,
+      { connection: { baseURL: "http://127.0.0.1:8000/v1/" } },
     );
     expect(deps.createOrUpdateProvider).toHaveBeenCalledWith(
       "openai-compatible",
@@ -363,6 +405,10 @@ describe("connect subcommand", () => {
     expect(deps.checkProviderApiKey).toHaveBeenCalledWith(
       "lmstudio_openai",
       "1234",
+      undefined,
+      undefined,
+      undefined,
+      { connection: { baseURL: "http://localhost:8000/v1" } },
     );
     expect(deps.createOrUpdateProvider).toHaveBeenCalledWith(
       "lmstudio_openai",

--- a/src/cli/subcommands/connect.ts
+++ b/src/cli/subcommands/connect.ts
@@ -26,6 +26,7 @@ import {
   checkProviderApiKey,
   createOrUpdateProvider,
   type ProviderConnectionOptions,
+  type ProviderOperationOptions,
   providerStorageTargetLabel,
 } from "@/providers/byok-providers";
 import {
@@ -62,6 +63,7 @@ interface ConnectSubcommandDeps {
     accessKey?: string,
     region?: string,
     profile?: string,
+    operationOptions?: ProviderOperationOptions,
   ) => Promise<void>;
   createOrUpdateProvider: (
     providerType: string,
@@ -466,7 +468,23 @@ export async function runConnectSubcommand(
       if (provider.target !== "local") {
         await io.ensureSettingsReady();
       }
-      await io.checkProviderApiKey(provider.byokProvider.providerType, apiKey);
+      if (hasConnectionOptions(connectionOptions)) {
+        // The API key must be validated against the user-supplied endpoint, not
+        // the provider's default one, or third-party keys fail with a 401.
+        await io.checkProviderApiKey(
+          provider.byokProvider.providerType,
+          apiKey,
+          undefined,
+          undefined,
+          undefined,
+          { connection: connectionOptions },
+        );
+      } else {
+        await io.checkProviderApiKey(
+          provider.byokProvider.providerType,
+          apiKey,
+        );
+      }
 
       io.stdout("Saving provider...");
       if (hasConnectionOptions(connectionOptions)) {


### PR DESCRIPTION
## Summary

Fixes #3381.

`letta connect openai-compatible --base-url <URL> --api-key <KEY>` returns 401 from
`api.openai.com` even with a valid key. `ConnectSubcommandDeps.checkProviderApiKey` declares five
parameters where the real function takes six, so the call site dropped the connection options
without a type error and the base URL never reached the check. Everything below the CLI already
handles it.

Now forwards `connectionOptions`, branching on `hasConnectionOptions(...)` like the
`createOrUpdateProvider` call below it. Three existing tests asserted the two-argument call, so
they are updated; one new test covers the reported case.

`operationOptions.target` is left unset on purpose. `useLocalProviderStore()` falls back to
`defaultProviderStorageTarget()`, so passing it would change which store is used.

## Verification

```
$ bun run check
✓ 12 checks passed

$ bun test src/cli/subcommands/connect.test.ts
 22 pass  0 fail
```

With only the production file reverted to `origin/main`, four tests fail. The new one fails on the
missing options:

```
    "third-party-key",
-   undefined,
-   undefined,
-   undefined,
-   { "connection": { "baseURL": "http://localhost:8080/v1" } },
```

## AI Disclosure

- [ ] This pull request was written entirely by a human
- [x] This pull request was written with AI assistance and reviewed and edited by a human
- [x] I have read the [AI Policy](https://github.com/letta-ai/letta-code/blob/main/AI_POLICY.md) and agree to its terms

## AI Tool(s) Used

Claude Code (Opus 5), used to locate the dropped parameter, write the fix and the test, and capture
the output above.

## Human Verification

I have reviewed and understand every change in this pull request and take responsibility for its correctness.
