### PR TITLE
fix(tools): deliver task notification when a background Bash exits

### DIFF
--- a/src/tools/bash-background-notification.test.ts
+++ b/src/tools/bash-background-notification.test.ts
@@ -1,0 +1,148 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { bash } from "@/tools/impl/bash";
+import { kill_bash } from "@/tools/impl/kill-bash";
+import { backgroundProcesses } from "@/tools/impl/process_manager";
+import {
+  clearPendingMessages,
+  type QueuedMessage,
+  setMessageQueueAdder,
+} from "@/utils/message-queue-bridge";
+
+const isWindows = process.platform === "win32";
+
+/**
+ * Regression coverage for letta-ai/letta-code#3226.
+ *
+ * Bash.md promises the agent it will be notified when a `run_in_background`
+ * command finishes, so a completed shell must reach the message queue the same
+ * way a background subagent's completion does.
+ *
+ * Assertions match on the shell's own task id rather than on `queued[0]`: the
+ * process registry and the queue bridge are module-level singletons, and a
+ * shell torn down by a previous test can deliver its exit event here.
+ */
+describe.skipIf(isWindows)("Background bash completion notifications", () => {
+  let queued: QueuedMessage[] = [];
+
+  const startBackground = async (args: {
+    command: string;
+    description?: string;
+    timeout?: number;
+    parentScope?: { agentId: string; conversationId: string };
+  }): Promise<string> => {
+    const result = await bash({ ...args, run_in_background: true });
+    const bashId = result.content[0]?.text.match(/bash_\d+/)?.[0];
+    expect(bashId).toBeDefined();
+    return bashId as string;
+  };
+
+  const notificationsFor = (bashId: string): QueuedMessage[] =>
+    queued.filter((message) => message.text.includes(`<task-id>${bashId}<`));
+
+  /** Wait for this shell's own notification, ignoring any strays. */
+  const waitForNotification = async (
+    bashId: string,
+    timeoutMs = 5_000,
+  ): Promise<QueuedMessage> => {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+      const [match] = notificationsFor(bashId);
+      if (match) return match;
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    }
+    throw new Error(`No task notification queued for ${bashId}`);
+  };
+
+  beforeEach(() => {
+    queued = [];
+    clearPendingMessages();
+    setMessageQueueAdder((message) => {
+      queued.push(message);
+    });
+  });
+
+  afterEach(() => {
+    setMessageQueueAdder(null);
+    clearPendingMessages();
+    for (const proc of backgroundProcesses.values()) {
+      try {
+        proc.process.kill("SIGTERM");
+      } catch {
+        // Ignore cleanup failures for already-exited processes
+      }
+    }
+    backgroundProcesses.clear();
+  });
+
+  test("queues a task notification when a background command succeeds", async () => {
+    const bashId = await startBackground({
+      command: "echo 'deploy finished'",
+      description: "Watch deploy",
+      parentScope: { agentId: "agent-1", conversationId: "conv-1" },
+    });
+
+    const notification = await waitForNotification(bashId);
+
+    expect(notification.kind).toBe("task_notification");
+    expect(notification.agentId).toBe("agent-1");
+    expect(notification.conversationId).toBe("conv-1");
+    expect(notification.text).toContain("<status>completed</status>");
+    expect(notification.text).toContain(
+      'Background command "Watch deploy" completed',
+    );
+    expect(notification.text).toContain("deploy finished");
+    expect(notification.text).toContain("Full transcript available at:");
+  });
+
+  test("reports a failing background command as failed with its exit code", async () => {
+    const bashId = await startBackground({
+      command: "echo 'boom' >&2; exit 3",
+      description: "Failing job",
+    });
+
+    const notification = await waitForNotification(bashId);
+
+    expect(notification.text).toContain("<status>failed</status>");
+    expect(notification.text).toContain("Exit code: 3");
+    expect(notification.text).toContain("boom");
+  });
+
+  test("falls back to the command when no description is given", async () => {
+    const bashId = await startBackground({ command: "echo hi" });
+
+    const notification = await waitForNotification(bashId);
+
+    expect(notification.text).toContain(
+      'Background command "echo hi" completed',
+    );
+  });
+
+  test("notifies exactly once when a shell times out", async () => {
+    const bashId = await startBackground({
+      command: "sleep 5",
+      description: "Slow job",
+      timeout: 150,
+    });
+
+    const notification = await waitForNotification(bashId);
+    expect(notification.text).toContain("<status>failed</status>");
+    expect(notification.text).toContain("Command timed out after 150ms");
+
+    // A timed-out shell is force-killed after its completion promise rejects;
+    // that teardown must not queue a second wake-up.
+    await new Promise((resolve) => setTimeout(resolve, 400));
+    expect(notificationsFor(bashId)).toHaveLength(1);
+  });
+
+  test("stays silent when the agent deliberately kills the shell", async () => {
+    const bashId = await startBackground({
+      command: "sleep 5",
+      description: "Cancelled job",
+    });
+
+    expect((await kill_bash({ shell_id: bashId })).killed).toBe(true);
+    await new Promise((resolve) => setTimeout(resolve, 400));
+
+    expect(notificationsFor(bashId)).toHaveLength(0);
+  });
+});

