### PR TITLE
fix(channels): pin the agent's current model on channel-created conversations

### DIFF
--- a/src/channels/registry-routes.test.ts
+++ b/src/channels/registry-routes.test.ts
@@ -1,0 +1,128 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  __testSetBackend,
+  type Backend,
+  type ConversationCreateBody,
+} from "@/backend";
+import {
+  createChannelRouteProvisioner,
+  resolveConversationModelPin,
+} from "@/channels/registry-routes";
+
+const AGENT_MODEL = "anthropic/claude-sonnet-4-5";
+const AGENT_MODEL_SETTINGS = {
+  provider_type: "anthropic",
+  max_output_tokens: 4096,
+} as const;
+
+function stubBackend(overrides: {
+  retrieveAgent?: (agentId: string) => Promise<unknown>;
+  onCreate?: (body: ConversationCreateBody) => void;
+}): Backend {
+  return {
+    retrieveAgent:
+      overrides.retrieveAgent ??
+      (async () => ({
+        id: "agent-1",
+        model: AGENT_MODEL,
+        model_settings: AGENT_MODEL_SETTINGS,
+      })),
+    createConversation: async (body: ConversationCreateBody) => {
+      overrides.onCreate?.(body);
+      return { id: "conv-1", agent_id: body.agent_id };
+    },
+  } as unknown as Backend;
+}
+
+describe("resolveConversationModelPin", () => {
+  afterEach(() => {
+    __testSetBackend(null);
+  });
+
+  test("resolves the agent's current model and model settings", async () => {
+    __testSetBackend(stubBackend({}));
+
+    const pin = await resolveConversationModelPin("agent-1");
+
+    expect(pin).toEqual({
+      model: AGENT_MODEL,
+      model_settings: AGENT_MODEL_SETTINGS,
+    });
+  });
+
+  test("omits model fields the agent does not define", async () => {
+    __testSetBackend(
+      stubBackend({
+        retrieveAgent: async () => ({ id: "agent-1", model: null }),
+      }),
+    );
+
+    const pin = await resolveConversationModelPin("agent-1");
+
+    expect(pin).toEqual({});
+  });
+
+  test("returns an empty pin when the agent lookup fails", async () => {
+    __testSetBackend(
+      stubBackend({
+        retrieveAgent: async () => {
+          throw new Error("agent lookup failed");
+        },
+      }),
+    );
+
+    const pin = await resolveConversationModelPin("agent-1");
+
+    expect(pin).toEqual({});
+  });
+});
+
+describe("createConversationForAgent", () => {
+  afterEach(() => {
+    __testSetBackend(null);
+  });
+
+  function createProvisioner() {
+    return createChannelRouteProvisioner({ emitEvent: () => {} });
+  }
+
+  test("pins the agent's current model on the created conversation", async () => {
+    const bodies: ConversationCreateBody[] = [];
+    __testSetBackend(stubBackend({ onCreate: (body) => bodies.push(body) }));
+
+    const conversationId = await createProvisioner().createConversationForAgent(
+      "agent-1",
+      "Slack thread",
+    );
+
+    expect(conversationId).toBe("conv-1");
+    expect(bodies).toHaveLength(1);
+    expect(bodies[0]).toEqual({
+      agent_id: "agent-1",
+      model: AGENT_MODEL,
+      model_settings: AGENT_MODEL_SETTINGS,
+      summary: "Slack thread",
+    });
+  });
+
+  test("falls back to modelless creation when the agent lookup fails", async () => {
+    const bodies: ConversationCreateBody[] = [];
+    __testSetBackend(
+      stubBackend({
+        retrieveAgent: async () => {
+          throw new Error("agent lookup failed");
+        },
+        onCreate: (body) => bodies.push(body),
+      }),
+    );
+
+    const conversationId =
+      await createProvisioner().createConversationForAgent("agent-1");
+
+    expect(conversationId).toBe("conv-1");
+    expect(bodies).toHaveLength(1);
+    expect(bodies[0]).toEqual({ agent_id: "agent-1" });
+    expect(bodies[0]).not.toHaveProperty("model");
+    expect(bodies[0]).not.toHaveProperty("model_settings");
+  });
+});

