### PR TITLE
feat(channels): export a shared runtime-command executor

### DIFF
--- a/src/channels-public.ts
+++ b/src/channels-public.ts
@@ -1,4 +1,33 @@
 export type {
+  ChannelModelListEntry,
+  ParsedChannelModelCommand,
+  RuntimeCommandAbortResult,
+  RuntimeCommandClient,
+  RuntimeCommandExecuteResult,
+  RuntimeCommandListModelsResult,
+  RuntimeCommandReply,
+  RuntimeCommandScope,
+  RuntimeCommandUpdateModelResult,
+  RuntimeExecuteCommandId,
+} from "./channels/command-runtime-executor";
+export {
+  buildChannelCancelAcceptedMessage,
+  buildChannelCancelNoActiveTurnMessage,
+  buildChannelCurrentModelMessage,
+  buildChannelCurrentModelUnavailableMessage,
+  buildChannelModelListMessage,
+  buildChannelModelListUnavailableMessage,
+  buildChannelModelNotFoundText,
+  buildChannelModelUpdatedMessage,
+  buildChannelModelUpdateFailedMessage,
+  parseChannelModelCommand,
+  runChannelCancelCommand,
+  runChannelModelListCommand,
+  runChannelModelUpdateCommand,
+  runChannelReflectionCommand,
+  runChannelReloadCommand,
+} from "./channels/command-runtime-executor";
+export type {
   ChannelDisplayNameResolver,
   ChannelSlashCommandDefinition,
   ChannelSlashCommandHandlerResult,

--- a/src/channels/command-runtime-executor.test.ts
+++ b/src/channels/command-runtime-executor.test.ts
@@ -1,0 +1,500 @@
+import { describe, expect, test } from "bun:test";
+import {
+  parseChannelModelCommand,
+  type RuntimeCommandAbortResult,
+  type RuntimeCommandClient,
+  type RuntimeCommandExecuteResult,
+  type RuntimeCommandListModelsResult,
+  type RuntimeCommandScope,
+  type RuntimeCommandUpdateModelResult,
+  runChannelCancelCommand,
+  runChannelModelListCommand,
+  runChannelModelUpdateCommand,
+  runChannelReflectionCommand,
+  runChannelReloadCommand,
+} from "@/channels/command-runtime-executor";
+import type { ListModelsResponseModelEntry } from "@/types/protocol_v2";
+
+const RUNTIME: RuntimeCommandScope = {
+  agent_id: "agent-1",
+  conversation_id: "conv-1",
+};
+
+const MODEL_ENTRIES: ListModelsResponseModelEntry[] = [
+  {
+    id: "model-opus",
+    handle: "anthropic/claude-opus",
+    label: "Claude Opus",
+    description: "Best quality",
+    isDefault: true,
+  },
+  {
+    id: "model-fast",
+    handle: "anthropic/claude-haiku",
+    label: "Claude Haiku",
+    description: "Fastest",
+    isFeatured: true,
+  },
+];
+
+type RecordedCall =
+  | { method: "listModels" }
+  | {
+      method: "updateModel";
+      params: { runtime: RuntimeCommandScope; modelIdentifier: string };
+    }
+  | {
+      method: "abortMessage";
+      params: { runtime: RuntimeCommandScope; runId: string | null };
+    }
+  | {
+      method: "executeCommand";
+      params: {
+        runtime: RuntimeCommandScope;
+        commandId: "reflect" | "reload";
+        args?: string;
+      };
+    };
+
+function createFakeClient(
+  overrides: {
+    listModels?: RuntimeCommandListModelsResult | Error;
+    updateModel?: RuntimeCommandUpdateModelResult | Error;
+    abortMessage?: RuntimeCommandAbortResult | Error;
+    executeCommand?: RuntimeCommandExecuteResult | Error;
+  } = {},
+): { client: RuntimeCommandClient; calls: RecordedCall[] } {
+  const calls: RecordedCall[] = [];
+  const resolveOrThrow = async <T>(
+    value: T | Error | undefined,
+    fallback: T,
+  ) => {
+    if (value instanceof Error) throw value;
+    return value ?? fallback;
+  };
+  const client: RuntimeCommandClient = {
+    listModels: async () => {
+      calls.push({ method: "listModels" });
+      return resolveOrThrow(overrides.listModels, {
+        success: true,
+        entries: MODEL_ENTRIES,
+      });
+    },
+    updateModel: async (params) => {
+      calls.push({ method: "updateModel", params });
+      return resolveOrThrow(overrides.updateModel, { success: true });
+    },
+    abortMessage: async (params) => {
+      calls.push({ method: "abortMessage", params });
+      return resolveOrThrow(overrides.abortMessage, {
+        success: true,
+        aborted: true,
+      });
+    },
+    executeCommand: async (params) => {
+      calls.push({ method: "executeCommand", params });
+      return resolveOrThrow(overrides.executeCommand, {
+        success: true,
+        output: "done",
+      });
+    },
+  };
+  return { client, calls };
+}
+
+describe("parseChannelModelCommand", () => {
+  test("empty or whitespace args mean show the current model", () => {
+    expect(parseChannelModelCommand("")).toEqual({ kind: "current" });
+    expect(parseChannelModelCommand("   ")).toEqual({ kind: "current" });
+  });
+
+  test("list is matched case-insensitively", () => {
+    expect(parseChannelModelCommand("list")).toEqual({ kind: "list" });
+    expect(parseChannelModelCommand(" LIST ")).toEqual({ kind: "list" });
+  });
+
+  test("anything else is a trimmed model identifier", () => {
+    expect(parseChannelModelCommand(" anthropic/claude-opus ")).toEqual({
+      kind: "update",
+      modelIdentifier: "anthropic/claude-opus",
+    });
+  });
+});
+
+describe("runChannelModelListCommand", () => {
+  test("sends list_models and renders the model selector", async () => {
+    const { client, calls } = createFakeClient({
+      listModels: {
+        success: true,
+        entries: MODEL_ENTRIES,
+        availableHandles: ["anthropic/claude-opus"],
+        error: undefined,
+      },
+    });
+
+    const result = await runChannelModelListCommand({
+      channelId: "telegram",
+      client,
+      recentHandles: ["anthropic/claude-opus"],
+    });
+
+    expect(calls).toEqual([{ method: "listModels" }]);
+    expect(result.handled).toBe(true);
+    expect(result.text).toContain("Telegram model selector");
+    expect(result.text).toContain("Recent models:");
+    expect(result.text).toContain("Available models:");
+    expect(result.text).toContain("Claude Opus");
+    expect(result.text).toContain("/model model-opus");
+    // Availability was reported, so no fallback note is rendered.
+    expect(result.text).not.toContain("Availability lookup failed");
+    expect(result.text).not.toContain("Available model data was not returned");
+  });
+
+  test("null availableHandles renders the lookup-failed note", async () => {
+    const { client } = createFakeClient({
+      listModels: {
+        success: true,
+        entries: MODEL_ENTRIES,
+        availableHandles: null,
+      },
+    });
+
+    const result = await runChannelModelListCommand({
+      channelId: "telegram",
+      client,
+    });
+
+    expect(result.text).toContain(
+      "Availability lookup failed; showing built-in recommended models.",
+    );
+  });
+
+  test("absent availableHandles renders the not-returned note", async () => {
+    const { client } = createFakeClient({
+      listModels: { success: true, entries: MODEL_ENTRIES },
+    });
+
+    const result = await runChannelModelListCommand({
+      channelId: "telegram",
+      client,
+    });
+
+    expect(result.text).toContain(
+      "Available model data was not returned; showing built-in recommended models.",
+    );
+  });
+
+  test("failure renders the unavailable message with the server error", async () => {
+    const { client } = createFakeClient({
+      listModels: { success: false, entries: [], error: "backend down" },
+    });
+
+    const result = await runChannelModelListCommand({
+      channelId: "telegram",
+      client,
+    });
+
+    expect(result.text).toBe(
+      "Telegram could not load the model list: backend down",
+    );
+  });
+
+  test("failure without a server error uses the default copy", async () => {
+    const { client } = createFakeClient({
+      listModels: { success: false, entries: [] },
+    });
+
+    const result = await runChannelModelListCommand({
+      channelId: "telegram",
+      client,
+    });
+
+    expect(result.text).toBe(
+      "Telegram could not load the model list: Failed to list models",
+    );
+  });
+
+  test("uses the injected display-name resolver", async () => {
+    const { client } = createFakeClient();
+
+    const result = await runChannelModelListCommand({
+      channelId: "my-plugin",
+      client,
+      channelDisplayName: () => "My Plugin",
+    });
+
+    expect(result.text).toContain("My Plugin model selector");
+  });
+
+  test("transport errors propagate to the host", async () => {
+    const { client } = createFakeClient({
+      listModels: new Error("relay timeout"),
+    });
+
+    await expect(
+      runChannelModelListCommand({ channelId: "telegram", client }),
+    ).rejects.toThrow("relay timeout");
+  });
+});
+
+describe("runChannelModelUpdateCommand", () => {
+  test("sends update_model for the runtime and renders success", async () => {
+    const { client, calls } = createFakeClient({
+      updateModel: {
+        success: true,
+        modelHandle: "anthropic/claude-opus",
+        appliedTo: "conversation",
+      },
+    });
+
+    const result = await runChannelModelUpdateCommand({
+      channelId: "telegram",
+      client,
+      runtime: RUNTIME,
+      modelIdentifier: "opus",
+      resolveModelLabel: (handle) =>
+        handle === "anthropic/claude-opus" ? "Claude Opus" : undefined,
+    });
+
+    expect(calls).toEqual([
+      {
+        method: "updateModel",
+        params: { runtime: RUNTIME, modelIdentifier: "opus" },
+      },
+    ]);
+    expect(result.success).toBe(true);
+    expect(result.modelHandle).toBe("anthropic/claude-opus");
+    expect(result.text).toBe(
+      "Telegram updated this conversation's model to Claude Opus (anthropic/claude-opus).",
+    );
+  });
+
+  test("agent-scoped updates say agent and fall back to the identifier label", async () => {
+    const { client } = createFakeClient({
+      updateModel: { success: true, appliedTo: "agent" },
+    });
+
+    const result = await runChannelModelUpdateCommand({
+      channelId: "telegram",
+      client,
+      runtime: RUNTIME,
+      modelIdentifier: "opus",
+    });
+
+    // No server handle and no label resolver: the identifier stands in for
+    // both, so the parenthetical handle suffix collapses.
+    expect(result.modelHandle).toBe("opus");
+    expect(result.text).toBe("Telegram updated this agent's model to opus.");
+  });
+
+  test("failure renders the update-failed message with the server error", async () => {
+    const { client } = createFakeClient({
+      updateModel: { success: false, error: "unknown model" },
+    });
+
+    const result = await runChannelModelUpdateCommand({
+      channelId: "telegram",
+      client,
+      runtime: RUNTIME,
+      modelIdentifier: "bogus",
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.modelHandle).toBeUndefined();
+    expect(result.text).toBe(
+      "Telegram could not switch this chat's routed model to bogus: unknown model",
+    );
+  });
+
+  test("failure without a server error uses the default copy", async () => {
+    const { client } = createFakeClient({
+      updateModel: { success: false },
+    });
+
+    const result = await runChannelModelUpdateCommand({
+      channelId: "telegram",
+      client,
+      runtime: RUNTIME,
+      modelIdentifier: "bogus",
+    });
+
+    expect(result.text).toBe(
+      "Telegram could not switch this chat's routed model to bogus: Failed to update model",
+    );
+  });
+
+  test("transport errors propagate to the host", async () => {
+    const { client } = createFakeClient({
+      updateModel: new Error("relay timeout"),
+    });
+
+    await expect(
+      runChannelModelUpdateCommand({
+        channelId: "telegram",
+        client,
+        runtime: RUNTIME,
+        modelIdentifier: "opus",
+      }),
+    ).rejects.toThrow("relay timeout");
+  });
+});
+
+describe("runChannelCancelCommand", () => {
+  test("sends abort_message with a null run id", async () => {
+    const { client, calls } = createFakeClient({
+      abortMessage: { success: true, aborted: true },
+    });
+
+    const result = await runChannelCancelCommand({
+      client,
+      runtime: RUNTIME,
+      channelId: "telegram",
+    });
+
+    expect(calls).toEqual([
+      { method: "abortMessage", params: { runtime: RUNTIME, runId: null } },
+    ]);
+    expect(result.cancelled).toBe(true);
+    expect(result.text).toBe(
+      "Telegram cancelled the in-progress agent turn for this chat.",
+    );
+  });
+
+  test("no active turn renders the no-active-turn message", async () => {
+    const { client } = createFakeClient({
+      abortMessage: { success: true, aborted: false },
+    });
+
+    const result = await runChannelCancelCommand({
+      client,
+      runtime: RUNTIME,
+      channelId: "telegram",
+    });
+
+    expect(result.cancelled).toBe(false);
+    expect(result.text).toBe(
+      "Telegram received /cancel, but there is no in-progress agent turn to cancel for this chat.",
+    );
+  });
+
+  test("an unsuccessful abort is not a cancellation even if aborted is set", async () => {
+    const { client } = createFakeClient({
+      abortMessage: { success: false, aborted: true },
+    });
+
+    const result = await runChannelCancelCommand({
+      client,
+      runtime: RUNTIME,
+      channelId: "telegram",
+    });
+
+    expect(result.cancelled).toBe(false);
+  });
+
+  test("omits text when no channel id is provided (host renders)", async () => {
+    const { client } = createFakeClient({
+      abortMessage: { success: true, aborted: true },
+    });
+
+    const result = await runChannelCancelCommand({ client, runtime: RUNTIME });
+
+    expect(result.cancelled).toBe(true);
+    expect(result.text).toBeUndefined();
+  });
+
+  test("transport errors propagate to the host", async () => {
+    const { client } = createFakeClient({
+      abortMessage: new Error("relay timeout"),
+    });
+
+    await expect(
+      runChannelCancelCommand({ client, runtime: RUNTIME }),
+    ).rejects.toThrow("relay timeout");
+  });
+});
+
+describe("runChannelReflectionCommand and runChannelReloadCommand", () => {
+  test("reflection sends execute_command reflect and relays its output", async () => {
+    const { client, calls } = createFakeClient({
+      executeCommand: { success: true, output: "Reflection started." },
+    });
+
+    const result = await runChannelReflectionCommand({
+      client,
+      runtime: RUNTIME,
+    });
+
+    expect(calls).toEqual([
+      {
+        method: "executeCommand",
+        params: { runtime: RUNTIME, commandId: "reflect" },
+      },
+    ]);
+    expect(result).toEqual({ handled: true, text: "Reflection started." });
+  });
+
+  test("reload sends execute_command reload and relays its output", async () => {
+    const { client, calls } = createFakeClient({
+      executeCommand: { success: true, output: "Reloaded." },
+    });
+
+    const result = await runChannelReloadCommand({ client, runtime: RUNTIME });
+
+    expect(calls).toEqual([
+      {
+        method: "executeCommand",
+        params: { runtime: RUNTIME, commandId: "reload" },
+      },
+    ]);
+    expect(result).toEqual({ handled: true, text: "Reloaded." });
+  });
+
+  test("trimmed args are forwarded; blank args are omitted", async () => {
+    const { client, calls } = createFakeClient();
+
+    await runChannelReflectionCommand({
+      client,
+      runtime: RUNTIME,
+      args: "  focus on memory  ",
+    });
+    await runChannelReloadCommand({ client, runtime: RUNTIME, args: "   " });
+
+    expect(calls).toEqual([
+      {
+        method: "executeCommand",
+        params: {
+          runtime: RUNTIME,
+          commandId: "reflect",
+          args: "focus on memory",
+        },
+      },
+      {
+        method: "executeCommand",
+        params: { runtime: RUNTIME, commandId: "reload" },
+      },
+    ]);
+  });
+
+  test("failed executions still relay the server-rendered output", async () => {
+    const { client } = createFakeClient({
+      executeCommand: { success: false, output: "Reload failed: no agent." },
+    });
+
+    const result = await runChannelReloadCommand({ client, runtime: RUNTIME });
+
+    expect(result).toEqual({
+      handled: true,
+      text: "Reload failed: no agent.",
+    });
+  });
+
+  test("transport errors propagate to the host", async () => {
+    const { client } = createFakeClient({
+      executeCommand: new Error("relay timeout"),
+    });
+
+    await expect(
+      runChannelReflectionCommand({ client, runtime: RUNTIME }),
+    ).rejects.toThrow("relay timeout");
+  });
+});

--- a/src/channels/command-runtime-executor.ts
+++ b/src/channels/command-runtime-executor.ts
@@ -1,0 +1,556 @@
+/**
+ * Shared runtime-command executor for the channel slash commands whose
+ * semantics are pure app-server protocol: `/model <handle>`, `/model list`,
+ * `/cancel`, `/reflection`, and `/reload`.
+ *
+ * Every channel host — the local `letta server --channel` gateway and Letta
+ * Cloud's Slack gateway — ends up sending the same protocol commands
+ * (`update_model`, `list_models`, `abort_message`, `execute_command`) and
+ * rendering a reply. Implementing that twice lets the two hosts drift, so the
+ * protocol semantics and reply rendering live here once, parameterized by a
+ * minimal injected {@link RuntimeCommandClient} that each host backs with its
+ * own transport (in-process App Server client locally, the Redis listener
+ * relay in Cloud).
+ *
+ * Like `command-surface.ts`, this module must stay free of host-local
+ * dependencies (plugin registry, adapters, settings, websockets) so external
+ * hosts can consume it from the public channels entrypoint.
+ */
+
+import type { ListModelsResponseModelEntry } from "@/types/protocol_v2";
+import {
+  type ChannelDisplayNameResolver,
+  defaultChannelDisplayName,
+} from "./command-surface";
+
+// ─────────────────────────────────────────────────────────────────────────────
+//  Injected client
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Runtime identity the protocol commands target. */
+export interface RuntimeCommandScope {
+  agent_id: string;
+  conversation_id: string;
+}
+
+/** App-server `execute_command` ids reachable from channel slash commands. */
+export type RuntimeExecuteCommandId = "reflect" | "reload";
+
+/** Result of a `list_models` round trip. */
+export interface RuntimeCommandListModelsResult {
+  success: boolean;
+  entries: ListModelsResponseModelEntry[];
+  /**
+   * Handles available to this user. Tri-state mirrors the wire format:
+   * `null` = availability lookup failed; `undefined` = the server did not
+   * report availability. Both cases render an explanatory note.
+   */
+  availableHandles?: string[] | null;
+  error?: string;
+}
+
+/** Result of an `update_model` round trip. */
+export interface RuntimeCommandUpdateModelResult {
+  success: boolean;
+  /** Canonical handle the server applied (may differ from the request). */
+  modelHandle?: string;
+  appliedTo?: "agent" | "conversation";
+  error?: string;
+}
+
+/** Result of an `abort_message` round trip. */
+export interface RuntimeCommandAbortResult {
+  success: boolean;
+  aborted: boolean;
+  error?: string;
+}
+
+/** Result of an `execute_command` round trip. */
+export interface RuntimeCommandExecuteResult {
+  success: boolean;
+  output: string;
+}
+
+/**
+ * Minimal transport interface a channel host injects into the executor.
+ *
+ * Each method corresponds to exactly one app-server protocol command; the
+ * host owns request-id generation, correlation, and timeouts. Transport-level
+ * failures should be thrown — the executor intentionally does not catch them
+ * so each host can apply its own failure copy and logging.
+ */
+export interface RuntimeCommandClient {
+  listModels(): Promise<RuntimeCommandListModelsResult>;
+  updateModel(params: {
+    runtime: RuntimeCommandScope;
+    /** User-provided handle or id; sent as both `model_id` and `model_handle`. */
+    modelIdentifier: string;
+  }): Promise<RuntimeCommandUpdateModelResult>;
+  abortMessage(params: {
+    runtime: RuntimeCommandScope;
+    runId: string | null;
+  }): Promise<RuntimeCommandAbortResult>;
+  executeCommand(params: {
+    runtime: RuntimeCommandScope;
+    commandId: RuntimeExecuteCommandId;
+    args?: string;
+  }): Promise<RuntimeCommandExecuteResult>;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+//  Model entry helpers (pure)
+// ─────────────────────────────────────────────────────────────────────────────
+
+export type ChannelModelListEntry = Pick<
+  ListModelsResponseModelEntry,
+  | "id"
+  | "handle"
+  | "label"
+  | "description"
+  | "isDefault"
+  | "isFeatured"
+  | "updateArgs"
+>;
+
+const DEFAULT_CHANNEL_MODEL_LIST_LIMIT = 8;
+
+function getModelEntryRank(entry: ChannelModelListEntry): number {
+  if (entry.isDefault) return 0;
+  if (entry.isFeatured) return 1;
+  const effort = (
+    entry.updateArgs as { reasoning_effort?: unknown } | undefined
+  )?.reasoning_effort;
+  if (effort === "medium") return 2;
+  if (effort === "high") return 3;
+  return 4;
+}
+
+function preferModelEntry(
+  current: ChannelModelListEntry,
+  candidate: ChannelModelListEntry,
+): ChannelModelListEntry {
+  return getModelEntryRank(candidate) < getModelEntryRank(current)
+    ? candidate
+    : current;
+}
+
+export function buildModelEntriesByHandle(
+  entries: ChannelModelListEntry[],
+): Map<string, ChannelModelListEntry> {
+  const byHandle = new Map<string, ChannelModelListEntry>();
+  for (const entry of entries) {
+    const current = byHandle.get(entry.handle);
+    byHandle.set(
+      entry.handle,
+      current ? preferModelEntry(current, entry) : entry,
+    );
+  }
+  return byHandle;
+}
+
+function makeUnknownModelEntry(handle: string): ChannelModelListEntry {
+  return {
+    id: handle,
+    handle,
+    label: handle,
+    description: "",
+  };
+}
+
+export function resolveModelHandles(params: {
+  handles: string[];
+  byHandle: Map<string, ChannelModelListEntry>;
+  availableHandles?: Set<string> | null;
+}): ChannelModelListEntry[] {
+  const { handles, byHandle, availableHandles } = params;
+  const seen = new Set<string>();
+  const resolved: ChannelModelListEntry[] = [];
+  for (const handle of handles) {
+    if (!handle || seen.has(handle)) continue;
+    seen.add(handle);
+    if (availableHandles && !availableHandles.has(handle)) continue;
+    resolved.push(byHandle.get(handle) ?? makeUnknownModelEntry(handle));
+  }
+  return resolved;
+}
+
+export function getFallbackModelEntries(
+  byHandle: Map<string, ChannelModelListEntry>,
+): ChannelModelListEntry[] {
+  const preferred = Array.from(byHandle.values()).filter(
+    (entry) => entry.isDefault || entry.isFeatured,
+  );
+  return preferred.length > 0 ? preferred : Array.from(byHandle.values());
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+//  Reply rendering (pure; display name injected)
+// ─────────────────────────────────────────────────────────────────────────────
+
+function modelCommandPrefix(channelId: string): "/model" | "@agent /model" {
+  return channelId === "slack" ? "@agent /model" : "/model";
+}
+
+export function buildChannelModelNotFoundText(channelId: string): string {
+  return `Model not found. Use ${modelCommandPrefix(channelId)} list to see available models.`;
+}
+
+export function buildChannelCurrentModelMessage(
+  channelId: string,
+  params: {
+    modelLabel: string;
+    modelHandle: string | null;
+    scope?: "agent" | "conversation";
+  },
+  displayNameResolver: ChannelDisplayNameResolver = defaultChannelDisplayName,
+): string {
+  const displayName = displayNameResolver(channelId);
+  const scope = params.scope === "agent" ? "agent" : "conversation";
+  const handleText =
+    params.modelHandle && params.modelHandle !== params.modelLabel
+      ? ` (${params.modelHandle})`
+      : "";
+  const switchCommand = modelCommandPrefix(channelId);
+  return [
+    `${displayName} current ${scope} model: ${params.modelLabel}${handleText}.`,
+    `Use ${switchCommand} list to see available models, or ${switchCommand} <handle-or-id> to switch.`,
+  ].join("\n");
+}
+
+function formatChannelModelEntry(
+  channelId: string,
+  entry: ChannelModelListEntry,
+): string {
+  const selector = entry.id || entry.handle;
+  const handleText = entry.handle === entry.label ? "" : ` — ${entry.handle}`;
+  return `• ${entry.label}${handleText} (${modelCommandPrefix(channelId)} ${selector})`;
+}
+
+function appendModelEntrySection(
+  lines: string[],
+  channelId: string,
+  title: string,
+  entries: ChannelModelListEntry[],
+  limit: number,
+): void {
+  if (entries.length === 0) return;
+  lines.push("", `${title}:`);
+  for (const entry of entries.slice(0, limit)) {
+    lines.push(formatChannelModelEntry(channelId, entry));
+  }
+  const remaining = entries.length - limit;
+  if (remaining > 0) {
+    lines.push(`…and ${remaining} more.`);
+  }
+}
+
+export function buildChannelModelListMessage(
+  channelId: string,
+  params: {
+    entries: ListModelsResponseModelEntry[];
+    availableHandles?: string[] | null;
+    recentHandles?: string[];
+    limit?: number;
+  },
+  displayNameResolver: ChannelDisplayNameResolver = defaultChannelDisplayName,
+): string {
+  const displayName = displayNameResolver(channelId);
+  const limit = params.limit ?? DEFAULT_CHANNEL_MODEL_LIST_LIMIT;
+  const entries = params.entries as ChannelModelListEntry[];
+  const byHandle = buildModelEntriesByHandle(entries);
+  const availableHandleList = Array.isArray(params.availableHandles)
+    ? params.availableHandles
+    : null;
+  const availableSet = availableHandleList
+    ? new Set(availableHandleList)
+    : null;
+  const recentEntries = resolveModelHandles({
+    handles: params.recentHandles ?? [],
+    byHandle,
+    availableHandles: availableSet,
+  });
+  const availableEntries = availableHandleList
+    ? resolveModelHandles({ handles: availableHandleList, byHandle })
+    : getFallbackModelEntries(byHandle);
+
+  const lines = [`${displayName} model selector`];
+  if (params.availableHandles === null) {
+    lines.push(
+      "Availability lookup failed; showing built-in recommended models.",
+    );
+  } else if (params.availableHandles === undefined) {
+    lines.push(
+      "Available model data was not returned; showing built-in recommended models.",
+    );
+  }
+
+  appendModelEntrySection(
+    lines,
+    channelId,
+    "Recent models",
+    recentEntries,
+    limit,
+  );
+  appendModelEntrySection(
+    lines,
+    channelId,
+    "Available models",
+    availableEntries,
+    limit,
+  );
+
+  if (availableEntries.length === 0) {
+    lines.push(
+      "",
+      "No available models were reported. Use /connect in Letta Code to configure a provider, then try again.",
+    );
+  }
+
+  lines.push("");
+  if (channelId === "slack") {
+    lines.push(
+      "Mention the app with @agent /model <handle-or-id> to switch this thread's routed model. Use @agent /model to show the current model. Legacy !model still works after a mention.",
+    );
+  } else {
+    lines.push(
+      "Use /model <handle-or-id> to switch this chat's routed model, or /model to show the current model.",
+    );
+  }
+  return lines.join("\n");
+}
+
+export function buildChannelModelListUnavailableMessage(
+  channelId: string,
+  error: string,
+  displayNameResolver: ChannelDisplayNameResolver = defaultChannelDisplayName,
+): string {
+  const displayName = displayNameResolver(channelId);
+  return `${displayName} could not load the model list: ${error}`;
+}
+
+export function buildChannelCurrentModelUnavailableMessage(
+  channelId: string,
+  error: string,
+  displayNameResolver: ChannelDisplayNameResolver = defaultChannelDisplayName,
+): string {
+  const displayName = displayNameResolver(channelId);
+  return `${displayName} could not load the current model: ${error}`;
+}
+
+export function buildChannelModelUpdatedMessage(
+  channelId: string,
+  params: {
+    modelLabel: string;
+    modelHandle: string;
+    appliedTo?: "agent" | "conversation";
+  },
+  displayNameResolver: ChannelDisplayNameResolver = defaultChannelDisplayName,
+): string {
+  const displayName = displayNameResolver(channelId);
+  const scope = params.appliedTo === "agent" ? "agent" : "conversation";
+  const handleText =
+    params.modelHandle === params.modelLabel ? "" : ` (${params.modelHandle})`;
+  return `${displayName} updated this ${scope}'s model to ${params.modelLabel}${handleText}.`;
+}
+
+export function buildChannelModelUpdateFailedMessage(
+  channelId: string,
+  identifier: string,
+  error: string,
+  displayNameResolver: ChannelDisplayNameResolver = defaultChannelDisplayName,
+): string {
+  const displayName = displayNameResolver(channelId);
+  return `${displayName} could not switch this chat's routed model to ${identifier}: ${error}`;
+}
+
+export function buildChannelCancelAcceptedMessage(
+  channelId: string,
+  displayNameResolver: ChannelDisplayNameResolver = defaultChannelDisplayName,
+): string {
+  const displayName = displayNameResolver(channelId);
+  return `${displayName} cancelled the in-progress agent turn for this chat.`;
+}
+
+export function buildChannelCancelNoActiveTurnMessage(
+  channelId: string,
+  displayNameResolver: ChannelDisplayNameResolver = defaultChannelDisplayName,
+): string {
+  const displayName = displayNameResolver(channelId);
+  return `${displayName} received /cancel, but there is no in-progress agent turn to cancel for this chat.`;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+//  Command executors
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Rendered reply from a shared runtime-command executor. */
+export interface RuntimeCommandReply {
+  handled: true;
+  text: string;
+}
+
+export type ParsedChannelModelCommand =
+  | { kind: "current" }
+  | { kind: "list" }
+  | { kind: "update"; modelIdentifier: string };
+
+/**
+ * Classify `/model` arguments: empty → show the current model (host-owned),
+ * `list` (case-insensitive) → list models, anything else → switch to it.
+ */
+export function parseChannelModelCommand(
+  args: string,
+): ParsedChannelModelCommand {
+  const modelIdentifier = args.trim();
+  if (!modelIdentifier) {
+    return { kind: "current" };
+  }
+  if (modelIdentifier.toLowerCase() === "list") {
+    return { kind: "list" };
+  }
+  return { kind: "update", modelIdentifier };
+}
+
+/** `/model list` — send `list_models` and render the selector reply. */
+export async function runChannelModelListCommand(params: {
+  channelId: string;
+  client: RuntimeCommandClient;
+  /** Host-tracked recently used handles (e.g. local settings). */
+  recentHandles?: string[];
+  channelDisplayName?: ChannelDisplayNameResolver;
+}): Promise<RuntimeCommandReply> {
+  const displayNameResolver =
+    params.channelDisplayName ?? defaultChannelDisplayName;
+  const result = await params.client.listModels();
+  return {
+    handled: true,
+    text: result.success
+      ? buildChannelModelListMessage(
+          params.channelId,
+          {
+            entries: result.entries,
+            availableHandles: result.availableHandles,
+            recentHandles: params.recentHandles,
+          },
+          displayNameResolver,
+        )
+      : buildChannelModelListUnavailableMessage(
+          params.channelId,
+          result.error ?? "Failed to list models",
+          displayNameResolver,
+        ),
+  };
+}
+
+/** `/model <handle-or-id>` — send `update_model` and render the outcome. */
+export async function runChannelModelUpdateCommand(params: {
+  channelId: string;
+  client: RuntimeCommandClient;
+  runtime: RuntimeCommandScope;
+  modelIdentifier: string;
+  /** Optional handle → human label lookup (e.g. the local model catalog). */
+  resolveModelLabel?: (modelHandle: string) => string | undefined;
+  channelDisplayName?: ChannelDisplayNameResolver;
+}): Promise<RuntimeCommandReply & { success: boolean; modelHandle?: string }> {
+  const displayNameResolver =
+    params.channelDisplayName ?? defaultChannelDisplayName;
+  const result = await params.client.updateModel({
+    runtime: params.runtime,
+    modelIdentifier: params.modelIdentifier,
+  });
+  if (!result.success) {
+    return {
+      handled: true,
+      success: false,
+      text: buildChannelModelUpdateFailedMessage(
+        params.channelId,
+        params.modelIdentifier,
+        result.error ?? "Failed to update model",
+        displayNameResolver,
+      ),
+    };
+  }
+  const appliedHandle = result.modelHandle ?? params.modelIdentifier;
+  return {
+    handled: true,
+    success: true,
+    modelHandle: appliedHandle,
+    text: buildChannelModelUpdatedMessage(
+      params.channelId,
+      {
+        modelLabel:
+          params.resolveModelLabel?.(appliedHandle) ?? params.modelIdentifier,
+        modelHandle: appliedHandle,
+        appliedTo: result.appliedTo,
+      },
+      displayNameResolver,
+    ),
+  };
+}
+
+/**
+ * `/cancel` — send `abort_message` for the routed runtime. `text` is only
+ * rendered when `channelId` is provided; hosts that render cancel outcomes
+ * themselves (e.g. via `ChannelSlashCommandHandlers` default text) can rely
+ * on `cancelled` alone.
+ */
+export async function runChannelCancelCommand(params: {
+  client: RuntimeCommandClient;
+  runtime: RuntimeCommandScope;
+  channelId?: string;
+  channelDisplayName?: ChannelDisplayNameResolver;
+}): Promise<{ handled: true; cancelled: boolean; text?: string }> {
+  const response = await params.client.abortMessage({
+    runtime: params.runtime,
+    runId: null,
+  });
+  const cancelled = response.success && response.aborted;
+  if (params.channelId === undefined) {
+    return { handled: true, cancelled };
+  }
+  const displayNameResolver =
+    params.channelDisplayName ?? defaultChannelDisplayName;
+  return {
+    handled: true,
+    cancelled,
+    text: cancelled
+      ? buildChannelCancelAcceptedMessage(params.channelId, displayNameResolver)
+      : buildChannelCancelNoActiveTurnMessage(
+          params.channelId,
+          displayNameResolver,
+        ),
+  };
+}
+
+async function runChannelExecuteCommand(params: {
+  client: RuntimeCommandClient;
+  runtime: RuntimeCommandScope;
+  commandId: RuntimeExecuteCommandId;
+  args?: string;
+}): Promise<RuntimeCommandReply> {
+  const trimmedArgs = params.args?.trim();
+  const response = await params.client.executeCommand({
+    runtime: params.runtime,
+    commandId: params.commandId,
+    ...(trimmedArgs ? { args: trimmedArgs } : {}),
+  });
+  return { handled: true, text: response.output };
+}
+
+/** `/reflection` — send `execute_command` (`reflect`) and relay its output. */
+export function runChannelReflectionCommand(params: {
+  client: RuntimeCommandClient;
+  runtime: RuntimeCommandScope;
+  args?: string;
+}): Promise<RuntimeCommandReply> {
+  return runChannelExecuteCommand({ ...params, commandId: "reflect" });
+}
+
+/** `/reload` — send `execute_command` (`reload`) and relay its output. */
+export function runChannelReloadCommand(params: {
+  client: RuntimeCommandClient;
+  runtime: RuntimeCommandScope;
+  args?: string;
+}): Promise<RuntimeCommandReply> {
+  return runChannelExecuteCommand({ ...params, commandId: "reload" });
+}

--- a/src/channels/commands.ts
+++ b/src/channels/commands.ts
@@ -7,6 +7,16 @@ import {
   canRunChannelCommand,
 } from "./access-control";
 import {
+  buildChannelCancelAcceptedMessage as buildChannelCancelAcceptedMessageWith,
+  buildChannelCancelNoActiveTurnMessage as buildChannelCancelNoActiveTurnMessageWith,
+  buildChannelCurrentModelMessage as buildChannelCurrentModelMessageWith,
+  buildChannelCurrentModelUnavailableMessage as buildChannelCurrentModelUnavailableMessageWith,
+  buildChannelModelListMessage as buildChannelModelListMessageWith,
+  buildChannelModelListUnavailableMessage as buildChannelModelListUnavailableMessageWith,
+  buildChannelModelUpdatedMessage as buildChannelModelUpdatedMessageWith,
+  buildChannelModelUpdateFailedMessage as buildChannelModelUpdateFailedMessageWith,
+} from "./command-runtime-executor";
+import {
   buildChannelHelpMessage as buildChannelHelpMessageWith,
   buildUnsupportedChannelCommandMessage as buildUnsupportedChannelCommandMessageWith,
   type ChannelSlashCommandHandlerResult,
@@ -26,6 +36,13 @@ import type {
   InboundChannelMessage,
 } from "./types";
 
+export type { ChannelModelListEntry } from "./command-runtime-executor";
+export {
+  buildChannelModelNotFoundText,
+  buildModelEntriesByHandle,
+  getFallbackModelEntries,
+  resolveModelHandles,
+} from "./command-runtime-executor";
 export type {
   ChannelSlashCommandDefinition,
   ChannelSlashCommandHandlerResult,
@@ -197,13 +214,14 @@ export function buildChannelCancelUnavailableMessage(
 export function buildChannelCancelNoActiveTurnMessage(
   channelId: string,
 ): string {
-  const displayName = channelDisplayName(channelId);
-  return `${displayName} received /cancel, but there is no in-progress agent turn to cancel for this chat.`;
+  return buildChannelCancelNoActiveTurnMessageWith(
+    channelId,
+    channelDisplayName,
+  );
 }
 
 export function buildChannelCancelAcceptedMessage(channelId: string): string {
-  const displayName = channelDisplayName(channelId);
-  return `${displayName} cancelled the in-progress agent turn for this chat.`;
+  return buildChannelCancelAcceptedMessageWith(channelId, channelDisplayName);
 }
 
 export function buildChannelChatLinkMessage(
@@ -259,96 +277,6 @@ export function buildChannelNewConversationUnavailableMessage(
   return `${displayName} cannot start a new conversation for this chat because no agent is configured.`;
 }
 
-export type ChannelModelListEntry = Pick<
-  ListModelsResponseModelEntry,
-  | "id"
-  | "handle"
-  | "label"
-  | "description"
-  | "isDefault"
-  | "isFeatured"
-  | "updateArgs"
->;
-
-const DEFAULT_CHANNEL_MODEL_LIST_LIMIT = 8;
-
-function getModelEntryRank(entry: ChannelModelListEntry): number {
-  if (entry.isDefault) return 0;
-  if (entry.isFeatured) return 1;
-  const effort = (
-    entry.updateArgs as { reasoning_effort?: unknown } | undefined
-  )?.reasoning_effort;
-  if (effort === "medium") return 2;
-  if (effort === "high") return 3;
-  return 4;
-}
-
-function preferModelEntry(
-  current: ChannelModelListEntry,
-  candidate: ChannelModelListEntry,
-): ChannelModelListEntry {
-  return getModelEntryRank(candidate) < getModelEntryRank(current)
-    ? candidate
-    : current;
-}
-
-export function buildModelEntriesByHandle(
-  entries: ChannelModelListEntry[],
-): Map<string, ChannelModelListEntry> {
-  const byHandle = new Map<string, ChannelModelListEntry>();
-  for (const entry of entries) {
-    const current = byHandle.get(entry.handle);
-    byHandle.set(
-      entry.handle,
-      current ? preferModelEntry(current, entry) : entry,
-    );
-  }
-  return byHandle;
-}
-
-function makeUnknownModelEntry(handle: string): ChannelModelListEntry {
-  return {
-    id: handle,
-    handle,
-    label: handle,
-    description: "",
-  };
-}
-
-export function resolveModelHandles(params: {
-  handles: string[];
-  byHandle: Map<string, ChannelModelListEntry>;
-  availableHandles?: Set<string> | null;
-}): ChannelModelListEntry[] {
-  const { handles, byHandle, availableHandles } = params;
-  const seen = new Set<string>();
-  const resolved: ChannelModelListEntry[] = [];
-  for (const handle of handles) {
-    if (!handle || seen.has(handle)) continue;
-    seen.add(handle);
-    if (availableHandles && !availableHandles.has(handle)) continue;
-    resolved.push(byHandle.get(handle) ?? makeUnknownModelEntry(handle));
-  }
-  return resolved;
-}
-
-export function getFallbackModelEntries(
-  byHandle: Map<string, ChannelModelListEntry>,
-): ChannelModelListEntry[] {
-  const preferred = Array.from(byHandle.values()).filter(
-    (entry) => entry.isDefault || entry.isFeatured,
-  );
-  return preferred.length > 0 ? preferred : Array.from(byHandle.values());
-}
-
-function modelCommandPrefix(channelId: string): "/model" | "@agent /model" {
-  return channelId === "slack" ? "@agent /model" : "/model";
-}
-
-export function buildChannelModelNotFoundText(channelId: string): string {
-  return `Model not found. Use ${modelCommandPrefix(channelId)} list to see available models.`;
-}
-
 export function buildChannelCurrentModelMessage(
   channelId: string,
   params: {
@@ -357,44 +285,11 @@ export function buildChannelCurrentModelMessage(
     scope?: "agent" | "conversation";
   },
 ): string {
-  const displayName = channelDisplayName(channelId);
-  const scope = params.scope === "agent" ? "agent" : "conversation";
-  const handleText =
-    params.modelHandle && params.modelHandle !== params.modelLabel
-      ? ` (${params.modelHandle})`
-      : "";
-  const switchCommand = modelCommandPrefix(channelId);
-  return [
-    `${displayName} current ${scope} model: ${params.modelLabel}${handleText}.`,
-    `Use ${switchCommand} list to see available models, or ${switchCommand} <handle-or-id> to switch.`,
-  ].join("\n");
-}
-
-function formatChannelModelEntry(
-  channelId: string,
-  entry: ChannelModelListEntry,
-): string {
-  const selector = entry.id || entry.handle;
-  const handleText = entry.handle === entry.label ? "" : ` — ${entry.handle}`;
-  return `• ${entry.label}${handleText} (${modelCommandPrefix(channelId)} ${selector})`;
-}
-
-function appendModelEntrySection(
-  lines: string[],
-  channelId: string,
-  title: string,
-  entries: ChannelModelListEntry[],
-  limit: number,
-): void {
-  if (entries.length === 0) return;
-  lines.push("", `${title}:`);
-  for (const entry of entries.slice(0, limit)) {
-    lines.push(formatChannelModelEntry(channelId, entry));
-  }
-  const remaining = entries.length - limit;
-  if (remaining > 0) {
-    lines.push(`…and ${remaining} more.`);
-  }
+  return buildChannelCurrentModelMessageWith(
+    channelId,
+    params,
+    channelDisplayName,
+  );
 }
 
 export function buildChannelModelListMessage(
@@ -406,85 +301,33 @@ export function buildChannelModelListMessage(
     limit?: number;
   },
 ): string {
-  const displayName = channelDisplayName(channelId);
-  const limit = params.limit ?? DEFAULT_CHANNEL_MODEL_LIST_LIMIT;
-  const entries = params.entries as ChannelModelListEntry[];
-  const byHandle = buildModelEntriesByHandle(entries);
-  const availableHandleList = Array.isArray(params.availableHandles)
-    ? params.availableHandles
-    : null;
-  const availableSet = availableHandleList
-    ? new Set(availableHandleList)
-    : null;
-  const recentEntries = resolveModelHandles({
-    handles: params.recentHandles ?? [],
-    byHandle,
-    availableHandles: availableSet,
-  });
-  const availableEntries = availableHandleList
-    ? resolveModelHandles({ handles: availableHandleList, byHandle })
-    : getFallbackModelEntries(byHandle);
-
-  const lines = [`${displayName} model selector`];
-  if (params.availableHandles === null) {
-    lines.push(
-      "Availability lookup failed; showing built-in recommended models.",
-    );
-  } else if (params.availableHandles === undefined) {
-    lines.push(
-      "Available model data was not returned; showing built-in recommended models.",
-    );
-  }
-
-  appendModelEntrySection(
-    lines,
+  return buildChannelModelListMessageWith(
     channelId,
-    "Recent models",
-    recentEntries,
-    limit,
+    params,
+    channelDisplayName,
   );
-  appendModelEntrySection(
-    lines,
-    channelId,
-    "Available models",
-    availableEntries,
-    limit,
-  );
-
-  if (availableEntries.length === 0) {
-    lines.push(
-      "",
-      "No available models were reported. Use /connect in Letta Code to configure a provider, then try again.",
-    );
-  }
-
-  lines.push("");
-  if (channelId === "slack") {
-    lines.push(
-      "Mention the app with @agent /model <handle-or-id> to switch this thread's routed model. Use @agent /model to show the current model. Legacy !model still works after a mention.",
-    );
-  } else {
-    lines.push(
-      "Use /model <handle-or-id> to switch this chat's routed model, or /model to show the current model.",
-    );
-  }
-  return lines.join("\n");
 }
 
 export function buildChannelModelListUnavailableMessage(
   channelId: string,
   error: string,
 ): string {
-  const displayName = channelDisplayName(channelId);
-  return `${displayName} could not load the model list: ${error}`;
+  return buildChannelModelListUnavailableMessageWith(
+    channelId,
+    error,
+    channelDisplayName,
+  );
 }
 
 export function buildChannelCurrentModelUnavailableMessage(
   channelId: string,
   error: string,
 ): string {
-  const displayName = channelDisplayName(channelId);
-  return `${displayName} could not load the current model: ${error}`;
+  return buildChannelCurrentModelUnavailableMessageWith(
+    channelId,
+    error,
+    channelDisplayName,
+  );
 }
 
 export function buildChannelModelUpdatedMessage(
@@ -495,11 +338,11 @@ export function buildChannelModelUpdatedMessage(
     appliedTo?: "agent" | "conversation";
   },
 ): string {
-  const displayName = channelDisplayName(channelId);
-  const scope = params.appliedTo === "agent" ? "agent" : "conversation";
-  const handleText =
-    params.modelHandle === params.modelLabel ? "" : ` (${params.modelHandle})`;
-  return `${displayName} updated this ${scope}'s model to ${params.modelLabel}${handleText}.`;
+  return buildChannelModelUpdatedMessageWith(
+    channelId,
+    params,
+    channelDisplayName,
+  );
 }
 
 export function buildChannelModelUpdateFailedMessage(
@@ -507,8 +350,12 @@ export function buildChannelModelUpdateFailedMessage(
   identifier: string,
   error: string,
 ): string {
-  const displayName = channelDisplayName(channelId);
-  return `${displayName} could not switch this chat's routed model to ${identifier}: ${error}`;
+  return buildChannelModelUpdateFailedMessageWith(
+    channelId,
+    identifier,
+    error,
+    channelDisplayName,
+  );
 }
 
 export function buildChannelModelUnavailableMessage(channelId: string): string {

--- a/src/channels/gateway-local.ts
+++ b/src/channels/gateway-local.ts
@@ -18,15 +18,20 @@ import type {
 } from "@/types/service-protocol";
 import { createChannelRichDraftStreamer } from "./channel-rich-draft-streamer";
 import {
+  type RuntimeCommandClient,
+  runChannelCancelCommand,
+  runChannelModelListCommand,
+  runChannelModelUpdateCommand,
+  runChannelReflectionCommand,
+  runChannelReloadCommand,
+} from "./command-runtime-executor";
+import {
   buildChannelCurrentModelMessage,
   buildChannelCurrentModelUnavailableMessage,
-  buildChannelModelListMessage,
-  buildChannelModelListUnavailableMessage,
-  buildChannelModelUpdatedMessage,
-  buildChannelModelUpdateFailedMessage,
 } from "./commands";
 import { ChannelGateway, type ChannelGatewayDelivery } from "./gateway-core";
 import { buildGatewayMessageChannelTool } from "./message-channel-gateway-tool";
+import { getChannelDisplayName } from "./plugin-registry";
 import {
   type ChannelsCommand,
   handleChannelsProtocolCommand,
@@ -136,6 +141,14 @@ function gatewayClientMessageId(delivery: {
     .digest("hex")
     .slice(0, 32);
   return `cm-channel-${digest}`;
+}
+
+function channelDisplayName(channelId: string): string {
+  try {
+    return getChannelDisplayName(channelId);
+  } catch {
+    return channelId;
+  }
 }
 
 function isListModelsResponse(
@@ -438,9 +451,86 @@ export async function startLocalChannelGateway(
     routedRuntimeRegistrationRefresher.requestRefresh();
   });
 
+  const executeRemoteCommand = (
+    runtime: RuntimeScope,
+    commandId: "reload" | "reflect",
+  ): Promise<ExecuteCommandResponseMessage> =>
+    client.request<ExecuteCommandResponseMessage>(
+      {
+        type: "execute_command",
+        request_id: client.nextRequestId(`channel-${commandId}`),
+        runtime,
+        command_id: commandId,
+      },
+      { predicate: isExecuteCommandResponse },
+    );
+
+  // In-process transport for the shared runtime-command executor: the same
+  // command semantics Letta Cloud reaches over its listener relay, backed
+  // here by the direct App Server connection. Local-only side effects
+  // (recent-model tracking, gateway model-status cache) stay in this client.
+  const runtimeCommandClient: RuntimeCommandClient = {
+    listModels: async () => {
+      const response = await client.request<ListModelsResponseMessage>(
+        {
+          type: "list_models",
+          request_id: client.nextRequestId("channel-model-list"),
+        },
+        { predicate: isListModelsResponse },
+      );
+      return {
+        success: response.success,
+        entries: response.entries,
+        availableHandles: response.available_handles,
+        error: response.error,
+      };
+    },
+    updateModel: async ({ runtime, modelIdentifier }) => {
+      const response = await client.request<UpdateModelResponseMessage>(
+        {
+          type: "update_model",
+          request_id: client.nextRequestId("channel-model-update"),
+          runtime,
+          payload: {
+            model_id: modelIdentifier,
+            model_handle: modelIdentifier,
+          },
+        },
+        { predicate: isUpdateModelResponse },
+      );
+      if (!response.success) {
+        return { success: false, error: response.error };
+      }
+      settingsManager.addRecentModel(response.model_handle ?? modelIdentifier);
+      gateway.updateModelStatus(
+        runtime,
+        response.model_handle ?? modelIdentifier,
+      );
+      return {
+        success: true,
+        modelHandle: response.model_handle,
+        appliedTo: response.applied_to,
+      };
+    },
+    abortMessage: async ({ runtime, runId }) => {
+      const response = await client.abort({ runtime, run_id: runId });
+      return { success: response.success, aborted: response.aborted };
+    },
+    executeCommand: async ({ runtime, commandId }) => {
+      const response =
+        commandId === "reflect"
+          ? await executeRemoteCommand(runtime, "reflect")
+          : await executeRemoteCommand(runtime, "reload");
+      return { success: response.success, output: response.output };
+    },
+  };
+
   registry.setCancelHandler(async ({ runtime }) => {
-    const response = await client.abort({ runtime, run_id: null });
-    return response.success && response.aborted;
+    const result = await runChannelCancelCommand({
+      client: runtimeCommandClient,
+      runtime,
+    });
+    return result.cancelled;
   });
 
   registry.setModelHandler(async ({ channelId, runtime, modelIdentifier }) => {
@@ -498,88 +588,30 @@ export async function startLocalChannelGateway(
     }
 
     if (modelIdentifier.toLowerCase() === "list") {
-      const response = await client.request<ListModelsResponseMessage>(
-        {
-          type: "list_models",
-          request_id: client.nextRequestId("channel-model-list"),
-        },
-        { predicate: isListModelsResponse },
-      );
-      return {
-        handled: true,
-        text: response.success
-          ? buildChannelModelListMessage(channelId, {
-              entries: response.entries,
-              availableHandles: response.available_handles,
-              recentHandles: settingsManager.getRecentModels(),
-            })
-          : buildChannelModelListUnavailableMessage(
-              channelId,
-              response.error ?? "Failed to list models",
-            ),
-      };
+      return runChannelModelListCommand({
+        channelId,
+        client: runtimeCommandClient,
+        recentHandles: settingsManager.getRecentModels(),
+        channelDisplayName,
+      });
     }
 
-    const response = await client.request<UpdateModelResponseMessage>(
-      {
-        type: "update_model",
-        request_id: client.nextRequestId("channel-model-update"),
-        runtime,
-        payload: {
-          model_id: modelIdentifier,
-          model_handle: modelIdentifier,
-        },
-      },
-      { predicate: isUpdateModelResponse },
-    );
-    if (!response.success) {
-      return {
-        handled: true,
-        text: buildChannelModelUpdateFailedMessage(
-          channelId,
-          modelIdentifier,
-          response.error ?? "Failed to update model",
-        ),
-      };
-    }
-    settingsManager.addRecentModel(response.model_handle ?? modelIdentifier);
-    gateway.updateModelStatus(
+    return runChannelModelUpdateCommand({
+      channelId,
+      client: runtimeCommandClient,
       runtime,
-      response.model_handle ?? modelIdentifier,
-    );
-    return {
-      handled: true,
-      text: buildChannelModelUpdatedMessage(channelId, {
-        modelLabel:
-          getModelInfo(response.model_handle ?? modelIdentifier)?.label ??
-          modelIdentifier,
-        modelHandle: response.model_handle ?? modelIdentifier,
-        appliedTo: response.applied_to,
-      }),
-    };
+      modelIdentifier,
+      resolveModelLabel: (modelHandle) => getModelInfo(modelHandle)?.label,
+      channelDisplayName,
+    });
   });
 
-  const executeRemoteCommand = (
-    runtime: RuntimeScope,
-    commandId: "reload" | "reflect",
-  ): Promise<ExecuteCommandResponseMessage> =>
-    client.request<ExecuteCommandResponseMessage>(
-      {
-        type: "execute_command",
-        request_id: client.nextRequestId(`channel-${commandId}`),
-        runtime,
-        command_id: commandId,
-      },
-      { predicate: isExecuteCommandResponse },
-    );
-  registry.setReloadHandler(async ({ runtime }) => {
-    const response = await executeRemoteCommand(runtime, "reload");
-    return { handled: true, text: response.output };
-  });
-  registry.setReflectionHandler(async ({ runtime }) => {
-    const response = await executeRemoteCommand(runtime, "reflect");
-    return { handled: true, text: response.output };
-  });
+  registry.setReloadHandler(async ({ runtime }) =>
+    runChannelReloadCommand({ client: runtimeCommandClient, runtime }),
+  );
+  registry.setReflectionHandler(async ({ runtime }) =>
+    runChannelReflectionCommand({ client: runtimeCommandClient, runtime }),
+  );
 
   registry.setReady();
   return {

--- a/src/channels/slack/model-picker-blocks.ts
+++ b/src/channels/slack/model-picker-blocks.ts
@@ -3,7 +3,7 @@ import {
   type ChannelModelListEntry,
   getFallbackModelEntries,
   resolveModelHandles,
-} from "@/channels/commands";
+} from "@/channels/command-runtime-executor";
 import type { ChannelModelPickerData } from "@/channels/types";
 
 const SLACK_MODEL_PICKER_OPTION_LIMIT = 100;


### PR DESCRIPTION
## Problem

The slash commands whose semantics are pure app-server protocol — `/model <handle>`, `/model list`, `/cancel`, `/reflection`, `/reload` — are implemented twice:

- **Locally**, in the channel gateway (`src/channels/gateway-local.ts` handlers wired through `ChannelSlashCommandHandlers`): parse args → send `update_model` / `list_models` / `abort_message` / `execute_command` over the in-process App Server connection → render the reply.
- **In Letta Cloud** (letta-cloud #14100), in the Slack gateway's command handlers: the exact same parse → protocol command → render pipeline, just transported over the Redis listener relay.

Two copies of the same semantics can drift — different error copy, different `list` matching, different fallback behavior when the server omits `model_handle`, etc.

## Design: one executor, an injected client

`src/channels/command-runtime-executor.ts` now owns the shared semantics once. Like `command-surface.ts`, it is host-free (no plugin registry, adapters, settings, or websockets) so it is exported from the public `@letta-ai/letta-code/channels` entrypoint (`src/channels-public.ts`).

Each host injects a minimal `RuntimeCommandClient` — one method per protocol command, with the host owning request ids, correlation, and timeouts:

```ts
interface RuntimeCommandClient {
  listModels(): Promise<RuntimeCommandListModelsResult>;
  updateModel(params: { runtime; modelIdentifier: string }): Promise<RuntimeCommandUpdateModelResult>;
  abortMessage(params: { runtime; runId: string | null }): Promise<RuntimeCommandAbortResult>;
  executeCommand(params: { runtime; commandId: "reflect" | "reload"; args?: string }): Promise<RuntimeCommandExecuteResult>;
}
```

On top of that, the executor exposes one pure handler per command, returning the rendered reply:

- `parseChannelModelCommand(args)` — empty → current (host-owned), `list` → list, else identifier
- `runChannelModelListCommand` / `runChannelModelUpdateCommand`
- `runChannelCancelCommand` (returns `cancelled` plus optional rendered text)
- `runChannelReflectionCommand` / `runChannelReloadCommand`

Reply rendering (model selector, update success/failure, cancel outcomes) moved from `channels/commands.ts` into the executor in display-name-parameterized form; `commands.ts` keeps its exact public surface as thin wrappers bound to the plugin-registry resolver, so all existing rendering is byte-identical. Transport failures intentionally propagate — each host applies its own failure copy and logging.

## Local host refactored to consume it

`gateway-local.ts` now builds an in-process `RuntimeCommandClient` over its App Server connection and routes `/model list`, `/model <handle>`, `/cancel`, `/reflection`, and `/reload` through the shared executor. Behavior is unchanged (existing tests untouched and passing). Host-side pieces that stayed local by design:

- the bare `/model` current-model branch (gateway model-status cache, runtime re-registration, model picker payload) — out of scope for the shared executor
- recent-model tracking (`settingsManager.addRecentModel`) and the gateway model-status cache update, kept inside the local client's `updateModel`
- route resolution and no-route / listener-unavailable messaging (already host-specific in both hosts)

## Follow-up

letta-cloud follows up by slimming its Slack handlers to transport (a relay-backed `RuntimeCommandClient`) plus its host-owned commands (`/agent`, `/config`, `/convo`, route pause/resume), consuming this executor for the five shared commands.

## Testing

- `bun run check` — 12/12 pass
- New focused suite `src/channels/command-runtime-executor.test.ts` (25 tests): per command, parsed args → client calls → rendered output, plus error paths and transport-error propagation
- Touched suites (`commands`, `registry-command-routing`, `registry-reload-routing`, `registry-controls`, `listen-model-update`, `listen-reflection-runtime`, `command-surface`) all pass
- Full unit suite via `scripts/run-unit-tests.cjs`: only failure is the known pre-existing Bun segfault in `src/websocket/app-server.test.ts` (crash during teardown; zero real test failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
