### PR TITLE
feat(cli): render ExitWorktree results as a compact summary

### DIFF
--- a/src/cli/components/ExitWorktreeResultRenderer.tsx
+++ b/src/cli/components/ExitWorktreeResultRenderer.tsx
@@ -1,0 +1,129 @@
+import { Box } from "ink";
+import { CLI_GLYPHS } from "@/cli/helpers/glyphs";
+import { useTerminalWidth } from "@/cli/hooks/use-terminal-width";
+import { Text } from "./Text";
+
+const PREFIX_WIDTH = 5; // `  └  ` or `     `
+const LABEL_WIDTH = 8;
+
+export interface ExitWorktreeDisplayResult {
+  action: "removed" | "left";
+  path?: string;
+  branch?: string;
+  lock?: string;
+  cwd?: string;
+  switchedCwd?: boolean;
+}
+
+export function parseExitWorktreeResult(
+  text: string,
+): ExitWorktreeDisplayResult | null {
+  const normalized = text.replace(/\r\n/g, "\n");
+  const firstLine = normalized.split("\n").find((line) => line.trim());
+  const action =
+    firstLine?.trim() === "Removed worktree."
+      ? "removed"
+      : firstLine?.trim() === "Left worktree."
+        ? "left"
+        : null;
+  if (!action) {
+    return null;
+  }
+
+  const field = (name: string): string | undefined => {
+    const match = normalized.match(new RegExp(`^${name}:\\s*(.+)$`, "m"));
+    return match?.[1]?.trim();
+  };
+
+  const result: ExitWorktreeDisplayResult = {
+    action,
+    path: field("Path"),
+    branch: field("Branch"),
+    lock: field("Lock"),
+    cwd: field("CWD"),
+  };
+
+  if (
+    normalized.includes(
+      "This conversation's working directory is now the primary checkout.",
+    )
+  ) {
+    result.switchedCwd = true;
+  } else if (
+    normalized.includes("The working directory could not be switched")
+  ) {
+    result.switchedCwd = false;
+  }
+
+  if (!result.path && !result.branch && !result.cwd) {
+    return null;
+  }
+
+  return result;
+}
+
+function DetailRow({ label, value }: { label: string; value: string }) {
+  const columns = useTerminalWidth();
+  const contentWidth = Math.max(0, columns - PREFIX_WIDTH);
+  const valueWidth = Math.max(0, contentWidth - LABEL_WIDTH);
+
+  return (
+    <Box flexDirection="row">
+      <Box width={PREFIX_WIDTH} flexShrink={0}>
+        <Text>{" ".repeat(PREFIX_WIDTH)}</Text>
+      </Box>
+      <Box flexGrow={1} width={contentWidth} flexDirection="row">
+        <Box width={LABEL_WIDTH} flexShrink={0}>
+          <Text dimColor>{label}:</Text>
+        </Box>
+        <Box flexGrow={1} width={valueWidth}>
+          <Text wrap="truncate-end">{value}</Text>
+        </Box>
+      </Box>
+    </Box>
+  );
+}
+
+export function ExitWorktreeResultRenderer({
+  resultText,
+}: {
+  resultText: string;
+}) {
+  const parsed = parseExitWorktreeResult(resultText);
+  const columns = useTerminalWidth();
+  const contentWidth = Math.max(0, columns - PREFIX_WIDTH);
+
+  if (!parsed) {
+    return null;
+  }
+
+  // Only surface the CWD row when the switch succeeded. A failed switch is the
+  // one case worth spelling out, because the session is somewhere unexpected.
+  const cwdValue =
+    parsed.switchedCwd === false
+      ? "⚠ not switched"
+      : (parsed.cwd ?? "primary checkout");
+
+  return (
+    <Box flexDirection="column">
+      <Box flexDirection="row">
+        <Box width={PREFIX_WIDTH} flexShrink={0}>
+          <Text>{`  ${CLI_GLYPHS.result}  `}</Text>
+        </Box>
+        <Box flexGrow={1} width={contentWidth}>
+          <Text>
+            {parsed.action === "removed"
+              ? "Removed worktree"
+              : "Left worktree (kept on disk)"}
+          </Text>
+        </Box>
+      </Box>
+      {parsed.path ? <DetailRow label="Path" value={parsed.path} /> : null}
+      {parsed.branch ? (
+        <DetailRow label="Branch" value={parsed.branch} />
+      ) : null}
+      {parsed.lock ? <DetailRow label="Lock" value={parsed.lock} /> : null}
+      <DetailRow label="CWD" value={cwdValue} />
+    </Box>
+  );
+}

