### PR TITLE
feat: propagate super run correlation through listener turns

### DIFF
--- a/scripts/source-file-size-baseline.json
+++ b/scripts/source-file-size-baseline.json
@@ -45,6 +45,6 @@
   "src/websocket/listener/file-commands.ts": 1053,
   "src/websocket/listener/lifecycle.ts": 1051,
   "src/websocket/listener/protocol-inbound.ts": 2264,
-  "src/websocket/listener/protocol-outbound.ts": 1083,
+  "src/websocket/listener/protocol-outbound.ts": 1085,
   "src/websocket/listener/turn.ts": 1013
 }

--- a/scripts/source-file-size-baseline.json
+++ b/scripts/source-file-size-baseline.json
@@ -45,6 +45,6 @@
   "src/websocket/listener/file-commands.ts": 1053,
   "src/websocket/listener/lifecycle.ts": 1051,
   "src/websocket/listener/protocol-inbound.ts": 2264,
-  "src/websocket/listener/protocol-outbound.ts": 1085,
-  "src/websocket/listener/turn.ts": 1010
+  "src/websocket/listener/protocol-outbound.ts": 1083,
+  "src/websocket/listener/turn.ts": 1013
 }

--- a/src/agent/message.ts
+++ b/src/agent/message.ts
@@ -226,6 +226,8 @@ export type SendMessageStreamOptions = {
    * for self-hosted / single-user / pre-channel-split flows.
    */
   actingUserId?: string;
+  /** Cloud super-run correlation propagated into Node core run metadata. */
+  superRunId?: string;
 };
 
 export type SendMessageStreamRequestOptions = {
@@ -432,6 +434,9 @@ export async function sendMessageStreamWithBackend(
   // SendMessageStreamOptions.actingUserId for full context.
   if (opts.actingUserId) {
     extraHeaders["X-Letta-Acting-User-Id"] = opts.actingUserId;
+  }
+  if (opts.superRunId) {
+    extraHeaders["X-Letta-Super-Run-Id"] = opts.superRunId;
   }
 
   const messageSummary = normalizedMessages

--- a/src/agent/send-message-stream-acting-user.test.ts
+++ b/src/agent/send-message-stream-acting-user.test.ts
@@ -24,22 +24,27 @@ import { fileURLToPath } from "node:url";
  * actual behavior is exercised end-to-end by the queue and
  * listener integration tests.
  */
-describe("sendMessageStream acting-user header propagation (contract)", () => {
+describe("sendMessageStream listener metadata header propagation (contract)", () => {
   const source = readFileSync(
     fileURLToPath(new URL("../agent/message.ts", import.meta.url)),
     "utf-8",
   );
 
-  test("public option is declared on SendMessageStreamOptions", () => {
+  test("public options are declared on SendMessageStreamOptions", () => {
     expect(source).toContain("actingUserId?: string;");
+    expect(source).toContain("superRunId?: string;");
   });
 
-  test("header is set from opts.actingUserId when present", () => {
+  test("headers are set from listener metadata when present", () => {
     // Pin the precise injection so a refactor that drops the
-    // condition or renames the header is caught.
+    // condition or renames either header is caught.
     expect(source).toMatch(/if\s*\(\s*opts\.actingUserId\s*\)\s*\{/);
     expect(source).toContain(
       'extraHeaders["X-Letta-Acting-User-Id"] = opts.actingUserId',
+    );
+    expect(source).toMatch(/if\s*\(\s*opts\.superRunId\s*\)\s*\{/);
+    expect(source).toContain(
+      'extraHeaders["X-Letta-Super-Run-Id"] = opts.superRunId',
     );
   });
 

--- a/src/types/runtime-scope.ts
+++ b/src/types/runtime-scope.ts
@@ -13,5 +13,7 @@
 export interface RuntimeScope {
   agent_id: string;
   conversation_id: string;
+  /** Super-run correlation for cloud-owned queued turns. */
+  super_run_id?: string;
   acting_user_id?: string;
 }

--- a/src/websocket/listener/approval.test.ts
+++ b/src/websocket/listener/approval.test.ts
@@ -56,11 +56,12 @@ function createScopedRuntime(
   return getOrCreateScopedRuntime(createRuntime(), agentId, conversationId);
 }
 
-function beginApprovalWait(runtime: ConversationRuntime) {
+function beginApprovalWait(runtime: ConversationRuntime, superRunId?: string) {
   return runtime.turnLifecycle.begin({
     origin: "message",
     workingDirectory: process.cwd(),
     initialStatus: "WAITING_ON_APPROVAL",
+    superRunId,
   });
 }
 
@@ -287,7 +288,9 @@ describe("listener approval lifecycle", () => {
   test("resolving an approval does not falsely finalize its enclosing turn", async () => {
     const runtime = createScopedRuntime();
     const socket = new MockSocket();
-    const turnLease = beginApprovalWait(runtime);
+    runtime.listener.socket = socket as unknown as WebSocket;
+    runtime.listener.transport = socket;
+    const turnLease = beginApprovalWait(runtime, "super-run-approval");
     const pending = requestApprovalOverWS(
       runtime,
       socket,
@@ -305,6 +308,11 @@ describe("listener approval lifecycle", () => {
     await expect(pending).resolves.toEqual(makeSuccessResponse("perm-status"));
     expect(runtime.loopStatus).toBe("WAITING_ON_APPROVAL");
     expect(runtime.isProcessing).toBe(true);
+    expect(socket.sentPayloads.length).toBeGreaterThan(1);
+    for (const payload of socket.sentPayloads) {
+      const message = JSON.parse(payload);
+      expect(message.runtime.super_run_id).toBe("super-run-approval");
+    }
   });
 
   test("approval routing and state stay isolated by conversation", async () => {

--- a/src/websocket/listener/approval.ts
+++ b/src/websocket/listener/approval.ts
@@ -286,11 +286,11 @@ export function resolvePendingApprovalResolver(
     setCommandLoopStatus(runtime, "WAITING_ON_INPUT");
   }
   pending.resolve(response);
-  emitLoopStatusIfOpen(runtime.listener, {
+  emitLoopStatusIfOpen(runtime, {
     agent_id: runtime.agentId,
     conversation_id: runtime.conversationId,
   });
-  emitDeviceStatusIfOpen(runtime.listener, {
+  emitDeviceStatusIfOpen(runtime, {
     agent_id: runtime.agentId,
     conversation_id: runtime.conversationId,
   });
@@ -309,11 +309,11 @@ export function rejectPendingApprovalResolvers(
   if (!runtime.isProcessing && !runtime.cancelRequested) {
     setCommandLoopStatus(runtime, "WAITING_ON_INPUT");
   }
-  emitLoopStatusIfOpen(runtime.listener, {
+  emitLoopStatusIfOpen(runtime, {
     agent_id: runtime.agentId,
     conversation_id: runtime.conversationId,
   });
-  emitDeviceStatusIfOpen(runtime.listener, {
+  emitDeviceStatusIfOpen(runtime, {
     agent_id: runtime.agentId,
     conversation_id: runtime.conversationId,
   });
@@ -468,11 +468,11 @@ export function requestApprovalOverWS(
       scope,
       TO_SUBSCRIBERS,
     );
-    emitLoopStatusIfOpen(runtime.listener, {
+    emitLoopStatusIfOpen(runtime, {
       agent_id: runtime.agentId,
       conversation_id: runtime.conversationId,
     });
-    emitDeviceStatusIfOpen(runtime.listener, {
+    emitDeviceStatusIfOpen(runtime, {
       agent_id: runtime.agentId,
       conversation_id: runtime.conversationId,
     });

--- a/src/websocket/listener/control-inputs.ts
+++ b/src/websocket/listener/control-inputs.ts
@@ -175,6 +175,7 @@ export async function handleApprovalResponseInput(
     runtime: {
       agent_id?: string | null;
       conversation_id?: string | null;
+      super_run_id?: string | null;
     };
     response: ApprovalResponseBody;
     connectionId?: ListenerConnectionId;
@@ -213,6 +214,7 @@ export async function handleApprovalResponseInput(
       opts?: {
         onStatusChange?: StartListenerOptions["onStatusChange"];
         connectionId?: string;
+        superRunId?: string;
       },
     ) => Promise<boolean>;
     scheduleQueuePump: (
@@ -271,6 +273,9 @@ export async function handleApprovalResponseInput(
       {
         onStatusChange: params.opts.onStatusChange,
         connectionId: params.opts.connectionId,
+        ...(params.runtime.super_run_id
+          ? { superRunId: params.runtime.super_run_id }
+          : {}),
       },
     )
   ) {

--- a/src/websocket/listener/message-router.test.ts
+++ b/src/websocket/listener/message-router.test.ts
@@ -169,7 +169,11 @@ describe("listener message router ownership handoff", () => {
         JSON.stringify({
           type: "input",
           request_id: "input-race",
-          runtime: { agent_id: "agent-1", conversation_id: "conv-1" },
+          runtime: {
+            agent_id: "agent-1",
+            conversation_id: "conv-1",
+            super_run_id: "super-run-queued",
+          },
           payload: {
             kind: "create_message",
             messages: [
@@ -188,7 +192,11 @@ describe("listener message router ownership handoff", () => {
         JSON.stringify({
           type: "input",
           request_id: "input-race-retry",
-          runtime: { agent_id: "agent-1", conversation_id: "conv-1" },
+          runtime: {
+            agent_id: "agent-1",
+            conversation_id: "conv-1",
+            super_run_id: "super-run-queued",
+          },
           payload: {
             kind: "create_message",
             messages: [
@@ -236,6 +244,8 @@ describe("listener message router ownership handoff", () => {
         client_message_id: "cm-input-race",
       },
     ]);
+    expect(processedTurns[0]?.superRunId).toBe("super-run-queued");
+    expect(processedTurns[0]?.noCoalesce).toBe(true);
     expect(runtime.queuedMessagesByItemId.size).toBe(0);
     expect(sent).toContainEqual(
       expect.objectContaining({
@@ -255,14 +265,16 @@ describe("listener message router ownership handoff", () => {
     );
   });
 
-  test("preserves the acting user on a directly-owned input and deduplicates retries", async () => {
+  test("preserves turn metadata on a directly-owned input and deduplicates retries", async () => {
     const listener = createRuntime();
     const runtime = getOrCreateScopedRuntime(listener, "agent-1", "conv-1");
     const socket = new MockSocket();
     const sent: unknown[] = [];
     let receivedActingUserId: string | undefined;
+    let receivedSuperRunId: string | undefined;
     const processIncomingMessage = mock(async (incoming: IncomingMessage) => {
       receivedActingUserId = incoming.actingUserId;
+      receivedSuperRunId = incoming.superRunId;
     });
     setActiveRuntime(listener);
     const handleMessage = createListenerMessageHandler({
@@ -296,6 +308,7 @@ describe("listener message router ownership handoff", () => {
             agent_id: "agent-1",
             conversation_id: "conv-1",
             acting_user_id: "cloud-user-1",
+            super_run_id: "super-run-direct",
           },
           payload: {
             kind: "create_message",
@@ -321,6 +334,7 @@ describe("listener message router ownership handoff", () => {
             agent_id: "agent-1",
             conversation_id: "conv-1",
             acting_user_id: "cloud-user-1",
+            super_run_id: "super-run-direct",
           },
           payload: {
             kind: "create_message",
@@ -339,6 +353,7 @@ describe("listener message router ownership handoff", () => {
 
     expect(processIncomingMessage).toHaveBeenCalledTimes(1);
     expect(receivedActingUserId).toBe("cloud-user-1");
+    expect(receivedSuperRunId).toBe("super-run-direct");
     expect(sent).toContainEqual(
       expect.objectContaining({
         type: "input_accepted",

--- a/src/websocket/listener/message-router.ts
+++ b/src/websocket/listener/message-router.ts
@@ -420,6 +420,7 @@ export function createListenerMessageHandler(
           connectionId,
           agentId: parsed.runtime.agent_id,
           conversationId: parsed.runtime.conversation_id,
+          superRunId: parsed.runtime.super_run_id,
           clientToolAllowlist: inputPayload.client_tool_allowlist,
           clientToolset: inputPayload.client_toolset,
           externalToolScopeIds: inputPayload.external_tool_scope_ids,

--- a/src/websocket/listener/message-router.ts
+++ b/src/websocket/listener/message-router.ts
@@ -421,6 +421,7 @@ export function createListenerMessageHandler(
           agentId: parsed.runtime.agent_id,
           conversationId: parsed.runtime.conversation_id,
           superRunId: parsed.runtime.super_run_id,
+          noCoalesce: parsed.runtime.super_run_id !== undefined,
           clientToolAllowlist: inputPayload.client_tool_allowlist,
           clientToolset: inputPayload.client_toolset,
           externalToolScopeIds: inputPayload.external_tool_scope_ids,

--- a/src/websocket/listener/protocol-outbound.test.ts
+++ b/src/websocket/listener/protocol-outbound.test.ts
@@ -79,6 +79,112 @@ function parseOnlyStreamDelta(socket: MockSocket): StreamDeltaMessage {
   return message as StreamDeltaMessage;
 }
 
+describe("emitProtocolV2Message runtime scope", () => {
+  test("includes the active super run on outbound frames", () => {
+    const listener = createListenerRuntime();
+    const runtime = getOrCreateScopedRuntime(listener, "agent-1", "conv-1");
+    const socket = new MockSocket();
+    const lease = runtime.turnLifecycle.begin({
+      origin: "message",
+      workingDirectory: process.cwd(),
+      superRunId: "super-run-1",
+    });
+
+    emitProtocolV2Message(
+      socket as never,
+      runtime,
+      {
+        type: "update_loop_status",
+        loop_status: { status: "WAITING_ON_INPUT", active_run_ids: [] },
+      } as never,
+      undefined,
+      TO_SUBSCRIBERS,
+    );
+
+    expect(socket.sentPayloads).toHaveLength(1);
+    const message = JSON.parse(socket.sentPayloads[0] ?? "{}");
+    expect(message.runtime).toEqual({
+      agent_id: "agent-1",
+      conversation_id: "conv-1",
+      super_run_id: "super-run-1",
+    });
+    runtime.turnLifecycle.finish(lease, "end_turn");
+    runtime.turnLifecycle.releaseSuperRunId(lease);
+  });
+
+  test("does not coalesce status frames from different super runs", async () => {
+    const listener = createListenerRuntime();
+    const runtime = getOrCreateScopedRuntime(listener, "agent-1", "conv-1");
+    const socket = new MockSocket();
+    socket.bufferedAmount = OUTBOUND_QUEUE_LIMITS.HIGH_WATERMARK_BUFFERED_BYTES;
+    const firstLease = runtime.turnLifecycle.begin({
+      origin: "message",
+      workingDirectory: process.cwd(),
+      superRunId: "super-run-1",
+    });
+
+    emitProtocolV2Message(
+      socket as never,
+      runtime,
+      {
+        type: "update_loop_status",
+        loop_status: { status: "WAITING_ON_INPUT", active_run_ids: [] },
+      } as never,
+      undefined,
+      TO_SUBSCRIBERS,
+    );
+    emitProtocolV2Message(
+      socket as never,
+      runtime,
+      {
+        type: "turn_finished",
+        turn_id: "turn-1",
+        stop_reason: "end_turn",
+      } as never,
+      undefined,
+      TO_SUBSCRIBERS,
+    );
+    runtime.turnLifecycle.finish(firstLease, "end_turn");
+    runtime.turnLifecycle.releaseSuperRunId(firstLease);
+
+    const secondLease = runtime.turnLifecycle.begin({
+      origin: "message",
+      workingDirectory: process.cwd(),
+      superRunId: "super-run-2",
+    });
+    emitProtocolV2Message(
+      socket as never,
+      runtime,
+      {
+        type: "update_loop_status",
+        loop_status: {
+          status: "SENDING_API_REQUEST",
+          active_run_ids: [],
+        },
+      } as never,
+      undefined,
+      TO_SUBSCRIBERS,
+    );
+
+    socket.bufferedAmount = 0;
+    await Bun.sleep(OUTBOUND_QUEUE_LIMITS.DRAIN_POLL_MS + 10);
+
+    const messages = socket.sentPayloads.map((payload) => JSON.parse(payload));
+    expect(messages.map((message) => message.type)).toEqual([
+      "update_loop_status",
+      "turn_finished",
+      "update_loop_status",
+    ]);
+    expect(messages.map((message) => message.runtime.super_run_id)).toEqual([
+      "super-run-1",
+      "super-run-1",
+      "super-run-2",
+    ]);
+    runtime.turnLifecycle.finish(secondLease, "end_turn");
+    runtime.turnLifecycle.releaseSuperRunId(secondLease);
+  });
+});
+
 describe("emitProtocolV2Message backpressure", () => {
   test("never sheds stream deltas that snapshots cannot replay", () => {
     const { runtime, socket } = createRuntime();

--- a/src/websocket/listener/protocol-outbound.ts
+++ b/src/websocket/listener/protocol-outbound.ts
@@ -68,10 +68,7 @@ import type {
 } from "./types";
 
 type RuntimeCarrier = ListenerRuntime | ConversationRuntime | null;
-type PartialRuntimeScope = {
-  agent_id?: string | null;
-  conversation_id?: string | null;
-};
+type PartialRuntimeScope = { [K in keyof RuntimeScope]?: RuntimeScope[K] | null };
 
 const GIT_CONTEXT_CACHE_TTL_MS = 15_000;
 const MAX_GIT_CONTEXT_CACHE_ENTRIES = 64;
@@ -153,6 +150,7 @@ function getScopeForRuntime(
     return {
       agent_id: scope?.agent_id ?? runtime.agentId,
       conversation_id: scope?.conversation_id ?? runtime.conversationId,
+      super_run_id: scope?.super_run_id ?? runtime.superRunId ?? undefined,
     };
   }
   return scope ?? {};

--- a/src/websocket/listener/protocol-outbound.ts
+++ b/src/websocket/listener/protocol-outbound.ts
@@ -441,7 +441,7 @@ export function emitProtocolV2Message(
       frameClass,
       ...(frameClass === "status"
         ? {
-            coalesceKey: `${message.type}:${runtimeScope.agent_id ?? ""}:${runtimeScope.conversation_id ?? ""}`,
+            coalesceKey: `${message.type}:${runtimeScope.agent_id ?? ""}:${runtimeScope.conversation_id ?? ""}:${runtimeScope.super_run_id ?? ""}`,
           }
         : {}),
       build: () => {

--- a/src/websocket/listener/protocol-outbound.ts
+++ b/src/websocket/listener/protocol-outbound.ts
@@ -68,7 +68,9 @@ import type {
 } from "./types";
 
 type RuntimeCarrier = ListenerRuntime | ConversationRuntime | null;
-type PartialRuntimeScope = { [K in keyof RuntimeScope]?: RuntimeScope[K] | null };
+type PartialRuntimeScope = {
+  [K in keyof RuntimeScope]?: RuntimeScope[K] | null;
+};
 
 const GIT_CONTEXT_CACHE_TTL_MS = 15_000;
 const MAX_GIT_CONTEXT_CACHE_ENTRIES = 64;

--- a/src/websocket/listener/queue-no-coalesce.test.ts
+++ b/src/websocket/listener/queue-no-coalesce.test.ts
@@ -99,6 +99,36 @@ describe("queue noCoalesce batching", () => {
     });
   });
 
+  test("a different super run waits for the active turn to finish", () => {
+    const runtime = getOrCreateScopedRuntime(
+      createRuntime(),
+      "agent-1",
+      "conv-1",
+    );
+    const activeLease = runtime.turnLifecycle.begin({
+      origin: "message",
+      workingDirectory: process.cwd(),
+      superRunId: "super-run-active",
+    });
+    expect(
+      enqueueInboundUserMessage(runtime, {
+        ...bridgeMessage("next", "otid-next"),
+        superRunId: "super-run-next",
+      }),
+    ).toBe(true);
+
+    expect(
+      consumeQueuedTurn(runtime, { matchActiveSuperRun: true }),
+    ).toBeNull();
+    expect(runtime.queueRuntime.length).toBe(1);
+
+    runtime.turnLifecycle.finish(activeLease, "end_turn");
+    runtime.turnLifecycle.releaseSuperRunId(activeLease);
+    const next = consumeQueuedTurn(runtime);
+    expect(next?.queuedTurn.superRunId).toBe("super-run-next");
+    expect(next?.dequeuedBatch.items).toHaveLength(1);
+  });
+
   test("plain messages still coalesce (existing behavior unchanged)", () => {
     const runtime = getOrCreateScopedRuntime(
       createRuntime(),

--- a/src/websocket/listener/queue.ts
+++ b/src/websocket/listener/queue.ts
@@ -255,7 +255,10 @@ export function shouldProcessInboundMessageDirectly(
   );
 }
 
-export function consumeQueuedTurn(runtime: ConversationRuntime): {
+export function consumeQueuedTurn(
+  runtime: ConversationRuntime,
+  options?: { matchActiveSuperRun?: boolean },
+): {
   dequeuedBatch: DequeuedBatch;
   queuedTurn: IncomingMessage;
 } | null {
@@ -334,6 +337,19 @@ export function consumeQueuedTurn(runtime: ConversationRuntime): {
     queueLen === 0
   ) {
     return null;
+  }
+
+  if (options?.matchActiveSuperRun) {
+    const activeSuperRunId = runtime.superRunId;
+    const crossesSuperRun = queuedItems.slice(0, queueLen).some((item) => {
+      if (item.kind !== "message") return false;
+      const queuedSuperRunId =
+        runtime.queuedMessagesByItemId.get(item.id)?.superRunId ?? null;
+      return queuedSuperRunId !== activeSuperRunId;
+    });
+    if (crossesSuperRun) {
+      return null;
+    }
   }
 
   const dequeuedBatch = runtime.queueRuntime.consumeItems(queueLen);

--- a/src/websocket/listener/recovery-lease.test.ts
+++ b/src/websocket/listener/recovery-lease.test.ts
@@ -103,7 +103,7 @@ describe("recovered approval lease boundaries", () => {
       createTransport([]),
       { request_id: "perm-1", decision: { behavior: "allow" } },
       async (
-        _message,
+        message,
         _socket,
         ownerRuntime,
         _onStatusChange,
@@ -111,9 +111,12 @@ describe("recovered approval lease boundaries", () => {
         _batchId,
         turnLease,
       ) => {
+        expect(message.superRunId).toBe("super-run-recovered");
+        expect(ownerRuntime.superRunId).toBe("super-run-recovered");
         if (turnLease) ownerRuntime.turnLifecycle.finish(turnLease, "end_turn");
       },
       {
+        superRunId: "super-run-recovered",
         dependencies: {
           applySuggestedPermissions: async () => {
             permissionWriteStarted = true;
@@ -222,6 +225,7 @@ describe("recovered approval lease boundaries", () => {
       { request_id: "perm-1", decision: { behavior: "allow" } },
       mock(async () => {}),
       {
+        superRunId: "super-run-failed-recovery",
         dependencies: {
           applySuggestedPermissions: async () => false,
           ensureSecretsHydrated: async () => {},
@@ -242,6 +246,7 @@ describe("recovered approval lease boundaries", () => {
     runtime.turnLifecycle.requestCancellation();
     rejectExecution(new Error("tool execution crashed"));
     await handled.catch(() => {});
+    expect(runtime.superRunId).toBeNull();
 
     const deltas = sentPayloads
       .map((payload) => JSON.parse(payload))

--- a/src/websocket/listener/recovery.ts
+++ b/src/websocket/listener/recovery.ts
@@ -407,6 +407,7 @@ export async function resolveRecoveredApprovalResponse(
       connectionId: string,
     ) => void;
     connectionId?: string;
+    superRunId?: string;
     dependencies?: {
       applySuggestedPermissions?: typeof applySuggestedPermissionsForApproval;
       classifyApprovals?: typeof classifyApprovalsWithSuggestions;
@@ -447,6 +448,7 @@ export async function resolveRecoveredApprovalResponse(
   const scope = {
     agent_id: recovered.agentId,
     conversation_id: recovered.conversationId,
+    ...(opts?.superRunId ? { super_run_id: opts.superRunId } : {}),
   } as const;
   const respondedEntry = recovered.approvalsByRequestId.get(requestId);
   let autoDecisionsToAppend: ApprovalDecision[] = [];
@@ -543,6 +545,7 @@ export async function resolveRecoveredApprovalResponse(
           origin: "approval_recovery",
           workingDirectory,
           initialStatus: "EXECUTING_CLIENT_SIDE_TOOL",
+          superRunId: opts?.superRunId,
         })
       : null;
   let continuationFinalized = false;
@@ -751,7 +754,9 @@ export async function resolveRecoveredApprovalResponse(
       },
     ]);
     let continuationBatchId = `batch-recovered-${crypto.randomUUID()}`;
-    const consumedQueuedTurn = consumeQueuedTurn(runtime);
+    const consumedQueuedTurn = consumeQueuedTurn(runtime, {
+      matchActiveSuperRun: true,
+    });
     if (consumedQueuedTurn) {
       const { dequeuedBatch, queuedTurn } = consumedQueuedTurn;
       continuationBatchId = dequeuedBatch.batchId;
@@ -771,6 +776,7 @@ export async function resolveRecoveredApprovalResponse(
         type: "message",
         agentId: recovered.agentId,
         conversationId: recovered.conversationId,
+        ...(opts?.superRunId ? { superRunId: opts.superRunId } : {}),
         messages: continuationInput.messages,
       },
       socket,
@@ -807,20 +813,24 @@ export async function resolveRecoveredApprovalResponse(
       recovered.responsesByRequestId.clear();
     }
     const stopReason = recoveryLease.signal.aborted ? "cancelled" : "error";
-    finishListenerTurn(runtime, recoveryLease, {
-      stopReason,
-      socket,
-      agentId: recovered.agentId,
-      conversationId: recovered.conversationId,
-      turnId: `batch-recovered-${requestId}`,
-      error:
-        stopReason === "error"
-          ? getTranscriptLoopErrorMessage({
-              error,
-              message: error instanceof Error ? error.message : String(error),
-            })
-          : undefined,
-    });
+    try {
+      finishListenerTurn(runtime, recoveryLease, {
+        stopReason,
+        socket,
+        agentId: recovered.agentId,
+        conversationId: recovered.conversationId,
+        turnId: `batch-recovered-${requestId}`,
+        error:
+          stopReason === "error"
+            ? getTranscriptLoopErrorMessage({
+                error,
+                message: error instanceof Error ? error.message : String(error),
+              })
+            : undefined,
+      });
+    } finally {
+      runtime.turnLifecycle.releaseSuperRunId(recoveryLease);
+    }
     throw error;
   }
 }

--- a/src/websocket/listener/runtime.ts
+++ b/src/websocket/listener/runtime.ts
@@ -252,6 +252,7 @@ export function createConversationRuntime(
     key: runtimeKey,
     agentId: normalizedAgentId,
     conversationId: normalizedConversationId,
+    superRunId: null,
     skillSources: listener.skillSourcesByConversation.get(runtimeKey)?.slice(),
     activeConnectionId: null,
     turnLifecycle,

--- a/src/websocket/listener/runtime.ts
+++ b/src/websocket/listener/runtime.ts
@@ -252,7 +252,9 @@ export function createConversationRuntime(
     key: runtimeKey,
     agentId: normalizedAgentId,
     conversationId: normalizedConversationId,
-    superRunId: null,
+    get superRunId() {
+      return turnLifecycle.superRunId;
+    },
     skillSources: listener.skillSourcesByConversation.get(runtimeKey)?.slice(),
     activeConnectionId: null,
     turnLifecycle,

--- a/src/websocket/listener/scope.ts
+++ b/src/websocket/listener/scope.ts
@@ -61,6 +61,7 @@ export function resolveRuntimeScope(
   params?: {
     agent_id?: string | null;
     conversation_id?: string | null;
+    super_run_id?: string | null;
   },
 ): RuntimeScope | null {
   const resolvedAgentId = resolveScopedAgentId(runtime, params);
@@ -71,5 +72,6 @@ export function resolveRuntimeScope(
   return {
     agent_id: resolvedAgentId,
     conversation_id: resolvedConversationId,
+    ...(params?.super_run_id ? { super_run_id: params.super_run_id } : {}),
   };
 }

--- a/src/websocket/listener/send.ts
+++ b/src/websocket/listener/send.ts
@@ -402,7 +402,9 @@ export async function resolveStaleApprovals(
           otid: crypto.randomUUID(),
         },
       ]);
-      const consumedQueuedTurn = consumeQueuedTurn(runtime);
+      const consumedQueuedTurn = consumeQueuedTurn(runtime, {
+        matchActiveSuperRun: true,
+      });
       if (consumedQueuedTurn) {
         const { dequeuedBatch, queuedTurn } = consumedQueuedTurn;
         continuationInput = appendQueuedTurnToInput(

--- a/src/websocket/listener/turn-approval.ts
+++ b/src/websocket/listener/turn-approval.ts
@@ -577,7 +577,9 @@ export async function handleApprovalStop(params: {
     },
   ]);
   let continuationBatchId = dequeuedBatchId;
-  const consumedQueuedTurn = consumeQueuedTurn(runtime);
+  const consumedQueuedTurn = consumeQueuedTurn(runtime, {
+    matchActiveSuperRun: true,
+  });
   if (consumedQueuedTurn) {
     const { dequeuedBatch, queuedTurn } = consumedQueuedTurn;
     continuationBatchId = dequeuedBatch.batchId;

--- a/src/websocket/listener/turn-lifecycle.test.ts
+++ b/src/websocket/listener/turn-lifecycle.test.ts
@@ -116,14 +116,19 @@ describe("TurnLifecycle", () => {
     const staleLease = lifecycle.begin({
       origin: "message",
       workingDirectory: "/tmp/old",
+      superRunId: "super-run-old",
     });
 
     expect(lifecycle.reset("cancelled").finished).toBe(true);
+    expect(lifecycle.superRunId).toBeNull();
     const currentLease = lifecycle.begin({
       origin: "message",
       workingDirectory: "/tmp/new",
+      superRunId: "super-run-new",
     });
 
+    expect(lifecycle.releaseSuperRunId(staleLease)).toBe(false);
+    expect(lifecycle.superRunId).toBe("super-run-new");
     expect(lifecycle.setRunId(staleLease, "stale-run")).toBe(false);
     expect(lifecycle.setStatus(staleLease, "PROCESSING_API_RESPONSE")).toBe(
       false,
@@ -132,6 +137,10 @@ describe("TurnLifecycle", () => {
     expect(lifecycle.isCurrent(currentLease)).toBe(true);
     expect(lifecycle.activeWorkingDirectory).toBe("/tmp/new");
     expect(lifecycle.lastStopReason).toBeNull();
+    expect(lifecycle.finish(currentLease, "end_turn").finished).toBe(true);
+    expect(lifecycle.superRunId).toBe("super-run-new");
+    expect(lifecycle.releaseSuperRunId(currentLease)).toBe(true);
+    expect(lifecycle.superRunId).toBeNull();
   });
 
   test("finishes a lease exactly once", () => {

--- a/src/websocket/listener/turn-lifecycle.ts
+++ b/src/websocket/listener/turn-lifecycle.ts
@@ -87,6 +87,7 @@ export class TurnLifecycle {
   readonly #createId: () => string;
   #state: TurnState = IDLE_STATE;
   #lastStopReason: StopReasonType | null = null;
+  #superRunOwner: { leaseId: string; superRunId: string | null } | null = null;
 
   constructor(createId: () => string = () => crypto.randomUUID()) {
     this.#createId = createId;
@@ -114,6 +115,10 @@ export class TurnLifecycle {
 
   get activeRunId(): string | null {
     return this.#state.kind === "active" ? this.#state.runId : null;
+  }
+
+  get superRunId(): string | null {
+    return this.#superRunOwner?.superRunId ?? null;
   }
 
   get executingToolCallIds(): readonly string[] {
@@ -168,6 +173,7 @@ export class TurnLifecycle {
     initialStatus?: ActiveTurnLoopStatus;
     abortController?: AbortController;
     executingToolCallIds?: readonly string[];
+    superRunId?: string;
   }): TurnLease {
     if (this.#state.kind === "active" || this.#state.kind === "cancelling") {
       throw new Error(
@@ -180,6 +186,10 @@ export class TurnLifecycle {
       id: this.#createId(),
       signal: abortController.signal,
     });
+    this.#superRunOwner = {
+      leaseId: lease.id,
+      superRunId: options.superRunId ?? null,
+    };
     this.#state = {
       kind: "active",
       origin: options.origin,
@@ -210,6 +220,14 @@ export class TurnLifecycle {
       return false;
     }
     this.#state = { ...this.#state, loopStatus: status };
+    return true;
+  }
+
+  releaseSuperRunId(lease: TurnLease): boolean {
+    if (this.#superRunOwner?.leaseId !== lease.id) {
+      return false;
+    }
+    this.#superRunOwner = null;
     return true;
   }
 
@@ -250,6 +268,7 @@ export class TurnLifecycle {
     if (this.#state.kind !== "idle") {
       return false;
     }
+    this.#superRunOwner = null;
     this.#state = {
       kind: "command",
       loopStatus: "EXECUTING_COMMAND",
@@ -359,6 +378,7 @@ export class TurnLifecycle {
 
   reset(stopReason: StopReasonType = "cancelled"): TurnFinishTransition {
     const state = this.#state;
+    this.#superRunOwner = null;
     if (state.kind === "active" || state.kind === "cancelling") {
       if (!state.abortController.signal.aborted) {
         state.abortController.abort();

--- a/src/websocket/listener/turn.ts
+++ b/src/websocket/listener/turn.ts
@@ -134,6 +134,7 @@ async function handleIncomingMessageInner(
   const agentId = msg.agentId;
   const requestedConversationId = msg.conversationId || undefined;
   const conversationId = requestedConversationId ?? "default";
+  runtime.superRunId = msg.superRunId ?? null;
   const normalizedAgentId = normalizeCwdAgentId(agentId);
   const turnWorkingDirectory = getConversationWorkingDirectory(
     runtime.listener,
@@ -300,6 +301,7 @@ async function handleIncomingMessageInner(
         ? { overrideModel: providerFallback.overrideModel }
         : {}),
       ...(msg.actingUserId ? { actingUserId: msg.actingUserId } : {}),
+      ...(msg.superRunId ? { superRunId: msg.superRunId } : {}),
       ...(pendingNormalizationInterruptedToolCallIds.length > 0
         ? {
             approvalNormalization: {
@@ -991,6 +993,7 @@ async function handleIncomingMessageInner(
     if (runtime.activeConnectionId === connectionId) {
       runtime.activeConnectionId = null;
     }
+    runtime.superRunId = null;
 
     try {
       if (finalizedByThisInvocation) {

--- a/src/websocket/listener/turn.ts
+++ b/src/websocket/listener/turn.ts
@@ -134,7 +134,6 @@ async function handleIncomingMessageInner(
   const agentId = msg.agentId;
   const requestedConversationId = msg.conversationId || undefined;
   const conversationId = requestedConversationId ?? "default";
-  runtime.superRunId = msg.superRunId ?? null;
   const normalizedAgentId = normalizeCwdAgentId(agentId);
   const turnWorkingDirectory = getConversationWorkingDirectory(
     runtime.listener,
@@ -164,6 +163,7 @@ async function handleIncomingMessageInner(
     runtime.turnLifecycle.begin({
       origin: "message",
       workingDirectory: turnWorkingDirectory,
+      superRunId: msg.superRunId,
     });
   if (connectionId) {
     runtime.activeConnectionId = connectionId;
@@ -993,7 +993,6 @@ async function handleIncomingMessageInner(
     if (runtime.activeConnectionId === connectionId) {
       runtime.activeConnectionId = null;
     }
-    runtime.superRunId = null;
 
     try {
       if (finalizedByThisInvocation) {
@@ -1006,6 +1005,7 @@ async function handleIncomingMessageInner(
       }
     } finally {
       releaseListenerTurnContext({ runtime, agentId, conversationId });
+      runtime.turnLifecycle.releaseSuperRunId(turnLease);
     }
 
     evictConversationRuntimeIfIdle(runtime);

--- a/src/websocket/listener/types.ts
+++ b/src/websocket/listener/types.ts
@@ -191,8 +191,8 @@ export type ConversationRuntime = {
   key: string;
   agentId: string | null;
   conversationId: string;
-  /** Active super-run correlation for the currently executing turn. */
-  superRunId: string | null;
+  /** Super-run correlation owned by the active or unwinding turn lease. */
+  readonly superRunId: string | null;
   /** Runtime-scoped SDK override. Undefined uses the process defaults. */
   skillSources: SkillSource[] | undefined;
   /** Connection currently executing this conversation's turn, if client-owned. */

--- a/src/websocket/listener/types.ts
+++ b/src/websocket/listener/types.ts
@@ -75,6 +75,8 @@ export interface IncomingMessage {
   connectionId?: ListenerConnectionId;
   agentId?: string;
   conversationId?: string;
+  /** Cloud super-run correlation for this turn. */
+  superRunId?: string;
   /** Queue this message as its own turn; never merge with other messages. */
   noCoalesce?: boolean;
   /**
@@ -189,6 +191,8 @@ export type ConversationRuntime = {
   key: string;
   agentId: string | null;
   conversationId: string;
+  /** Active super-run correlation for the currently executing turn. */
+  superRunId: string | null;
   /** Runtime-scoped SDK override. Undefined uses the process defaults. */
   skillSources: SkillSource[] | undefined;
   /** Connection currently executing this conversation's turn, if client-owned. */


### PR DESCRIPTION
## Summary

- Propagate optional `super_run_id` from cloud input frames through listener turns and Node core request metadata.
- Keep correlation owned by the turn lifecycle so status, approval, recovery, and terminal frames retain the correct super run without leaking into replacement turns.
- Keep different super runs separate during queue steering and outbound status coalescing while preserving legacy clients that omit the field.

👾 Generated with [Letta Code](https://letta.com)