### PR TITLE
fix(stream): abort wedged HTTP read after terminal SSE sequence [LET-10707]

### DIFF
--- a/scripts/source-file-size-baseline.json
+++ b/scripts/source-file-size-baseline.json
@@ -16,7 +16,7 @@
   "src/cli/components/ModelSelector.tsx": 1259,
   "src/cli/components/ProviderSelector.tsx": 1692,
   "src/cli/components/ToolCallMessageRich.tsx": 1109,
-  "src/cli/helpers/accumulator.ts": 1596,
+  "src/cli/helpers/accumulator.ts": 1600,
   "src/cli/helpers/reflection-transcript.ts": 1956,
   "src/cli/mods/local-mod-loader.test.ts": 1043,
   "src/cli/reflection-transcript.test.ts": 1084,
@@ -46,5 +46,6 @@
   "src/websocket/listener/file-commands.ts": 1053,
   "src/websocket/listener/lifecycle.ts": 1051,
   "src/websocket/listener/protocol-inbound.ts": 2264,
-  "src/websocket/listener/protocol-outbound.ts": 1085
+  "src/websocket/listener/protocol-outbound.ts": 1085,
+  "src/websocket/listener/turn.ts": 1007
 }

--- a/scripts/source-file-size-baseline.json
+++ b/scripts/source-file-size-baseline.json
@@ -47,5 +47,5 @@
   "src/websocket/listener/lifecycle.ts": 1051,
   "src/websocket/listener/protocol-inbound.ts": 2264,
   "src/websocket/listener/protocol-outbound.ts": 1085,
-  "src/websocket/listener/turn.ts": 1007
+  "src/websocket/listener/turn.ts": 1010
 }

--- a/src/cli/helpers/accumulator.ts
+++ b/src/cli/helpers/accumulator.ts
@@ -431,7 +431,11 @@ function formatRetryEventStatusLines(
   ];
 }
 
