### PR TITLE
feat(channels): support host-extra command definitions in the shared surface

### DIFF
--- a/src/channels-public.ts
+++ b/src/channels-public.ts
@@ -33,6 +33,7 @@ export type {
   ChannelSlashCommandHandlerResult,
   ChannelSlashCommandHandlers,
   ChannelSlashCommandKind,
+  ChannelSlashCommandSurfaceOptions,
   ParsedChannelSlashCommand,
 } from "./channels/command-surface";
 export {

--- a/src/channels/command-surface.test.ts
+++ b/src/channels/command-surface.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, test } from "bun:test";
 import {
   buildChannelHelpMessage,
   buildUnsupportedChannelCommandMessage,
+  type ChannelSlashCommandDefinition,
+  type ChannelSlashCommandSurfaceOptions,
   defaultChannelDisplayName,
   listChannelSlashCommands,
   parseChannelBangCommand,
@@ -54,6 +56,226 @@ describe("listChannelSlashCommands", () => {
     expect(
       second.find((command) => command.name === "reflection")?.aliases,
     ).toEqual(["reflect"]);
+  });
+});
+
+const CLOUD_EXTRA_COMMANDS: ChannelSlashCommandDefinition[] = [
+  { name: "agent", kind: "direct", summary: "Show the connected agent." },
+  {
+    name: "config",
+    kind: "direct",
+    summary: "Get the Slack connection settings link.",
+  },
+  {
+    name: "convo",
+    kind: "direct",
+    summary: "Get the link to this conversation in Letta.",
+  },
+];
+
+const CLOUD_SURFACE_OPTIONS: ChannelSlashCommandSurfaceOptions = {
+  extraCommands: CLOUD_EXTRA_COMMANDS,
+  extraCommandsLabel: "Cloud-only commands",
+};
+
+describe("host-extra command definitions", () => {
+  test("listChannelSlashCommands appends extras after the shared surface", () => {
+    const names = listChannelSlashCommands(CLOUD_SURFACE_OPTIONS).map(
+      (command) => command.name,
+    );
+    expect(names).toEqual([
+      "help",
+      "status",
+      "whoami",
+      "pause",
+      "resume",
+      "cancel",
+      "chat",
+      "feedback",
+      "model",
+      "reflection",
+      "reload",
+      "agent",
+      "config",
+      "convo",
+    ]);
+  });
+
+  test("shared names win on collision; colliding extras and aliases are dropped", () => {
+    const merged = listChannelSlashCommands({
+      extraCommands: [
+        // Collides with a shared command name (case-insensitively).
+        { name: "Model", kind: "direct", summary: "host model override" },
+        // Collides with a shared alias.
+        { name: "reflect", kind: "direct", summary: "host reflect override" },
+        // Collides with a Slack mention-only shared command.
+        { name: "new", kind: "direct", summary: "host new override" },
+        // Survives, but its colliding alias is filtered.
+        {
+          name: "agent",
+          aliases: ["status", "who"],
+          kind: "direct",
+          summary: "Show the connected agent.",
+        },
+        // Collides with the earlier surviving extra.
+        { name: "agent", kind: "direct", summary: "duplicate extra" },
+        // Collides with the earlier surviving extra's alias.
+        { name: "who", kind: "direct", summary: "alias collision" },
+      ],
+    });
+    const extras = merged.slice(11);
+    expect(extras).toEqual([
+      {
+        name: "agent",
+        aliases: ["who"],
+        kind: "direct",
+        summary: "Show the connected agent.",
+      },
+    ]);
+    expect(
+      merged.find((command) => command.name === "model")?.summary,
+    ).toContain("switch the model");
+  });
+
+  test("parseChannelSlashCommand parses extras without any registration", () => {
+    expect(parseChannelSlashCommand("/agent show")).toEqual({
+      name: "agent",
+      args: "show",
+      raw: "/agent show",
+    });
+    expect(parseChannelSlashCommand("/convo")).toMatchObject({
+      name: "convo",
+      args: "",
+    });
+  });
+
+  test("slack help renders extras in a labeled section before the closing lines", () => {
+    const message = buildChannelHelpMessage(
+      "slack",
+      defaultChannelDisplayName,
+      CLOUD_SURFACE_OPTIONS,
+    );
+    const lines = message.split("\n");
+    const labelIndex = lines.indexOf("Cloud-only commands:");
+    expect(labelIndex).toBeGreaterThan(0);
+    expect(lines[labelIndex - 1]).toBe(
+      "@agent /reload - reload settings, local mods, and agent secrets",
+    );
+    expect(lines[labelIndex + 1]).toBe(
+      "@agent /agent - Show the connected agent.",
+    );
+    expect(lines[labelIndex + 2]).toBe(
+      "@agent /config - Get the Slack connection settings link.",
+    );
+    expect(lines[labelIndex + 3]).toBe(
+      "@agent /convo - Get the link to this conversation in Letta.",
+    );
+    expect(lines[labelIndex + 4]).toStartWith("Legacy bang aliases still work");
+  });
+
+  test("generic help renders extras as a labeled paragraph after the shared list", () => {
+    const message = buildChannelHelpMessage(
+      "telegram",
+      defaultChannelDisplayName,
+      CLOUD_SURFACE_OPTIONS,
+    );
+    expect(message).toContain(
+      "Supported slash commands here: /help, /status, /whoami, /pause, /resume, /cancel, /chat, /feedback, /model, /reflection, /reload.\n\nCloud-only commands here: /agent, /config, /convo.",
+    );
+  });
+
+  test("help uses the default extras label when none is provided", () => {
+    const message = buildChannelHelpMessage(
+      "telegram",
+      defaultChannelDisplayName,
+      { extraCommands: CLOUD_EXTRA_COMMANDS },
+    );
+    expect(message).toContain("Host commands here: /agent, /config, /convo.");
+  });
+
+  test("unknown-command suggestions include extras", () => {
+    const command = parseChannelSlashCommand("/bogus");
+    expect(command).not.toBeNull();
+    if (!command) return;
+    expect(
+      buildUnsupportedChannelCommandMessage(
+        "telegram",
+        command,
+        defaultChannelDisplayName,
+        CLOUD_SURFACE_OPTIONS,
+      ),
+    ).toContain(
+      "Supported slash commands: /help, /status, /whoami, /pause, /resume, /cancel, /chat, /feedback, /model, /reflection, /reload, /agent, /config, /convo.",
+    );
+    expect(
+      buildUnsupportedChannelCommandMessage(
+        "slack",
+        command,
+        defaultChannelDisplayName,
+        CLOUD_SURFACE_OPTIONS,
+      ),
+    ).toContain(
+      "@agent /reload, @agent /agent, @agent /config, @agent /convo.",
+    );
+  });
+
+  test("bang-command suggestions stay on the legacy alias list", () => {
+    const command = parseChannelBangCommand("!bogus");
+    expect(command).not.toBeNull();
+    if (!command) return;
+    const message = buildUnsupportedChannelCommandMessage(
+      "slack",
+      command,
+      defaultChannelDisplayName,
+      CLOUD_SURFACE_OPTIONS,
+    );
+    expect(message).toContain(
+      "Supported bang commands: !help, !detach, !model, !new, !reload.",
+    );
+  });
+
+  test("empty or omitted extras keep every rendered string byte-identical", () => {
+    for (const options of [undefined, {}, { extraCommands: [] }] as const) {
+      expect(
+        buildChannelHelpMessage("slack", defaultChannelDisplayName, options),
+      ).toBe(buildChannelHelpMessage("slack"));
+      expect(
+        buildChannelHelpMessage("telegram", defaultChannelDisplayName, options),
+      ).toBe(buildChannelHelpMessage("telegram"));
+      expect(listChannelSlashCommands(options)).toEqual(
+        listChannelSlashCommands(),
+      );
+      const command = parseChannelSlashCommand("/bogus");
+      expect(command).not.toBeNull();
+      if (!command) continue;
+      expect(
+        buildUnsupportedChannelCommandMessage(
+          "slack",
+          command,
+          defaultChannelDisplayName,
+          options,
+        ),
+      ).toBe(buildUnsupportedChannelCommandMessage("slack", command));
+    }
+  });
+
+  test("returns fresh copies of extras so callers cannot mutate host input", () => {
+    const extras: ChannelSlashCommandDefinition[] = [
+      {
+        name: "agent",
+        aliases: ["who"],
+        kind: "direct",
+        summary: "Show the connected agent.",
+      },
+    ];
+    const merged = listChannelSlashCommands({ extraCommands: extras });
+    const extra = merged.at(-1);
+    expect(extra).toBeDefined();
+    if (!extra) return;
+    extra.name = "mutated";
+    extra.aliases?.push("mutated-alias");
+    expect(extras[0]?.name).toBe("agent");
+    expect(extras[0]?.aliases).toEqual(["who"]);
   });
 });
 

