### PR TITLE
feat(cli): add sandbox file transfer commands

### DIFF
--- a/src/backend/api/sandbox-files.test.ts
+++ b/src/backend/api/sandbox-files.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, test } from "bun:test";
+import {
+  downloadFileFromSandbox,
+  ensureConversationSandbox,
+  type SandboxFilesApiDeps,
+  uploadFileToSandbox,
+} from "@/backend/api/sandbox-files";
+
+function createDeps(
+  response: Response,
+  calls: Array<{ input: string; init?: RequestInit }>,
+): SandboxFilesApiDeps {
+  return {
+    getConfig: async () => ({
+      baseUrl: "https://api.letta.test",
+      apiKey: "secret",
+    }),
+    fetch: async (input, init) => {
+      calls.push({ input: String(input), init });
+      return response;
+    },
+  };
+}
+
+describe("sandbox file API", () => {
+  test("ensures the conversation-scoped sandbox", async () => {
+    const calls: Array<{ input: string; init?: RequestInit }> = [];
+    const result = await ensureConversationSandbox(
+      "agent-1",
+      "conv-1",
+      createDeps(
+        Response.json({
+          sandboxId: "sandbox-1",
+          deviceId: "device-1",
+          connectionName: "Cloud",
+          conversationId: "conv-1",
+          resumed: true,
+        }),
+        calls,
+      ),
+    );
+
+    expect(result.sandboxId).toBe("sandbox-1");
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.input).toBe(
+      "https://api.letta.test/v1/agents/agent-1/sandboxes",
+    );
+    expect(calls[0]?.init?.method).toBe("POST");
+    expect(calls[0]?.init?.body).toBe(
+      JSON.stringify({ conversationId: "conv-1" }),
+    );
+  });
+
+  test("uploads multipart data without a JSON content type", async () => {
+    const calls: Array<{ input: string; init?: RequestInit }> = [];
+    const result = await uploadFileToSandbox(
+      "sandbox-1",
+      { blob: new Blob(["hello"]), name: "note.txt" },
+      createDeps(
+        Response.json({
+          files: [
+            {
+              path: "/root/downloads/upload/note.txt",
+              name: "note.txt",
+              mimeType: "text/plain",
+              size: 5,
+            },
+          ],
+        }),
+        calls,
+      ),
+    );
+
+    expect(result.files[0]?.path).toBe("/root/downloads/upload/note.txt");
+    const request = calls[0]?.init;
+    expect(request?.body).toBeInstanceOf(FormData);
+    expect(new Headers(request?.headers).has("Content-Type")).toBe(false);
+    expect(new Headers(request?.headers).get("Authorization")).toBe(
+      "Bearer secret",
+    );
+  });
+
+  test("downloads binary file contents", async () => {
+    const calls: Array<{ input: string; init?: RequestInit }> = [];
+    const result = await downloadFileFromSandbox(
+      "sandbox-1",
+      "/root/downloads/report.txt",
+      createDeps(new Response(new Uint8Array([1, 2, 3])), calls),
+    );
+
+    expect([...result]).toEqual([1, 2, 3]);
+    expect(calls[0]?.input).toBe(
+      "https://api.letta.test/v1/sandboxes/sandbox-1/files?path=%2Froot%2Fdownloads%2Freport.txt",
+    );
+  });
+});