--- a/src/channels/registry-routes.ts
+++ b/src/channels/registry-routes.ts
@@ -1,4 +1,5 @@
-import { getBackend } from "@/backend";
+import { type ConversationCreateBody, getBackend } from "@/backend";
+import { debugWarn } from "@/utils/debug";
 import { LEGACY_CHANNEL_ACCOUNT_ID } from "./accounts";
 import type { ChannelRegistryEvent } from "./registry-events";
 import {
@@ -23,6 +24,38 @@ import type {
   WhatsAppChannelAccount,
 } from "./types";
 
+type ConversationModelPin = Pick<
+  ConversationCreateBody,
+  "model" | "model_settings"
+>;
+
+/**
+ * Resolve the agent's current model (and model settings) so channel-created
+ * conversations pin it at creation time. A conversation created without an
+ * explicit model live-inherits the agent's model, so a later agent-level
+ * model change would silently switch active channel threads. If the agent
+ * lookup fails, return an empty pin so thread handling never breaks — the
+ * conversation is then created modelless, matching the previous behavior.
+ */
+export async function resolveConversationModelPin(
+  agentId: string,
+): Promise<ConversationModelPin> {
+  try {
+    const agent = await getBackend().retrieveAgent(agentId);
+    return {
+      ...(agent.model ? { model: agent.model } : {}),
+      ...(agent.model_settings ? { model_settings: agent.model_settings } : {}),
+    };
+  } catch (error) {
+    debugWarn(
+      "channels",
+      `Failed to resolve model for agent ${agentId}; creating channel conversation without a pinned model`,
+      error,
+    );
+    return {};
+  }
+}
+
 export function createChannelRouteProvisioner(deps: {
   emitEvent: (event: ChannelRegistryEvent) => void;
 }) {
@@ -30,8 +63,10 @@ export function createChannelRouteProvisioner(deps: {
     agentId: string,
     summary?: string,
   ): Promise<string> {
+    const modelPin = await resolveConversationModelPin(agentId);
     const conversation = await getBackend().createConversation({
       agent_id: agentId,
+      ...modelPin,
       ...(summary ? { summary } : {}),
     });
     return conversation.id;


### PR DESCRIPTION
## Incident

Conversations created by the local channel host (`letta server --channel`) for new Slack/Discord/Telegram/WhatsApp/Signal threads were created **without a model**, so they live-inherited the agent's model. A later agent-level model change silently switched the model of active channel threads — in the real incident, an agent PATCH changed an active Slack thread's model mid-conversation.

## Fix: copy-on-create semantics

The intended semantics are that a conversation without a specified model resolves the agent's current model **once at creation, never again**. All five channel route creators (Slack, Telegram, Discord, WhatsApp, Signal) funnel through the shared `createConversationForAgent` helper in `src/channels/registry-routes.ts`, so a single resolution point covers every channel:

- `resolveConversationModelPin` retrieves the agent and returns its current `model` and `model_settings`, which are spread into the conversation-create request body.
- If the agent lookup fails, the conversation is created modelless (previous behavior) with a warning — thread handling never breaks.

This is the sibling of the Letta Cloud webhook-path fix, letta-cloud #14077 (resolve agent model + model_settings, spread into the conversation-create body, warn-and-fall-back on lookup failure).

## Tests

- New `src/channels/registry-routes.test.ts` (object-level backend stubbing via `__testSetBackend`, no module mocks):
  - created conversation carries the resolved model and model_settings
  - model fields the agent does not define are omitted
  - agent-lookup failure falls back to modelless creation and still returns the conversation id
- Existing slack/telegram/discord/whatsapp/signal registry tests pass unchanged.
- `bun run check`: 12/12 pass.
- Full unit suite (`node scripts/run-unit-tests.cjs`): 0 real test failures. The run exits 1 only because of a **pre-existing Bun 1.3.0 segfault** in `src/websocket/app-server.test.ts` (reproduces standalone and on clean main, unrelated to this change). The files the crashed shard skipped were re-run directly: all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)