### PR TITLE
fix(tools): load bundled client tools named in the allowlist

### DIFF
--- a/scripts/source-file-size-baseline.json
+++ b/scripts/source-file-size-baseline.json
@@ -37,7 +37,7 @@
   "src/settings-manager.test.ts": 1669,
   "src/settings-manager.ts": 2112,
   "src/tools/impl/enter-worktree.ts": 1260,
-  "src/tools/manager.ts": 3080,
+  "src/tools/manager.ts": 3077,
   "src/tools/tool-execution-context.test.ts": 1138,
   "src/types/protocol_v2.ts": 2911,
   "src/websocket/listen-client-concurrency.test.ts": 2686,

--- a/src/tools/client-toolset.test.ts
+++ b/src/tools/client-toolset.test.ts
@@ -78,6 +78,48 @@ describe("request-scoped client toolsets", () => {
     );
   });
 
+  test("loads bundled tools named only in the allowlist", async () => {
+    const prepared = await prepareToolExecutionContextForResolvedTarget({
+      modelIdentifier: "anthropic/claude-sonnet-5",
+      toolsetPreference: "auto",
+      clientToolAllowlist: ["Read", "LS", "Glob", "Grep"],
+    });
+
+    // LS, Glob and Grep are not in the default base; allowlisting them is
+    // what loads them.
+    expect([...prepared.preparedToolContext.loadedToolNames].sort()).toEqual([
+      "Glob",
+      "Grep",
+      "LS",
+      "Read",
+    ]);
+  });
+
+  test("ignores allowlist entries that are not bundled client tools", async () => {
+    const prepared = await prepareToolExecutionContextForResolvedTarget({
+      modelIdentifier: "anthropic/claude-sonnet-5",
+      toolsetPreference: "auto",
+      clientToolAllowlist: ["Read", "mcp__files__read", "SomeCustomTool"],
+    });
+
+    expect(prepared.preparedToolContext.loadedToolNames).toEqual(["Read"]);
+  });
+
+  test("does not leak one turn's tools into the next", async () => {
+    await prepareToolExecutionContextForResolvedTarget({
+      modelIdentifier: "anthropic/claude-sonnet-5",
+      toolsetPreference: "auto",
+      clientToolset: { include: ["Glob"] },
+    });
+
+    const prepared = await prepareToolExecutionContextForResolvedTarget({
+      modelIdentifier: "anthropic/claude-sonnet-5",
+      toolsetPreference: "auto",
+    });
+
+    expect(prepared.preparedToolContext.loadedToolNames).not.toContain("Glob");
+  });
+
   test("rejects unknown bundled tool names", async () => {
     expect(
       prepareToolExecutionContextForResolvedTarget({

--- a/src/tools/manager.ts
+++ b/src/tools/manager.ts
@@ -1507,13 +1507,10 @@ async function resolveBaseToolNamesForModel(
   }
 
   if (options?.include && options.include.length > 0) {
-    const seen = new Set(baseToolNames);
-    for (const name of options.include) {
-      if (!seen.has(name)) {
-        baseToolNames.push(name);
-        seen.add(name);
-      }
-    }
+    // Copy rather than push: the branches above bind shared module-level
+    // preset arrays, so appending in place would leak one turn's tools into
+    // the preset itself for the life of the process.
+    baseToolNames = [...new Set([...baseToolNames, ...options.include])];
   }
 
   if (options?.exclude && options.exclude.length > 0) {

--- a/src/tools/toolset.ts
+++ b/src/tools/toolset.ts
@@ -94,6 +94,31 @@ function resolveIncludedToolNames(toolNames: string[] | undefined): ToolName[] {
   });
 }
 
+/**
+ * Bundled client tools named in the allowlist, so that allowlisting a tool
+ * also loads it. Without this an allowlist is only a filter over whatever the
+ * base happens to carry, so a client asking for exactly ["Read", "LS",
+ * "Glob", "Grep"] silently gets just the ones its base already had.
+ *
+ * Unknown names are skipped rather than rejected: unlike `include`, an
+ * allowlist legitimately carries MCP and other external tool names that are
+ * not bundled client tools.
+ */
+function resolveAllowlistedToolNames(
+  allowlist: string[] | undefined,
+): ToolName[] {
+  if (!allowlist) return [];
+
+  const toolNames: ToolName[] = [];
+  for (const allowedName of allowlist) {
+    const internalName = getInternalToolName(allowedName);
+    if (Object.hasOwn(TOOL_DEFINITIONS, internalName)) {
+      toolNames.push(internalName as ToolName);
+    }
+  }
+  return toolNames;
+}
+
 function appendUniqueToolNames(
   baseToolNames: ToolName[],
   includedToolNames: ToolName[],
@@ -236,7 +261,10 @@ export async function prepareToolExecutionContextForResolvedTarget(params: {
       ? (resolveModel(modelIdentifier) ?? modelIdentifier)
       : null;
   const effectiveToolsetPreference = clientToolset?.base ?? toolsetPreference;
-  const includedToolNames = resolveIncludedToolNames(clientToolset?.include);
+  const includedToolNames = appendUniqueToolNames(
+    resolveIncludedToolNames(clientToolset?.include),
+    resolveAllowlistedToolNames(clientToolAllowlist),
+  );
 
   if (effectiveToolsetPreference === "auto") {
     const derivedToolset = effectiveModel


### PR DESCRIPTION
`client_tool_allowlist` only filtered the tools a base already carried, so allowlisting a bundled tool did not load it. A client asking for exactly `["Read", "LS", "Glob", "Grep"]` got a session that could only call `Read` — `LS`, `Glob` and `Grep` are not in the default base — and the agent silently found nothing instead of erroring.

Bundled tools named in the allowlist are now resolved through `TOOL_DEFINITIONS` and loaded alongside `clientToolset.include`. Unknown names are skipped rather than rejected, since an allowlist legitimately carries MCP and other external tool names.

`resolveBaseToolNamesForModel` also bound the shared preset arrays (`ANTHROPIC_DEFAULT_TOOLS`, `OPENAI_PASCAL_TOOLS`, `TOOL_NAMES`) and pushed includes straight into them, so one turn's extra tools stayed in the preset for the life of the process. It copies before merging now. This is in the same path the change above feeds, so it ships with it.
