### PR TITLE
feat(backend): hot-reload agent records from disk on mtime change

### DIFF
--- a/0001-local-store-agent-hot-reload.patch
+++ b/0001-local-store-agent-hot-reload.patch
@@ -1,0 +1,129 @@
+From 078924812cd74d8f7ce0fb2a555d31f31f3ade2c Mon Sep 17 00:00:00 2001
+From: Simon <sich97@users.noreply.github.com>
+Date: Sun, 9 Aug 2026 10:43:03 +0200
+Subject: [PATCH] local: hot-reload agent records from disk on mtime change
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Conversation records in the local backend already hot-reload from disk
+when their on-disk mtime changes (see refreshConversationRecordFromStorage).
+Agent records do not — they are loaded once at startup into an in-memory
+Map (local-store.ts) and every read returns the cached copy.
+
+This makes it impossible to patch an agent's model_settings (e.g.
+context_window_limit, max_tokens) from an external script without
+restarting the entire server, which drops in-flight Slack/channel turns.
+
+This commit mirrors the conversation hot-reload pattern for agent records:
+
+  - Add agentRecordMtimeMsById field to track each agent file's last
+    seen mtime.
+  - Add agentRecordFileMtimeMs(agentId) helper to stat the agent JSON
+    file on disk.
+  - Add refreshAgentRecordFromStorage(agentId) which returns the cached
+    record on a fast-path mtime match, and otherwise re-reads and
+    re-validates the file via normalizeAgentRecord.
+  - Hook refreshAgentRecordFromStorage into retrieveAgentRecord so
+    every agent read picks up external edits transparently.
+  - Update loadFromStorage and persistAgent to record the mtime after
+    initial load / Letta-internal writes, so self-writes don't trigger
+    spurious re-reads on the next access.
+
+The behavior is identical to the conversation hot-reload: when nothing
+on disk has changed, the call is a single statSync (no JSON parse).
+When something has changed, the file is re-read, normalized via the
+existing normalizeAgentRecord function, and replaces the cached copy.
+
+Test: src/backend/local/local-store-agent-hot-reload.test.ts
+---
+ src/backend/local/local-store.ts | 52 ++++++++++++++++++++++++++++++++
+ 1 file changed, 52 insertions(+)
+
+diff --git a/src/backend/local/local-store.ts b/src/backend/local/local-store.ts
+index bddb818..2fb04f6 100644
+--- a/src/backend/local/local-store.ts
++++ b/src/backend/local/local-store.ts
+@@ -1146,6 +1146,7 @@ export class LocalStore {
+     string,
+     LocalMessage[]
+   >();
++  private readonly agentRecordMtimeMsById = new Map<string, number>();
+   private readonly loadedConversationKeys = new Set<string>();
+   private readonly loadRepairedConversationKeys = new Set<string>();
+   private readonly transcriptMetadataByConversationKey = new Map<
+@@ -1301,6 +1302,7 @@ export class LocalStore {
+   }
+ 
+   retrieveAgentRecord(agentId: string): LocalAgentRecord {
++    this.refreshAgentRecordFromStorage(agentId);
+     if (!this.strictAgentAccess) {
+       this.ensureAgent(agentId);
+     }
+@@ -3131,6 +3133,7 @@ export class LocalStore {
+         const agent = normalizeAgentRecord(raw, this.defaultAgentModel);
+         if (agent?.id) {
+           this.agents.set(agent.id, agent);
++          this.recordAgentRecordMtime(agent.id);
+           if (shouldPersistSubagentHiddenBackfill(raw, agent)) {
+             this.persistAgent(agent.id);
+           }
+@@ -3149,6 +3152,55 @@ export class LocalStore {
+       join(agentsDir, `${encodePathSegment(agentId)}.json`),
+       `${JSON.stringify(agent, null, 2)}\n`,
+     );
++    this.recordAgentRecordMtime(agentId);
++  }
++
++  private agentRecordFileMtimeMs(agentId: string): number | undefined {
++    if (!this.storageDir) return undefined;
++    try {
++      return statSync(
++        join(this.storageDir, "agents", `${encodePathSegment(agentId)}.json`),
++      ).mtimeMs;
++    } catch {
++      return undefined;
++    }
++  }
++
++  private recordAgentRecordMtime(
++    agentId: string,
++    options: { mtimeMs?: number } = {},
++  ): void {
++    if (!this.storageDir) return;
++    const mtimeMs =
++      options.mtimeMs ?? this.agentRecordFileMtimeMs(agentId);
++    if (mtimeMs === undefined) {
++      this.agentRecordMtimeMsById.delete(agentId);
++      return;
++    }
++    this.agentRecordMtimeMsById.set(agentId, mtimeMs);
++  }
++
++  private refreshAgentRecordFromStorage(agentId: string): void {
++    if (!this.storageDir) return;
++    if (!this.agents.has(agentId)) return;
++    const mtimeMs = this.agentRecordFileMtimeMs(agentId);
++    if (mtimeMs === undefined) return;
++    if (this.agentRecordMtimeMsById.get(agentId) === mtimeMs) return;
++
++    const filePath = join(
++      this.storageDir,
++      "agents",
++      `${encodePathSegment(agentId)}.json`,
++    );
++    try {
++      const raw = readJsonFile<unknown>(filePath);
++      const agent = normalizeAgentRecord(raw, this.defaultAgentModel);
++      if (!agent?.id || agent.id !== agentId) return;
++      this.agents.set(agentId, agent);
++      this.recordAgentRecordMtime(agentId, { mtimeMs });
++    } catch {
++      // Leave the cached record in place on parse/IO failure.
++    }
+   }
+ 
+   private projectAgent(record: LocalAgentRecord): AgentState {
+-- 
+2.55.0
+

--- a/src/backend/local/local-store-agent-hot-reload.test.ts
+++ b/src/backend/local/local-store-agent-hot-reload.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { LocalBackend } from "@/backend/local/local-backend";
+
+describe("local agent hot-reload", () => {
+  test("retrieves patched model_settings after the agent JSON file is modified on disk", async () => {
+    const storageDir = await mkdtemp(join(tmpdir(), "local-backend-agent-reload-"));
+
+    try {
+      const backend = new LocalBackend({ storageDir, memfsEnabled: false });
+      const agent = await backend.createAgent({
+        name: "Reload target",
+      } as never);
+
+      const agentsDir = join(storageDir, "agents");
+      const agentFile = join(agentsDir, `${agent.id}.json`);
+      const initial = JSON.parse(await readFile(agentFile, "utf8"));
+      expect(initial.model_settings?.context_window_limit).not.toBe(96000);
+      expect(initial.model_settings?.max_tokens).not.toBe(32000);
+
+      // Wait long enough for the mtime to advance even on filesystems
+      // with second-resolution timestamps.
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      const patched = {
+        ...initial,
+        model_settings: {
+          ...initial.model_settings,
+          context_window_limit: 96000,
+          max_tokens: 32000,
+        },
+      };
+      await writeFile(agentFile, `${JSON.stringify(patched, null, 2)}\n`);
+
+      const reloaded = await backend.retrieveAgent(agent.id);
+      expect(reloaded).toMatchObject({
+        id: agent.id,
+        model_settings: expect.objectContaining({
+          context_window_limit: 96000,
+          max_tokens: 32000,
+        }),
+      });
+    } finally {
+      await rm(storageDir, { recursive: true, force: true });
+    }
+  });
+
+  test("does not reload when the file mtime is unchanged", async () => {
+    const storageDir = await mkdtemp(join(tmpdir(), "local-backend-agent-norewrite-"));
+
+    try {
+      const backend = new LocalBackend({ storageDir, memfsEnabled: false });
+      const agent = await backend.createAgent({
+        name: "No-op target",
+      } as never);
+
+      // Multiple back-to-back reads should hit the in-memory cache.
+      const first = await backend.retrieveAgent(agent.id);
+      const second = await backend.retrieveAgent(agent.id);
+      expect(first).toMatchObject({ id: agent.id });
+      expect(second).toMatchObject({ id: agent.id });
+    } finally {
+      await rm(storageDir, { recursive: true, force: true });
+    }
+  });
+
+  test("preserves the cached record if the on-disk JSON fails to parse", async () => {
+    const storageDir = await mkdtemp(join(tmpdir(), "local-backend-agent-corrupt-"));
+
+    try {
+      const backend = new LocalBackend({ storageDir, memfsEnabled: false });
+      const agent = await backend.createAgent({
+        name: "Corrupt target",
+      } as never);
+
+      const agentFile = join(storageDir, "agents", `${agent.id}.json`);
+
+      // Wait so the file's mtime advances.
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      await writeFile(agentFile, "{ this is not valid json");
+
+      // The cached record must survive — corrupted disk content must not
+      // crash the live agent.
+      const still = await backend.retrieveAgent(agent.id);
+      expect(still).toMatchObject({ id: agent.id, name: "Corrupt target" });
+    } finally {
+      await rm(storageDir, { recursive: true, force: true });
+    }
+  });
+
+  test("survives the agent file being deleted on disk", async () => {
+    const storageDir = await mkdtemp(join(tmpdir(), "local-backend-agent-deleted-"));
+
+    try {
+      const backend = new LocalBackend({ storageDir, memfsEnabled: false });
+      const agent = await backend.createAgent({
+        name: "Deleted target",
+      } as never);
+
+      const agentFile = join(storageDir, "agents", `${agent.id}.json`);
+      await rm(agentFile);
+
+      // In-memory copy still wins when the on-disk file is gone.
+      const still = await backend.retrieveAgent(agent.id);
+      expect(still).toMatchObject({ id: agent.id, name: "Deleted target" });
+    } finally {
+      await rm(storageDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/backend/local/local-store.ts
+++ b/src/backend/local/local-store.ts
@@ -1146,6 +1146,7 @@ export class LocalStore {
     string,
     LocalMessage[]
   >();
+  private readonly agentRecordMtimeMsById = new Map<string, number>();
   private readonly loadedConversationKeys = new Set<string>();
   private readonly loadRepairedConversationKeys = new Set<string>();
   private readonly transcriptMetadataByConversationKey = new Map<
@@ -1301,6 +1302,7 @@ export class LocalStore {
   }
 
   retrieveAgentRecord(agentId: string): LocalAgentRecord {
+    this.refreshAgentRecordFromStorage(agentId);
     if (!this.strictAgentAccess) {
       this.ensureAgent(agentId);
     }
@@ -3131,6 +3133,7 @@ export class LocalStore {
         const agent = normalizeAgentRecord(raw, this.defaultAgentModel);
         if (agent?.id) {
           this.agents.set(agent.id, agent);
+          this.recordAgentRecordMtime(agent.id);
           if (shouldPersistSubagentHiddenBackfill(raw, agent)) {
             this.persistAgent(agent.id);
           }
@@ -3149,6 +3152,55 @@ export class LocalStore {
       join(agentsDir, `${encodePathSegment(agentId)}.json`),
       `${JSON.stringify(agent, null, 2)}\n`,
     );
+    this.recordAgentRecordMtime(agentId);
+  }
+
+  private agentRecordFileMtimeMs(agentId: string): number | undefined {
+    if (!this.storageDir) return undefined;
+    try {
+      return statSync(
+        join(this.storageDir, "agents", `${encodePathSegment(agentId)}.json`),
+      ).mtimeMs;
+    } catch {
+      return undefined;
+    }
+  }
+
+  private recordAgentRecordMtime(
+    agentId: string,
+    options: { mtimeMs?: number } = {},
+  ): void {
+    if (!this.storageDir) return;
+    const mtimeMs =
+      options.mtimeMs ?? this.agentRecordFileMtimeMs(agentId);
+    if (mtimeMs === undefined) {
+      this.agentRecordMtimeMsById.delete(agentId);
+      return;
+    }
+    this.agentRecordMtimeMsById.set(agentId, mtimeMs);
+  }
+
+  private refreshAgentRecordFromStorage(agentId: string): void {
+    if (!this.storageDir) return;
+    if (!this.agents.has(agentId)) return;
+    const mtimeMs = this.agentRecordFileMtimeMs(agentId);
+    if (mtimeMs === undefined) return;
+    if (this.agentRecordMtimeMsById.get(agentId) === mtimeMs) return;
+
+    const filePath = join(
+      this.storageDir,
+      "agents",
+      `${encodePathSegment(agentId)}.json`,
+    );
+    try {
+      const raw = readJsonFile<unknown>(filePath);
+      const agent = normalizeAgentRecord(raw, this.defaultAgentModel);
+      if (!agent?.id || agent.id !== agentId) return;
+      this.agents.set(agentId, agent);
+      this.recordAgentRecordMtime(agentId, { mtimeMs });
+    } catch {
+      // Leave the cached record in place on parse/IO failure.
+    }
   }
 
   private projectAgent(record: LocalAgentRecord): AgentState {


### PR DESCRIPTION
## Summary

Conversation records in the local backend already hot-reload from disk when their on-disk mtime changes (`refreshConversationRecordFromStorage`). Agent records do not — they are loaded once at startup into an in-memory `Map` (`src/backend/local/local-store.ts:1143`) and every read returns the cached copy.

This makes it impossible to patch an agent's `model_settings` (e.g. `context_window_limit`, `max_tokens`) from an external script without restarting the entire server, which drops in-flight Slack/channel turns.

This PR mirrors the existing conversation hot-reload pattern for agent records:

- Add `agentRecordMtimeMsById` field to track each agent file's last seen mtime.
- Add `agentRecordFileMtimeMs(agentId)` helper to stat the agent JSON file on disk.
- Add `refreshAgentRecordFromStorage(agentId)` which returns the cached record on a fast-path mtime match, and otherwise re-reads and re-validates the file via `normalizeAgentRecord`.
- Hook `refreshAgentRecordFromStorage` into `retrieveAgentRecord` so every agent read picks up external edits transparently.
- Update `loadFromStorage` and `persistAgent` to record the mtime after initial load / Letta-internal writes, so self-writes don't trigger spurious re-reads on the next access.

The behavior is identical to the conversation hot-reload: when nothing on disk has changed, the call is a single `statSync` (no JSON parse). When something has changed, the file is re-read, normalized via the existing `normalizeAgentRecord` function, and replaces the cached copy.

**Failure modes / tradeoffs:**

- **Stat overhead:** every `retrieveAgentRecord` call now performs one `statSync`. On local NVMe this is sub-millisecond and well below the noise floor of an LLM turn, but it is technically a new syscall on a previously cache-only path.
- **Corrupt-file tolerance:** if the on-disk file becomes unparseable JSON, the cached in-memory record is preserved (the agent keeps working). The bad file is left in place — no auto-repair. This matches how `refreshConversationRecordFromStorage` handles parse failures.
- **Mtime resolution:** on filesystems with 1-second mtime resolution, two writes within the same second will look identical and the second will be ignored. The conversation refresh has the same property. For the realistic case (a human or watchdog script running `jq` to patch a file), this is a non-issue.
- **External tool responsibility:** scripts that patch agent files should write atomically (temp file + rename) so the refresh never observes a half-written file. `jq -i` and `python -c 'json.dump(...)'` followed by `os.replace()` both do this by default.

## Verification

- `git am 0001-local-store-agent-hot-reload.patch` applies cleanly against `letta-ai/letta-code@main` (commit `bddb818`) with no offsets or rejects.
- `tsc --noEmit --strict false --skipLibCheck --noResolve src/backend/local/local-store.ts` against the patched file reports no new errors in any of the lines I added (the unresolved-module errors are all pre-existing imports of `@letta-ai/letta-client` and the `@/*` aliases, which require the project's full dependency graph to resolve).
- New tests added in `src/backend/local/local-store-agent-hot-reload.test.ts` mirroring the existing `local-store-appledouble.test.ts` pattern.

## AI Disclosure

- [x] This pull request was written with AI assistance and reviewed and edited by a human
- [x] I have read the [AI Policy](https://github.com/letta-ai/letta-code/blob/main/AI_POLICY.md) and agree to its terms

## AI Tool(s) Used

- Anthropic Claude (Sonnet 4.5) — used to read the Letta Code source on GitHub, identify the pattern used for conversation hot-reload, draft the implementation, draft the test file by mirroring `local-store-appledouble.test.ts`, draft this description, and verify the patch applies cleanly via `git am` against `main`. The submitter (human) reviewed the diff and the AI disclosure.

## Human Verification

I have reviewed and understand every change in this pull request and take responsibility for its correctness.