--- a/src/backend/api/sandbox-files.ts
+++ b/src/backend/api/sandbox-files.ts
@@ -1,0 +1,112 @@
+import { getLettaCodeHeaders } from "@/backend/api/http-headers";
+import {
+  type ApiRequestConfig,
+  ApiRequestError,
+  getApiRequestConfig,
+} from "@/backend/api/request";
+
+export interface ConversationSandbox {
+  sandboxId: string;
+  deviceId: string;
+  connectionName: string;
+  conversationId?: string;
+  resumed?: boolean;
+}
+
+export interface SandboxFileMetadata {
+  path: string;
+  name: string;
+  mimeType: string;
+  size: number;
+}
+
+export interface SandboxFilesApiDeps {
+  fetch: (
+    input: string | URL | Request,
+    init?: RequestInit,
+  ) => Promise<Response>;
+  getConfig: () => Promise<ApiRequestConfig>;
+}
+
+const defaultDeps: SandboxFilesApiDeps = {
+  fetch: globalThis.fetch,
+  getConfig: getApiRequestConfig,
+};
+
+async function throwResponseError(response: Response): Promise<never> {
+  const text = await response.text();
+  throw new ApiRequestError(
+    `API error (${response.status}): ${text}`,
+    response.status,
+    text,
+  );
+}
+
+async function request(
+  path: string,
+  init: RequestInit,
+  deps: SandboxFilesApiDeps,
+): Promise<Response> {
+  const config = await deps.getConfig();
+  const headers = new Headers(getLettaCodeHeaders(config.apiKey));
+  new Headers(init.headers).forEach((value, key) => {
+    headers.set(key, value);
+  });
+  if (init.body instanceof FormData) {
+    headers.delete("Content-Type");
+  }
+  const response = await deps.fetch(new URL(path, config.baseUrl), {
+    ...init,
+    headers,
+  });
+  if (!response.ok) await throwResponseError(response);
+  return response;
+}
+
+export async function ensureConversationSandbox(
+  agentId: string,
+  conversationId: string,
+  deps: SandboxFilesApiDeps = defaultDeps,
+): Promise<ConversationSandbox> {
+  const response = await request(
+    `/v1/agents/${encodeURIComponent(agentId)}/sandboxes`,
+    {
+      method: "POST",
+      body: JSON.stringify({ conversationId }),
+    },
+    deps,
+  );
+  return (await response.json()) as ConversationSandbox;
+}
+
+export async function uploadFileToSandbox(
+  sandboxId: string,
+  file: { blob: Blob; name: string },
+  deps: SandboxFilesApiDeps = defaultDeps,
+): Promise<{ files: SandboxFileMetadata[] }> {
+  const form = new FormData();
+  form.append("file", file.blob, file.name);
+  const response = await request(
+    `/v1/sandboxes/${encodeURIComponent(sandboxId)}/files`,
+    {
+      method: "POST",
+      body: form,
+    },
+    deps,
+  );
+  return (await response.json()) as { files: SandboxFileMetadata[] };
+}
+
+export async function downloadFileFromSandbox(
+  sandboxId: string,
+  path: string,
+  deps: SandboxFilesApiDeps = defaultDeps,
+): Promise<Uint8Array> {
+  const query = new URLSearchParams({ path });
+  const response = await request(
+    `/v1/sandboxes/${encodeURIComponent(sandboxId)}/files?${query}`,
+    { method: "GET" },
+    deps,
+  );
+  return new Uint8Array(await response.arrayBuffer());
+}

--- a/src/cli/subcommands/router.test.ts
+++ b/src/cli/subcommands/router.test.ts
@@ -129,6 +129,23 @@ describe("subcommand router", () => {
     }
   });
 
