### PR TITLE
feat(listener): support environment skill directories [LET-10735]

### DIFF
--- a/src/cli/subcommands/listen.tsx
+++ b/src/cli/subcommands/listen.tsx
@@ -288,7 +288,7 @@ export async function runListenSubcommand(argv: string[]): Promise<number> {
   }
 
   const debugMode = !!values.debug;
-  const skillsDirectory = values.skills;
+  const skillsDirectory = values.skills ?? process.env.LETTA_SKILLS_DIRECTORY;
 
   // Show help
   if (values.help) {

--- a/src/cli/subcommands/listen.tsx
+++ b/src/cli/subcommands/listen.tsx
@@ -209,6 +209,7 @@ export const __listenSubcommandTestUtils = {
 const LISTEN_OPTIONS = {
   "env-name": { type: "string" },
   channels: { type: "string" },
+  skills: { type: "string" },
   "install-channel-runtimes": { type: "boolean" },
   help: { type: "boolean", short: "h" },
   debug: { type: "boolean" },
@@ -216,7 +217,7 @@ const LISTEN_OPTIONS = {
 
 function printListenUsage(): void {
   console.log(
-    "Usage: letta server [--env-name <name>] [--channels <list>] [--debug]\n",
+    "Usage: letta server [--env-name <name>] [--channels <list>] [--skills <path>] [--debug]\n",
   );
   console.log(
     "Register this letta-code instance to receive messages from Letta Cloud.\n",
@@ -227,6 +228,9 @@ function printListenUsage(): void {
   );
   console.log(
     "  --channels <list>  Comma-separated channel names to enable (e.g. telegram)",
+  );
+  console.log(
+    "  --skills <path>     Use this directory for environment-provided skills",
   );
   console.log(
     "  --install-channel-runtimes  Install missing runtime deps for the selected channels before startup",
@@ -284,6 +288,7 @@ export async function runListenSubcommand(argv: string[]): Promise<number> {
   }
 
   const debugMode = !!values.debug;
+  const skillsDirectory = values.skills;
 
   // Show help
   if (values.help) {
@@ -750,6 +755,7 @@ export async function runListenSubcommand(argv: string[]): Promise<number> {
           supportsSplitStatusChannels: nextSupportsSplitStatusChannels,
           deviceId,
           connectionName,
+          skillsDirectory,
           onWsEvent: shouldLogWsEvents ? wsEventLogger : undefined,
           onStatusChange: (status) => {
             sessionLog.log(`status: ${status}`);
@@ -844,6 +850,7 @@ export async function runListenSubcommand(argv: string[]): Promise<number> {
           supportsSplitStatusChannels: nextSupportsSplitStatusChannels,
           deviceId,
           connectionName,
+          skillsDirectory,
           onWsEvent: shouldLogWsEvents ? wsEventLogger : undefined,
           onStatusChange: (status) => {
             sessionLog.log(`status: ${status}`);

--- a/src/tools/toolset-caching.test.ts
+++ b/src/tools/toolset-caching.test.ts
@@ -20,6 +20,7 @@ describe("listener tool prep metadata reuse", () => {
   });
 
   test("listener turn passes cached agent metadata into reflection and tool prep", () => {
+    const listenSource = readSource("../cli/subcommands/listen.tsx");
     const turnSource = readSource("../websocket/listener/turn.ts");
     const setupSource = readSource("../websocket/listener/turn-setup.ts");
     const completionSource = readSource(
@@ -30,7 +31,13 @@ describe("listener tool prep metadata reuse", () => {
     expect(setupSource).toContain(
       "cachedAgent = (await getBackend().retrieveAgent(",
     );
+    expect(listenSource).toContain('skills: { type: "string" }');
+    expect(listenSource.match(/skillsDirectory,/g)).toHaveLength(2);
     expect(setupSource).toContain("prepareToolExecutionContextForScope({");
+    expect(setupSource).toContain(
+      "skillsDirectory: listenerOptions?.skillsDirectory,",
+    );
+    expect(readSource("./toolset.ts")).toContain("{ skillsDirectory }");
     expect(turnSource).toContain("getCachedAgent: setup.getCachedAgent,");
     expect(completionSource).toContain("buildMaybeLaunchReflectionSubagent({");
     expect(completionSource).toContain("cachedAgent: params.getCachedAgent(),");

--- a/src/tools/toolset-caching.test.ts
+++ b/src/tools/toolset-caching.test.ts
@@ -32,6 +32,7 @@ describe("listener tool prep metadata reuse", () => {
       "cachedAgent = (await getBackend().retrieveAgent(",
     );
     expect(listenSource).toContain('skills: { type: "string" }');
+    expect(listenSource).toContain("process.env.LETTA_SKILLS_DIRECTORY");
     expect(listenSource.match(/skillsDirectory,/g)).toHaveLength(2);
     expect(setupSource).toContain("prepareToolExecutionContextForScope({");
     expect(setupSource).toContain(

--- a/src/tools/toolset.ts
+++ b/src/tools/toolset.ts
@@ -341,6 +341,7 @@ export async function prepareToolExecutionContextForScope(params: {
   externalToolScopeIds?: string[];
   workingDirectory?: string;
   permissionModeState?: PermissionModeState;
+  skillsDirectory?: string;
   skillSources?: SkillSource[];
   cachedAgent?: AgentState | null;
   modContext?: ModContext;
@@ -361,6 +362,7 @@ export async function prepareToolExecutionContextForScope(params: {
     externalToolScopeIds,
     workingDirectory,
     permissionModeState,
+    skillsDirectory,
     skillSources,
     cachedAgent,
     modContext,
@@ -438,6 +440,7 @@ export async function prepareToolExecutionContextForScope(params: {
       agentName: (agent as AgentState).name ?? null,
       conversationId: scopedConversationId,
       workingDirectory,
+      ...(skillsDirectory !== undefined ? { skillsDirectory } : {}),
       ...(skillSources !== undefined ? { skillSources } : {}),
     },
   });

--- a/src/websocket/listener/turn-setup.ts
+++ b/src/websocket/listener/turn-setup.ts
@@ -268,9 +268,10 @@ export async function prepareListenerTurn(params: {
     runtime.listener,
     agentId,
   );
-  const environmentDeviceId = connectionId
-    ? runtime.listener.connections.get(connectionId)?.options.deviceId
-    : undefined;
+  const listenerOptions = connectionId
+    ? runtime.listener.connections.get(connectionId)?.options
+    : runtime.listener.connections.values().next().value?.options;
+  const environmentDeviceId = listenerOptions?.deviceId;
   const preparedToolContext = await prepareToolExecutionContextForScope({
     connectionId,
     environmentDeviceId,
@@ -286,6 +287,7 @@ export async function prepareListenerTurn(params: {
     externalToolScopeIds: msg.externalToolScopeIds,
     workingDirectory,
     permissionModeState,
+    skillsDirectory: listenerOptions?.skillsDirectory,
     skillSources: runtime.skillSources,
     cachedAgent,
     modContext: createListenerAgentModContext(agentId),

--- a/src/websocket/listener/types.ts
+++ b/src/websocket/listener/types.ts
@@ -41,6 +41,7 @@ export interface StartListenerOptions {
   supportsSplitStatusChannels?: boolean;
   deviceId: string;
   connectionName: string;
+  skillsDirectory?: string;
   onConnected: (connectionId: string) => void | Promise<void>;
   onDisconnected: () => void;
   onNeedsReregister?: () => void;


### PR DESCRIPTION
## Summary

- accept `--skills <path>` on remote listeners
- also accept `LETTA_SKILLS_DIRECTORY` so managed runtimes can roll out the setting without breaking older listener builds
- carry the selected directory into each turn’s tool context
- preserve the existing precedence where project skills remain above the explicit directory, followed by agent, global, and bundled skills
- cover the listener-to-tool-context wiring with a focused regression test

Validated with `bun run check`, the focused test, and a live `remote --help` invocation.

👾 Generated with [Letta Code](https://letta.com)