### PR TITLE
fix(turn): pin the turn-start effective model across tool-call continuations

### DIFF
--- a/scripts/isolated-unit-tests.json
+++ b/scripts/isolated-unit-tests.json
@@ -129,6 +129,11 @@
       "reason": "Uses several top-level Bun module mocks and exercises real concurrent listener state."
     },
     {
+      "path": "src/websocket/listen-turn-model-pin.test.ts",
+      "timeoutMs": 30000,
+      "reason": "Uses top-level Bun module mocks for agent message/stream/backend modules to capture per-request override_model."
+    },
+    {
       "path": "src/websocket/listener/auth-lifecycle.test.ts",
       "timeoutMs": 30000,
       "reason": "Exercises real WebSockets while mutating listener, settings, HOME, and process environment state."

--- a/scripts/source-file-size-baseline.json
+++ b/scripts/source-file-size-baseline.json
@@ -46,6 +46,5 @@
   "src/websocket/listener/file-commands.ts": 1053,
   "src/websocket/listener/lifecycle.ts": 1051,
   "src/websocket/listener/protocol-inbound.ts": 2264,
-  "src/websocket/listener/protocol-outbound.ts": 1085,
-  "src/websocket/listener/turn.ts": 1010
+  "src/websocket/listener/protocol-outbound.ts": 1085
 }

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -1980,11 +1980,11 @@ export async function handleHeadlessCommand(
   // Cache the agent from the initial fetch to avoid redundant agents.retrieve
   // calls on every while-loop iteration.
   let cachedAgent: AgentState | null = null;
-  // Capture the resolved model (conversation override → agent fallback) so
-  // subsequent while-loop iterations can prepare the correct toolset without
-  // re-fetching the conversation model. This is only for local tool context;
-  // request-scoped override_model should remain reserved for provider fallback.
-  let preparedEffectiveModel: string | null | undefined;
+  // Capture the resolved model (conversation override → agent fallback) for
+  // toolset prep on later iterations, and pin it on every request of the
+  // turn via override_model — the server re-resolves per request, so a
+  // mid-turn agent PATCH could otherwise switch models between tool calls.
+  let preparedEffectiveModel: string | undefined;
   {
     const initialToolContext = await prepareHeadlessToolExecutionContext({
       agentId: agent.id,
@@ -1996,7 +1996,7 @@ export async function handleHeadlessCommand(
     availableTools = initialToolContext.availableTools;
     cachedAgent = initialToolContext.preparedToolContext.agent;
     preparedEffectiveModel =
-      initialToolContext.preparedToolContext.effectiveModel;
+      initialToolContext.preparedToolContext.effectiveModel ?? undefined;
   }
 
   // If input-format is stream-json, use bidirectional mode
@@ -2617,7 +2617,7 @@ ${SYSTEM_REMINDER_CLOSE}
           currentInput,
           {
             agentId: agent.id,
-            overrideModel: overrideModelHandle,
+            overrideModel: overrideModelHandle ?? preparedEffectiveModel,
             preparedToolContext:
               turnToolContext.preparedToolContext.preparedToolContext,
           },

--- a/src/websocket/listen-model-update.test.ts
+++ b/src/websocket/listen-model-update.test.ts
@@ -399,6 +399,9 @@ describe("listen-client applyModelUpdateForRuntime wiring", () => {
         reasoning: { reasoning_effort: "high" },
       });
       expect(scopedRuntime.currentToolset).toBe("codex");
+      // Active turns pin their turn-start model on every request, so a live
+      // switch must be recorded on the runtime to take effect mid-turn.
+      expect(scopedRuntime.liveModelSwitchHandle).toBe("chatgpt-jin/gpt-5.5");
     } finally {
       if (previousHome === undefined) {
         delete process.env.HOME;

--- a/src/websocket/listen-turn-model-pin.test.ts
+++ b/src/websocket/listen-turn-model-pin.test.ts
@@ -1,0 +1,556 @@
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import WebSocket from "ws";
+import { permissionMode } from "@/permissions/mode";
+import { sharedReminderProviders } from "@/reminders/engine";
+import { settingsManager } from "@/settings-manager";
+import { clearTools } from "@/tools/manager";
+import type { ConversationRuntime } from "@/websocket/listener/types";
+
+/**
+ * A listener turn spans multiple HTTP requests (one per client-side tool
+ * round-trip) while the server re-resolves the effective model per request.
+ * These tests pin the turn-scoped model snapshot behavior: every request of
+ * a turn carries the turn-start resolved model via override_model, provider
+ * fallback still wins, and a live mid-turn /model switch still takes effect.
+ */
+
+type MockStream = {
+  conversationId: string;
+  agentId?: string;
+};
+
+type DrainResult = {
+  stopReason: string;
+  approvals?: Array<{
+    toolCallId: string;
+    toolName: string;
+    toolArgs: string;
+  }>;
+  apiDurationMs: number;
+};
+
+const defaultDrainResult: DrainResult = {
+  stopReason: "end_turn",
+  approvals: [],
+  apiDurationMs: 0,
+};
+
+const sendMessageStreamCalls: Array<{
+  conversationId: string;
+  messages: unknown[];
+  opts?: {
+    agentId?: string;
+    overrideModel?: string;
+  };
+}> = [];
+const sendMessageStreamMock = mock(
+  async (
+    conversationId: string,
+    messages: unknown[],
+    opts?: {
+      agentId?: string;
+      overrideModel?: string;
+    },
+  ): Promise<MockStream> => {
+    sendMessageStreamCalls.push({ conversationId, messages, opts });
+    return {
+      conversationId,
+      agentId: opts?.agentId,
+    };
+  },
+);
+const getStreamToolContextIdMock = mock(() => null);
+const drainHandlers = new Map<
+  string,
+  (abortSignal?: AbortSignal) => Promise<DrainResult>
+>();
+const drainStreamWithResumeMock = mock(
+  async (
+    stream: MockStream,
+    _buffers: unknown,
+    _refresh: () => void,
+    abortSignal?: AbortSignal,
+  ) => {
+    const handler = drainHandlers.get(stream.conversationId);
+    if (handler) {
+      return handler(abortSignal);
+    }
+    return defaultDrainResult;
+  },
+);
+
+type MockAgentRecord = {
+  id: string;
+  model: string;
+  llm_config?: Record<string, unknown>;
+};
+const agentsById = new Map<string, MockAgentRecord>();
+const conversationModelById = new Map<string, string | null>();
+const retrieveAgentMock = mock(async (agentId: string) => {
+  const record = agentsById.get(agentId);
+  return {
+    id: agentId,
+    model: record?.model ?? "anthropic/claude-sonnet-4",
+    ...(record?.llm_config ? { llm_config: record.llm_config } : {}),
+  };
+});
+const retrieveConversationMock = mock(async (conversationId: string) => ({
+  id: conversationId,
+  model: conversationModelById.get(conversationId) ?? null,
+  in_context_message_ids: [],
+}));
+const listAgentMessagesMock = mock(async () => ({
+  getPaginatedItems: () => [],
+}));
+const cancelConversationMock = mock(async (_conversationId: string) => {});
+const retrieveRunMock = mock(async (runId: string) => ({
+  id: runId,
+  status: "completed",
+}));
+const getClientMock = mock(async () => ({
+  agents: {
+    retrieve: retrieveAgentMock,
+    messages: {
+      list: listAgentMessagesMock,
+    },
+  },
+  conversations: {
+    retrieve: retrieveConversationMock,
+    cancel: cancelConversationMock,
+  },
+  runs: {
+    retrieve: retrieveRunMock,
+  },
+}));
+const classifyApprovalsMock = mock(async () => ({
+  autoAllowed: [],
+  autoDenied: [],
+  needsUserInput: [],
+}));
+const executeApprovalBatchMock = mock(async () => []);
+
+const realStreamModule = await import("@/cli/helpers/stream");
+const realDrainStreamWithResume = realStreamModule.drainStreamWithResume;
+const realAgentMessageModule = await import("@/agent/message");
+const realSendMessageStream = realAgentMessageModule.sendMessageStream;
+const realGetStreamToolContextId =
+  realAgentMessageModule.getStreamToolContextId;
+// Capture real implementations BEFORE applying `mock.module(...)` so they can
+// be restored in afterAll: `mock.restore()` does NOT undo `mock.module()`
+// swaps, and module identity is process-global.
+const realApprovalClassificationModule = await import(
+  "@/cli/helpers/approval-classification"
+);
+const realClassifyApprovals =
+  realApprovalClassificationModule.classifyApprovals;
+const realApprovalExecutionModule = await import("@/agent/approval-execution");
+const realExecuteApprovalBatch =
+  realApprovalExecutionModule.executeApprovalBatch;
+
+mock.module("../agent/message", () => ({
+  sendMessageStream: sendMessageStreamMock,
+  getStreamToolContextId: getStreamToolContextIdMock,
+  getStreamRequestContext: () => undefined,
+  getStreamRequestStartTime: () => undefined,
+  buildConversationMessagesCreateRequestBody: (
+    conversationId: string,
+    messages: unknown[],
+    opts?: { agentId?: string; streamTokens?: boolean; background?: boolean },
+    clientTools?: unknown[],
+    clientSkills?: unknown[],
+  ) => ({
+    messages,
+    streaming: true,
+    stream_tokens: opts?.streamTokens ?? true,
+    include_pings: true,
+    background: opts?.background ?? true,
+    client_skills: clientSkills ?? [],
+    client_tools: clientTools ?? [],
+    include_compaction_messages: true,
+    ...(conversationId === "default" && opts?.agentId
+      ? { agent_id: opts.agentId }
+      : {}),
+  }),
+}));
+
+mock.module("../cli/helpers/stream", () => ({
+  ...realStreamModule,
+  drainStreamWithResume: drainStreamWithResumeMock,
+}));
+
+mock.module("../backend/api/client", () => ({
+  getClient: getClientMock,
+  getServerUrl: () => "https://example.test",
+  clearLastSDKDiagnostic: () => {},
+  consumeLastSDKDiagnostic: () => null,
+}));
+
+mock.module("../cli/helpers/approval-classification", () => ({
+  classifyApprovals: classifyApprovalsMock,
+}));
+
+mock.module("../agent/approval-execution", () => ({
+  executeApprovalBatch: executeApprovalBatchMock,
+}));
+
+const listenClientModule = await import("@/websocket/listen-client");
+const { __listenClientTestUtils } = listenClientModule;
+
+class MockSocket {
+  readyState: number = WebSocket.OPEN;
+  sentPayloads: string[] = [];
+
+  send(data: string): void {
+    this.sentPayloads.push(data);
+  }
+
+  close(): void {}
+
+  removeAllListeners(): this {
+    return this;
+  }
+}
+
+function makeIncomingMessage(
+  agentId: string,
+  conversationId: string,
+  text: string,
+) {
+  return {
+    type: "message" as const,
+    agentId,
+    conversationId,
+    messages: [{ role: "user" as const, content: text }],
+  };
+}
+
+function createRuntime(agentId: string, conversationId: string) {
+  const listener = __listenClientTestUtils.createListenerRuntime();
+  return {
+    listener,
+    runtime: __listenClientTestUtils.getOrCreateScopedRuntime(
+      listener,
+      agentId,
+      conversationId,
+    ) as ConversationRuntime,
+  };
+}
+
+function stubApprovalRoundTrip(toolCallId: string) {
+  // biome-ignore lint/suspicious/noExplicitAny: mock method access
+  (classifyApprovalsMock as any).mockImplementationOnce(async () => ({
+    autoAllowed: [
+      {
+        approval: {
+          toolCallId,
+          toolName: "Bash",
+          toolArgs: '{"command":"pwd"}',
+        },
+        permission: { decision: "allow" },
+        context: null,
+        parsedArgs: { command: "pwd" },
+      },
+    ],
+    autoDenied: [],
+    needsUserInput: [],
+  }));
+  // biome-ignore lint/suspicious/noExplicitAny: mock method access
+  (executeApprovalBatchMock as any).mockResolvedValueOnce([
+    {
+      type: "tool",
+      tool_call_id: toolCallId,
+      status: "success",
+      tool_return: "ok",
+    },
+  ]);
+}
+
+function requiresApprovalDrain(toolCallId: string): DrainResult {
+  return {
+    stopReason: "requires_approval",
+    approvals: [
+      {
+        toolCallId,
+        toolName: "Bash",
+        toolArgs: '{"command":"pwd"}',
+      },
+    ],
+    apiDurationMs: 0,
+  };
+}
+
+// Stub reminder providers that touch settingsManager/process.cwd so
+// handleIncomingMessage works without a fully initialised environment.
+const origSessionContext = sharedReminderProviders["session-context"];
+const origAgentInfo = sharedReminderProviders["agent-info"];
+const originalGetLocalProjectSettings = settingsManager.getLocalProjectSettings;
+const originalGetSettings = settingsManager.getSettings;
+const originalTranscriptRoot = process.env.LETTA_TRANSCRIPT_ROOT;
+let testTranscriptRoot: string | null = null;
+
+describe("listener turn-scoped model pinning", () => {
+  beforeEach(async () => {
+    testTranscriptRoot = await mkdtemp(join(tmpdir(), "letta-turn-pin-"));
+    process.env.LETTA_TRANSCRIPT_ROOT = testTranscriptRoot;
+
+    sharedReminderProviders["session-context"] = async () => null;
+    sharedReminderProviders["agent-info"] = async () => null;
+    (settingsManager as typeof settingsManager).getSettings = (() =>
+      ({
+        memoryReminderInterval: null,
+      }) as ReturnType<
+        typeof settingsManager.getSettings
+      >) as typeof settingsManager.getSettings;
+    (settingsManager as typeof settingsManager).getLocalProjectSettings = () =>
+      ({}) as ReturnType<typeof settingsManager.getLocalProjectSettings>;
+
+    agentsById.clear();
+    conversationModelById.clear();
+    clearTools();
+    permissionMode.reset();
+    sendMessageStreamMock.mockClear();
+    sendMessageStreamCalls.length = 0;
+    getStreamToolContextIdMock.mockClear();
+    drainStreamWithResumeMock.mockClear();
+    getClientMock.mockClear();
+    retrieveAgentMock.mockClear();
+    retrieveConversationMock.mockClear();
+    classifyApprovalsMock.mockClear();
+    executeApprovalBatchMock.mockClear();
+    drainHandlers.clear();
+    __listenClientTestUtils.setActiveRuntime(null);
+  });
+
+  afterEach(async () => {
+    sharedReminderProviders["session-context"] = origSessionContext;
+    sharedReminderProviders["agent-info"] = origAgentInfo;
+    (settingsManager as typeof settingsManager).getSettings =
+      originalGetSettings;
+    (settingsManager as typeof settingsManager).getLocalProjectSettings =
+      originalGetLocalProjectSettings;
+    clearTools();
+    permissionMode.reset();
+    __listenClientTestUtils.setActiveRuntime(null);
+    if (originalTranscriptRoot === undefined) {
+      delete process.env.LETTA_TRANSCRIPT_ROOT;
+    } else {
+      process.env.LETTA_TRANSCRIPT_ROOT = originalTranscriptRoot;
+    }
+    if (testTranscriptRoot) {
+      await rm(testTranscriptRoot, { recursive: true, force: true });
+      testTranscriptRoot = null;
+    }
+  });
+
+  afterAll(() => {
+    // `mock.module()` swaps are process-global: restore the captured real
+    // implementations so other test files see the real modules.
+    classifyApprovalsMock.mockReset();
+    // biome-ignore lint/suspicious/noExplicitAny: real implementations have wider signatures than the narrow zero-arg mocks
+    (classifyApprovalsMock as any).mockImplementation(realClassifyApprovals);
+    executeApprovalBatchMock.mockReset();
+    // biome-ignore lint/suspicious/noExplicitAny: see above
+    (executeApprovalBatchMock as any).mockImplementation(
+      realExecuteApprovalBatch,
+    );
+    sendMessageStreamMock.mockReset();
+    // biome-ignore lint/suspicious/noExplicitAny: see above
+    (sendMessageStreamMock as any).mockImplementation(realSendMessageStream);
+    getStreamToolContextIdMock.mockReset();
+    // biome-ignore lint/suspicious/noExplicitAny: see above
+    (getStreamToolContextIdMock as any).mockImplementation(
+      realGetStreamToolContextId,
+    );
+    drainStreamWithResumeMock.mockReset();
+    // biome-ignore lint/suspicious/noExplicitAny: see above
+    (drainStreamWithResumeMock as any).mockImplementation(
+      realDrainStreamWithResume,
+    );
+    mock.restore();
+  });
+
+  test("pins the turn-start model on every request even when the agent model changes mid-turn", async () => {
+    agentsById.set("agent-pin", {
+      id: "agent-pin",
+      model: "anthropic/claude-sonnet-4-5",
+    });
+    const { runtime } = createRuntime("agent-pin", "conv-pin");
+    const socket = new MockSocket();
+
+    let drainCount = 0;
+    drainHandlers.set("conv-pin", async () => {
+      drainCount += 1;
+      if (drainCount === 1) {
+        // Simulate an external agent PATCH landing between tool calls.
+        agentsById.set("agent-pin", {
+          id: "agent-pin",
+          model: "openai/gpt-5.4",
+        });
+        return requiresApprovalDrain("tc-pin-1");
+      }
+      return defaultDrainResult;
+    });
+    stubApprovalRoundTrip("tc-pin-1");
+
+    await __listenClientTestUtils.handleIncomingMessage(
+      makeIncomingMessage("agent-pin", "conv-pin", "run it"),
+      socket as unknown as WebSocket,
+      runtime,
+    );
+
+    expect(sendMessageStreamCalls.length).toBe(2);
+    expect(sendMessageStreamCalls[0]?.opts?.overrideModel).toBe(
+      "anthropic/claude-sonnet-4-5",
+    );
+    // The approval continuation is a separate HTTP request; without the pin
+    // the server would re-resolve the (patched) agent model here.
+    expect(sendMessageStreamCalls[1]?.opts?.overrideModel).toBe(
+      "anthropic/claude-sonnet-4-5",
+    );
+    expect(
+      (sendMessageStreamCalls[1]?.messages?.[0] as { type?: string }).type,
+    ).toBe("approval");
+  });
+
+  test("pins the conversation-level model override when present", async () => {
+    agentsById.set("agent-conv", {
+      id: "agent-conv",
+      model: "anthropic/claude-sonnet-4-5",
+    });
+    conversationModelById.set("conv-override", "openai/gpt-5.4");
+    const { runtime } = createRuntime("agent-conv", "conv-override");
+    const socket = new MockSocket();
+
+    let drainCount = 0;
+    drainHandlers.set("conv-override", async () => {
+      drainCount += 1;
+      if (drainCount === 1) {
+        return requiresApprovalDrain("tc-conv-1");
+      }
+      return defaultDrainResult;
+    });
+    stubApprovalRoundTrip("tc-conv-1");
+
+    await __listenClientTestUtils.handleIncomingMessage(
+      makeIncomingMessage("agent-conv", "conv-override", "run it"),
+      socket as unknown as WebSocket,
+      runtime,
+    );
+
+    expect(sendMessageStreamCalls.length).toBe(2);
+    // The snapshot IS the resolved conversation-override → agent-fallback
+    // value, so the conversation override wins over the agent model.
+    expect(sendMessageStreamCalls[0]?.opts?.overrideModel).toBe(
+      "openai/gpt-5.4",
+    );
+    expect(sendMessageStreamCalls[1]?.opts?.overrideModel).toBe(
+      "openai/gpt-5.4",
+    );
+  });
+
+  test("live mid-turn /model switch beats the turn-start snapshot and resets on the next turn", async () => {
+    agentsById.set("agent-live", {
+      id: "agent-live",
+      model: "anthropic/claude-sonnet-4-5",
+    });
+    const { runtime } = createRuntime("agent-live", "conv-live");
+    const socket = new MockSocket();
+
+    let drainCount = 0;
+    drainHandlers.set("conv-live", async () => {
+      drainCount += 1;
+      if (drainCount === 1) {
+        // Simulate applyModelUpdateForRuntime landing mid-turn.
+        runtime.liveModelSwitchHandle = "zai/glm-4.6";
+        return requiresApprovalDrain("tc-live-1");
+      }
+      return defaultDrainResult;
+    });
+    stubApprovalRoundTrip("tc-live-1");
+
+    await __listenClientTestUtils.handleIncomingMessage(
+      makeIncomingMessage("agent-live", "conv-live", "run it"),
+      socket as unknown as WebSocket,
+      runtime,
+    );
+
+    expect(sendMessageStreamCalls.length).toBe(2);
+    expect(sendMessageStreamCalls[0]?.opts?.overrideModel).toBe(
+      "anthropic/claude-sonnet-4-5",
+    );
+    // The deliberate user switch must win over the turn-start snapshot.
+    expect(sendMessageStreamCalls[1]?.opts?.overrideModel).toBe("zai/glm-4.6");
+
+    // A new turn re-resolves from agent/conversation config: the recorded
+    // live switch must not leak into the next turn's requests.
+    await __listenClientTestUtils.handleIncomingMessage(
+      makeIncomingMessage("agent-live", "conv-live", "again"),
+      socket as unknown as WebSocket,
+      runtime,
+    );
+    expect(sendMessageStreamCalls.length).toBe(3);
+    expect(sendMessageStreamCalls[2]?.opts?.overrideModel).toBe(
+      "anthropic/claude-sonnet-4-5",
+    );
+    expect(runtime.liveModelSwitchHandle).toBeNull();
+  });
+
+  test("provider fallback still overrides the turn-start snapshot", async () => {
+    agentsById.set("agent-fallback", {
+      id: "agent-fallback",
+      model: "anthropic/claude-sonnet-5",
+      llm_config: {
+        context_window: 200000,
+        model: "anthropic/claude-sonnet-5",
+        model_endpoint_type: "anthropic",
+        reasoning_effort: "high",
+        enable_reasoner: true,
+      },
+    });
+    const { runtime } = createRuntime("agent-fallback", "conv-fallback");
+    const socket = new MockSocket();
+
+    let drainCount = 0;
+    drainHandlers.set("conv-fallback", async () => {
+      drainCount += 1;
+      if (drainCount <= 2) {
+        return {
+          stopReason: "llm_api_error",
+          approvals: [],
+          apiDurationMs: 0,
+        };
+      }
+      return defaultDrainResult;
+    });
+
+    await __listenClientTestUtils.handleIncomingMessage(
+      makeIncomingMessage("agent-fallback", "conv-fallback", "run it"),
+      socket as unknown as WebSocket,
+      runtime,
+    );
+
+    expect(sendMessageStreamCalls.length).toBe(3);
+    expect(sendMessageStreamCalls[0]?.opts?.overrideModel).toBe(
+      "anthropic/claude-sonnet-5",
+    );
+    // First retry has not applied the fallback yet: still pinned.
+    expect(sendMessageStreamCalls[1]?.opts?.overrideModel).toBe(
+      "anthropic/claude-sonnet-5",
+    );
+    // Second retry applies the Bedrock fallback, which beats the snapshot.
+    expect(sendMessageStreamCalls[2]?.opts?.overrideModel).toBe(
+      "bedrock/us.anthropic.claude-sonnet-5",
+    );
+  }, 15000);
+});

--- a/src/websocket/listener-provider-fallback.test.ts
+++ b/src/websocket/listener-provider-fallback.test.ts
@@ -3,6 +3,7 @@ import type { AgentState } from "@letta-ai/letta-client/resources/agents/agents"
 import {
   createProviderFallbackState,
   maybeApplyProviderFallback,
+  resolveTurnRequestOverrideModel,
 } from "@/websocket/listener/provider-fallback";
 
 function agentWithModel(
@@ -65,5 +66,45 @@ describe("listener provider fallback", () => {
       );
       expect(state.overrideModel).toBe("bedrock/us.anthropic.claude-opus-4-7");
     }
+  });
+});
+
+describe("turn request override model precedence", () => {
+  test("falls back to the turn-start snapshot when nothing else is set", () => {
+    expect(
+      resolveTurnRequestOverrideModel({
+        turnStartEffectiveModel: "anthropic/claude-sonnet-5",
+      }),
+    ).toBe("anthropic/claude-sonnet-5");
+  });
+
+  test("a live /model switch beats the turn-start snapshot", () => {
+    expect(
+      resolveTurnRequestOverrideModel({
+        liveModelSwitchHandle: "openai/gpt-5.4",
+        turnStartEffectiveModel: "anthropic/claude-sonnet-5",
+      }),
+    ).toBe("openai/gpt-5.4");
+  });
+
+  test("provider fallback beats both the live switch and the snapshot", () => {
+    expect(
+      resolveTurnRequestOverrideModel({
+        providerFallbackOverride: "bedrock/us.anthropic.claude-sonnet-5",
+        liveModelSwitchHandle: "openai/gpt-5.4",
+        turnStartEffectiveModel: "anthropic/claude-sonnet-5",
+      }),
+    ).toBe("bedrock/us.anthropic.claude-sonnet-5");
+  });
+
+  test("returns undefined when no source resolves a model", () => {
+    expect(
+      resolveTurnRequestOverrideModel({
+        providerFallbackOverride: null,
+        liveModelSwitchHandle: null,
+        turnStartEffectiveModel: null,
+      }),
+    ).toBeUndefined();
+    expect(resolveTurnRequestOverrideModel({})).toBeUndefined();
   });
 });

--- a/src/websocket/listener/commands/model-toolset.ts
+++ b/src/websocket/listener/commands/model-toolset.ts
@@ -517,6 +517,11 @@ export async function applyModelUpdateForRuntime(params: {
     appliedTo = "conversation";
   }
 
+  // A turn in flight pins its turn-start effective model on every request
+  // (override_model), so a deliberate live switch must be recorded on the
+  // runtime for the active turn's next continuation to pick it up.
+  scopedRuntime.liveModelSwitchHandle = model.handle;
+
   const toolsetPreference = settingsManager.getToolsetPreference(agentId);
   const previousToolNames = scopedRuntime.currentLoadedTools;
   let nextToolset: ToolsetName;

--- a/src/websocket/listener/provider-fallback.ts
+++ b/src/websocket/listener/provider-fallback.ts
@@ -28,6 +28,33 @@ export function createProviderFallbackState(
   };
 }
 
+/**
+ * Resolve the override_model to attach to one request of a listener turn.
+ *
+ * A turn spans multiple HTTP requests (one per client-side tool round-trip)
+ * and the server re-resolves the effective model on every request, so an
+ * agent/conversation PATCH landing mid-turn would otherwise switch the model
+ * between tool calls while tool schemas stay pinned to the turn-start
+ * toolset. Pinning the turn-start snapshot closes that gap.
+ *
+ * Precedence: provider fallback (reliability action) beats a live /model
+ * switch (deliberate user action), which beats the turn-start snapshot. The
+ * snapshot itself is the resolved conversation-override → agent-fallback
+ * value, so conversation-level model overrides win inherently.
+ */
+export function resolveTurnRequestOverrideModel(params: {
+  providerFallbackOverride?: string | null;
+  liveModelSwitchHandle?: string | null;
+  turnStartEffectiveModel?: string | null;
+}): string | undefined {
+  return (
+    params.providerFallbackOverride ??
+    params.liveModelSwitchHandle ??
+    params.turnStartEffectiveModel ??
+    undefined
+  );
+}
+
 export function maybeApplyProviderFallback(
   state: ProviderFallbackState | undefined,
   attempt: number,

--- a/src/websocket/listener/runtime.ts
+++ b/src/websocket/listener/runtime.ts
@@ -290,6 +290,7 @@ export function createConversationRuntime(
     currentToolsetPreference: "auto",
     currentLoadedTools: [],
     currentAvailableSkills: [],
+    liveModelSwitchHandle: null,
     pendingApprovalBatchByToolCallId: new Map(),
     approvalMessageIdByToolCallId: new Map(),
     pendingInterruptedResults: null,

--- a/src/websocket/listener/turn-send.ts
+++ b/src/websocket/listener/turn-send.ts
@@ -5,7 +5,11 @@ import type {
   LettaStreamingResponse,
 } from "@letta-ai/letta-client/resources/agents/messages";
 import type { sendMessageStream } from "@/agent/message";
-import type { ProviderFallbackState } from "./provider-fallback";
+import type { ConversationPermissionModeState } from "./permission-mode";
+import {
+  type ProviderFallbackState,
+  resolveTurnRequestOverrideModel,
+} from "./provider-fallback";
 import { finalizeHandledRecoveryTurn } from "./recovery";
 import {
   type ApprovalContinuationSendResult,
@@ -14,8 +18,75 @@ import {
   sendMessageStreamWithRetry,
 } from "./send";
 import type { ListenerTransport } from "./transport";
+import type { TurnInputState } from "./turn-input-state";
 import type { TurnFinishTransition, TurnLease } from "./turn-lifecycle";
 import type { ConversationRuntime } from "./types";
+
+type SendOptions = NonNullable<Parameters<typeof sendMessageStream>[2]>;
+
+/**
+ * Build the per-request send options for one listener turn.
+ *
+ * The returned builder is re-evaluated for every request of the turn (initial
+ * send, tool-call approval continuations, retries). It pins the turn-start
+ * effective model on each request via override_model: a turn spans multiple
+ * HTTP requests and the server re-resolves the effective model per request,
+ * so an agent/conversation PATCH landing mid-turn would otherwise switch the
+ * model between tool calls while tool schemas stay pinned to the turn-start
+ * toolset. Precedence: provider fallback > live /model switch > turn-start
+ * snapshot (see resolveTurnRequestOverrideModel).
+ */
+export function createTurnSendOptionsBuilder(params: {
+  agentId: string;
+  workingDirectory: string;
+  permissionModeState: ConversationPermissionModeState;
+  runtime: ConversationRuntime;
+  preparedToolContext: SendOptions["preparedToolContext"];
+  /** Turn-start resolved model (conversation override → agent fallback). */
+  turnStartEffectiveModel: string | null;
+  providerFallback: ProviderFallbackState;
+  actingUserId: string | undefined;
+  getTurnInput: () => TurnInputState;
+  getPendingNormalizationInterruptedToolCallIds: () => string[];
+}): () => SendOptions {
+  return () => {
+    const turnInput = params.getTurnInput();
+    const pendingNormalizationInterruptedToolCallIds =
+      params.getPendingNormalizationInterruptedToolCallIds();
+    const overrideModel = resolveTurnRequestOverrideModel({
+      providerFallbackOverride: params.providerFallback.overrideModel,
+      liveModelSwitchHandle: params.runtime.liveModelSwitchHandle,
+      turnStartEffectiveModel: params.turnStartEffectiveModel,
+    });
+    return {
+      agentId: params.agentId,
+      streamTokens: true,
+      background: true,
+      workingDirectory: params.workingDirectory,
+      permissionModeState: params.permissionModeState,
+      ...(params.runtime.skillSources !== undefined
+        ? { skillSources: params.runtime.skillSources }
+        : {}),
+      preparedToolContext: params.preparedToolContext,
+      ...(turnInput.imageFailureModesByMessageOtid
+        ? {
+            imageFailureModesByMessageOtid:
+              turnInput.imageFailureModesByMessageOtid,
+          }
+        : {}),
+      ...(overrideModel ? { overrideModel } : {}),
+      ...(params.actingUserId ? { actingUserId: params.actingUserId } : {}),
+      ...(pendingNormalizationInterruptedToolCallIds.length > 0
+        ? {
+            approvalNormalization: {
+              interruptedToolCallIds:
+                pendingNormalizationInterruptedToolCallIds,
+            },
+          }
+        : {}),
+    };
+  };
+}
 
 export function createTurnInputSender(params: {
   conversationId: string;

--- a/src/websocket/listener/turn.ts
+++ b/src/websocket/listener/turn.ts
@@ -3,10 +3,7 @@ import type { LettaStreamingResponse } from "@letta-ai/letta-client/resources/ag
 import type { ApprovalResult } from "@/agent/approval-execution";
 import { fetchRunErrorInfo } from "@/agent/approval-recovery";
 import { getResumeDataFromBackend } from "@/agent/check-approval";
-import {
-  getStreamToolContextId,
-  type sendMessageStream,
-} from "@/agent/message";
+import { getStreamToolContextId } from "@/agent/message";
 import {
   getRetryDelayMs,
   isEmptyResponseRetryable,
@@ -83,7 +80,10 @@ import {
 } from "./turn-input-state";
 import type { TurnLease } from "./turn-lifecycle";
 import { notifyTurnFinished, notifyTurnStarted } from "./turn-observers";
-import { createTurnInputSender } from "./turn-send";
+import {
+  createTurnInputSender,
+  createTurnSendOptionsBuilder,
+} from "./turn-send";
 import { prepareListenerTurn } from "./turn-setup";
 import { setTurnLoopStatus } from "./turn-status";
 import { finishListenerTurn } from "./turn-terminal";
@@ -207,6 +207,9 @@ async function handleIncomingMessageInner(
   try {
     runtime.lastTerminalLoopErrorMessage = null;
     runtime.lastTerminalLoopErrorRunId = null;
+    // Each turn re-resolves its effective model at turn start; a live /model
+    // switch recorded for a previous turn must not leak into this one.
+    runtime.liveModelSwitchHandle = null;
     setTurnLoopStatus(runtime, turnLease, "SENDING_API_REQUEST", {
       agent_id: agentId ?? null,
       conversation_id: conversationId,
@@ -280,34 +283,18 @@ async function handleIncomingMessageInner(
     let pendingNormalizationInterruptedToolCallIds =
       setup.pendingNormalizationInterruptedToolCallIds;
     const preparedToolContext = setup.preparedToolContext;
-    const buildSendOptions = (): Parameters<typeof sendMessageStream>[2] => ({
+    const buildSendOptions = createTurnSendOptionsBuilder({
       agentId,
-      streamTokens: true,
-      background: true,
       workingDirectory: turnWorkingDirectory,
       permissionModeState: turnPermissionModeState,
-      ...(runtime.skillSources !== undefined
-        ? { skillSources: runtime.skillSources }
-        : {}),
+      runtime,
       preparedToolContext: preparedToolContext.preparedToolContext,
-      ...(turnInput.imageFailureModesByMessageOtid
-        ? {
-            imageFailureModesByMessageOtid:
-              turnInput.imageFailureModesByMessageOtid,
-          }
-        : {}),
-      ...(providerFallback.overrideModel
-        ? { overrideModel: providerFallback.overrideModel }
-        : {}),
-      ...(msg.actingUserId ? { actingUserId: msg.actingUserId } : {}),
-      ...(pendingNormalizationInterruptedToolCallIds.length > 0
-        ? {
-            approvalNormalization: {
-              interruptedToolCallIds:
-                pendingNormalizationInterruptedToolCallIds,
-            },
-          }
-        : {}),
+      turnStartEffectiveModel: preparedToolContext.effectiveModel,
+      providerFallback,
+      actingUserId: msg.actingUserId,
+      getTurnInput: () => turnInput,
+      getPendingNormalizationInterruptedToolCallIds: () =>
+        pendingNormalizationInterruptedToolCallIds,
     });
 
     const turnInputSender = createTurnInputSender({

--- a/src/websocket/listener/types.ts
+++ b/src/websocket/listener/types.ts
@@ -218,6 +218,15 @@ export type ConversationRuntime = {
   currentToolsetPreference: ToolsetPreference;
   currentLoadedTools: string[];
   currentAvailableSkills: AvailableSkillSummary[];
+  /**
+   * Model handle applied by a live /model (update_model) switch. Active turns
+   * pin their turn-start effective model on every request of the turn, so a
+   * deliberate mid-turn switch must be recorded here to still take effect on
+   * the next continuation request. Beats the turn-start snapshot but not
+   * provider fallback; cleared at each turn start so new turns re-resolve
+   * from conversation/agent config.
+   */
+  liveModelSwitchHandle: string | null;
   pendingApprovalBatchByToolCallId: Map<string, string>;
   /**
    * tool_call_id -> server-assigned id of the approval_request_message that


### PR DESCRIPTION
## Problem

A Letta Code turn is not one HTTP request. Every client-side tool round-trip (initial send, each approval continuation, each retry) is a separate POST, and core intentionally re-resolves the effective model **per request**: conversation override first, then `agent.llm_config`. A conversation with no model override therefore falls through to the agent's config freshly on every continuation — so an agent `PATCH` that lands mid-turn switches the model **between tool calls of the same turn**.

This is not theoretical: during an active Slack turn, an agent model PATCH switched the run GPT → K2.7 → K3 across consecutive tool-call continuations.

It also creates a schema/model mismatch. The client already snapshots the turn-start effective model and pins the **tool schemas** (toolset) to it for the whole turn — but deliberately withheld that snapshot from the requests themselves (`headless.ts` said so explicitly: "request-scoped override_model should remain reserved for provider fallback"). So the tool schemas stayed pinned to the turn-start model while the LLM underneath switched.

## Fix

Pin the turn-start effective model on **every request of the turn** using the existing non-mutating `override_model` request field:

- **Listener** (`src/websocket/listener/turn.ts` / `turn-send.ts`): the per-request send-options builder (extracted to `createTurnSendOptionsBuilder`) now resolves `override_model` via `resolveTurnRequestOverrideModel`, with the turn-start snapshot (`preparedToolContext.effectiveModel`, i.e. the resolved conversation-override → agent-fallback value) as the base.
- **Headless** (`src/headless.ts`): the one-shot loop now passes the already-captured `preparedEffectiveModel` into `sendMessageStream` instead of deliberately withholding it; the carve-out comment is deleted.

### Precedence

```
provider fallback  >  live /model switch  >  turn-start snapshot
```

- **Provider fallback** (`providerFallback.overrideModel` / `overrideModelHandle`) is a reliability action taken mid-turn and must keep winning — unchanged.
- **Live mid-turn `/model` switch** is a deliberate user action and must beat the snapshot. `applyModelUpdateForRuntime` now records the switched handle on the conversation runtime (`liveModelSwitchHandle`); the active turn picks it up on its next continuation. It is cleared at every turn start so a recorded switch can never mask a later external config change — new turns re-resolve from conversation/agent config as before.
- **Conversation-level model override** continues to win over the agent model inherently: the snapshot *is* the resolved conversation-override → agent-fallback value.

External mid-turn PATCHes are the only thing that loses — which is the point: they now take effect at the next turn boundary, when the toolset is re-derived alongside the model.

## Tests

- `src/websocket/listen-turn-model-pin.test.ts` (new, isolated): drives real listener turns through `handleIncomingMessage` with a mocked transport/backend and asserts, per request:
  - all requests of a multi-tool-call turn carry the same `override_model` equal to the turn-start resolved model even when the agent model is patched mid-turn;
  - the conversation-level override is the pinned value when present;
  - a live mid-turn `/model` switch takes effect on the continuation request and does not leak into the next turn;
  - provider fallback (Bedrock) still overrides the pin on retry.
- `src/websocket/listener-provider-fallback.test.ts`: unit precedence tests for `resolveTurnRequestOverrideModel`.
- `src/websocket/listen-model-update.test.ts`: asserts `applyModelUpdateForRuntime` records `liveModelSwitchHandle`.

`bun run check` passes (12/12). Full unit suite: 0 test failures across all shards. Note: `src/websocket/app-server.test.ts` hits a **pre-existing Bun 1.3.0 segfault at process teardown** (reproduces standalone and on clean origin/main; zero test failures before the crash; file untouched by this change). The 67 files its shard skipped were re-run directly — all pass (581 tests, 0 fail).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
