### PR TITLE
feat(channels): export the slash-command surface for external channel hosts

### DIFF
--- a/src/channels-public.ts
+++ b/src/channels-public.ts
@@ -1,4 +1,20 @@
 export type {
+  ChannelDisplayNameResolver,
+  ChannelSlashCommandDefinition,
+  ChannelSlashCommandHandlerResult,
+  ChannelSlashCommandHandlers,
+  ChannelSlashCommandKind,
+  ParsedChannelSlashCommand,
+} from "./channels/command-surface";
+export {
+  buildChannelHelpMessage,
+  buildUnsupportedChannelCommandMessage,
+  defaultChannelDisplayName,
+  listChannelSlashCommands,
+  parseChannelBangCommand,
+  parseChannelSlashCommand,
+} from "./channels/command-surface";
+export type {
   CollectLettaSseAssistantTextOptions,
   CollectLettaSseAssistantTextResult,
   FormatLettaStreamCoreErrorOptions,

--- a/src/channels/command-surface.test.ts
+++ b/src/channels/command-surface.test.ts
@@ -1,0 +1,207 @@
+import { describe, expect, test } from "bun:test";
+import {
+  buildChannelHelpMessage,
+  buildUnsupportedChannelCommandMessage,
+  defaultChannelDisplayName,
+  listChannelSlashCommands,
+  parseChannelBangCommand,
+  parseChannelSlashCommand,
+} from "@/channels/command-surface";
+import {
+  buildChannelHelpMessage as buildChannelHelpMessageLocal,
+  buildUnsupportedChannelCommandMessage as buildUnsupportedChannelCommandMessageLocal,
+} from "@/channels/commands";
+
+describe("listChannelSlashCommands", () => {
+  test("lists the full command surface in order", () => {
+    expect(listChannelSlashCommands().map((command) => command.name)).toEqual([
+      "help",
+      "status",
+      "whoami",
+      "pause",
+      "resume",
+      "cancel",
+      "chat",
+      "feedback",
+      "model",
+      "reflection",
+      "reload",
+    ]);
+  });
+
+  test("includes aliases and kinds", () => {
+    const byName = new Map(
+      listChannelSlashCommands().map((command) => [command.name, command]),
+    );
+    expect(byName.get("reflection")?.aliases).toEqual(["reflect"]);
+    expect(byName.get("model")?.kind).toBe("agent-scoped");
+    expect(byName.get("help")?.kind).toBe("direct");
+    for (const command of byName.values()) {
+      expect(command.summary.length).toBeGreaterThan(0);
+    }
+  });
+
+  test("returns fresh copies so callers cannot mutate the registry", () => {
+    const first = listChannelSlashCommands();
+    const firstEntry = first[0];
+    expect(firstEntry).toBeDefined();
+    if (firstEntry) {
+      firstEntry.name = "mutated";
+    }
+    first.find((command) => command.aliases)?.aliases?.push("mutated-alias");
+    const second = listChannelSlashCommands();
+    expect(second[0]?.name).toBe("help");
+    expect(
+      second.find((command) => command.name === "reflection")?.aliases,
+    ).toEqual(["reflect"]);
+  });
+});
+
+describe("parseChannelSlashCommand", () => {
+  test("parses name, args, and raw text", () => {
+    expect(parseChannelSlashCommand("/model list")).toEqual({
+      name: "model",
+      args: "list",
+      raw: "/model list",
+    });
+  });
+
+  test("lowercases the command name and strips bot suffixes", () => {
+    expect(parseChannelSlashCommand("/Help@letta_bot")).toMatchObject({
+      name: "help",
+      args: "",
+    });
+  });
+
+  test("returns null for normal messages and bang commands", () => {
+    expect(parseChannelSlashCommand("hello there")).toBeNull();
+    expect(parseChannelSlashCommand("!help")).toBeNull();
+    expect(parseChannelSlashCommand("")).toBeNull();
+  });
+
+  test("keeps continuation lines as args", () => {
+    expect(
+      parseChannelSlashCommand("/feedback first line\nsecond line"),
+    ).toEqual({
+      name: "feedback",
+      args: "first line\nsecond line",
+      raw: "/feedback first line",
+    });
+  });
+
+  test("ignores stacked duplicate command lines", () => {
+    expect(parseChannelSlashCommand("/status\n/status")).toEqual({
+      name: "status",
+      args: "",
+      raw: "/status",
+    });
+  });
+});
+
+describe("parseChannelBangCommand", () => {
+  test("parses bang commands", () => {
+    expect(parseChannelBangCommand("!model sonnet")).toEqual({
+      name: "model",
+      args: "sonnet",
+      raw: "!model sonnet",
+    });
+  });
+
+  test("returns null for slash commands and plain text", () => {
+    expect(parseChannelBangCommand("/model")).toBeNull();
+    expect(parseChannelBangCommand("model")).toBeNull();
+  });
+});
+
+describe("defaultChannelDisplayName", () => {
+  test("maps first-party channel ids to display names", () => {
+    expect(defaultChannelDisplayName("slack")).toBe("Slack");
+    expect(defaultChannelDisplayName("telegram")).toBe("Telegram");
+    expect(defaultChannelDisplayName("whatsapp")).toBe("WhatsApp");
+  });
+
+  test("falls back to the raw channel id", () => {
+    expect(defaultChannelDisplayName("my-custom-channel")).toBe(
+      "my-custom-channel",
+    );
+  });
+});
+
+describe("buildChannelHelpMessage", () => {
+  test("renders slack mention guidance with the default resolver", () => {
+    const message = buildChannelHelpMessage("slack");
+    expect(message).toStartWith("Slack is connected to Letta Code.");
+    expect(message).toContain("@agent /model <handle-or-id>");
+    expect(message).toContain("Legacy bang aliases still work after a mention");
+  });
+
+  test("renders the generic slash command list for other channels", () => {
+    const message = buildChannelHelpMessage("telegram");
+    expect(message).toStartWith("Telegram is connected to Letta Code.");
+    expect(message).toContain(
+      "Supported slash commands here: /help, /status, /whoami, /pause, /resume, /cancel, /chat, /feedback, /model, /reflection, /reload.",
+    );
+  });
+
+  test("uses an injected display-name resolver", () => {
+    const message = buildChannelHelpMessage(
+      "telegram",
+      (channelId) => `Cloud ${channelId}`,
+    );
+    expect(message).toStartWith("Cloud telegram is connected to Letta Code.");
+  });
+
+  test("matches the local host rendering for first-party channels", () => {
+    expect(buildChannelHelpMessage("slack")).toBe(
+      buildChannelHelpMessageLocal("slack"),
+    );
+    expect(buildChannelHelpMessage("telegram")).toBe(
+      buildChannelHelpMessageLocal("telegram"),
+    );
+  });
+});
+
+describe("buildUnsupportedChannelCommandMessage", () => {
+  test("lists slash commands for unknown slash commands", () => {
+    const command = parseChannelSlashCommand("/bogus now");
+    expect(command).not.toBeNull();
+    if (!command) return;
+    const message = buildUnsupportedChannelCommandMessage("telegram", command);
+    expect(message).toContain(
+      "Telegram received /bogus now, but that slash command is not supported in channels yet.",
+    );
+    expect(message).toContain("Supported slash commands: /help,");
+  });
+
+  test("lists mention examples for unknown slack slash commands", () => {
+    const command = parseChannelSlashCommand("/bogus");
+    expect(command).not.toBeNull();
+    if (!command) return;
+    const message = buildUnsupportedChannelCommandMessage("slack", command);
+    expect(message).toContain(
+      "Supported Slack mention commands: @agent /help,",
+    );
+  });
+
+  test("lists bang aliases for unknown bang commands", () => {
+    const command = parseChannelBangCommand("!bogus");
+    expect(command).not.toBeNull();
+    if (!command) return;
+    const message = buildUnsupportedChannelCommandMessage("slack", command);
+    expect(message).toContain(
+      "Supported bang commands: !help, !detach, !model, !new, !reload.",
+    );
+  });
+
+  test("uses an injected display-name resolver and matches local rendering", () => {
+    const command = parseChannelSlashCommand("/bogus");
+    expect(command).not.toBeNull();
+    if (!command) return;
+    expect(
+      buildUnsupportedChannelCommandMessage("slack", command, () => "Custom"),
+    ).toStartWith("Custom received /bogus,");
+    expect(buildUnsupportedChannelCommandMessage("slack", command)).toBe(
+      buildUnsupportedChannelCommandMessageLocal("slack", command),
+    );
+  });
+});

--- a/src/channels/command-surface.ts
+++ b/src/channels/command-surface.ts
@@ -1,0 +1,353 @@
+/**
+ * Pure channel slash-command surface: the command list, parsing, help text,
+ * and unknown-command messaging shared by every channel host.
+ *
+ * This module must stay free of host-local dependencies (plugin registry,
+ * adapters, feedback handlers) so external channel hosts — e.g. Letta Cloud's
+ * Slack gateway — can render the exact same command surface as
+ * `letta server --channel`. Command execution stays host-injected via
+ * `ChannelSlashCommandHandlers`.
+ */
+
+import type { ChannelModelPickerData, InboundChannelMessage } from "./types";
+
+export type ChannelSlashCommandKind = "direct" | "agent-scoped";
+
+export type ParsedChannelSlashCommand = {
+  name: string;
+  args: string;
+  raw: string;
+};
+
+export type ChannelSlashCommandDefinition = {
+  name: string;
+  aliases?: string[];
+  kind: ChannelSlashCommandKind;
+  summary: string;
+};
+
+export type ChannelSlashCommandHandlerResult = {
+  handled: boolean;
+  text?: string;
+  modelPicker?: ChannelModelPickerData;
+};
+
+export type ChannelSlashCommandHandlers = {
+  cancel?: (
+    command: ParsedChannelSlashCommand,
+    msg: InboundChannelMessage,
+  ) => Promise<ChannelSlashCommandHandlerResult>;
+  chat?: (
+    command: ParsedChannelSlashCommand,
+    msg: InboundChannelMessage,
+  ) => Promise<ChannelSlashCommandHandlerResult>;
+  detach?: (
+    command: ParsedChannelSlashCommand,
+    msg: InboundChannelMessage,
+  ) => Promise<ChannelSlashCommandHandlerResult>;
+  model?: (
+    command: ParsedChannelSlashCommand,
+    msg: InboundChannelMessage,
+  ) => Promise<ChannelSlashCommandHandlerResult>;
+  newConversation?: (
+    command: ParsedChannelSlashCommand,
+    msg: InboundChannelMessage,
+  ) => Promise<ChannelSlashCommandHandlerResult>;
+  pause?: (
+    command: ParsedChannelSlashCommand,
+    msg: InboundChannelMessage,
+  ) => Promise<ChannelSlashCommandHandlerResult>;
+  reflection?: (
+    command: ParsedChannelSlashCommand,
+    msg: InboundChannelMessage,
+  ) => Promise<ChannelSlashCommandHandlerResult>;
+  reload?: (
+    command: ParsedChannelSlashCommand,
+    msg: InboundChannelMessage,
+  ) => Promise<ChannelSlashCommandHandlerResult>;
+  resume?: (
+    command: ParsedChannelSlashCommand,
+    msg: InboundChannelMessage,
+  ) => Promise<ChannelSlashCommandHandlerResult>;
+};
+
+/** Resolves a channel id (e.g. "slack") to its human display name. */
+export type ChannelDisplayNameResolver = (channelId: string) => string;
+
+const DEFAULT_CHANNEL_DISPLAY_NAMES: Readonly<Record<string, string>> = {
+  custom: "Custom",
+  discord: "Discord",
+  signal: "Signal",
+  slack: "Slack",
+  telegram: "Telegram",
+  whatsapp: "WhatsApp",
+};
+
+/**
+ * Default display-name resolver: first-party channel display names, falling
+ * back to the raw channel id. Hosts with a richer registry (e.g. user-installed
+ * channel plugins) should inject their own resolver.
+ */
+export function defaultChannelDisplayName(channelId: string): string {
+  return DEFAULT_CHANNEL_DISPLAY_NAMES[channelId] ?? channelId;
+}
+
+const CHANNEL_SLASH_COMMANDS: ChannelSlashCommandDefinition[] = [
+  {
+    name: "help",
+    kind: "direct",
+    summary: "Show channel usage guidance.",
+  },
+  {
+    name: "status",
+    kind: "direct",
+    summary: "Show this chat's channel connection status.",
+  },
+  {
+    name: "whoami",
+    kind: "direct",
+    summary: "Show your access tier and runnable commands here.",
+  },
+  {
+    name: "pause",
+    kind: "direct",
+    summary: "Pause agent routing for this chat.",
+  },
+  {
+    name: "resume",
+    kind: "direct",
+    summary: "Resume agent routing for this chat.",
+  },
+  {
+    name: "cancel",
+    kind: "agent-scoped",
+    summary: "Cancel the in-progress agent turn for this chat.",
+  },
+  {
+    name: "chat",
+    kind: "direct",
+    summary: "Show the Letta web chat link for this channel route.",
+  },
+  {
+    name: "feedback",
+    kind: "direct",
+    summary: "Send feedback about Letta Code from this routed chat.",
+  },
+  {
+    name: "model",
+    kind: "agent-scoped",
+    summary:
+      "Show, list, or switch the model for this chat's routed conversation.",
+  },
+  {
+    name: "reflection",
+    aliases: ["reflect"],
+    kind: "agent-scoped",
+    summary: "Start a memory reflection pass for this conversation.",
+  },
+  {
+    name: "reload",
+    kind: "agent-scoped",
+    summary: "Reload settings, local mods, and agent secrets.",
+  },
+];
+
+const SLACK_MENTION_COMMAND_NAMES = [
+  "help",
+  "detach",
+  "model",
+  "new",
+  "reload",
+] as const;
+
+export function listChannelSlashCommands(): ChannelSlashCommandDefinition[] {
+  return CHANNEL_SLASH_COMMANDS.map((definition) => ({
+    ...definition,
+    aliases: definition.aliases ? [...definition.aliases] : undefined,
+  }));
+}
+
+type ChannelCommandPrefix = "/" | "!";
+
+function parseSingleLineChannelCommand(
+  text: string,
+  prefix: ChannelCommandPrefix,
+): ParsedChannelSlashCommand | null {
+  const trimmed = text.trim();
+  const escapedPrefix = prefix === "/" ? "\\/" : "!";
+  const match = trimmed.match(
+    new RegExp(
+      `^${escapedPrefix}([A-Za-z][\\w-]*)(?:@[A-Za-z0-9_]+)?(?:[^\\S\\r\\n]+(.*))?$`,
+    ),
+  );
+  if (!match) {
+    return null;
+  }
+  const [, name, args] = match;
+  if (!name) {
+    return null;
+  }
+
+  return {
+    name: name.toLowerCase(),
+    args: args?.trim() ?? "",
+    raw: trimmed,
+  };
+}
+
+function parseAnySingleLineChannelCommand(
+  text: string,
+): ParsedChannelSlashCommand | null {
+  return (
+    parseSingleLineChannelCommand(text, "/") ??
+    parseSingleLineChannelCommand(text, "!")
+  );
+}
+
+function parseChannelCommand(
+  text: string,
+  prefix: ChannelCommandPrefix,
+): ParsedChannelSlashCommand | null {
+  const lines = text
+    .trim()
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+  const [firstLine, ...remainingLines] = lines;
+  if (!firstLine) {
+    return null;
+  }
+
+  const firstCommand = parseSingleLineChannelCommand(firstLine, prefix);
+  if (!firstCommand) {
+    return null;
+  }
+
+  // Debounced channel input can stack duplicate Slack event copies. If a later
+  // line is another channel command, never treat it as the first command's arg.
+  const laterCommand = remainingLines.find((line) =>
+    Boolean(parseAnySingleLineChannelCommand(line)),
+  );
+  if (laterCommand) {
+    return firstCommand;
+  }
+
+  const continuationArgs = remainingLines.join("\n").trim();
+  if (!continuationArgs) {
+    return firstCommand;
+  }
+  return {
+    ...firstCommand,
+    args: [firstCommand.args, continuationArgs]
+      .filter((part) => part.length > 0)
+      .join("\n"),
+  };
+}
+
+export function parseChannelSlashCommand(
+  text: string,
+): ParsedChannelSlashCommand | null {
+  return parseChannelCommand(text, "/");
+}
+
+export function parseChannelBangCommand(
+  text: string,
+): ParsedChannelSlashCommand | null {
+  return parseChannelCommand(text, "!");
+}
+
+function supportedCommandsText(prefix: "/" | "!" = "/"): string {
+  return listChannelSlashCommands()
+    .map((definition) => `${prefix}${definition.name}`)
+    .join(", ");
+}
+
+const SLACK_MENTION_SLASH_COMMAND_EXAMPLES = [
+  "@agent /help",
+  "@agent /status",
+  "@agent /whoami",
+  "@agent /model",
+  "@agent /model list",
+  "@agent /model <handle-or-id>",
+  "@agent /cancel",
+  "@agent /chat",
+  "@agent /feedback <message>",
+  "@agent /reflection",
+  "@agent /detach",
+  "@agent /new",
+  "@agent /reload",
+] as const;
+
+function supportedSlackMentionSlashCommandsText(): string {
+  return SLACK_MENTION_SLASH_COMMAND_EXAMPLES.join(", ");
+}
+
+function supportedBangCommandsText(): string {
+  return SLACK_MENTION_COMMAND_NAMES.map((name) => `!${name}`).join(", ");
+}
+
+export function isSupportedSlackMentionCommand(commandName: string): boolean {
+  return SLACK_MENTION_COMMAND_NAMES.includes(
+    commandName as (typeof SLACK_MENTION_COMMAND_NAMES)[number],
+  );
+}
+
+export function buildChannelHelpMessage(
+  channelId: string,
+  resolveDisplayName: ChannelDisplayNameResolver = defaultChannelDisplayName,
+): string {
+  const displayName = resolveDisplayName(channelId);
+
+  if (channelId === "slack") {
+    return [
+      `${displayName} is connected to Letta Code.`,
+      "Talk by mentioning the app in a channel thread. Once a thread is routed, normal replies continue the same agent conversation until detached.",
+      "Control commands start immediately after the mention:",
+      "@agent /model - show this thread's current model",
+      "@agent /model list - show available models",
+      "@agent /model <handle-or-id> - switch this thread's model",
+      "@agent /status - show route and listener status",
+      "@agent /cancel - cancel the current turn",
+      "@agent /chat - show the web chat link",
+      "@agent /feedback <message> - send feedback to the Letta team from this routed thread",
+      "@agent /reflection - start a memory reflection pass",
+      "@agent /detach - stop replying in this thread until mentioned again",
+      "@agent /new - start a fresh conversation for this thread",
+      "@agent /reload - reload settings, local mods, and agent secrets",
+      `Legacy bang aliases still work after a mention: ${supportedBangCommandsText()}.`,
+      "If this chat is not connected yet, send a normal message and follow the pairing instructions.",
+    ].join("\n");
+  }
+
+  return [
+    `${displayName} is connected to Letta Code.`,
+    "Send a normal message here and the connected agent will reply in this chat.",
+    `Supported slash commands here: ${supportedCommandsText()}.`,
+    "If this chat is not connected yet, send any non-command message and follow the pairing instructions.",
+  ].join("\n\n");
+}
+
+export function buildUnsupportedChannelCommandMessage(
+  channelId: string,
+  command: ParsedChannelSlashCommand,
+  resolveDisplayName: ChannelDisplayNameResolver = defaultChannelDisplayName,
+): string {
+  const displayName = resolveDisplayName(channelId);
+  const isBang = command.raw.startsWith("!");
+  const commandKind = isBang ? "bang" : "slash";
+  const supportedCommands = isBang
+    ? supportedBangCommandsText()
+    : channelId === "slack"
+      ? supportedSlackMentionSlashCommandsText()
+      : supportedCommandsText();
+  const supportedLabel =
+    channelId === "slack" && !isBang
+      ? "Slack mention commands"
+      : `${commandKind} commands`;
+
+  return [
+    `${displayName} received ${command.raw}, but that ${commandKind} command is not supported in channels yet.`,
+    `Supported ${supportedLabel}: ${supportedCommands}.`,
+    `Send normal messages without a leading ${isBang ? "bang" : "slash"} command to talk to the connected agent.`,
+  ].join("\n\n");
+}

--- a/src/channels/commands.ts
+++ b/src/channels/commands.ts
@@ -6,6 +6,16 @@ import {
   canonicalizeChannelCommandName,
   canRunChannelCommand,
 } from "./access-control";
+import {
+  buildChannelHelpMessage as buildChannelHelpMessageWith,
+  buildUnsupportedChannelCommandMessage as buildUnsupportedChannelCommandMessageWith,
+  type ChannelSlashCommandHandlerResult,
+  type ChannelSlashCommandHandlers,
+  isSupportedSlackMentionCommand,
+  type ParsedChannelSlashCommand,
+  parseChannelBangCommand,
+  parseChannelSlashCommand,
+} from "./command-surface";
 import { handleChannelFeedbackCommand } from "./feedback";
 import { getChannelDisplayName } from "./plugin-registry";
 import { buildDirectReplyOptions } from "./registry-presentation";
@@ -16,69 +26,22 @@ import type {
   InboundChannelMessage,
 } from "./types";
 
-export type ChannelSlashCommandKind = "direct" | "agent-scoped";
-
-export type ParsedChannelSlashCommand = {
-  name: string;
-  args: string;
-  raw: string;
-};
-
-export type ChannelSlashCommandDefinition = {
-  name: string;
-  aliases?: string[];
-  kind: ChannelSlashCommandKind;
-  summary: string;
-};
-
-export type ChannelSlashCommandHandlerResult = {
-  handled: boolean;
-  text?: string;
-  modelPicker?: ChannelModelPickerData;
-};
+export type {
+  ChannelSlashCommandDefinition,
+  ChannelSlashCommandHandlerResult,
+  ChannelSlashCommandHandlers,
+  ChannelSlashCommandKind,
+  ParsedChannelSlashCommand,
+} from "./command-surface";
+export {
+  listChannelSlashCommands,
+  parseChannelBangCommand,
+  parseChannelSlashCommand,
+} from "./command-surface";
 
 type ChannelDirectReplyPayload = {
   text: string;
   modelPicker?: ChannelModelPickerData;
-};
-
-export type ChannelSlashCommandHandlers = {
-  cancel?: (
-    command: ParsedChannelSlashCommand,
-    msg: InboundChannelMessage,
-  ) => Promise<ChannelSlashCommandHandlerResult>;
-  chat?: (
-    command: ParsedChannelSlashCommand,
-    msg: InboundChannelMessage,
-  ) => Promise<ChannelSlashCommandHandlerResult>;
-  detach?: (
-    command: ParsedChannelSlashCommand,
-    msg: InboundChannelMessage,
-  ) => Promise<ChannelSlashCommandHandlerResult>;
-  model?: (
-    command: ParsedChannelSlashCommand,
-    msg: InboundChannelMessage,
-  ) => Promise<ChannelSlashCommandHandlerResult>;
-  newConversation?: (
-    command: ParsedChannelSlashCommand,
-    msg: InboundChannelMessage,
-  ) => Promise<ChannelSlashCommandHandlerResult>;
-  pause?: (
-    command: ParsedChannelSlashCommand,
-    msg: InboundChannelMessage,
-  ) => Promise<ChannelSlashCommandHandlerResult>;
-  reflection?: (
-    command: ParsedChannelSlashCommand,
-    msg: InboundChannelMessage,
-  ) => Promise<ChannelSlashCommandHandlerResult>;
-  reload?: (
-    command: ParsedChannelSlashCommand,
-    msg: InboundChannelMessage,
-  ) => Promise<ChannelSlashCommandHandlerResult>;
-  resume?: (
-    command: ParsedChannelSlashCommand,
-    msg: InboundChannelMessage,
-  ) => Promise<ChannelSlashCommandHandlerResult>;
 };
 
 export type ChannelStatusContext = {
@@ -96,212 +59,12 @@ export type ChannelSlashCommandOptions = {
   commandGate?: ChannelCommandGate;
 };
 
-const CHANNEL_SLASH_COMMANDS: ChannelSlashCommandDefinition[] = [
-  {
-    name: "help",
-    kind: "direct",
-    summary: "Show channel usage guidance.",
-  },
-  {
-    name: "status",
-    kind: "direct",
-    summary: "Show this chat's channel connection status.",
-  },
-  {
-    name: "whoami",
-    kind: "direct",
-    summary: "Show your access tier and runnable commands here.",
-  },
-  {
-    name: "pause",
-    kind: "direct",
-    summary: "Pause agent routing for this chat.",
-  },
-  {
-    name: "resume",
-    kind: "direct",
-    summary: "Resume agent routing for this chat.",
-  },
-  {
-    name: "cancel",
-    kind: "agent-scoped",
-    summary: "Cancel the in-progress agent turn for this chat.",
-  },
-  {
-    name: "chat",
-    kind: "direct",
-    summary: "Show the Letta web chat link for this channel route.",
-  },
-  {
-    name: "feedback",
-    kind: "direct",
-    summary: "Send feedback about Letta Code from this routed chat.",
-  },
-  {
-    name: "model",
-    kind: "agent-scoped",
-    summary:
-      "Show, list, or switch the model for this chat's routed conversation.",
-  },
-  {
-    name: "reflection",
-    aliases: ["reflect"],
-    kind: "agent-scoped",
-    summary: "Start a memory reflection pass for this conversation.",
-  },
-  {
-    name: "reload",
-    kind: "agent-scoped",
-    summary: "Reload settings, local mods, and agent secrets.",
-  },
-];
-
-const SLACK_MENTION_COMMAND_NAMES = [
-  "help",
-  "detach",
-  "model",
-  "new",
-  "reload",
-] as const;
-
 function channelDisplayName(channelId: string): string {
   try {
     return getChannelDisplayName(channelId);
   } catch {
     return channelId;
   }
-}
-
-export function listChannelSlashCommands(): ChannelSlashCommandDefinition[] {
-  return CHANNEL_SLASH_COMMANDS.map((definition) => ({
-    ...definition,
-    aliases: definition.aliases ? [...definition.aliases] : undefined,
-  }));
-}
-
-type ChannelCommandPrefix = "/" | "!";
-
-function parseSingleLineChannelCommand(
-  text: string,
-  prefix: ChannelCommandPrefix,
-): ParsedChannelSlashCommand | null {
-  const trimmed = text.trim();
-  const escapedPrefix = prefix === "/" ? "\\/" : "!";
-  const match = trimmed.match(
-    new RegExp(
-      `^${escapedPrefix}([A-Za-z][\\w-]*)(?:@[A-Za-z0-9_]+)?(?:[^\\S\\r\\n]+(.*))?$`,
-    ),
-  );
-  if (!match) {
-    return null;
-  }
-  const [, name, args] = match;
-  if (!name) {
-    return null;
-  }
-
-  return {
-    name: name.toLowerCase(),
-    args: args?.trim() ?? "",
-    raw: trimmed,
-  };
-}
-
-function parseAnySingleLineChannelCommand(
-  text: string,
-): ParsedChannelSlashCommand | null {
-  return (
-    parseSingleLineChannelCommand(text, "/") ??
-    parseSingleLineChannelCommand(text, "!")
-  );
-}
-
-function parseChannelCommand(
-  text: string,
-  prefix: ChannelCommandPrefix,
-): ParsedChannelSlashCommand | null {
-  const lines = text
-    .trim()
-    .split(/\r?\n/)
-    .map((line) => line.trim())
-    .filter((line) => line.length > 0);
-  const [firstLine, ...remainingLines] = lines;
-  if (!firstLine) {
-    return null;
-  }
-
-  const firstCommand = parseSingleLineChannelCommand(firstLine, prefix);
-  if (!firstCommand) {
-    return null;
-  }
-
-  // Debounced channel input can stack duplicate Slack event copies. If a later
-  // line is another channel command, never treat it as the first command's arg.
-  const laterCommand = remainingLines.find((line) =>
-    Boolean(parseAnySingleLineChannelCommand(line)),
-  );
-  if (laterCommand) {
-    return firstCommand;
-  }
-
-  const continuationArgs = remainingLines.join("\n").trim();
-  if (!continuationArgs) {
-    return firstCommand;
-  }
-  return {
-    ...firstCommand,
-    args: [firstCommand.args, continuationArgs]
-      .filter((part) => part.length > 0)
-      .join("\n"),
-  };
-}
-
-export function parseChannelSlashCommand(
-  text: string,
-): ParsedChannelSlashCommand | null {
-  return parseChannelCommand(text, "/");
-}
-
-export function parseChannelBangCommand(
-  text: string,
-): ParsedChannelSlashCommand | null {
-  return parseChannelCommand(text, "!");
-}
-
-function supportedCommandsText(prefix: "/" | "!" = "/"): string {
-  return listChannelSlashCommands()
-    .map((definition) => `${prefix}${definition.name}`)
-    .join(", ");
-}
-
-const SLACK_MENTION_SLASH_COMMAND_EXAMPLES = [
-  "@agent /help",
-  "@agent /status",
-  "@agent /whoami",
-  "@agent /model",
-  "@agent /model list",
-  "@agent /model <handle-or-id>",
-  "@agent /cancel",
-  "@agent /chat",
-  "@agent /feedback <message>",
-  "@agent /reflection",
-  "@agent /detach",
-  "@agent /new",
-  "@agent /reload",
-] as const;
-
-function supportedSlackMentionSlashCommandsText(): string {
-  return SLACK_MENTION_SLASH_COMMAND_EXAMPLES.join(", ");
-}
-
-function supportedBangCommandsText(): string {
-  return SLACK_MENTION_COMMAND_NAMES.map((name) => `!${name}`).join(", ");
-}
-
-function isSupportedSlackMentionCommand(commandName: string): boolean {
-  return SLACK_MENTION_COMMAND_NAMES.includes(
-    commandName as (typeof SLACK_MENTION_COMMAND_NAMES)[number],
-  );
 }
 
 function isSlackMentionSlashCommand(
@@ -325,59 +88,18 @@ function isSlackMentionControlCommand(
 }
 
 export function buildChannelHelpMessage(channelId: string): string {
-  const displayName = channelDisplayName(channelId);
-
-  if (channelId === "slack") {
-    return [
-      `${displayName} is connected to Letta Code.`,
-      "Talk by mentioning the app in a channel thread. Once a thread is routed, normal replies continue the same agent conversation until detached.",
-      "Control commands start immediately after the mention:",
-      "@agent /model - show this thread's current model",
-      "@agent /model list - show available models",
-      "@agent /model <handle-or-id> - switch this thread's model",
-      "@agent /status - show route and listener status",
-      "@agent /cancel - cancel the current turn",
-      "@agent /chat - show the web chat link",
-      "@agent /feedback <message> - send feedback to the Letta team from this routed thread",
-      "@agent /reflection - start a memory reflection pass",
-      "@agent /detach - stop replying in this thread until mentioned again",
-      "@agent /new - start a fresh conversation for this thread",
-      "@agent /reload - reload settings, local mods, and agent secrets",
-      `Legacy bang aliases still work after a mention: ${supportedBangCommandsText()}.`,
-      "If this chat is not connected yet, send a normal message and follow the pairing instructions.",
-    ].join("\n");
-  }
-
-  return [
-    `${displayName} is connected to Letta Code.`,
-    "Send a normal message here and the connected agent will reply in this chat.",
-    `Supported slash commands here: ${supportedCommandsText()}.`,
-    "If this chat is not connected yet, send any non-command message and follow the pairing instructions.",
-  ].join("\n\n");
+  return buildChannelHelpMessageWith(channelId, channelDisplayName);
 }
 
 export function buildUnsupportedChannelCommandMessage(
   channelId: string,
   command: ParsedChannelSlashCommand,
 ): string {
-  const displayName = channelDisplayName(channelId);
-  const isBang = command.raw.startsWith("!");
-  const commandKind = isBang ? "bang" : "slash";
-  const supportedCommands = isBang
-    ? supportedBangCommandsText()
-    : channelId === "slack"
-      ? supportedSlackMentionSlashCommandsText()
-      : supportedCommandsText();
-  const supportedLabel =
-    channelId === "slack" && !isBang
-      ? "Slack mention commands"
-      : `${commandKind} commands`;
-
-  return [
-    `${displayName} received ${command.raw}, but that ${commandKind} command is not supported in channels yet.`,
-    `Supported ${supportedLabel}: ${supportedCommands}.`,
-    `Send normal messages without a leading ${isBang ? "bang" : "slash"} command to talk to the connected agent.`,
-  ].join("\n\n");
+  return buildUnsupportedChannelCommandMessageWith(
+    channelId,
+    command,
+    channelDisplayName,
+  );
 }
 
 export function buildChannelStatusMessage(


### PR DESCRIPTION
## Goal: one command-surface bottleneck

External channel hosts — first consumer: Letta Cloud's Slack gateway — must render the **same** slash-command surface as `letta server --channel`: the command list, slash/bang parsing, help text, and unknown-command messaging. Today Cloud maintains its own 4-command registry that drifts from this package. With this PR, Cloud deletes that registry and imports the surface from `@letta-ai/letta-code/channels`, supplying only its own execution handlers. Per product decision, all commands are exposed to all users, so no access-control surface is exported.

This is a sibling of #3726, which exported the lifecycle-error formatter through the same `channels-public` bottleneck. Command **execution** stays host-injected via `ChannelSlashCommandHandlers`.

## What changed

- **New `src/channels/command-surface.ts`** — the pure surface, moved verbatim out of `src/channels/commands.ts`:
  - `ChannelSlashCommandDefinition` list + `listChannelSlashCommands()`
  - `parseChannelSlashCommand` / `parseChannelBangCommand` (incl. multiline continuation and stacked-duplicate handling)
  - `buildChannelHelpMessage` / `buildUnsupportedChannelCommandMessage`
  - `ChannelSlashCommandKind`, `ParsedChannelSlashCommand`, `ChannelSlashCommandHandlerResult`, `ChannelSlashCommandHandlers` types
  - The only host-local dependency (plugin-registry display names) is now an injectable `ChannelDisplayNameResolver` parameter defaulting to `defaultChannelDisplayName` (first-party display names, falling back to the raw channel id).
- **`src/channels/commands.ts`** re-imports/re-exports the moved symbols and wraps the two display-name-dependent builders with the plugin-registry resolver, so local host behavior is **byte-identical** (user-installed plugin display names keep working). Execution (`tryHandleChannelSlashCommand`), status/model/pause/etc. builders, and access-control stay put and are **not** exported publicly.
- **`src/channels-public.ts`** exports the pure surface (types + functions) only.
- **New `src/channels/command-surface.test.ts`** — focused coverage for the moved module, including parity assertions against the local `commands.ts` wrappers.

No behavior change for the local host; existing tests pass unchanged.

## Testing

- `bun run check` — all 12 checks pass
- `bun test src/channels/command-surface.test.ts src/channels/commands.test.ts src/channels/registry-community-copy.test.ts src/channels/access-control.test.ts` — 84 pass, 0 fail
- `node scripts/run-unit-tests.cjs` — 0 test failures across every shard; the run aborts with a Bun 1.3.0 segfault inside `src/websocket/app-server.test.ts` that reproduces identically on a clean `origin/main` checkout on the same machine (pre-existing, unrelated). The 67 files the crashed shard never reached were run separately in runner order: 577 pass, 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)