--- a/src/cli/components/ToolCallMessageRich.tsx
+++ b/src/cli/components/ToolCallMessageRich.tsx
@@ -98,10 +98,6 @@ import {
   MultiEditRenderer,
   WriteRenderer,
 } from "./DiffRenderer.js";
-import {
-  EnterWorktreeResultRenderer,
-  parseEnterWorktreeResult,
-} from "./EnterWorktreeResultRenderer.js";
 import { MarkdownDisplay } from "./MarkdownDisplay.js";
 import { MemoryDiffRenderer } from "./MemoryDiffRenderer.js";
 import { PlanRenderer } from "./PlanRenderer.js";
@@ -112,6 +108,10 @@ import {
   type StyledSpan,
 } from "./SyntaxHighlightedCommand";
 import { TodoRenderer } from "./TodoRenderer.js";
+import {
+  hasWorktreeResultRenderer,
+  WorktreeToolResult,
+} from "./WorktreeResultRenderer.js";
 
 const LIVE_SHELL_ARGS_MAX_LINES = 2;
 
@@ -585,12 +585,12 @@ export const ToolCallMessage = memo(
           // Fall through to regular handling if parsing fails
         }
 
-        // Check if this is EnterWorktree - show a compact structured summary
-        // instead of the full instructional tool return.
-        if (rawName === "EnterWorktree" && line.resultOk !== false) {
-          if (parseEnterWorktreeResult(extractedText)) {
-            return <EnterWorktreeResultRenderer resultText={extractedText} />;
-          }
+        // Worktree tools show a compact structured summary instead of the
+        // full instructional tool return.
+        if (hasWorktreeResultRenderer(rawName, extractedText, line.resultOk)) {
+          return (
+            <WorktreeToolResult toolName={rawName} resultText={extractedText} />
+          );
         }
 
         // Check if this is a file edit tool - show diff instead of success message

--- a/src/cli/components/WorktreeResultRenderer.tsx
+++ b/src/cli/components/WorktreeResultRenderer.tsx
@@ -1,0 +1,46 @@
+import {
+  EnterWorktreeResultRenderer,
+  parseEnterWorktreeResult,
+} from "./EnterWorktreeResultRenderer.js";
+import {
+  ExitWorktreeResultRenderer,
+  parseExitWorktreeResult,
+} from "./ExitWorktreeResultRenderer.js";
+
+/**
+ * Single dispatch point for the worktree tools' compact result summaries, so
+ * ToolCallMessageRich carries one branch rather than one per tool. A failed
+ * call keeps the raw tool return, which carries the error text.
+ */
+export function hasWorktreeResultRenderer(
+  toolName: string,
+  resultText: string,
+  resultOk?: boolean,
+): boolean {
+  if (resultOk === false) {
+    return false;
+  }
+  if (toolName === "EnterWorktree") {
+    return parseEnterWorktreeResult(resultText) !== null;
+  }
+  if (toolName === "ExitWorktree") {
+    return parseExitWorktreeResult(resultText) !== null;
+  }
+  return false;
+}
+
+export function WorktreeToolResult({
+  toolName,
+  resultText,
+}: {
+  toolName: string;
+  resultText: string;
+}) {
+  if (toolName === "EnterWorktree") {
+    return <EnterWorktreeResultRenderer resultText={resultText} />;
+  }
+  if (toolName === "ExitWorktree") {
+    return <ExitWorktreeResultRenderer resultText={resultText} />;
+  }
+  return null;
+}

--- a/src/cli/exit-worktree-result-renderer.test.tsx
+++ b/src/cli/exit-worktree-result-renderer.test.tsx
@@ -1,0 +1,157 @@
+import { expect, test } from "bun:test";
+import { Readable, Writable } from "node:stream";
+import { render } from "ink";
+import stripAnsi from "strip-ansi";
+import { parseExitWorktreeResult } from "@/cli/components/ExitWorktreeResultRenderer";
+import { ToolCallMessage } from "@/cli/components/ToolCallMessageRich";
+
+class CaptureStream extends Writable {
+  columns = 120;
+  rows = 24;
+  isTTY = true;
+  chunks: string[] = [];
+
+  override _write(
+    chunk: Buffer | string,
+    _encoding: BufferEncoding,
+    callback: (error?: Error | null) => void,
+  ) {
+    this.chunks.push(String(chunk));
+    callback();
+  }
+}
+
+function createInputStream(): NodeJS.ReadStream {
+  const input = new Readable({ read() {} }) as NodeJS.ReadStream;
+  input.isTTY = true;
+  input.setRawMode = () => input;
+  input.ref = () => input;
+  input.unref = () => input;
+  return input;
+}
+
+const removedWorktreeResult = [
+  "Removed worktree.",
+  "",
+  "Path: /Users/loaner/dev/letta-code-prod/.letta/worktrees/render-test-worktree",
+  "Branch: deleted letta/render-test-worktree-a90824a8",
+  "Lock: released",
+  "CWD: /Users/loaner/dev/letta-code-prod",
+  "",
+  "This conversation's working directory is now the primary checkout.",
+].join("\n");
+
+const keptWorktreeResult = [
+  "Left worktree.",
+  "",
+  "Path: /Users/loaner/dev/letta-code-prod/.letta/worktrees/render-test-worktree",
+  "Branch: letta/render-test-worktree-a90824a8",
+  "CWD: /Users/loaner/dev/letta-code-prod",
+  "",
+  "This conversation's working directory is now the primary checkout.",
+  "",
+  "The worktree and its branch were left on disk; re-enter it with EnterWorktree `path`.",
+].join("\n");
+
+async function renderExitWorktreeToolCall(
+  resultText = removedWorktreeResult,
+): Promise<string> {
+  const stdout = new CaptureStream() as CaptureStream & NodeJS.WriteStream;
+  const instance = render(
+    <ToolCallMessage
+      line={{
+        kind: "tool_call",
+        id: "call-exit-worktree",
+        toolCallId: "call-exit-worktree",
+        name: "ExitWorktree",
+        argsText: JSON.stringify({ action: "remove" }),
+        resultText,
+        resultOk: true,
+        phase: "finished",
+      }}
+      isStreaming={false}
+    />,
+    {
+      stdout,
+      stdin: createInputStream(),
+      debug: false,
+      patchConsole: false,
+      exitOnCtrlC: false,
+    },
+  );
+
+  await new Promise((resolve) => setTimeout(resolve, 20));
+  instance.unmount();
+  instance.cleanup();
+
+  return stripAnsi(stdout.chunks.join(""));
+}
+
+test("parses ExitWorktree tool result fields", () => {
+  expect(parseExitWorktreeResult(removedWorktreeResult)).toEqual({
+    action: "removed",
+    path: "/Users/loaner/dev/letta-code-prod/.letta/worktrees/render-test-worktree",
+    branch: "deleted letta/render-test-worktree-a90824a8",
+    lock: "released",
+    cwd: "/Users/loaner/dev/letta-code-prod",
+    switchedCwd: true,
+  });
+});
+
+test("ExitWorktree tool result renders a compact structured summary", async () => {
+  const output = await renderExitWorktreeToolCall();
+
+  expect(output).toContain("ExitWorktree");
+  expect(output).toContain("Removed worktree");
+  expect(output).toContain("Path:");
+  expect(output).toContain("render-test-worktree");
+  expect(output).toContain("Branch:");
+  expect(output).toContain("deleted letta/render-test-worktree-a90824a8");
+  expect(output).toContain("Lock:");
+  expect(output).toContain("released");
+  expect(output).toContain("CWD:");
+  expect(output).not.toContain("This conversation's working directory");
+});
+
+test("ExitWorktree tool result distinguishes a kept worktree", async () => {
+  expect(parseExitWorktreeResult(keptWorktreeResult)).toEqual({
+    action: "left",
+    path: "/Users/loaner/dev/letta-code-prod/.letta/worktrees/render-test-worktree",
+    branch: "letta/render-test-worktree-a90824a8",
+    lock: undefined,
+    cwd: "/Users/loaner/dev/letta-code-prod",
+    switchedCwd: true,
+  });
+
+  const output = await renderExitWorktreeToolCall(keptWorktreeResult);
+
+  expect(output).toContain("Left worktree (kept on disk)");
+  expect(output).not.toContain("Removed worktree");
+  expect(output).not.toContain("Lock:");
+  expect(output).not.toContain("re-enter it with EnterWorktree");
+});
+
+test("ExitWorktree renderer flags a working directory that did not switch", async () => {
+  const strandedResult = [
+    "Removed worktree.",
+    "",
+    "Path: /repo/.letta/worktrees/stranded",
+    "Branch: deleted letta/stranded-1234",
+    "CWD: /repo",
+    "",
+    "⚠ The working directory could not be switched and may still point at /repo/.letta/worktrees/stranded.",
+  ].join("\n");
+
+  expect(parseExitWorktreeResult(strandedResult)?.switchedCwd).toBe(false);
+
+  const output = await renderExitWorktreeToolCall(strandedResult);
+  expect(output).toContain("not switched");
+});
+
+test("non-ExitWorktree text is not claimed by the parser", () => {
+  expect(
+    parseExitWorktreeResult("Created worktree.\n\nPath: /repo"),
+  ).toBeNull();
+  expect(parseExitWorktreeResult("Not in a managed worktree.")).toBeNull();
+  expect(parseExitWorktreeResult("Removed worktree.")).toBeNull();
+});

--- a/src/tools/exit-worktree.test.ts
+++ b/src/tools/exit-worktree.test.ts
@@ -172,7 +172,12 @@ describe("ExitWorktree tool", () => {
     expect(result.status).toBe("success");
     expect(result.returned_to).toBe(repo);
     expect(result.removed).toBe(false);
-    expect(result.content[0]?.text).toContain("kept on disk");
+    // The TUI renderer parses these labeled fields; keep them in lockstep
+    // with src/cli/components/ExitWorktreeResultRenderer.tsx.
+    expect(result.content[0]?.text).toContain("Left worktree.");
+    expect(result.content[0]?.text).toContain(`Path: ${worktreePath}`);
+    expect(result.content[0]?.text).toContain(`Branch: ${branchName}`);
+    expect(result.content[0]?.text).toContain(`CWD: ${repo}`);
     expect(await exists(worktreePath)).toBe(true);
     expect(git(["branch", "--list", branchName], repo)).toContain(branchName);
   });
@@ -189,6 +194,8 @@ describe("ExitWorktree tool", () => {
     expect(result.status).toBe("success");
     expect(result.removed).toBe(true);
     expect(result.returned_to).toBe(repo);
+    expect(result.content[0]?.text).toContain("Removed worktree.");
+    expect(result.content[0]?.text).toContain(`Branch: deleted ${branchName}`);
     expect(await exists(worktreePath)).toBe(false);
     expect(git(["branch", "--list", branchName], repo)).toBe("");
   });
@@ -283,7 +290,7 @@ describe("ExitWorktree tool", () => {
     );
 
     expect(result.status).toBe("success");
-    expect(result.content[0]?.text).toContain("released the cross-agent");
+    expect(result.content[0]?.text).toContain("Lock: released");
     expect(await lockExists(worktreeGitDir)).toBe(false);
   });
 