--- a/src/tools/impl/bash.ts
+++ b/src/tools/impl/bash.ts
@@ -3,6 +3,11 @@ import {
   consumeWorkingDirectoryRecovery,
   getCurrentWorkingDirectory,
 } from "@/runtime-context";
+import { addToMessageQueue } from "@/utils/message-queue-bridge.js";
+import {
+  formatTaskNotification,
+  resolveNotificationScope,
+} from "@/utils/task-notifications.js";
 import { noteExpectedWorktreeForLauncher } from "@/websocket/listener/worktree-ownership";
 import {
   appendBackgroundProcessOutput,
@@ -177,6 +182,98 @@ export async function spawnCommand(
   throw new Error(suffix ? `${reason} (tried: ${suffix})` : reason);
 }
 
+/** Lines of each stream to replay in a completion notification. */
+const NOTIFICATION_TAIL_LINES = 50;
+
+function formatStreamTail(
+  label: "stdout" | "stderr",
+  retainedLines: string[],
+  totalLines: number,
+): string | undefined {
+  if (retainedLines.length === 0) {
+    return undefined;
+  }
+  const tail = retainedLines.slice(-NOTIFICATION_TAIL_LINES);
+  const header =
+    tail.length < totalLines
+      ? `[${label} - last ${tail.length} of ${totalLines} lines]`
+      : `[${label}]`;
+  return `${header}\n${tail.join("\n")}`;
+}
+
+function formatBackgroundOutputTail(bgProcess: BackgroundProcess): string {
+  const sections = [
+    formatStreamTail(
+      "stdout",
+      bgProcess.stdout,
+      bgProcess.totalStdoutLines ?? bgProcess.stdout.length,
+    ),
+    formatStreamTail(
+      "stderr",
+      bgProcess.stderr,
+      bgProcess.totalStderrLines ?? bgProcess.stderr.length,
+    ),
+  ].filter(Boolean);
+
+  return sections.length > 0 ? sections.join("\n\n") : "(no output)";
+}
+
+/**
+ * Queue the completion notification for a background shell.
+ *
+ * Mirrors the subagent path in task.ts: format the same `<task-notification>`
+ * XML and hand it to the message-queue bridge, which wakes the parent turn.
+ * Bash.md promises the agent it will be notified when a `run_in_background`
+ * command finishes, so without this the agent plans around a wake-up that
+ * never arrives (letta-ai/letta-code#3226).
+ *
+ * Called from the shell runner's single completion promise, which settles
+ * exactly once, so the agent is woken exactly once per background shell.
+ */
+function notifyBackgroundCompletion(params: {
+  bashId: string;
+  description?: string;
+  outputFile: string;
+  bgProcess: BackgroundProcess;
+  scope: ReturnType<typeof resolveNotificationScope>;
+  status: "completed" | "failed";
+  detail: string;
+}): void {
+  const { bashId, description, outputFile, bgProcess, scope, status, detail } =
+    params;
+  if (bgProcess.completionNotificationSuppressed) {
+    return;
+  }
+
+  const label = description?.trim() || bgProcess.command;
+  const durationMs = bgProcess.startTime
+    ? Math.max(0, Date.now() - bgProcess.startTime.getTime())
+    : undefined;
+
+  const { content: result } = truncateByChars(
+    [`$ ${bgProcess.command}`, detail, formatBackgroundOutputTail(bgProcess)]
+      .filter(Boolean)
+      .join("\n\n"),
+    LIMITS.BASH_NOTIFICATION_CHARS,
+    "Bash",
+    { useMiddleTruncation: true },
+  );
+
+  addToMessageQueue({
+    kind: "task_notification",
+    text: formatTaskNotification({
+      taskId: bashId,
+      status,
+      summary: `Background command "${label}" ${status}`,
+      result,
+      outputFile,
+      usage: durationMs === undefined ? undefined : { durationMs },
+    }),
+    agentId: scope?.agentId,
+    conversationId: scope?.conversationId,
+  });
+}
+
 interface BashArgs {
   command: string;
   timeout?: number;
@@ -201,7 +298,7 @@ export async function bash(args: BashArgs): Promise<BashResult> {
   const {
     command,
     timeout = 120000,
-    description: _description,
+    description,
     run_in_background = false,
     signal,
     onOutput,
@@ -302,11 +399,28 @@ export async function bash(args: BashArgs): Promise<BashResult> {
     };
     backgroundProcesses.set(bashId, bgProcess);
 
+    // Resolve the routing scope now rather than on completion: by the time the
+    // shell exits the turn that launched it is gone, so the process-global
+    // agent context may already point at a different conversation.
+    const notificationScope = resolveNotificationScope(parentScope);
+
     void runningProcess.completion.then(
       ({ exitCode }) => {
         bgProcess.status = exitCode === 0 ? "completed" : "failed";
         bgProcess.exitCode = exitCode;
         appendToOutputFile(outputFile, `\n[exit code: ${exitCode}]\n`);
+        notifyBackgroundCompletion({
+          bashId,
+          description,
+          outputFile,
+          bgProcess,
+          scope: notificationScope,
+          status: exitCode === 0 ? "completed" : "failed",
+          detail:
+            exitCode === null
+              ? "Terminated by signal before exiting"
+              : `Exit code: ${exitCode}`,
+        });
         scheduleBackgroundProcessCleanup(bashId);
       },
       (error: unknown) => {
@@ -322,6 +436,15 @@ export async function bash(args: BashArgs): Promise<BashResult> {
             ? `\n[timeout after ${timeout}ms]\n`
             : `\n[error] ${message}\n`,
         );
+        notifyBackgroundCompletion({
+          bashId,
+          description,
+          outputFile,
+          bgProcess,
+          scope: notificationScope,
+          status: "failed",
+          detail: err.killed ? message : `Error: ${message}`,
+        });
         scheduleBackgroundProcessCleanup(bashId);
       },
     );

--- a/src/tools/impl/kill-bash.ts
+++ b/src/tools/impl/kill-bash.ts
@@ -17,6 +17,9 @@ export async function kill_bash(args: KillBashArgs): Promise<KillBashResult> {
   const proc = backgroundProcesses.get(shell_id);
   if (!proc) return { killed: false };
   try {
+    // The kill below still fires the child's "exit" event; suppress the
+    // completion notification so a deliberate stop does not wake the agent.
+    proc.completionNotificationSuppressed = true;
     proc.process.kill("SIGTERM");
     clearBackgroundProcessCleanup(shell_id);
     backgroundProcesses.delete(shell_id);

--- a/src/tools/impl/process_manager.ts
+++ b/src/tools/impl/process_manager.ts
@@ -33,6 +33,12 @@ export interface BackgroundProcess {
   totalStderrLines?: number;
   cleanupTimer?: TimerHandle;
   runtimeScope?: BackgroundRuntimeScope;
+  /**
+   * Set when the agent deliberately stops the shell (KillBash/TaskStop) so the
+   * resulting "exit" event does not wake it with a failure notification for a
+   * process it just killed on purpose.
+   */
+  completionNotificationSuppressed?: boolean;
 }
 
 export interface BackgroundTask {

--- a/src/tools/impl/task.ts
+++ b/src/tools/impl/task.ts
@@ -25,7 +25,10 @@ import { runSubagentStopHooks } from "@/hooks";
 import { getCurrentWorkingDirectory } from "@/runtime-context";
 import { addToMessageQueue } from "@/utils/message-queue-bridge.js";
 import { sleep } from "@/utils/sleep";
-import { formatTaskNotification } from "@/utils/task-notifications.js";
+import {
+  formatTaskNotification,
+  resolveNotificationScope,
+} from "@/utils/task-notifications.js";
 import {
   appendToOutputFile,
   assertBackgroundTaskCapacity,
@@ -228,27 +231,6 @@ function writeTaskTranscriptResult(
   );
 }
 
-function resolveParentScope(parentScope?: {
-  agentId: string;
-  conversationId: string;
-}): { agentId: string; conversationId: string } | undefined {
-  if (parentScope?.agentId) {
-    return {
-      agentId: parentScope.agentId,
-      conversationId: parentScope.conversationId || "default",
-    };
-  }
-
-  try {
-    return {
-      agentId: getCurrentAgentId(),
-      conversationId: getConversationId() ?? "default",
-    };
-  } catch {
-    return undefined;
-  }
-}
-
 /**
  * Wait briefly for a background subagent to publish its agent URL.
  * This keeps Task mostly non-blocking while allowing static transcript rows
@@ -380,7 +362,7 @@ export function spawnBackgroundSubagentTask(
   const shouldEmitCompletionNotification =
     emitCompletionNotification ?? !silentCompletion;
 
-  const resolvedParentScope = resolveParentScope(parentScope);
+  const resolvedParentScope = resolveNotificationScope(parentScope);
 
   const spawnSubagentFn = deps?.spawnSubagentImpl ?? spawnSubagent;
   const addToMessageQueueFn = deps?.addToMessageQueueImpl ?? addToMessageQueue;
@@ -745,7 +727,7 @@ export async function task(args: TaskArgs): Promise<string> {
   const prompt = inputPrompt;
 
   const isBackground = args.run_in_background ?? config.background;
-  const resolvedParentScope = resolveParentScope(args.parentScope);
+  const resolvedParentScope = resolveNotificationScope(args.parentScope);
 
   // Handle background execution
   if (isBackground) {

--- a/src/tools/impl/truncation.ts
+++ b/src/tools/impl/truncation.ts
@@ -12,6 +12,10 @@ export const LIMITS = {
   // Command output limits
   BASH_OUTPUT_CHARS: 30_000, // 30K characters for bash/shell output
   TASK_OUTPUT_CHARS: 30_000, // 30K characters for subagent task output
+  // Background shell completion notifications are injected into the agent's
+  // context unprompted, so they get a tighter budget than a tool return the
+  // agent actually asked for. The full transcript stays in the output file.
+  BASH_NOTIFICATION_CHARS: 10_000,
 
   // File reading limits
   READ_MAX_LINES: 2_000, // Max lines per file read

--- a/src/utils/task-notifications.ts
+++ b/src/utils/task-notifications.ts
@@ -1,3 +1,4 @@
+import { getConversationId, getCurrentAgentId } from "@/agent/context";
 import { SYSTEM_REMINDER_OPEN } from "@/constants";
 
 /**
@@ -10,6 +11,11 @@ import { SYSTEM_REMINDER_OPEN } from "@/constants";
 // ============================================================================
 // Types
 // ============================================================================
+
+export interface NotificationScope {
+  agentId: string;
+  conversationId: string;
+}
 
 export interface TaskNotification {
   taskId: string;
@@ -42,6 +48,36 @@ function unescapeXml(str: string): string {
 // ============================================================================
 // Public API
 // ============================================================================
+
+/**
+ * Resolve the agent/conversation scope a completion notification routes to.
+ *
+ * Prefers the scope injected by executeTool, which is the only correct source
+ * in listener/desktop mode where several agent scopes share one process, and
+ * falls back to the process-global agent context for plain CLI sessions.
+ * Returns undefined when neither is available, in which case the caller should
+ * still queue the notification unscoped rather than drop it.
+ */
+export function resolveNotificationScope(parentScope?: {
+  agentId: string;
+  conversationId: string;
+}): NotificationScope | undefined {
+  if (parentScope?.agentId) {
+    return {
+      agentId: parentScope.agentId,
+      conversationId: parentScope.conversationId || "default",
+    };
+  }
+
+  try {
+    return {
+      agentId: getCurrentAgentId(),
+      conversationId: getConversationId() ?? "default",
+    };
+  } catch {
+    return undefined;
+  }
+}
 
 /**
  * Format a single notification as XML string for queueing.


### PR DESCRIPTION
Fixes #3226.

Rebased onto #3744, which unified shell process execution. That refactor collapsed background Bash's three terminal paths (`exit` / `error` / timeout) into a single `runningProcess.completion` promise, which simplified this change — see "Rebase note" below.

## The bug

`Bash.md` tells the agent that for `run_in_background` commands it "will be notified when it finishes" and that it "does not need to check the output right away":

https://github.com/letta-ai/letta-code/blob/main/src/tools/descriptions/Bash.md#L28

Nothing ever delivered that notification. `formatTaskNotification` was called from exactly one place — the subagent path in `src/tools/impl/task.ts` — so a backgrounded shell completed silently while the agent sat waiting for a wake-up that could not arrive. As reported in #3226, the agent promises the user "the watcher will ping you when the deploy is done" and the ping never comes.

This is not scoped to WS/listener sessions as the issue speculated: there was no call site anywhere, so it was unimplemented in every session type, plain CLI included.

## The fix

All the plumbing already existed from #827 (`formatTaskNotification`, the message-queue bridge, the CLI render path) — it just was never wired to shells. Both arms of the shell runner's completion promise now format the same `<task-notification>` XML as a subagent completion and hand it to `addToMessageQueue`.

Behavioral details worth reviewing:

- **Exactly one notification per shell**, because the completion promise settles exactly once.
- **KillBash/TaskStop marks the shell suppressed before killing**, so deliberately stopping a shell doesn't wake the agent with a failure notification for a process it just killed on purpose.
- **Tighter output budget than a tool return.** Notifications carry the last 50 lines of each stream under a new `BASH_NOTIFICATION_CHARS` (10K) limit rather than the 30K `BASH_OUTPUT_CHARS`, since this content enters context unprompted. The full transcript stays in the output file, which the notification links.
- **Routing scope resolves at launch, not at completion.** By the time a shell finishes, the launching turn is over and the process-global agent context may point at a different conversation — so the scope is captured up front. `resolveParentScope` moves from `task.ts` into `task-notifications.ts` as `resolveNotificationScope` and is now shared by both paths (no behavior change for subagents).

No change to `Bash.md` — the promise it already makes becomes true.

## Rebase note

The first version of this PR carried a once-guard, because the pre-#3744 code could reach a terminal state twice (timeout handler then `exit`; spawn `error` then `exit`). #3744's single completion promise makes that structurally impossible, so the guard is gone and the notifier is a plain function rather than a closure over `notified`. The timeout case now arrives through the promise's reject arm with `err.killed`, and is still covered by a test asserting exactly one notification.

## Testing

New `src/tools/bash-background-notification.test.ts` covers: success, non-zero exit with the code and stderr surfaced, description-less fallback to the command string, single-notification-on-timeout, and silence after `kill_bash`.

Assertions match on each shell's own task id rather than `queued[0]`, because the process registry and queue bridge are module-level singletons and a shell torn down by a previous test can deliver its completion into the next one. (That leakage is what made a first draft of these tests flake; the production path emits exactly once.)

- `bun test src/tools/` — 665 pass, 1 pre-existing unrelated failure (`shell-codex.test.ts` cwd fallback, a macOS `/tmp` → `/private/tmp` symlink artifact of my worktree location; fails identically on a clean tree)
- `bun run typecheck`, `bun run lint`, `check:cycles`, `check:boundaries`, `check:module-ownership`, `check:exported-functions`, `check:filename-casing`, `check:file-size`, `check:test-mock-isolation` — all clean

## Not covered

Manual end-to-end in an app-server/WS listener session, which is the configuration #3226 was originally observed in. The unit tests exercise the queue-bridge handoff but not the listener's delivery of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)