### PR TITLE
feat(reflection): double-write completion state to Cloud

### DIFF
--- a/src/backend/api/reflection.test.ts
+++ b/src/backend/api/reflection.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from "bun:test";
+import {
+  updateCloudReflectionConfig,
+  updateCloudReflectionConversationProgress,
+} from "./reflection";
+
+describe("Cloud reflection API", () => {
+  test("patches the agent config endpoint", async () => {
+    const calls: Array<{
+      method: string;
+      path: string;
+      body?: Record<string, unknown>;
+    }> = [];
+    const request = async <T>(
+      method: string,
+      path: string,
+      body?: Record<string, unknown>,
+    ): Promise<T> => {
+      calls.push({ method, path, body });
+      return {} as T;
+    };
+
+    await updateCloudReflectionConfig(
+      "agent/1",
+      { enabled: true, min_turn_count: 25 },
+      request,
+    );
+
+    expect(calls).toEqual([
+      {
+        method: "PATCH",
+        path: "/v1/agents/agent%2F1/reflection",
+        body: { enabled: true, min_turn_count: 25 },
+      },
+    ]);
+  });
+
+  test("patches the conversation progress endpoint", async () => {
+    const calls: Array<{
+      method: string;
+      path: string;
+      body?: Record<string, unknown>;
+    }> = [];
+    const request = async <T>(
+      method: string,
+      path: string,
+      body?: Record<string, unknown>,
+    ): Promise<T> => {
+      calls.push({ method, path, body });
+      return {} as T;
+    };
+
+    await updateCloudReflectionConversationProgress(
+      "agent/1",
+      "conversation/1",
+      { reflected_through_message_id: "message-1" },
+      request,
+    );
+
+    expect(calls).toEqual([
+      {
+        method: "PATCH",
+        path: "/v1/agents/agent%2F1/conversations/conversation%2F1/reflection",
+        body: { reflected_through_message_id: "message-1" },
+      },
+    ]);
+  });
+});

--- a/src/backend/api/reflection.ts
+++ b/src/backend/api/reflection.ts
@@ -1,0 +1,41 @@
+import { type ApiRequestMethod, apiRequest } from "./request";
+
+export interface UpdateCloudReflectionConfigInput {
+  enabled: boolean;
+  min_turn_count: number;
+}
+
+export interface UpdateCloudReflectionConversationProgressInput {
+  reflected_through_message_id: string;
+}
+
+type ReflectionApiRequest = <T>(
+  method: ApiRequestMethod,
+  path: string,
+  body?: Record<string, unknown>,
+) => Promise<T>;
+
+function agentPath(agentId: string): string {
+  return `/v1/agents/${encodeURIComponent(agentId)}`;
+}
+
+export async function updateCloudReflectionConfig(
+  agentId: string,
+  input: UpdateCloudReflectionConfigInput,
+  request: ReflectionApiRequest = apiRequest,
+): Promise<void> {
+  await request("PATCH", `${agentPath(agentId)}/reflection`, { ...input });
+}
+
+export async function updateCloudReflectionConversationProgress(
+  agentId: string,
+  conversationId: string,
+  input: UpdateCloudReflectionConversationProgressInput,
+  request: ReflectionApiRequest = apiRequest,
+): Promise<void> {
+  await request(
+    "PATCH",
+    `${agentPath(agentId)}/conversations/${encodeURIComponent(conversationId)}/reflection`,
+    { ...input },
+  );
+}

--- a/src/cli/app/use-submit-handler.ts
+++ b/src/cli/app/use-submit-handler.ts
@@ -81,6 +81,7 @@ import {
   sampleReflectionArenaComparisonModel,
   startReflectionArenaRun,
 } from "@/cli/helpers/reflection-arena";
+import { finalizeMultiReflectionCompletion } from "@/cli/helpers/reflection-completion";
 import {
   AUTO_REFLECTION_DESCRIPTION,
   finalizeReflectionMemoryWorktreeLaunch,
@@ -96,7 +97,6 @@ import {
   buildMultiReflectionPayload,
   buildReflectionAutoPayload,
   buildReflectionSelectorPrompt,
-  finalizeMultiReflectionPayload,
   readReflectionAutoSelection,
 } from "@/cli/helpers/reflection-transcript";
 import {
@@ -3370,7 +3370,7 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
                                 logRecompileFailure: (message) =>
                                   debugWarn("memory", message),
                               });