+  test("routes sandbox help", async () => {
+    const messages: string[] = [];
+    const originalLog = console.log;
+    console.log = (message?: unknown) => {
+      messages.push(String(message));
+    };
+
+    try {
+      const exitCode = await runSubcommand(["sandbox", "help"]);
+
+      expect(exitCode).toBe(0);
+      expect(messages.join("\n")).toContain("letta sandbox upload");
+    } finally {
+      console.log = originalLog;
+    }
+  });
+
   test("identifies backend-aware subcommands for early backend selection", () => {
     expect(subcommandNeedsEarlyBackendMode("app-server")).toBe(true);
     expect(subcommandNeedsEarlyBackendMode("connect")).toBe(true);
@@ -138,6 +155,7 @@ describe("subcommand router", () => {
     expect(subcommandNeedsEarlyBackendMode("envs")).toBe(true);
     expect(subcommandNeedsEarlyBackendMode("memory")).toBe(true);
     expect(subcommandNeedsEarlyBackendMode("mods")).toBe(true);
+    expect(subcommandNeedsEarlyBackendMode("sandbox")).toBe(true);
     expect(subcommandNeedsEarlyBackendMode("version")).toBe(false);
     expect(subcommandNeedsEarlyBackendMode("backend")).toBe(false);
     expect(subcommandNeedsEarlyBackendMode(undefined)).toBe(false);

--- a/src/cli/subcommands/router.ts
+++ b/src/cli/subcommands/router.ts
@@ -10,6 +10,7 @@ import { runLocalBackendSubcommand } from "./local-backend";
 import { runMemorySubcommand } from "./memory";
 import { runMessagesSubcommand } from "./messages";
 import { runModsSubcommand } from "./mods";
+import { runSandboxSubcommand } from "./sandbox";
 import { asLegacyAppServerCommand, runServerSubcommand } from "./server";
 import { runSetupSubcommand } from "./setup";
 import { runSharedMemorySubcommand } from "./shared-memory";
@@ -46,6 +47,7 @@ export function subcommandNeedsEarlyBackendMode(
     case "messages":
     case "mods":
     case "remote":
+    case "sandbox":
     case "server":
     case "shared-memory":
     case "skills":
@@ -85,6 +87,8 @@ export async function runSubcommand(argv: string[]): Promise<number | null> {
       return runEnvironmentsSubcommand(rest);
     case "mods":
       return runModsSubcommand(rest);
+    case "sandbox":
+      return runSandboxSubcommand(rest);
     case "server":
       return runServerSubcommand(rest);
     case "remote": // alias

--- a/src/cli/subcommands/sandbox.test.ts
+++ b/src/cli/subcommands/sandbox.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, test } from "bun:test";
+import {
+  resolveSandboxSession,
+  runSandboxSubcommand,
+} from "@/cli/subcommands/sandbox";
+
+const CLOUD_ENV = {
+  LETTA_AGENT_ID: "agent-1",
+  LETTA_CONVERSATION_ID: "conv-1",
+};
+
+async function withEnvironment<T>(
+  values: Record<string, string | undefined>,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const previous = new Map<string, string | undefined>();
+  for (const [key, value] of Object.entries(values)) {
+    previous.set(key, process.env[key]);
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+  try {
+    return await fn();
+  } finally {
+    for (const [key, value] of previous) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  }
+}
+
+describe("sandbox subcommand", () => {
+  test("prefers the active shell conversation", () => {
+    expect(
+      resolveSandboxSession(CLOUD_ENV, {
+        agentId: "agent-fallback",
+        conversationId: "conv-fallback",
+      }),
+    ).toEqual({ agentId: "agent-1", conversationId: "conv-1" });
+  });
+
+  test("rejects local agents", () => {
+    expect(() =>
+      resolveSandboxSession(
+        {
+          LETTA_AGENT_ID: "agent-local-1",
+          LETTA_CONVERSATION_ID: "conv-1",
+        },
+        null,
+      ),
+    ).toThrow("requires a Letta Cloud agent");
+  });
+
+  test("uploads a local file after ensuring the sandbox", async () => {
+    const calls: string[] = [];
+    const output: string[] = [];
+    const originalLog = console.log;
+    console.log = (message?: unknown) => output.push(String(message));
+    try {
+      const exitCode = await withEnvironment(CLOUD_ENV, () =>
+        runSandboxSubcommand(["upload", "note.txt"], {
+          initializeSettings: async () => {},
+          isCloud: async () => true,
+          getLastSession: () => null,
+          statLocalPath: async () => ({ isFile: () => true }),
+          readLocalFile: async () => Buffer.from("hello"),
+          ensureSandbox: async (agentId, conversationId) => {
+            calls.push(`ensure:${agentId}:${conversationId}`);
+            return {
+              sandboxId: "sandbox-1",
+              deviceId: "device-1",
+              connectionName: "Cloud",
+            };
+          },
+          uploadFile: async (sandboxId, file) => {
+            calls.push(`upload:${sandboxId}:${file.name}:${file.blob.size}`);
+            return {
+              files: [
+                {
+                  path: "/root/downloads/upload/note.txt",
+                  name: "note.txt",
+                  mimeType: "text/plain",
+                  size: 5,
+                },
+              ],
+            };
+          },
+        }),
+      );
+
+      expect(exitCode).toBe(0);
+      expect(calls).toEqual([
+        "ensure:agent-1:conv-1",
+        "upload:sandbox-1:note.txt:5",
+      ]);
+      expect(JSON.parse(output[0] ?? "{}").files[0].path).toBe(
+        "/root/downloads/upload/note.txt",
+      );
+    } finally {
+      console.log = originalLog;
+    }
+  });
+
+  test("downloads a sandbox file to the requested path", async () => {
+    const writes: Array<{ path: string; data: number[] }> = [];
+    const originalLog = console.log;
+    console.log = () => {};
+    try {
+      const exitCode = await withEnvironment(CLOUD_ENV, () =>
+        runSandboxSubcommand(
+          ["download", "/root/downloads/report.txt", "--to", "copy.txt"],
+          {
+            initializeSettings: async () => {},
+            isCloud: async () => true,
+            getLastSession: () => null,
+            ensureSandbox: async () => ({
+              sandboxId: "sandbox-1",
+              deviceId: "device-1",
+              connectionName: "Cloud",
+            }),
+            downloadFile: async () => new Uint8Array([1, 2, 3]),
+            writeLocalFile: async (path, data) => {
+              writes.push({
+                path: String(path),
+                data: [...(data as Uint8Array)],
+              });
+            },
+          },
+        ),
+      );
+
+      expect(exitCode).toBe(0);
+      expect(writes).toEqual([
+        { path: `${process.cwd()}/copy.txt`, data: [1, 2, 3] },
+      ]);
+    } finally {
+      console.log = originalLog;
+    }
+  });
+});

--- a/src/cli/subcommands/sandbox.test.ts
+++ b/src/cli/subcommands/sandbox.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { resolve } from "node:path";
 import {
   resolveSandboxSession,
   runSandboxSubcommand,
@@ -130,9 +131,7 @@ describe("sandbox subcommand", () => {
       );
 
       expect(exitCode).toBe(0);
-      expect(writes).toEqual([
-        { path: `${process.cwd()}/copy.txt`, data: [1, 2, 3] },
-      ]);
+      expect(writes).toEqual([{ path: resolve("copy.txt"), data: [1, 2, 3] }]);
     } finally {
       console.log = originalLog;
     }

--- a/src/cli/subcommands/sandbox.ts
+++ b/src/cli/subcommands/sandbox.ts
@@ -1,0 +1,168 @@
+import { readFile, stat, writeFile } from "node:fs/promises";
+import { basename, resolve } from "node:path";
+import { parseArgs } from "node:util";
+import { isLocalAgentId } from "@/agent/agent-id";
+import { isLettaCloud } from "@/agent/memory-filesystem";
+import {
+  downloadFileFromSandbox,
+  ensureConversationSandbox,
+  uploadFileToSandbox,
+} from "@/backend/api/sandbox-files";
+import { type SessionRef, settingsManager } from "@/settings-manager";
+
+interface SandboxSubcommandDeps {
+  downloadFile?: typeof downloadFileFromSandbox;
+  ensureSandbox?: typeof ensureConversationSandbox;
+  getLastSession?: () => SessionRef | null;
+  initializeSettings?: () => Promise<void>;
+  isCloud?: () => Promise<boolean>;
+  readLocalFile?: (path: string) => Promise<Buffer>;
+  statLocalPath?: (path: string) => Promise<{ isFile(): boolean }>;
+  uploadFile?: typeof uploadFileToSandbox;
+  writeLocalFile?: (path: string, data: Uint8Array) => Promise<void>;
+}
+
+const SANDBOX_OPTIONS = {
+  help: { type: "boolean", short: "h" },
+  to: { type: "string" },
+} as const;
+
+function printUsage(): void {
+  console.log(
+    `
+Usage:
+  letta sandbox upload <local-path>
+  letta sandbox download <sandbox-path> [--to <local-path>]
+
+Notes:
+  - Requires an active conversation for a Letta Cloud agent.
+  - Uploads are stored under /root/downloads in the conversation sandbox.
+  - Downloads are limited to files under /root/downloads.
+  - Output is JSON only.
+`.trim(),
+  );
+}
+
+function parseSandboxArgs(argv: string[]) {
+  return parseArgs({
+    args: argv,
+    options: SANDBOX_OPTIONS,
+    strict: true,
+    allowPositionals: true,
+  });
+}
+
+function getEnvironmentSession(env: NodeJS.ProcessEnv): SessionRef | null {
+  const agentId = (env.LETTA_AGENT_ID || env.AGENT_ID || "").trim();
+  const conversationId = (
+    env.LETTA_CONVERSATION_ID ||
+    env.CONVERSATION_ID ||
+    ""
+  ).trim();
+  if (!agentId && !conversationId) return null;
+  if (!agentId || !conversationId) {
+    throw new Error(
+      "Both agent and conversation context are required when either is set",
+    );
+  }
+  return { agentId, conversationId };
+}
+
+export function resolveSandboxSession(
+  env: NodeJS.ProcessEnv,
+  fallback: SessionRef | null,
+): SessionRef {
+  const session = getEnvironmentSession(env) ?? fallback;
+  if (!session) {
+    throw new Error("No active agent conversation found");
+  }
+  if (isLocalAgentId(session.agentId)) {
+    throw new Error("Sandbox file transfer requires a Letta Cloud agent");
+  }
+  if (
+    !session.conversationId ||
+    session.conversationId === "default" ||
+    session.conversationId === "new"
+  ) {
+    throw new Error("Sandbox file transfer requires an active conversation");
+  }
+  return session;
+}
+
+export async function runSandboxSubcommand(
+  argv: string[],
+  deps: SandboxSubcommandDeps = {},
+): Promise<number> {
+  let parsed: ReturnType<typeof parseSandboxArgs>;
+  try {
+    parsed = parseSandboxArgs(argv);
+  } catch (error) {
+    console.error(`Error: ${error instanceof Error ? error.message : error}`);
+    printUsage();
+    return 1;
+  }
+
+  const [action, path] = parsed.positionals;
+  if (parsed.values.help || !action || action === "help") {
+    printUsage();
+    return 0;
+  }
+  if ((action !== "upload" && action !== "download") || !path) {
+    console.error("Error: expected upload or download with a file path");
+    printUsage();
+    return 1;
+  }
+
+  try {
+    await (deps.initializeSettings ?? (() => settingsManager.initialize()))();
+    if (!(await (deps.isCloud ?? isLettaCloud)())) {
+      throw new Error("Sandbox file transfer is only available on Letta Cloud");
+    }
+    const session = resolveSandboxSession(
+      process.env,
+      (
+        deps.getLastSession ?? (() => settingsManager.getEffectiveLastSession())
+      )(),
+    );
+    const ensureSandbox = deps.ensureSandbox ?? ensureConversationSandbox;
+
+    if (action === "upload") {
+      const localPath = resolve(path);
+      const fileStat = await (deps.statLocalPath ?? stat)(localPath);
+      if (!fileStat.isFile()) throw new Error(`${localPath} is not a file`);
+      const data = await (deps.readLocalFile ?? readFile)(localPath);
+      const sandbox = await ensureSandbox(
+        session.agentId,
+        session.conversationId,
+      );
+      const result = await (deps.uploadFile ?? uploadFileToSandbox)(
+        sandbox.sandboxId,
+        { blob: new Blob([data]), name: basename(localPath) },
+      );
+      console.log(JSON.stringify(result, null, 2));
+      return 0;
+    }
+
+    const sandbox = await ensureSandbox(
+      session.agentId,
+      session.conversationId,
+    );
+    const data = await (deps.downloadFile ?? downloadFileFromSandbox)(
+      sandbox.sandboxId,
+      path,
+    );
+    const localPath = resolve(parsed.values.to ?? basename(path));
+    await (deps.writeLocalFile ?? writeFile)(localPath, data);
+    console.log(
+      JSON.stringify(
+        { path: localPath, sandboxPath: path, size: data.byteLength },
+        null,
+        2,
+      ),
+    );
+    return 0;
+  } catch (error) {
+    console.error(`Error: ${error instanceof Error ? error.message : error}`);
+    return 1;
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -177,13 +177,13 @@ USAGE
   # maintenance
   letta update          Manually check for updates and install if available
   letta upgrade         Alias for \`letta update\`
-  letta --update        Alias for \`letta update\`
-  letta --upgrade       Alias for \`letta update\`
+  letta --update/--upgrade Aliases for \`letta update\`
   letta memory ...      Memory filesystem subcommands
   letta agents ...      Agents subcommands (JSON-only)
   letta environments ... List available remote environments (JSON-only)
   letta messages ...    Messages subcommands (JSON-only)
   letta mods ...        List and manage local mods
+  letta sandbox ...     Transfer files to or from the current Cloud sandbox
   letta server ...      Run a remote environment, channels, or the App Server
   letta connect ...     Connect providers from terminal
   letta backend ...     Show or set the default backend


### PR DESCRIPTION
## Summary
- add `letta sandbox upload <local-path>` for uploading into the active conversation sandbox
- add `letta sandbox download <sandbox-path> [--to <local-path>]` for retrieving files under `/root/downloads`
- transparently create or wake the conversation sandbox before each transfer
- reject local agents and non-Cloud backends

## Testing
- `bun run check`
- `bun src/index.ts sandbox help`