### PR TITLE
fix(listener): keep split stream sockets alive

### DIFF
--- a/src/websocket/listener/heartbeat.test.ts
+++ b/src/websocket/listener/heartbeat.test.ts
@@ -1,5 +1,53 @@
 import { describe, expect, test } from "bun:test";
+import { __listenClientTestUtils } from "./client";
+import { openListenerConnection } from "./connection";
 import { createMissedPongWatchdog } from "./heartbeat";
+import { startConnectedListenerRuntime, stopRuntime } from "./lifecycle";
+import { setActiveRuntime } from "./runtime";
+import type { ListenerTransport } from "./transport";
+import type { StartListenerOptions } from "./types";
+
+function createRecordingTransport(messages: string[]): ListenerTransport {
+  return {
+    kind: "local",
+    bufferedAmount: 0,
+    isOpen: () => true,
+    send: (data: string) => messages.push(data),
+  };
+}
+
+function countPings(messages: string[]): number {
+  return messages.filter((message) => {
+    try {
+      return (JSON.parse(message) as { type?: string }).type === "ping";
+    } catch {
+      return false;
+    }
+  }).length;
+}
+
+async function waitFor(
+  predicate: () => boolean,
+  message: string,
+): Promise<void> {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    if (predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+  throw new Error(message);
+}
+
+function createOptions(connectionId: string): StartListenerOptions {
+  return {
+    connectionId,
+    wsUrl: "local://heartbeat-test",
+    deviceId: "heartbeat-device",
+    connectionName: "heartbeat-listener",
+    onConnected: () => {},
+    onDisconnected: () => {},
+    onError: () => {},
+  };
+}
 
 describe("listener heartbeat watchdog", () => {
   test("does not treat a delayed first interval as missed peer responses", () => {
@@ -32,5 +80,101 @@ describe("listener heartbeat watchdog", () => {
     watchdog.recordPing(90_000);
     watchdog.recordPing(120_000);
     expect(watchdog.shouldTerminate(120_000)).toBe(false);
+  });
+
+  test("split listeners ping control and the current stream transport", async () => {
+    const runtime = __listenClientTestUtils.createListenerRuntime();
+    const connectionId = "split-heartbeat";
+    const options = createOptions(connectionId);
+    const controlMessages: string[] = [];
+    const firstStreamMessages: string[] = [];
+    const replacementStreamMessages: string[] = [];
+    const control = createRecordingTransport(controlMessages);
+    const firstStream = createRecordingTransport(firstStreamMessages);
+    const replacementStream = createRecordingTransport(
+      replacementStreamMessages,
+    );
+    setActiveRuntime(runtime);
+    openListenerConnection({
+      runtime,
+      connectionId,
+      writer: control,
+      streamWriter: firstStream,
+      options,
+    });
+
+    try {
+      await startConnectedListenerRuntime(
+        runtime,
+        control,
+        options,
+        async () => {},
+        {
+          startCronScheduler: false,
+          startProcessServices: false,
+          streamTransport: firstStream,
+          heartbeatIntervalMs: 5,
+        },
+      );
+      await waitFor(
+        () =>
+          countPings(controlMessages) > 0 &&
+          countPings(firstStreamMessages) > 0,
+        "split listener did not ping both transports",
+      );
+
+      const firstStreamPingCount = countPings(firstStreamMessages);
+      const connection = runtime.connections.get(connectionId);
+      if (!connection) throw new Error("listener connection missing");
+      connection.streamWriter = replacementStream;
+
+      await waitFor(
+        () => countPings(replacementStreamMessages) > 0,
+        "replacement stream transport was not pinged",
+      );
+      expect(countPings(firstStreamMessages)).toBe(firstStreamPingCount);
+      expect(countPings(controlMessages)).toBeGreaterThan(0);
+    } finally {
+      stopRuntime(runtime, true);
+      setActiveRuntime(null);
+    }
+  });
+
+  test("single-socket listeners send only the control heartbeat", async () => {
+    const runtime = __listenClientTestUtils.createListenerRuntime();
+    const connectionId = "single-heartbeat";
+    const options = createOptions(connectionId);
+    const controlMessages: string[] = [];
+    const control = createRecordingTransport(controlMessages);
+    setActiveRuntime(runtime);
+    openListenerConnection({
+      runtime,
+      connectionId,
+      writer: control,
+      options,
+    });
+
+    try {
+      await startConnectedListenerRuntime(
+        runtime,
+        control,
+        options,
+        async () => {},
+        {
+          startCronScheduler: false,
+          startProcessServices: false,
+          heartbeatIntervalMs: 5,
+        },
+      );
+      await waitFor(
+        () => countPings(controlMessages) > 0,
+        "single listener did not send its control heartbeat",
+      );
+      expect(runtime.connections.get(connectionId)?.streamWriter).toBeNull();
+      expect(countPings(controlMessages)).toBeGreaterThan(0);
+    } finally {
+      stopRuntime(runtime, true);
+      setActiveRuntime(null);
+    }
   });
 });

--- a/src/websocket/listener/heartbeat.test.ts
+++ b/src/websocket/listener/heartbeat.test.ts
@@ -1,29 +1,21 @@
 import { describe, expect, test } from "bun:test";
 import { __listenClientTestUtils } from "./client";
 import { openListenerConnection } from "./connection";
-import { createMissedPongWatchdog } from "./heartbeat";
-import { startConnectedListenerRuntime, stopRuntime } from "./lifecycle";
-import { setActiveRuntime } from "./runtime";
+import {
+  createMissedPongWatchdog,
+  startConnectionHeartbeat,
+} from "./heartbeat";
+import { clearRuntimeTimers } from "./runtime";
 import type { ListenerTransport } from "./transport";
 import type { StartListenerOptions } from "./types";
 
-function createRecordingTransport(messages: string[]): ListenerTransport {
+function createOpenTransport(): ListenerTransport {
   return {
     kind: "local",
     bufferedAmount: 0,
     isOpen: () => true,
-    send: (data: string) => messages.push(data),
+    send: () => {},
   };
-}
-
-function countPings(messages: string[]): number {
-  return messages.filter((message) => {
-    try {
-      return (JSON.parse(message) as { type?: string }).type === "ping";
-    } catch {
-      return false;
-    }
-  }).length;
 }
 
 async function waitFor(
@@ -85,96 +77,85 @@ describe("listener heartbeat watchdog", () => {
   test("split listeners ping control and the current stream transport", async () => {
     const runtime = __listenClientTestUtils.createListenerRuntime();
     const connectionId = "split-heartbeat";
-    const options = createOptions(connectionId);
-    const controlMessages: string[] = [];
-    const firstStreamMessages: string[] = [];
-    const replacementStreamMessages: string[] = [];
-    const control = createRecordingTransport(controlMessages);
-    const firstStream = createRecordingTransport(firstStreamMessages);
-    const replacementStream = createRecordingTransport(
-      replacementStreamMessages,
-    );
-    setActiveRuntime(runtime);
+    const control = createOpenTransport();
+    const firstStream = createOpenTransport();
+    const replacementStream = createOpenTransport();
+    const pingTargets: ListenerTransport[] = [];
     openListenerConnection({
       runtime,
       connectionId,
       writer: control,
       streamWriter: firstStream,
-      options,
+      options: createOptions(connectionId),
     });
 
     try {
-      await startConnectedListenerRuntime(
+      startConnectionHeartbeat(
         runtime,
         control,
-        options,
-        async () => {},
-        {
-          startCronScheduler: false,
-          startProcessServices: false,
-          streamTransport: firstStream,
-          heartbeatIntervalMs: 5,
+        () => {},
+        (target) => {
+          pingTargets.push(target);
+          return true;
         },
+        { intervalMs: 5 },
       );
       await waitFor(
         () =>
-          countPings(controlMessages) > 0 &&
-          countPings(firstStreamMessages) > 0,
+          pingTargets.includes(control) && pingTargets.includes(firstStream),
         "split listener did not ping both transports",
       );
 
-      const firstStreamPingCount = countPings(firstStreamMessages);
+      const firstStreamPingCount = pingTargets.filter(
+        (target) => target === firstStream,
+      ).length;
       const connection = runtime.connections.get(connectionId);
       if (!connection) throw new Error("listener connection missing");
       connection.streamWriter = replacementStream;
 
       await waitFor(
-        () => countPings(replacementStreamMessages) > 0,
+        () => pingTargets.includes(replacementStream),
         "replacement stream transport was not pinged",
       );
-      expect(countPings(firstStreamMessages)).toBe(firstStreamPingCount);
-      expect(countPings(controlMessages)).toBeGreaterThan(0);
+      expect(
+        pingTargets.filter((target) => target === firstStream),
+      ).toHaveLength(firstStreamPingCount);
+      expect(pingTargets).toContain(control);
     } finally {
-      stopRuntime(runtime, true);
-      setActiveRuntime(null);
+      clearRuntimeTimers(runtime);
     }
   });
 
   test("single-socket listeners send only the control heartbeat", async () => {
     const runtime = __listenClientTestUtils.createListenerRuntime();
     const connectionId = "single-heartbeat";
-    const options = createOptions(connectionId);
-    const controlMessages: string[] = [];
-    const control = createRecordingTransport(controlMessages);
-    setActiveRuntime(runtime);
+    const control = createOpenTransport();
+    const pingTargets: ListenerTransport[] = [];
     openListenerConnection({
       runtime,
       connectionId,
       writer: control,
-      options,
+      options: createOptions(connectionId),
     });
 
     try {
-      await startConnectedListenerRuntime(
+      startConnectionHeartbeat(
         runtime,
         control,
-        options,
-        async () => {},
-        {
-          startCronScheduler: false,
-          startProcessServices: false,
-          heartbeatIntervalMs: 5,
+        () => {},
+        (target) => {
+          pingTargets.push(target);
+          return true;
         },
+        { intervalMs: 5 },
       );
       await waitFor(
-        () => countPings(controlMessages) > 0,
+        () => pingTargets.length > 0,
         "single listener did not send its control heartbeat",
       );
-      expect(runtime.connections.get(connectionId)?.streamWriter).toBeNull();
-      expect(countPings(controlMessages)).toBeGreaterThan(0);
+      expect(pingTargets.every((target) => target === control)).toBe(true);
     } finally {
-      stopRuntime(runtime, true);
-      setActiveRuntime(null);
+      clearRuntimeTimers(runtime);
     }
   });
 });

--- a/src/websocket/listener/heartbeat.ts
+++ b/src/websocket/listener/heartbeat.ts
@@ -12,7 +12,6 @@ export interface MissedPongWatchdog {
 
 export interface ConnectionHeartbeatOptions {
   intervalMs?: number;
-  sendStreamPing?: () => void;
 }
 
 /**
@@ -47,11 +46,25 @@ export function createMissedPongWatchdog(
   };
 }
 
+function getCurrentStreamTransport(
+  runtime: ListenerRuntime,
+  controlTransport: ListenerTransport,
+): ListenerTransport | null {
+  for (const connection of runtime.connections.values()) {
+    if (connection.writer !== controlTransport) continue;
+    const streamTransport = connection.streamWriter;
+    if (streamTransport && streamTransport !== controlTransport) {
+      return streamTransport;
+    }
+  }
+  return null;
+}
+
 export function startConnectionHeartbeat(
   runtime: ListenerRuntime,
   transport: ListenerTransport,
   onStale: () => void,
-  sendPing: () => boolean,
+  sendPing: (target: ListenerTransport) => boolean,
   options: ConnectionHeartbeatOptions = {},
 ): void {
   runtime.lastPongAt = Date.now();
@@ -71,9 +84,12 @@ export function startConnectionHeartbeat(
     }
 
     const sentAt = Date.now();
-    if (sendPing()) {
+    if (sendPing(transport)) {
       watchdog.recordPing(sentAt);
     }
-    options.sendStreamPing?.();
+    const streamTransport = getCurrentStreamTransport(runtime, transport);
+    if (streamTransport) {
+      sendPing(streamTransport);
+    }
   }, options.intervalMs ?? LISTENER_HEARTBEAT_INTERVAL_MS);
 }

--- a/src/websocket/listener/heartbeat.ts
+++ b/src/websocket/listener/heartbeat.ts
@@ -10,6 +10,11 @@ export interface MissedPongWatchdog {
   recordPing(sentAt: number): void;
 }
 
+export interface ConnectionHeartbeatOptions {
+  intervalMs?: number;
+  sendStreamPing?: () => void;
+}
+
 /**
  * Count actual unanswered heartbeat probes instead of elapsed wall time.
  *
@@ -47,6 +52,7 @@ export function startConnectionHeartbeat(
   transport: ListenerTransport,
   onStale: () => void,
   sendPing: () => boolean,
+  options: ConnectionHeartbeatOptions = {},
 ): void {
   runtime.lastPongAt = Date.now();
   const maxUnansweredPings = Math.max(
@@ -68,5 +74,6 @@ export function startConnectionHeartbeat(
     if (sendPing()) {
       watchdog.recordPing(sentAt);
     }
-  }, LISTENER_HEARTBEAT_INTERVAL_MS);
+    options.sendStreamPing?.();
+  }, options.intervalMs ?? LISTENER_HEARTBEAT_INTERVAL_MS);
 }

--- a/src/websocket/listener/lifecycle.ts
+++ b/src/websocket/listener/lifecycle.ts
@@ -381,6 +381,7 @@ export async function startConnectedListenerRuntime(
     startProcessServices?: boolean;
     streamTransport?: ListenerTransport | null;
     emitInitialState?: boolean;
+    heartbeatIntervalMs?: number;
   } = {},
 ): Promise<void> {
   if (runtime !== getActiveRuntime() || runtime.intentionallyClosed) return;
@@ -433,6 +434,23 @@ export async function startConnectedListenerRuntime(
           "listener_ping_send_failed",
           "listener_heartbeat",
         );
+      },
+      {
+        intervalMs: options.heartbeatIntervalMs,
+        sendStreamPing: options.streamTransport
+          ? () => {
+              const connection = runtime.connections.get(opts.connectionId);
+              if (connection?.writer !== transport) return;
+              const streamTransport = connection.streamWriter;
+              if (!streamTransport || streamTransport === transport) return;
+              safeTransportSend(
+                streamTransport,
+                { type: "ping" },
+                "listener_stream_ping_send_failed",
+                "listener_stream_heartbeat",
+              );
+            }
+          : undefined,
       },
     );
   }

--- a/src/websocket/listener/lifecycle.ts
+++ b/src/websocket/listener/lifecycle.ts
@@ -381,7 +381,6 @@ export async function startConnectedListenerRuntime(
     startProcessServices?: boolean;
     streamTransport?: ListenerTransport | null;
     emitInitialState?: boolean;
-    heartbeatIntervalMs?: number;
   } = {},
 ): Promise<void> {
   if (runtime !== getActiveRuntime() || runtime.intentionallyClosed) return;
@@ -427,30 +426,13 @@ export async function startConnectedListenerRuntime(
         );
         runtime.socket?.terminate();
       },
-      () => {
+      (heartbeatTransport) => {
         return safeTransportSend(
-          transport,
+          heartbeatTransport,
           { type: "ping" },
           "listener_ping_send_failed",
           "listener_heartbeat",
         );
-      },
-      {
-        intervalMs: options.heartbeatIntervalMs,
-        sendStreamPing: options.streamTransport
-          ? () => {
-              const connection = runtime.connections.get(opts.connectionId);
-              if (connection?.writer !== transport) return;
-              const streamTransport = connection.streamWriter;
-              if (!streamTransport || streamTransport === transport) return;
-              safeTransportSend(
-                streamTransport,
-                { type: "ping" },
-                "listener_stream_ping_send_failed",
-                "listener_stream_heartbeat",
-              );
-            }
-          : undefined,
       },
     );
   }


### PR DESCRIPTION
## Summary

- Send heartbeat traffic on both control and stream WebSocket connections for split Cloud listeners.
- Keep control pongs as the only input to the listener liveness watchdog.
- Resolve the stream writer from the current connection on every tick so reconnects do not retain a stale socket.
- Leave local and single-socket listener behavior unchanged.

## Before and after

Before, an idle stream connection received no traffic while the control connection stayed healthy. A proxy could close only the stream connection and force the listener to rebuild the pair.

After, the active stream connection receives the same periodic ping traffic. Stream pings are best effort and do not affect control liveness decisions.

## Risk

Low. The existing heartbeat timer remains the sole timer. Cleanup still clears it, and the heartbeat owner resolves the stream writer from the connection currently associated with the control transport.

## Validation

- `bun run check`
- `bun test src/websocket/listener/heartbeat.test.ts src/websocket/listener/split-stream-lifecycle.test.ts`

👾 Generated with [Letta Code](https://letta.com)