-function upsertStatusLine(b: Buffers, id: string, lines: string[]): void {
+export function upsertStatusLine(
+  b: Buffers,
+  id: string,
+  lines: string[],
+): void {
   const existing = b.byId.get(id);
   if (existing?.kind === "status") {
     existing.lines = lines;

--- a/src/cli/helpers/stream-terminal-eof-guard.ts
+++ b/src/cli/helpers/stream-terminal-eof-guard.ts
@@ -19,7 +19,11 @@ import { debugWarn } from "@/utils/debug";
  * The SDK iterator returns cleanly on its own controller's abort, so
  * drainStream proceeds with the stop reason it already received.
  */
-const DEFAULT_TERMINAL_EOF_GRACE_MS = 10_000;
+// The terminal frames normally follow within milliseconds (observed ~11ms in
+// production traces), and firing early costs nothing: the terminal state is
+// already in hand, so the abort only skips waiting for bookkeeping bytes.
+// 2s is ~200x the normal gap while keeping the user-visible dead air short.
+const DEFAULT_TERMINAL_EOF_GRACE_MS = 2_000;
 
 function getTerminalEofGraceMs(): number {
   const raw = process.env.LETTA_STREAM_TERMINAL_EOF_GRACE_MS;

--- a/src/cli/helpers/stream-terminal-eof-guard.ts
+++ b/src/cli/helpers/stream-terminal-eof-guard.ts
@@ -1,0 +1,80 @@
+import { telemetry } from "@/telemetry";
+import { debugWarn } from "@/utils/debug";
+
+/**
+ * Terminal-EOF guard for message streams (LET-10707).
+ *
+ * The generated letta-client consumes the [DONE] SSE frame internally and only
+ * finishes its iterator when the HTTP response body reports EOF. If the server
+ * (or an intermediary) never observably ends the response body, the iterator
+ * hangs forever and the turn wedges before tool execution — the client has all
+ * the semantic content (including the stop reason and any approval requests)
+ * but never gets control back. Seen in production as multi-hour stalls in
+ * PROCESSING_API_RESPONSE with zero executing tools.
+ *
+ * The guard arms once a stop_reason chunk has been received and re-arms on
+ * every subsequent chunk. After a stop_reason, the server only sends
+ * usage_statistics and [DONE], so the guard fires only after sustained silence
+ * following the terminal sequence — at which point it aborts the HTTP read.
+ * The SDK iterator returns cleanly on its own controller's abort, so
+ * drainStream proceeds with the stop reason it already received.
+ */
+const DEFAULT_TERMINAL_EOF_GRACE_MS = 10_000;
+
+function getTerminalEofGraceMs(): number {
+  const raw = process.env.LETTA_STREAM_TERMINAL_EOF_GRACE_MS;
+  if (raw) {
+    const parsed = Number(raw);
+    if (Number.isFinite(parsed) && parsed > 0) {
+      return parsed;
+    }
+  }
+  return DEFAULT_TERMINAL_EOF_GRACE_MS;
+}
+
+export type TerminalEofGuard = {
+  /** (Re-)start the grace timer. Call on every chunk after stop_reason. */
+  arm: () => void;
+  /** Cancel the timer. Call when the stream ends for any reason. */
+  clear: () => void;
+};
+
+export function createTerminalEofGuard(context: {
+  getStopReason: () => string | null;
+  getRunId: () => string | null;
+  abortHttpRead: () => void;
+}): TerminalEofGuard {
+  let timer: ReturnType<typeof setTimeout> | null = null;
+
+  return {
+    arm: () => {
+      if (timer) {
+        clearTimeout(timer);
+      }
+      const graceMs = getTerminalEofGraceMs();
+      timer = setTimeout(() => {
+        debugWarn(
+          "drainStream",
+          "Terminal-EOF guard fired: stop_reason=%s received but stream did not end within %dms - aborting HTTP read",
+          context.getStopReason(),
+          graceMs,
+        );
+        telemetry.trackError(
+          "stream_terminal_eof_guard_fired",
+          `Stream received stop_reason=${context.getStopReason()} but HTTP body did not end within ${graceMs}ms`,
+          "stream_drain",
+          {
+            runId: context.getRunId() ?? undefined,
+          },
+        );
+        context.abortHttpRead();
+      }, graceMs);
+    },
+    clear: () => {
+      if (timer) {
+        clearTimeout(timer);
+        timer = null;
+      }
+    },
+  };
+}

--- a/src/cli/helpers/stream-terminal-eof-guard.ts
+++ b/src/cli/helpers/stream-terminal-eof-guard.ts
@@ -45,8 +45,6 @@ export function createTerminalEofGuard(context: {
   getStopReason: () => string | null;
   getRunId: () => string | null;
   abortHttpRead: () => void;
-  /** Notify the consumer (e.g. to render a transcript notice). */
-  onFired?: (graceMs: number) => void;
 }): TerminalEofGuard {
   let timer: ReturnType<typeof setTimeout> | null = null;
   let fired = false;
@@ -73,7 +71,6 @@ export function createTerminalEofGuard(context: {
             runId: context.getRunId() ?? undefined,
           },
         );
-        context.onFired?.(graceMs);
         context.abortHttpRead();
       }, graceMs);
     },

--- a/src/cli/helpers/stream-terminal-eof-guard.ts
+++ b/src/cli/helpers/stream-terminal-eof-guard.ts
@@ -37,14 +37,19 @@ export type TerminalEofGuard = {
   arm: () => void;
   /** Cancel the timer. Call when the stream ends for any reason. */
   clear: () => void;
+  /** True if the guard aborted the HTTP read. */
+  fired: () => boolean;
 };
 
 export function createTerminalEofGuard(context: {
   getStopReason: () => string | null;
   getRunId: () => string | null;
   abortHttpRead: () => void;
+  /** Notify the consumer (e.g. to render a transcript notice). */
+  onFired?: (graceMs: number) => void;
 }): TerminalEofGuard {
   let timer: ReturnType<typeof setTimeout> | null = null;
+  let fired = false;
 
   return {
     arm: () => {
@@ -53,6 +58,7 @@ export function createTerminalEofGuard(context: {
       }
       const graceMs = getTerminalEofGraceMs();
       timer = setTimeout(() => {
+        fired = true;
         debugWarn(
           "drainStream",
           "Terminal-EOF guard fired: stop_reason=%s received but stream did not end within %dms - aborting HTTP read",
@@ -67,6 +73,7 @@ export function createTerminalEofGuard(context: {
             runId: context.getRunId() ?? undefined,
           },
         );
+        context.onFired?.(graceMs);
         context.abortHttpRead();
       }, graceMs);
     },
@@ -76,5 +83,6 @@ export function createTerminalEofGuard(context: {
         timer = null;
       }
     },
+    fired: () => fired,
   };
 }

--- a/src/cli/helpers/stream-terminal-eof.test.ts
+++ b/src/cli/helpers/stream-terminal-eof.test.ts
@@ -1,0 +1,200 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import type { Stream } from "@letta-ai/letta-client/core/streaming";
+import type { LettaStreamingResponse } from "@letta-ai/letta-client/resources/agents/messages";
+import { createBuffers } from "@/cli/helpers/accumulator";
+import { drainStream } from "@/cli/helpers/stream";
+
+/**
+ * Regression tests for the terminal-EOF guard (LET-10707).
+ *
+ * Production failure mode: the server finishes the run and emits the full
+ * terminal SSE sequence (stop_reason, usage_statistics, [DONE]), but the HTTP
+ * response body never observably ends at the client. The generated
+ * letta-client consumes [DONE] internally and only finishes its iterator on
+ * HTTP body EOF, so drainStream's `for await` waits forever and the turn
+ * wedges before tool execution (multi-hour stalls in PROCESSING_API_RESPONSE
+ * with zero executing tools).
+ *
+ * The fake streams below model the SDK contract: after yielding the parsed
+ * JSON events, the iterator stays pending until the stream controller is
+ * aborted, then returns cleanly (the SDK swallows AbortError and returns).
+ */
+
+function makeHangingTerminalStream(chunks: LettaStreamingResponse[]): {
+  stream: Stream<LettaStreamingResponse>;
+  controller: AbortController;
+} {
+  const controller = new AbortController();
+  const stream = {
+    controller,
+    async *[Symbol.asyncIterator]() {
+      for (const chunk of chunks) {
+        yield chunk;
+      }
+      // HTTP body never reports EOF. The real SDK iterator only finishes when
+      // the body ends or the controller aborts (clean return, no throw).
+      await new Promise<void>((resolve) => {
+        if (controller.signal.aborted) {
+          resolve();
+          return;
+        }
+        controller.signal.addEventListener("abort", () => resolve(), {
+          once: true,
+        });
+      });
+    },
+  } as unknown as Stream<LettaStreamingResponse>;
+  return { stream, controller };
+}
+
+const originalGrace = process.env.LETTA_STREAM_TERMINAL_EOF_GRACE_MS;
+
+afterEach(() => {
+  if (originalGrace === undefined) {
+    delete process.env.LETTA_STREAM_TERMINAL_EOF_GRACE_MS;
+  } else {
+    process.env.LETTA_STREAM_TERMINAL_EOF_GRACE_MS = originalGrace;
+  }
+});
+
+describe("drainStream terminal-EOF guard", () => {
+  test("returns requires_approval when body never ends after terminal sequence", async () => {
+    process.env.LETTA_STREAM_TERMINAL_EOF_GRACE_MS = "50";
+
+    const { stream, controller } = makeHangingTerminalStream([
+      {
+        message_type: "approval_request_message",
+        id: "message-approval-1",
+        tool_call: {
+          tool_call_id: "tc-updateplan",
+          name: "UpdatePlan",
+          arguments: '{"plan":"[]"}',
+        },
+      } as LettaStreamingResponse,
+      {
+        message_type: "stop_reason",
+        stop_reason: "requires_approval",
+      } as LettaStreamingResponse,
+      {
+        message_type: "usage_statistics",
+        prompt_tokens: 100,
+        completion_tokens: 10,
+        total_tokens: 110,
+      } as LettaStreamingResponse,
+    ]);
+
+    const buffers = createBuffers("agent-test");
+    const result = await drainStream(stream, buffers, () => {});
+
+    // Guard must have aborted the wedged HTTP read...
+    expect(controller.signal.aborted).toBe(true);
+    // ...and the drain must surface the already-received terminal state so the
+    // approval/tool-execution flow proceeds.
+    expect(result.stopReason).toBe("requires_approval");
+    expect(result.sawStopReasonChunk).toBe(true);
+    expect(result.approvals).toEqual([
+      {
+        toolCallId: "tc-updateplan",
+        toolName: "UpdatePlan",
+        toolArgs: '{"plan":"[]"}',
+        messageId: "message-approval-1",
+      },
+    ]);
+    expect(buffers.usage.totalTokens).toBe(110);
+  });
+
+  test("returns end_turn when body never ends after terminal sequence", async () => {
+    process.env.LETTA_STREAM_TERMINAL_EOF_GRACE_MS = "50";
+
+    const { stream, controller } = makeHangingTerminalStream([
+      {
+        message_type: "assistant_message",
+        id: "msg-1",
+        content: "done",
+      } as LettaStreamingResponse,
+      {
+        message_type: "stop_reason",
+        stop_reason: "end_turn",
+      } as LettaStreamingResponse,
+      {
+        message_type: "usage_statistics",
+        prompt_tokens: 5,
+        completion_tokens: 5,
+        total_tokens: 10,
+      } as LettaStreamingResponse,
+    ]);
+
+    const result = await drainStream(
+      stream,
+      createBuffers("agent-test"),
+      () => {},
+    );
+
+    expect(controller.signal.aborted).toBe(true);
+    expect(result.stopReason).toBe("end_turn");
+    expect(result.sawStopReasonChunk).toBe(true);
+  });
+
+  test("does not abort a stream that ends normally after the terminal sequence", async () => {
+    process.env.LETTA_STREAM_TERMINAL_EOF_GRACE_MS = "5000";
+
+    const controller = new AbortController();
+    const stream = {
+      controller,
+      async *[Symbol.asyncIterator]() {
+        yield {
+          message_type: "stop_reason",
+          stop_reason: "end_turn",
+        } as LettaStreamingResponse;
+        yield {
+          message_type: "usage_statistics",
+          prompt_tokens: 1,
+          completion_tokens: 1,
+          total_tokens: 2,
+        } as LettaStreamingResponse;
+        // Body ends normally (EOF) right after the terminal sequence.
+      },
+    } as unknown as Stream<LettaStreamingResponse>;
+
+    const result = await drainStream(
+      stream,
+      createBuffers("agent-test"),
+      () => {},
+    );
+
+    expect(controller.signal.aborted).toBe(false);
+    expect(result.stopReason).toBe("end_turn");
+  });
+
+  test("guard does not fire before a stop_reason chunk arrives", async () => {
+    process.env.LETTA_STREAM_TERMINAL_EOF_GRACE_MS = "30";
+
+    const controller = new AbortController();
+    const stream = {
+      controller,
+      async *[Symbol.asyncIterator]() {
+        yield {
+          message_type: "assistant_message",
+          id: "msg-slow",
+          content: "thinking",
+        } as LettaStreamingResponse;
+        // Mid-stream pause longer than the grace window: legitimate slow
+        // generation, no stop_reason yet — the guard must stay unarmed.
+        await new Promise((resolve) => setTimeout(resolve, 90));
+        yield {
+          message_type: "stop_reason",
+          stop_reason: "end_turn",
+        } as LettaStreamingResponse;
+      },
+    } as unknown as Stream<LettaStreamingResponse>;
+
+    const result = await drainStream(
+      stream,
+      createBuffers("agent-test"),
+      () => {},
+    );
+
+    expect(controller.signal.aborted).toBe(false);
+    expect(result.stopReason).toBe("end_turn");
+  });
+});

--- a/src/cli/helpers/stream-terminal-eof.test.ts
+++ b/src/cli/helpers/stream-terminal-eof.test.ts
@@ -101,6 +101,14 @@ describe("drainStream terminal-EOF guard", () => {
       },
     ]);
     expect(buffers.usage.totalTokens).toBe(110);
+    // The firing is reported so consumers (listener/headless) can surface it.
+    expect(result.terminalEofGuardFired).toBe(true);
+    // The stall is surfaced as a nonblocking status line in the transcript.
+    const statusLines = Array.from(buffers.byId.values()).filter(
+      (line) => line.kind === "status",
+    );
+    expect(statusLines).toHaveLength(1);
+    expect(statusLines[0]?.lines[0]).toContain("Stream did not close");
   });
 
   test("returns end_turn when body never ends after terminal sequence", async () => {
@@ -156,14 +164,16 @@ describe("drainStream terminal-EOF guard", () => {
       },
     } as unknown as Stream<LettaStreamingResponse>;
 
-    const result = await drainStream(
-      stream,
-      createBuffers("agent-test"),
-      () => {},
-    );
+    const buffers = createBuffers("agent-test");
+    const result = await drainStream(stream, buffers, () => {});
 
     expect(controller.signal.aborted).toBe(false);
     expect(result.stopReason).toBe("end_turn");
+    expect(result.terminalEofGuardFired).toBe(false);
+    // No stall, no notice.
+    expect(
+      Array.from(buffers.byId.values()).some((line) => line.kind === "status"),
+    ).toBe(false);
   });
 
   test("guard does not fire before a stop_reason chunk arrives", async () => {

--- a/src/cli/helpers/stream.ts
+++ b/src/cli/helpers/stream.ts
@@ -30,6 +30,7 @@ import {
   markIncompleteToolsAsCancelled,
   onChunk,
   removeIncompleteTools,
+  upsertStatusLine,
 } from "./accumulator";
 import { chunkLog } from "./chunk-log";
 import type { ContextTracker } from "./context-tracker";
@@ -76,6 +77,7 @@ export type DrainResult = {
   approvals?: ApprovalRequest[]; // NEW: supports parallel approvals
   apiDurationMs: number; // time spent in API call
   fallbackError?: string | null; // Error message for when we can't fetch details from server (no run_id)
+  terminalEofGuardFired?: boolean; // HTTP body never ended after the terminal SSE sequence; guard aborted the read
 };
 
 function summarizeStreamForDebug(stream: unknown): string {
@@ -193,6 +195,18 @@ export async function drainStream(
     getStopReason: () => streamProcessor.stopReason,
     getRunId: () => streamProcessor.lastRunId,
     abortHttpRead: () => abortStreamController(stream, "terminal_eof_guard"),
+    onFired: (graceMs) => {
+      // Surface the stall in the transcript: the turn already waited graceMs
+      // of dead air, so silently continuing would read as unexplained slowness.
+      upsertStatusLine(
+        buffers,
+        `terminal-eof-${streamProcessor.lastRunId ?? startTime}`,
+        [
+          `Stream did not close within ${Math.round(graceMs / 1000)}s of completing, continuing without waiting`,
+        ],
+      );
+      queueMicrotask(refresh);
+    },
   });
 
   // Capture the abort generation at stream start to detect if handleInterrupt ran
@@ -536,6 +550,7 @@ export async function drainStream(
     lastSeqId: streamProcessor.lastSeqId,
     apiDurationMs,
     fallbackError,
+    terminalEofGuardFired: terminalEofGuard.fired(),
   };
 }
 

--- a/src/cli/helpers/stream.ts
+++ b/src/cli/helpers/stream.ts
@@ -195,18 +195,6 @@ export async function drainStream(
     getStopReason: () => streamProcessor.stopReason,
     getRunId: () => streamProcessor.lastRunId,
     abortHttpRead: () => abortStreamController(stream, "terminal_eof_guard"),
-    onFired: (graceMs) => {
-      // Surface the stall in the transcript: the turn already waited graceMs
-      // of dead air, so silently continuing would read as unexplained slowness.
-      upsertStatusLine(
-        buffers,
-        `terminal-eof-${streamProcessor.lastRunId ?? startTime}`,
-        [
-          `Stream did not close within ${Math.round(graceMs / 1000)}s of completing, continuing without waiting`,
-        ],
-      );
-      queueMicrotask(refresh);
-    },
   });
 
   // Capture the abort generation at stream start to detect if handleInterrupt ran
@@ -446,6 +434,14 @@ export async function drainStream(
 
   if (!stopReason && streamProcessor.stopReason) {
     stopReason = streamProcessor.stopReason;
+  }
+
+  // Surface guard firings: the user already sat through the grace period of
+  // dead air, so continuing silently would read as unexplained slowness.
+  if (terminalEofGuard.fired()) {
+    upsertStatusLine(buffers, `terminal-eof-${startTime}`, [
+      "Stream did not close after completing, continued without waiting",
+    ]);
   }
 
   // If we aborted via listener but loop exited without setting stopReason

--- a/src/cli/helpers/stream.ts
+++ b/src/cli/helpers/stream.ts
@@ -42,6 +42,7 @@ import {
   type StreamResumePolicy,
   waitForResumeRetry,
 } from "./stream-resume";
+import { createTerminalEofGuard } from "./stream-terminal-eof-guard";
 
 export type { ApprovalRequest } from "./stream-processor";
 
@@ -186,6 +187,14 @@ export async function drainStream(
   // Track if we triggered abort via our listener (for eager cancellation)
   let abortedViaListener = false;
 
+  // Terminal-EOF guard: once the terminal SSE sequence has arrived, don't wait
+  // forever for HTTP body EOF (see stream-terminal-eof-guard.ts).
+  const terminalEofGuard = createTerminalEofGuard({
+    getStopReason: () => streamProcessor.stopReason,
+    getRunId: () => streamProcessor.lastRunId,
+    abortHttpRead: () => abortStreamController(stream, "terminal_eof_guard"),
+  });
+
   // Capture the abort generation at stream start to detect if handleInterrupt ran
   const startAbortGen = buffers.abortGeneration || 0;
 
@@ -263,6 +272,14 @@ export async function drainStream(
 
       const { shouldOutput, errorInfo, updatedApproval } =
         streamProcessor.processChunk(chunk);
+
+      // Once the terminal sequence starts (stop_reason received), (re-)arm the
+      // EOF guard on every subsequent chunk. Only usage_statistics and [DONE]
+      // legitimately follow stop_reason, so this fires only when the HTTP body
+      // stays open with no data after the terminal sequence.
+      if (streamProcessor.stopReason !== null) {
+        terminalEofGuard.arm();
+      }
 
       // Log chunk for feedback diagnostics
       try {
@@ -391,6 +408,8 @@ export async function drainStream(
     }
     queueMicrotask(refresh);
   } finally {
+    terminalEofGuard.clear();
+
     // Persist chunk log to disk (one write per stream, not per chunk)
     try {
       chunkLog.flush();

--- a/src/websocket/listener/recoverable-notices.ts
+++ b/src/websocket/listener/recoverable-notices.ts
@@ -19,7 +19,9 @@ import {
 import type { ListenerTransport } from "./transport";
 import type { ConversationRuntime, ListenerRuntime } from "./types";
 
-export type RecoverableStatusNoticeKind = "stale_approval_conflict_recovery";
+export type RecoverableStatusNoticeKind =
+  | "stale_approval_conflict_recovery"
+  | "stream_terminal_eof_guard";
 export type RecoverableRetryNoticeKind = "transient_provider_retry";
 
 type LifecycleNoticeVisibility = "debug_only" | "transcript";
@@ -44,6 +46,8 @@ export function getRecoverableStatusNoticeVisibility(
   switch (kind) {
     case "stale_approval_conflict_recovery":
       return "debug_only";
+    case "stream_terminal_eof_guard":
+      return "transcript";
     default:
       return "transcript";
   }
@@ -311,6 +315,28 @@ export function emitLoopErrorNotice(
     apiError: decision.apiError,
   });
   return decision.message;
+}
+
+/**
+ * The HTTP response body never ended after the terminal SSE sequence; the
+ * terminal-EOF guard aborted the read after a grace period of dead air.
+ * Surface it so the wait doesn't read as unexplained slowness (LET-10707).
+ */
+export function emitTerminalEofGuardNotice(
+  socket: ListenerTransport,
+  runtime: ListenerRuntime | ConversationRuntime,
+  params: {
+    runId?: string | null;
+    agentId?: string | null;
+    conversationId?: string | null;
+  },
+): void {
+  emitRecoverableStatusNotice(socket, runtime, {
+    kind: "stream_terminal_eof_guard",
+    message: "Stream did not close after completing, continued without waiting",
+    level: "warning",
+    ...params,
+  });
 }
 
 export function emitRecoverableStatusNotice(

--- a/src/websocket/listener/recoverable-notices.ts
+++ b/src/websocket/listener/recoverable-notices.ts
@@ -19,9 +19,7 @@ import {
 import type { ListenerTransport } from "./transport";
 import type { ConversationRuntime, ListenerRuntime } from "./types";
 
-export type RecoverableStatusNoticeKind =
-  | "stale_approval_conflict_recovery"
-  | "stream_terminal_eof_guard";
+export type RecoverableStatusNoticeKind = "stale_approval_conflict_recovery";
 export type RecoverableRetryNoticeKind = "transient_provider_retry";
 
 type LifecycleNoticeVisibility = "debug_only" | "transcript";
@@ -46,8 +44,6 @@ export function getRecoverableStatusNoticeVisibility(
   switch (kind) {
     case "stale_approval_conflict_recovery":
       return "debug_only";
-    case "stream_terminal_eof_guard":
-      return "transcript";
     default:
       return "transcript";
   }
@@ -315,28 +311,6 @@ export function emitLoopErrorNotice(
     apiError: decision.apiError,
   });
   return decision.message;
-}
-
-/**
- * The HTTP response body never ended after the terminal SSE sequence; the
- * terminal-EOF guard aborted the read after a grace period of dead air.
- * Surface it so the wait doesn't read as unexplained slowness (LET-10707).
- */
-export function emitTerminalEofGuardNotice(
-  socket: ListenerTransport,
-  runtime: ListenerRuntime | ConversationRuntime,
-  params: {
-    runId?: string | null;
-    agentId?: string | null;
-    conversationId?: string | null;
-  },
-): void {
-  emitRecoverableStatusNotice(socket, runtime, {
-    kind: "stream_terminal_eof_guard",
-    message: "Stream did not close after completing, continued without waiting",
-    level: "warning",
-    ...params,
-  });
 }
 
 export function emitRecoverableStatusNotice(

--- a/src/websocket/listener/turn.ts
+++ b/src/websocket/listener/turn.ts
@@ -54,6 +54,7 @@ import {
   emitLoopErrorNotice,
   emitRecoverableRetryNotice,
   emitRecoverableStatusNotice,
+  emitTerminalEofGuardNotice,
   getConsumerLoopErrorMessage,
   getTranscriptLoopErrorMessage as getSafeTerminalError,
 } from "./recoverable-notices";
@@ -443,9 +444,15 @@ async function handleIncomingMessageInner(
       const stopReason = result.stopReason;
       const approvals = result.approvals || [];
       const fallbackError = result.fallbackError ?? null;
-      if (finishIfInterrupted(runId || runtime.activeRunId)) {
-        break;
+
+      if (result.terminalEofGuardFired) {
+        emitTerminalEofGuardNotice(socket, runtime, {
+          runId: runId || runtime.activeRunId,
+          agentId,
+          conversationId,
+        });
       }
+
       if (finishIfInterrupted(runId || runtime.activeRunId)) {
         break;
       }

--- a/src/websocket/listener/turn.ts
+++ b/src/websocket/listener/turn.ts
@@ -45,6 +45,7 @@ import {
   emitLoopStatusUpdate,
   emitRetryDelta,
   emitRuntimeStateUpdates,
+  emitStatusDelta,
 } from "./protocol-outbound";
 import {
   createProviderFallbackState,
@@ -54,7 +55,6 @@ import {
   emitLoopErrorNotice,
   emitRecoverableRetryNotice,
   emitRecoverableStatusNotice,
-  emitTerminalEofGuardNotice,
   getConsumerLoopErrorMessage,
   getTranscriptLoopErrorMessage as getSafeTerminalError,
 } from "./recoverable-notices";
@@ -446,7 +446,10 @@ async function handleIncomingMessageInner(
       const fallbackError = result.fallbackError ?? null;
 
       if (result.terminalEofGuardFired) {
-        emitTerminalEofGuardNotice(socket, runtime, {
+        emitStatusDelta(socket, runtime, {
+          message:
+            "Stream did not close after completing, continued without waiting",
+          level: "warning",
           runId: runId || runtime.activeRunId,
           agentId,
           conversationId,


### PR DESCRIPTION
## Summary

- Fixes turns that wedge in `PROCESSING_API_RESPONSE` after the server has already finished the run. Production traces showed the server completing a run and emitting the full terminal SSE sequence while the client kept waiting on the message-stream HTTP response body forever; stalls ran from 34 minutes to 2+ hours and only an interrupt (which aborts the HTTP read and denies the pending tool call) cleared them.
- Root cause on the client side: the generated `@letta-ai/letta-client` consumes the `[DONE]` SSE frame internally (`done = true; continue;`) and only finishes its iterator when the HTTP body reports EOF. `drainStream` deliberately keeps reading past `stop_reason` to collect `usage_statistics`, so when the body end is never observed there is no exit path and no error.
- Fix: once a `stop_reason` chunk arrives, arm a grace timer (default 2s, override via `LETTA_STREAM_TERMINAL_EOF_GRACE_MS`) that re-arms on every subsequent chunk. Only `usage_statistics` and `[DONE]` legitimately follow `stop_reason` (observed gap in production traces is ~11ms; letta-code always sends `background: true`, so nothing else runs between them), so the timer fires only after sustained silence following the terminal sequence. When it fires, it aborts the stream controller; the SDK iterator returns cleanly on its own abort, and the drain proceeds with the stop reason, usage, and approval requests it already received, so auto-approved tools execute instead of hanging.
- The guard never arms before `stop_reason`, so slow generation and long tool turns are unaffected. Mid-stream disconnect handling (resume path) is unchanged and cannot be triggered by a guard firing (`canResume` requires no stop_reason chunk); this only covers the case where the terminal sequence was fully received.
- Regression tests: hanging-body streams (with and without a pending approval) reproduce the exact wedge and time out without the fix; normally-ending streams and slow mid-stream generation pin that the guard stays inert.

This is the client-side half of the investigation: server-side response-termination tracing landed separately, and a `[DONE]`-terminates-iterator change in the generated client is a possible follow-up. This guard protects against both a lost `[DONE]` frame and a lost body end regardless of where the server-side fix lands.

Each firing also emits a `stream_terminal_eof_guard_fired` telemetry event with the run ID, so after rollout this doubles as the occurrence counter for the underlying transport bug (frequency + environment clustering) with no extra instrumentation. Firings should correlate 1:1 with recovered turns; a firing without a recovered turn means the abort itself failed to unwedge the read and points back at the runtime.

👾 Generated with [Letta Code](https://letta.com)

## Update: guard firings are now user-visible

A firing means the user already sat through the grace period of dead air; silent continuation would read as unexplained slowness, and a frequently-firing guard would be invisible. Follow-up commits surface each firing as a nonblocking notice (no new protocol kinds — existing status mechanisms only):

- **TUI**: dimmed status line in the transcript ("Stream did not close after completing, continued without waiting"), same `upsertStatusLine` mechanism as provider-retry notices.
- **Desktop/web (listener)**: warning-level status delta via the existing `emitStatusDelta` path, same message.
- `DrainResult` gains `terminalEofGuardFired` for consumers.

Also removes a pre-existing duplicated `finishIfInterrupted` block in `turn.ts` (identical check twice in a row), and lowers the grace default from the initial 10s to 2s: the terminal frames normally follow within milliseconds, and firing "early" costs nothing because the terminal state is already in hand — the abort only skips waiting for bookkeeping bytes.
