### PR TITLE
feat(channels): export lifecycle-error formatting for external channel hosts

### DIFF
--- a/src/channels-public.ts
+++ b/src/channels-public.ts
@@ -12,6 +12,20 @@ export {
   LettaStreamNoAssistantMessageError,
 } from "./channels/core-stream";
 export type {
+  ChannelLifecycleErrorDisplay,
+  ChannelLifecycleErrorDisplayOptions,
+  ChannelLifecycleErrorFormatOptions,
+  ChannelLifecycleErrorKind,
+} from "./channels/lifecycle-error";
+export {
+  CHANNEL_LIFECYCLE_FALLBACK_ERROR_MESSAGE,
+  extractChannelLifecycleRunId,
+  formatChannelLifecycleErrorMessage,
+  getChannelLifecycleErrorDisplay,
+  normalizeChannelLifecycleErrorMessage,
+  sanitizeChannelLifecycleErrorText,
+} from "./channels/lifecycle-error";
+export type {
   ChannelMessageActionAdapter,
   ChannelMessageActionContext,
   ChannelMessageActionRequest,

--- a/src/channels-slack.ts
+++ b/src/channels-slack.ts
@@ -19,6 +19,10 @@ export {
 export type { CreateSlackMessageActionAdapterOptions } from "./channels/slack/message-action-contract";
 export { createSlackMessageActionAdapter } from "./channels/slack/message-action-contract";
 export {
+  formatSlackLifecycleErrorMessage,
+  shouldPostSlackTerminalError,
+} from "./channels/slack/presentation";
+export {
   resolveSlackConcreteActivity,
   SLACK_ASSISTANT_STARTUP_STATUS,
   SLACK_ASSISTANT_WORKING_STATUS,


### PR DESCRIPTION
## What

Letta Cloud's Slack gateway renders turn errors with its own ~8-line formatter (`Turn failed:` + raw text, or a generic server-issue line), so errors read differently from `letta server --channel` even though both run the exported `ChannelGateway`. The formatter (sanitization, error kinds like approval-pending / conversation-busy / db-lock, titles, run IDs, fallback copy) lives in the channel host and was never exported.

This PR adds it to the exported surface, no behavior change for the local host:

- `@letta-ai/letta-code/channels/slack`: `formatSlackLifecycleErrorMessage`, `shouldPostSlackTerminalError` (exactly what the local Slack adapter renders/gates with).
- `@letta-ai/letta-code/channels` (public): the generic lifecycle-error API — `getChannelLifecycleErrorDisplay`, `formatChannelLifecycleErrorMessage`, `normalizeChannelLifecycleErrorMessage`, `sanitizeChannelLifecycleErrorText`, `extractChannelLifecycleRunId`, fallback constant, and types — for any external host.

## Follow-ups

- letta-cloud consumes `formatSlackLifecycleErrorMessage` in its gateway Slack adapter (replacing `formatCloudSlackLifecycleError`) once this ships in a release.
- Slash-command parity (Cloud has /help /agent /config /convo; the channel host has the full set) is a separate design item: `channels/commands.ts` is entangled with the host plugin registry and command handlers need per-host execution adapters, so it can't be exported as-is.

## Validation

`bun run check`: all 12 checks pass (cycles, boundaries, biome, tsc, etc.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)