@@ -309,7 +316,7 @@ describe("ExitWorktree tool", () => {
     );
 
     expect(result.status).toBe("success");
-    expect(result.content[0]?.text).not.toContain("released the cross-agent");
+    expect(result.content[0]?.text).not.toContain("Lock:");
     expect(await lockExists(worktreeGitDir)).toBe(true);
   });
 });

--- a/src/tools/impl/exit-worktree.ts
+++ b/src/tools/impl/exit-worktree.ts
@@ -105,6 +105,43 @@ async function resolveCurrentBranch(
 }
 
 /**
+ * Labeled-field result, matching the EnterWorktree message shape so the TUI
+ * can render a compact summary instead of the raw tool return.
+ */
+function buildExitWorktreeMessage(params: {
+  removed: boolean;
+  worktreePath: string;
+  branchNote: string;
+  lockNote?: string;
+  primaryRoot: string;
+  switchedCwd: boolean;
+}): string {
+  const lines = [
+    params.removed ? "Removed worktree." : "Left worktree.",
+    "",
+    `Path: ${params.worktreePath}`,
+    `Branch: ${params.branchNote}`,
+  ];
+  if (params.lockNote) {
+    lines.push(`Lock: ${params.lockNote}`);
+  }
+  lines.push(
+    `CWD: ${params.primaryRoot}`,
+    "",
+    params.switchedCwd
+      ? "This conversation's working directory is now the primary checkout."
+      : `⚠ The working directory could not be switched and may still point at ${params.worktreePath}.`,
+  );
+  if (!params.removed) {
+    lines.push(
+      "",
+      "The worktree and its branch were left on disk; re-enter it with EnterWorktree `path`.",
+    );
+  }
+  return lines.join("\n");
+}
+
+/**
  * Leave the worktree this conversation is in and return to the primary
  * checkout, optionally deleting the worktree and its branch.
  *
@@ -188,8 +225,7 @@ export async function exit_worktree(
       executionContextId: args._executionContextId,
     });
 
-    const notes: string[] = [];
-
+    let lockNote: string | undefined;
     const worktreeGitDir = await resolveWorktreeGitDir(worktreePath);
     if (worktreeGitDir) {
       const released = await releaseWorktreeLock({
@@ -197,11 +233,12 @@ export async function exit_worktree(
         owner: lockOwner(runtimeContext),
       });
       if (released) {
-        notes.push("released the cross-agent worktree lock");
+        lockNote = "released";
       }
     }
 
     let removed = false;
+    let branchNote = branchName ?? "(detached)";
     if (action === "remove") {
       const removeArgs = ["worktree", "remove", worktreePath];
       if (discardChanges) {
@@ -216,27 +253,23 @@ export async function exit_worktree(
             ["branch", discardChanges ? "-D" : "-d", branchName],
             primaryRoot,
           );
-          notes.push(`deleted branch ${branchName}`);
+          branchNote = `deleted ${branchName}`;
         } catch (error) {
           // The worktree is already gone; surface the branch as a leftover
           // rather than failing an otherwise completed removal.
-          notes.push(
-            `⚠ kept branch ${branchName} (${formatGitFailure(error)})`,
-          );
+          branchNote = `⚠ kept ${branchName} (${formatGitFailure(error)})`;
         }
       }
     }
 
-    const headline = removed
-      ? `Removed worktree ${worktreePath}`
-      : `Left worktree ${worktreePath} (kept on disk)`;
-    const message = [
-      headline,
-      switchedCwd
-        ? `Working directory is now ${primaryRoot}`
-        : `⚠ could not switch the working directory; it may still point at ${worktreePath}`,
-      ...notes.map((note) => `- ${note}`),
-    ].join("\n");
+    const message = buildExitWorktreeMessage({
+      removed,
+      worktreePath,
+      branchNote,
+      lockNote,
+      primaryRoot,
+      switchedCwd,
+    });
 
     return textResult(message, "success", {
       returned_to: primaryRoot,


### PR DESCRIPTION
Follow-up to #3747, which shipped `ExitWorktree` without a TUI renderer — so its result rendered as the full instructional tool return while `EnterWorktree` right above it got a compact summary.

## What changed

**The message is now structured.** `ExitWorktree` emits the same labeled-field shape `EnterWorktree` already uses:

```
Removed worktree.

Path: /repo/.letta/worktrees/fix-login
Branch: deleted letta/fix-login-a90824a8
Lock: released
CWD: /repo

This conversation's working directory is now the primary checkout.
```

This is a model-facing change as much as a display one — the labeled form is the established convention for these tools, and it reads better than the prose it replaces.

**Renders as:**

```
  └  Removed worktree
     Path:   /repo/.letta/worktrees/fix-login
     Branch: deleted letta/fix-login-a90824a8
     Lock:   released
     CWD:    /repo
```

`Lock:` only appears when a lock was actually released. `CWD:` shows `⚠ not switched` if the working-directory switch failed — the one case worth spelling out, since the session is then somewhere unexpected.

## One dispatch point, not two

Rather than add a second per-tool branch to `ToolCallMessageRich`, both worktree renderers now go through a small `WorktreeResultRenderer` module. The `resultOk` guard moved into `hasWorktreeResultRenderer`, so a failed call still falls through to the raw tool return that carries the error text.

That keeps `ToolCallMessageRich.tsx` at **exactly** its 1109-line baseline. **No size baselines change in this PR** — the naive version pushed it to 1119, and since #3747 already raised `manager.ts`, I'd rather not make a habit of it.

## Keeping the two in lockstep

The renderer parses text the tool produces, which is a classic silent-drift setup. `exit-worktree.test.ts` now asserts the exact `Path:` / `Branch:` / `CWD:` lines against real git repos, with a comment pointing at the renderer. Changing the message without changing the renderer fails the tool test, not just the display test.

## Testing

New `src/cli/exit-worktree-result-renderer.test.tsx`, 5 tests: field parsing, the removed-summary render, the kept-worktree variant, the failed-cwd-switch warning, and negative cases (it must not claim `EnterWorktree` output, no-op text, or a headline with no fields).

- `bun test src/cli/` — 980 pass, 6 pre-existing failures (`reflection worktree completion messaging`; identical count on a clean tree)
- `bun test src/tools/` — 704 pass, 1 pre-existing failure (`shell-codex` cwd fallback; macOS `/tmp` → `/private/tmp` symlink artifact of my worktree location)
- All 44 worktree tests across `src/tools` and `src/cli` pass
- `typecheck`, `lint`, and all 8 `check:*` scripts clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)