-                            await finalizeMultiReflectionPayload(
+                            await finalizeMultiReflectionCompletion(
                               agentId,
                               autoReflectionPayload.manifest,
                               completionSuccess,
@@ -3489,7 +3489,7 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
                       logRecompileFailure: (message) =>
                         debugWarn("memory", message),
                     });
-                  await finalizeMultiReflectionPayload(
+                  await finalizeMultiReflectionCompletion(
                     agentId,
                     reflectionPayload.manifest,
                     completionSuccess,

--- a/src/cli/helpers/reflection-arena.ts
+++ b/src/cli/helpers/reflection-arena.ts
@@ -10,7 +10,6 @@ import {
   finalizeReflectionMemoryWorktree,
   type ReflectionMemoryWorktree,
   type ReflectionMemoryWorktreeFinalizeResult,
-  reflectionIntegrationConsumesTranscript,
   reflectionMemoryParentHasChanges,
 } from "@/agent/memory-worktree";
 import { buildAgentReference } from "@/cli/helpers/app-urls";
@@ -18,6 +17,7 @@ import {
   buildReflectionArenaHfChoiceRow,
   maybeUploadReflectionArenaChoiceToHf,
 } from "@/cli/helpers/reflection-arena-hf-upload";
+import { finalizeAutoReflectionCompletion } from "@/cli/helpers/reflection-completion";
 import {
   emitReflectionRunEnd,
   emitReflectionRunStart,
@@ -33,7 +33,6 @@ import {
 import {
   type AutoReflectionPayload,
   buildAutoReflectionPayload,
-  finalizeAutoReflectionPayload,
 } from "@/cli/helpers/reflection-transcript";
 import { telemetry } from "@/telemetry";
 import { debugLog, debugWarn } from "@/utils/debug";
@@ -899,6 +898,7 @@ export async function finalizeReflectionArenaChoice(
 
   const discarded: ReflectionArenaCandidateLabel[] = [];
   let integration: ReflectionMemoryWorktreeFinalizeResult | undefined;
+  let completionSuccess = false;
   let memoryBaseCommit: string | null = null;
   let memoryCandidateCommit: string | null = null;
 
@@ -931,6 +931,7 @@ export async function finalizeReflectionArenaChoice(
       logRecompileFailure: (message) => debugWarn("memory", message),
     });
     integration = finalized.integration;
+    completionSuccess = finalized.completionSuccess;
   }
 
   for (const candidate of run.candidates) {
@@ -944,12 +945,13 @@ export async function finalizeReflectionArenaChoice(
     });
   }
 
-  await finalizeAutoReflectionPayload(
+  await finalizeAutoReflectionCompletion(
     run.agentId,
     run.conversationId,
     run.payloadPath,
     run.endSnapshotLine,
-    integration ? reflectionIntegrationConsumesTranscript(integration) : false,
+    run.endMessageId,
+    completionSuccess,
   );
 
   const completedRun: ReflectionArenaRun = {

--- a/src/cli/helpers/reflection-completion.test.ts
+++ b/src/cli/helpers/reflection-completion.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, test } from "bun:test";
+import { syncReflectionCompletionToCloud } from "./reflection-completion";
+
+describe("reflection completion Cloud sync", () => {
+  test("creates config before writing conversation cursors", async () => {
+    const calls: string[] = [];
+    await syncReflectionCompletionToCloud(
+      {
+        agentId: "agent-1",
+        checkpoints: [
+          {
+            conversationId: "conversation-1",
+            reflectedThroughMessageId: "message-1",
+          },
+          {
+            conversationId: "conversation-2",
+            reflectedThroughMessageId: "message-2",
+          },
+        ],
+      },
+      {
+        isCloud: async () => true,
+        getSettings: () => ({
+          trigger: "step-count",
+          stepCount: 12,
+          merge: "auto",
+        }),
+        updateConfig: async (agentId, input) => {
+          calls.push(
+            `config:${agentId}:${input.enabled}:${input.min_turn_count}`,
+          );
+        },
+        updateProgress: async (agentId, conversationId, input) => {
+          calls.push(
+            `progress:${agentId}:${conversationId}:${input.reflected_through_message_id}`,
+          );
+        },
+      },
+    );
+
+    expect(calls).toEqual([
+      "config:agent-1:true:12",
+      "progress:agent-1:conversation-1:message-1",
+      "progress:agent-1:conversation-2:message-2",
+    ]);
+  });
+
+  test("writes disabled config for a manually completed reflection", async () => {
+    const configs: Array<{ enabled: boolean; min_turn_count: number }> = [];
+    await syncReflectionCompletionToCloud(
+      { agentId: "agent-1", checkpoints: [] },
+      {
+        isCloud: async () => true,
+        getSettings: () => ({ trigger: "off", stepCount: 25 }),
+        updateConfig: async (_agentId, input) => {
+          configs.push(input);
+        },
+      },
+    );
+
+    expect(configs).toEqual([{ enabled: false, min_turn_count: 25 }]);
+  });
+
+  test("skips local agents", async () => {
+    let writes = 0;
+    await syncReflectionCompletionToCloud(
+      {
+        agentId: "agent-local",
+        checkpoints: [
+          {
+            conversationId: "default",
+            reflectedThroughMessageId: "message-1",
+          },
+        ],
+      },
+      {
+        isCloud: async () => false,
+        updateConfig: async () => {
+          writes += 1;
+        },
+        updateProgress: async () => {
+          writes += 1;
+        },
+      },
+    );
+
+    expect(writes).toBe(0);
+  });
+
+  test("keeps reflection completion successful when Cloud config sync fails", async () => {
+    let cursorWrites = 0;
+    const warnings: string[] = [];
+    await syncReflectionCompletionToCloud(
+      {
+        agentId: "agent-1",
+        checkpoints: [
+          {
+            conversationId: "default",
+            reflectedThroughMessageId: "message-1",
+          },
+        ],
+      },
+      {
+        isCloud: async () => true,
+        getSettings: () => ({ trigger: "step-count", stepCount: 25 }),
+        updateConfig: async () => {
+          throw new Error("offline");
+        },
+        updateProgress: async () => {
+          cursorWrites += 1;
+        },
+        logWarning: (message) => warnings.push(message),
+      },
+    );
+
+    expect(cursorWrites).toBe(0);
+    expect(warnings).toEqual([
+      "Failed to sync Cloud reflection config: offline",
+    ]);
+  });
+});

--- a/src/cli/helpers/reflection-completion.ts
+++ b/src/cli/helpers/reflection-completion.ts
@@ -1,0 +1,152 @@
+import { isLettaCloud } from "@/agent/memory-filesystem";
+import { getBackend } from "@/backend";
+import {
+  updateCloudReflectionConfig,
+  updateCloudReflectionConversationProgress,
+} from "@/backend/api/reflection";
+import {
+  getReflectionSettings,
+  type ReflectionSettings,
+} from "@/cli/helpers/memory-reminder";
+import {
+  finalizeAutoReflectionPayload,
+  finalizeMultiReflectionPayload,
+  type MultiReflectionManifest,
+} from "@/cli/helpers/reflection-transcript";
+import { debugWarn } from "@/utils/debug";
+
+export interface ReflectionCompletionCheckpoint {
+  conversationId: string;
+  reflectedThroughMessageId: string;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function logCloudSyncWarning(message: string): void {
+  debugWarn("memory", message);
+}
+
+async function isCloudReflectionAgent(): Promise<boolean> {
+  const backend = getBackend();
+  return (
+    backend.capabilities.remoteMemfs &&
+    !backend.capabilities.localMemfs &&
+    (await isLettaCloud())
+  );
+}
+
+export async function syncReflectionCompletionToCloud(
+  params: {
+    agentId: string;
+    checkpoints: ReflectionCompletionCheckpoint[];
+  },
+  dependencies: {
+    isCloud?: () => Promise<boolean>;
+    getSettings?: (agentId: string) => ReflectionSettings;
+    updateConfig?: typeof updateCloudReflectionConfig;
+    updateProgress?: typeof updateCloudReflectionConversationProgress;
+    logWarning?: (message: string) => void;
+  } = {},
+): Promise<void> {
+  const logWarning = dependencies.logWarning ?? logCloudSyncWarning;
+  try {
+    if (!(await (dependencies.isCloud ?? isCloudReflectionAgent)())) {
+      return;
+    }
+  } catch (error) {
+    logWarning(
+      `Failed to detect Cloud reflection state: ${errorMessage(error)}`,
+    );
+    return;
+  }
+
+  let settings: ReflectionSettings;
+  try {
+    settings = (dependencies.getSettings ?? getReflectionSettings)(
+      params.agentId,
+    );
+  } catch (error) {
+    logWarning(
+      `Failed to resolve Cloud reflection config: ${errorMessage(error)}`,
+    );
+    return;
+  }
+  try {
+    await (dependencies.updateConfig ?? updateCloudReflectionConfig)(
+      params.agentId,
+      {
+        enabled: settings.trigger !== "off",
+        min_turn_count: settings.stepCount,
+      },
+    );
+  } catch (error) {
+    logWarning(
+      `Failed to sync Cloud reflection config: ${errorMessage(error)}`,
+    );
+    return;
+  }
+
+  for (const checkpoint of params.checkpoints) {
+    try {
+      await (
+        dependencies.updateProgress ?? updateCloudReflectionConversationProgress
+      )(params.agentId, checkpoint.conversationId, {
+        reflected_through_message_id: checkpoint.reflectedThroughMessageId,
+      });
+    } catch (error) {
+      logWarning(
+        `Failed to sync Cloud reflection progress for ${checkpoint.conversationId}: ${errorMessage(error)}`,
+      );
+    }
+  }
+}
+
+export async function finalizeAutoReflectionCompletion(
+  agentId: string,
+  conversationId: string,
+  payloadPath: string,
+  endSnapshotLine: number,
+  reflectedThroughMessageId: string | undefined,
+  success: boolean,
+): Promise<void> {
+  await finalizeAutoReflectionPayload(
+    agentId,
+    conversationId,
+    payloadPath,
+    endSnapshotLine,
+    success,
+  );
+  if (!success) {
+    return;
+  }
+
+  await syncReflectionCompletionToCloud({
+    agentId,
+    checkpoints: reflectedThroughMessageId
+      ? [{ conversationId, reflectedThroughMessageId }]
+      : [],
+  });
+}
+
+export async function finalizeMultiReflectionCompletion(
+  agentId: string,
+  manifest: MultiReflectionManifest,
+  success: boolean,
+): Promise<void> {
+  await finalizeMultiReflectionPayload(agentId, manifest, success);
+  if (!success) {
+    return;
+  }
+
+  await syncReflectionCompletionToCloud({
+    agentId,
+    checkpoints: manifest.transcripts
+      .filter((slice) => slice.mode === "unreflected")
+      .map((slice) => ({
+        conversationId: slice.conversation_id,
+        reflectedThroughMessageId: slice.end_message_id,
+      })),
+  });
+}

--- a/src/cli/helpers/reflection-launcher.ts
+++ b/src/cli/helpers/reflection-launcher.ts
@@ -23,6 +23,7 @@ import {
   handleMemorySubagentCompletion,
   type MemorySubagentSuccessMessageOverride,
 } from "@/cli/helpers/memory-subagent-completion";
+import { finalizeAutoReflectionCompletion } from "@/cli/helpers/reflection-completion";
 import {
   buildReflectionIntegrationConversationTitle,
   buildReflectionIntegrationPrompt,
@@ -31,7 +32,6 @@ import {
   buildAutoReflectionPayload,
   buildParentMemorySnapshot,
   buildReflectionSubagentPrompt,
-  finalizeAutoReflectionPayload,
   getReflectionTranscriptState,
 } from "@/cli/helpers/reflection-transcript";
 import { type ReflectionWorktreeCleanupOutcome, telemetry } from "@/telemetry";
@@ -741,11 +741,12 @@ export async function launchReflectionSubagent(
             logRecompileFailure: (message) => debugWarn("memory", message),
           });
 
-          await finalizeAutoReflectionPayload(
+          await finalizeAutoReflectionCompletion(
             agentId,
             conversationId,
             autoPayload.payloadPath,
             autoPayload.endSnapshotLine,
+            autoPayload.endMessageId,
             completionSuccess,
           );
           await onCompletionMessage?.(completionMessage, {


### PR DESCRIPTION
## Summary

- PATCH-upsert resolved reflection config after successful local reflection completion
- advance canonical Cloud cursors for automatic, manual multi-conversation, and arena reflections
- skip local/self-hosted agents and keep migration writes non-fatal

## Validation

- `bun run check`
- 49 focused and adjacent reflection tests

Linear: [LET-10945](https://linear.app/letta/issue/LET-10945/double-write-reflection-state-from-letta-code)