--- a/src/channels/command-surface.ts
+++ b/src/channels/command-surface.ts
@@ -7,6 +7,10 @@
  * Slack gateway — can render the exact same command surface as
  * `letta server --channel`. Command execution stays host-injected via
  * `ChannelSlashCommandHandlers`.
+ *
+ * Hosts with commands beyond the shared surface (e.g. Cloud's `/agent`,
+ * `/config`, `/convo`) declare them via `ChannelSlashCommandSurfaceOptions`
+ * so listing, help, and unknown-command rendering include them first-class.
  */
 
 import type { ChannelModelPickerData, InboundChannelMessage } from "./types";
@@ -25,6 +29,42 @@ export type ChannelSlashCommandDefinition = {
   kind: ChannelSlashCommandKind;
   summary: string;
 };
+
+/**
+ * Host-extra command surface options. External channel hosts (e.g. Letta
+ * Cloud's Slack gateway with `/agent`, `/config`, `/convo`) pass their extra
+ * definitions here so listing, help text, and unknown-command rendering
+ * include them without any host-side merging.
+ *
+ * Semantics:
+ * - Extras never override the shared surface: an extra whose name collides
+ *   (case-insensitively) with a shared command name or alias, a Slack
+ *   mention-only command name (`detach`, `new`), or an earlier extra is
+ *   dropped, and extra aliases that collide are filtered.
+ *   Shared-wins keeps hosts upgrade-safe when the shared surface later
+ *   absorbs a command a host had been providing as an extra.
+ * - Ordering is stable: shared commands first, in their fixed order, then the
+ *   surviving extras in the order the host provided them. Help output renders
+ *   extras in a labeled section (`extraCommandsLabel`).
+ * - Omitting the options (or passing no extras) keeps every rendered string
+ *   byte-identical to the extras-free surface.
+ *
+ * Parsing needs no extras hook: `parseChannelSlashCommand` /
+ * `parseChannelBangCommand` already accept any command-shaped token so hosts
+ * can dispatch extras (and render unknown-command replies) from the parsed
+ * name.
+ */
+export type ChannelSlashCommandSurfaceOptions = {
+  /** Host-specific command definitions appended after the shared surface. */
+  extraCommands?: readonly ChannelSlashCommandDefinition[];
+  /**
+   * Section label for extras in help output, e.g. "Cloud-only commands".
+   * Defaults to "Host commands".
+   */
+  extraCommandsLabel?: string;
+};
+
+const DEFAULT_EXTRA_COMMANDS_LABEL = "Host commands";
 
 export type ChannelSlashCommandHandlerResult = {
   handled: boolean;
@@ -160,11 +200,70 @@ const SLACK_MENTION_COMMAND_NAMES = [
   "reload",
 ] as const;
 
-export function listChannelSlashCommands(): ChannelSlashCommandDefinition[] {
-  return CHANNEL_SLASH_COMMANDS.map((definition) => ({
+function copyDefinition(
+  definition: ChannelSlashCommandDefinition,
+): ChannelSlashCommandDefinition {
+  return {
     ...definition,
     aliases: definition.aliases ? [...definition.aliases] : undefined,
-  }));
+  };
+}
+
+/**
+ * Applies the shared-wins dedupe documented on
+ * `ChannelSlashCommandSurfaceOptions`: returns the surviving host extras (as
+ * fresh copies) with colliding definitions dropped and colliding aliases
+ * filtered.
+ */
+function dedupedExtraCommands(
+  options?: ChannelSlashCommandSurfaceOptions,
+): ChannelSlashCommandDefinition[] {
+  const extras = options?.extraCommands;
+  if (!extras || extras.length === 0) {
+    return [];
+  }
+
+  // Slack mention-only command names (e.g. "detach", "new") are part of the
+  // shared surface even though they are not in the definition list, so they
+  // are reserved too.
+  const takenNames = new Set<string>(SLACK_MENTION_COMMAND_NAMES);
+  for (const definition of CHANNEL_SLASH_COMMANDS) {
+    takenNames.add(definition.name.toLowerCase());
+    for (const alias of definition.aliases ?? []) {
+      takenNames.add(alias.toLowerCase());
+    }
+  }
+
+  const surviving: ChannelSlashCommandDefinition[] = [];
+  for (const extra of extras) {
+    const nameKey = extra.name.toLowerCase();
+    if (takenNames.has(nameKey)) {
+      continue;
+    }
+    takenNames.add(nameKey);
+    const aliases = (extra.aliases ?? []).filter((alias) => {
+      const aliasKey = alias.toLowerCase();
+      if (takenNames.has(aliasKey)) {
+        return false;
+      }
+      takenNames.add(aliasKey);
+      return true;
+    });
+    surviving.push({
+      ...extra,
+      aliases: aliases.length > 0 ? aliases : undefined,
+    });
+  }
+  return surviving;
+}
+
+export function listChannelSlashCommands(
+  options?: ChannelSlashCommandSurfaceOptions,
+): ChannelSlashCommandDefinition[] {
+  return [
+    ...CHANNEL_SLASH_COMMANDS.map(copyDefinition),
+    ...dedupedExtraCommands(options),
+  ];
 }
 
 type ChannelCommandPrefix = "/" | "!";
@@ -256,8 +355,11 @@ export function parseChannelBangCommand(
   return parseChannelCommand(text, "!");
 }
 
-function supportedCommandsText(prefix: "/" | "!" = "/"): string {
-  return listChannelSlashCommands()
+function supportedCommandsText(
+  prefix: "/" | "!" = "/",
+  options?: ChannelSlashCommandSurfaceOptions,
+): string {
+  return listChannelSlashCommands(options)
     .map((definition) => `${prefix}${definition.name}`)
     .join(", ");
 }
@@ -278,8 +380,13 @@ const SLACK_MENTION_SLASH_COMMAND_EXAMPLES = [
   "@agent /reload",
 ] as const;
 
-function supportedSlackMentionSlashCommandsText(): string {
-  return SLACK_MENTION_SLASH_COMMAND_EXAMPLES.join(", ");
+function supportedSlackMentionSlashCommandsText(
+  options?: ChannelSlashCommandSurfaceOptions,
+): string {
+  const extras = dedupedExtraCommands(options).map(
+    (definition) => `@agent /${definition.name}`,
+  );
+  return [...SLACK_MENTION_SLASH_COMMAND_EXAMPLES, ...extras].join(", ");
 }
 
 function supportedBangCommandsText(): string {
@@ -295,10 +402,24 @@ export function isSupportedSlackMentionCommand(commandName: string): boolean {
 export function buildChannelHelpMessage(
   channelId: string,
   resolveDisplayName: ChannelDisplayNameResolver = defaultChannelDisplayName,
+  options?: ChannelSlashCommandSurfaceOptions,
 ): string {
   const displayName = resolveDisplayName(channelId);
+  const extras = dedupedExtraCommands(options);
+  const extrasLabel =
+    options?.extraCommandsLabel ?? DEFAULT_EXTRA_COMMANDS_LABEL;
 
   if (channelId === "slack") {
+    const extraLines =
+      extras.length > 0
+        ? [
+            `${extrasLabel}:`,
+            ...extras.map(
+              (definition) =>
+                `@agent /${definition.name} - ${definition.summary}`,
+            ),
+          ]
+        : [];
     return [
       `${displayName} is connected to Letta Code.`,
       "Talk by mentioning the app in a channel thread. Once a thread is routed, normal replies continue the same agent conversation until detached.",
@@ -314,15 +435,25 @@ export function buildChannelHelpMessage(
       "@agent /detach - stop replying in this thread until mentioned again",
       "@agent /new - start a fresh conversation for this thread",
       "@agent /reload - reload settings, local mods, and agent secrets",
+      ...extraLines,
       `Legacy bang aliases still work after a mention: ${supportedBangCommandsText()}.`,
       "If this chat is not connected yet, send a normal message and follow the pairing instructions.",
     ].join("\n");
   }
 
+  const extraParagraphs =
+    extras.length > 0
+      ? [
+          `${extrasLabel} here: ${extras
+            .map((definition) => `/${definition.name}`)
+            .join(", ")}.`,
+        ]
+      : [];
   return [
     `${displayName} is connected to Letta Code.`,
     "Send a normal message here and the connected agent will reply in this chat.",
     `Supported slash commands here: ${supportedCommandsText()}.`,
+    ...extraParagraphs,
     "If this chat is not connected yet, send any non-command message and follow the pairing instructions.",
   ].join("\n\n");
 }
@@ -331,15 +462,18 @@ export function buildUnsupportedChannelCommandMessage(
   channelId: string,
   command: ParsedChannelSlashCommand,
   resolveDisplayName: ChannelDisplayNameResolver = defaultChannelDisplayName,
+  options?: ChannelSlashCommandSurfaceOptions,
 ): string {
   const displayName = resolveDisplayName(channelId);
   const isBang = command.raw.startsWith("!");
   const commandKind = isBang ? "bang" : "slash";
+  // Bang commands are the legacy Slack-mention alias set; host extras are
+  // slash-only, so the bang list never includes them.
   const supportedCommands = isBang
     ? supportedBangCommandsText()
     : channelId === "slack"
-      ? supportedSlackMentionSlashCommandsText()
-      : supportedCommandsText();
+      ? supportedSlackMentionSlashCommandsText(options)
+      : supportedCommandsText("/", options);
   const supportedLabel =
     channelId === "slack" && !isBang
       ? "Slack mention commands"


### PR DESCRIPTION
## Why

The shared channel command surface (`src/channels/command-surface.ts`, #3729) exports a **fixed** definition list. Letta Cloud's Slack gateway adopted it in letta-cloud#14100 but has host-specific commands (`/agent`, `/config`, `/convo`) with no extension hook, so it had to bolt them on with a local merge: a cloud-side dispatch table plus hand-rolled help/whoami rendering that appends a "Cloud-only commands" section after the shared help text. That merge shim drifts silently as the shared surface evolves.

## Design

New `ChannelSlashCommandSurfaceOptions` (`{ extraCommands?: readonly ChannelSlashCommandDefinition[]; extraCommandsLabel?: string }`) accepted as a trailing optional parameter by:

- `listChannelSlashCommands(options?)` — returns shared definitions first (fixed order), then surviving extras in host order.
- `buildChannelHelpMessage(channelId, resolver?, options?)` — Slack help renders extras as `@agent /name - summary` lines under a `<label>:` heading immediately after the shared command lines (before the legacy-bang/pairing footer); generic help adds a `<label> here: /a, /b, /c.` paragraph right after the shared command list. Label defaults to `"Host commands"`; Cloud passes `"Cloud-only commands"` and gets equivalent-or-better output than its current append-at-the-end shim (extras now sit grouped with the command list, and reach every render path).
- `buildUnsupportedChannelCommandMessage(channelId, command, resolver?, options?)` — unknown-command suggestions include the extras for slash commands (both the Slack mention-example list and the generic list). The legacy bang alias list is intentionally unchanged: bang commands are the fixed Slack-mention alias set; extras are slash-only.

**Dedupe policy (shared wins):** an extra whose name collides case-insensitively with a shared command name or alias, a Slack mention-only command name (`detach`, `new`), or an earlier extra is dropped; colliding aliases of surviving extras are filtered. Shared-wins (rather than error-on-collision) keeps hosts upgrade-safe: if the shared surface later absorbs a command a host had been shipping as an extra, the host's next upgrade degrades gracefully instead of throwing at render time.

**Parsing needs no extras hook:** `parseChannelSlashCommand` already accepts any command-shaped token (that's what feeds the unknown-command flow), so hosts dispatch extras from the parsed name with zero registration. This is now documented on the options type and pinned by test.

## Backwards compatibility

- All options are trailing and optional; no existing call site or test needed edits.
- With options omitted, `{}`, or `extraCommands: []`, every rendered string is byte-identical to before (pinned by test), so local host (`letta server --channel`) behavior is unchanged.
- `ChannelSlashCommandSurfaceOptions` is exported from `channels-public.ts` for external hosts.

## Tests

New `host-extra command definitions` suite in `src/channels/command-surface.test.ts`: extras appended after the shared surface, collision/dedupe behavior (name, alias, mention-only, duplicate-extra, alias filtering), parsing extras, Slack + generic help sections, default label, unknown-command suggestions including extras, bang list unchanged, byte-identical no-extras output, and input non-mutation.

- `bun run check`: 12/12 pass
- `bun test src/channels/`: 1143 pass / 0 fail
- Full unit suite: zero real failures; known pre-existing Bun segfault in `src/websocket/app-server.test.ts` makes the full run exit 1 (documented, not chased)

## Follow-up

letta-cloud: slim the #14100 merge shim — `buildCloudSlackHelpMessage`/whoami/unsupported rendering collapse to shared-surface calls with `{ extraCommands: CLOUD_EXTRA_SLACK_COMMANDS, extraCommandsLabel: "Cloud-only commands" }`; only the dispatch table stays cloud-side (execution is host-owned by design).

🤖 Generated with [Claude Code](https://claude.com/claude-code)