### PR TITLE
fix(headless): target conversation cloud sandbox

### DIFF
--- a/src/backend/api/environments.test.ts
+++ b/src/backend/api/environments.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from "bun:test";
+import { createAgentSandbox } from "@/backend/api/environments";
+import type { apiRequest } from "@/backend/api/request";
+
+describe("Cloud sandbox environment resolution", () => {
+  test("sends conversationId in the create request body", async () => {
+    const calls: Array<{
+      method: string;
+      path: string;
+      body?: Record<string, unknown>;
+    }> = [];
+    const request = (async (
+      method: string,
+      path: string,
+      body?: Record<string, unknown>,
+    ) => {
+      calls.push({ method, path, body });
+      return {
+        sandboxId: "sandbox-1",
+        deviceId: "device-1",
+        connectionName: "Cloud",
+      };
+    }) as typeof apiRequest;
+
+    await createAgentSandbox("agent-1", { conversationId: "conv-1" }, request);
+
+    expect(calls).toEqual([
+      {
+        method: "POST",
+        path: "/v1/agents/agent-1/sandboxes",
+        body: { conversationId: "conv-1" },
+      },
+    ]);
+  });
+
+  test("keeps the virtual default conversation agent-scoped", async () => {
+    const bodies: Array<Record<string, unknown> | undefined> = [];
+    const request = (async (
+      _method: string,
+      _path: string,
+      body?: Record<string, unknown>,
+    ) => {
+      bodies.push(body);
+      return {
+        sandboxId: "sandbox-1",
+        deviceId: "device-1",
+        connectionName: "Cloud",
+      };
+    }) as typeof apiRequest;
+
+    await createAgentSandbox("agent-1", { conversationId: "default" }, request);
+
+    expect(bodies).toEqual([{}]);
+  });
+});

--- a/src/backend/api/environments.ts
+++ b/src/backend/api/environments.ts
@@ -90,11 +90,15 @@ export async function getEnvironmentConnection(
 
 export async function createAgentSandbox(
   agentId: string,
+  options: { conversationId?: string } = {},
+  request: typeof apiRequest = apiRequest,
 ): Promise<CreateAgentSandboxResponse> {
-  return apiRequest<CreateAgentSandboxResponse>(
+  const conversationId =
+    options.conversationId === "default" ? undefined : options.conversationId;
+  return request<CreateAgentSandboxResponse>(
     "POST",
     `/v1/agents/${encodeURIComponent(agentId)}/sandboxes`,
-    {},
+    conversationId ? { conversationId } : {},
   );
 }
 
@@ -166,11 +170,17 @@ export async function resolveEnvironmentConnectionId(
 
 export async function resolveAgentSandboxConnectionId(
   agentId: string,
-  options: { timeoutMs?: number; pollIntervalMs?: number } = {},
+  options: {
+    conversationId?: string;
+    timeoutMs?: number;
+    pollIntervalMs?: number;
+  } = {},
 ): Promise<{ connectionId: string; environment: EnvironmentConnection }> {
   const timeoutMs = options.timeoutMs ?? 3 * 60_000;
   const pollIntervalMs = options.pollIntervalMs ?? 2_000;
-  const sandbox = await createAgentSandbox(agentId);
+  const sandbox = await createAgentSandbox(agentId, {
+    conversationId: options.conversationId,
+  });
   const deviceId = sandbox.deviceId || `sandbox-${agentId}`;
   const deadline = Date.now() + timeoutMs;
   let lastEnvironment: EnvironmentConnection | null = null;

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -2312,7 +2312,7 @@ ${SYSTEM_REMINDER_CLOSE}
     const environmentSelector = String(explicitEnvironmentSelector);
     const useCloudSandbox = isCloudEnvironmentSelector(environmentSelector);
     const environmentRouting = useCloudSandbox
-      ? await resolveAgentSandboxConnectionId(agent.id)
+      ? await resolveAgentSandboxConnectionId(agent.id, { conversationId })
       : await resolveEnvironmentConnectionId(environmentSelector);
     const { connectionId, environment } = environmentRouting;
     const responseEnvironment = buildEnvironmentResponseMetadata({


### PR DESCRIPTION
## Summary
- pass the active conversation ID through `--environment cloud`
- create or resume the matching conversation-scoped sandbox before routing the prompt
- preserve the legacy agent-scoped behavior for the virtual `default` conversation

## Testing
- `bun run check`