### PR TITLE
fix(headless): correlate environment responses to input

### DIFF
--- a/scripts/source-file-size-baseline.json
+++ b/scripts/source-file-size-baseline.json
@@ -21,7 +21,7 @@
   "src/cli/mods/local-mod-loader.test.ts": 1043,
   "src/cli/reflection-transcript.test.ts": 1084,
   "src/cli/subcommands/skills.ts": 1264,
-  "src/headless.ts": 5253,
+  "src/headless.ts": 5105,
   "src/hooks/integration.test.ts": 1147,
   "src/index.ts": 2773,
   "src/mods/learning-harness.ts": 2434,

--- a/src/headless-environment-response.test.ts
+++ b/src/headless-environment-response.test.ts
@@ -1,59 +1,109 @@
 import { describe, expect, test } from "bun:test";
-import { __headlessTestUtils } from "@/headless";
+import { waitForEnvironmentAssistantMessage } from "@/headless-environment-response";
 
-function assistantMessage(id: string, text: string, createdAt: string) {
+function assistantMessage(
+  id: string,
+  text: string,
+  runId: string,
+  sequenceId: number,
+) {
   return {
     id,
     message_type: "assistant_message",
-    created_at: createdAt,
+    date: "2026-07-07T12:00:00.000Z",
     content: [{ type: "text", text }],
+    run_id: runId,
+    seq_id: sequenceId,
+  };
+}
+
+function userMessage(
+  id: string,
+  otid: string,
+  runId: string,
+  sequenceId: number,
+) {
+  return {
+    id,
+    message_type: "user_message",
+    date: "2026-07-07T12:00:00.000Z",
+    content: "Run the requested command",
+    otid,
+    run_id: runId,
+    seq_id: sequenceId,
   };
 }
 
 describe("headless environment-routed responses", () => {
-  test("waits for turn completion before returning the latest assistant message", async () => {
-    const startedAtMs = Date.parse("2026-07-07T12:00:00.000Z");
-    const baselineCompletionMs = Date.parse("2026-07-07T11:59:00.000Z");
-    let retrieveCalls = 0;
+  test("follows the submitted input across continuation runs", async () => {
     let messageCalls = 0;
+    const retrievedRunIds: string[] = [];
 
     const backend = {
-      async retrieveAgent() {
-        retrieveCalls += 1;
-        if (retrieveCalls < 3) {
-          return {
-            id: "agent-env",
-            last_run_completion: "2026-07-07T11:59:00.000Z",
-            last_stop_reason: "end_turn",
-          };
-        }
+      async retrieveRun(runId: string) {
+        retrievedRunIds.push(runId);
         return {
-          id: "agent-env",
-          last_run_completion: "2026-07-07T12:00:06.000Z",
-          last_stop_reason: "end_turn",
+          id: runId,
+          status: "completed",
+          stop_reason:
+            runId === "run-requested" ? "requires_approval" : "end_turn",
         };
       },
       async listConversationMessages() {
         messageCalls += 1;
-        if (messageCalls < 4) {
+        if (messageCalls === 1) {
           return [
+            assistantMessage(
+              "msg-unrelated",
+              "paused. the uncommitted fix only changes the test.",
+              "run-unrelated",
+              10,
+            ),
+          ];
+        }
+        if (messageCalls === 2) {
+          return [
+            assistantMessage(
+              "msg-unrelated",
+              "paused. the uncommitted fix only changes the test.",
+              "run-unrelated",
+              10,
+            ),
             assistantMessage(
               "msg-initial",
               "Let me gather the concrete details.",
-              "2026-07-07T12:00:01.000Z",
+              "run-requested",
+              12,
             ),
+            userMessage("msg-user", "otid-requested", "run-requested", 11),
           ];
         }
         return [
           assistantMessage(
+            "msg-next-turn",
+            "This belongs to the next user message.",
+            "run-next-turn",
+            18,
+          ),
+          userMessage("msg-next-user", "otid-next", "run-next-turn", 17),
+          assistantMessage(
             "msg-final",
             "Here's my concrete execution environment.",
-            "2026-07-07T12:00:05.000Z",
+            "run-continuation",
+            15,
           ),
           assistantMessage(
             "msg-initial",
             "Let me gather the concrete details.",
-            "2026-07-07T12:00:01.000Z",
+            "run-requested",
+            12,
+          ),
+          userMessage("msg-user", "otid-requested", "run-requested", 11),
+          assistantMessage(
+            "msg-unrelated",
+            "paused. the uncommitted fix only changes the test.",
+            "run-unrelated",
+            10,
           ),
         ];
       },
@@ -62,22 +112,20 @@ describe("headless environment-routed responses", () => {
       },
     };
 
-    const result = await __headlessTestUtils.waitForEnvironmentAssistantMessage(
-      {
-        backend: backend as never,
-        agentId: "agent-env",
-        conversationId: "conv-env",
-        startedAtMs,
-        baselineLastRunCompletionMs: baselineCompletionMs,
-        pollIntervalMs: 0,
-        timeoutMs: 1_000,
-      },
-    );
+    const result = await waitForEnvironmentAssistantMessage({
+      backend: backend as never,
+      agentId: "agent-env",
+      conversationId: "conv-env",
+      otid: "otid-requested",
+      pollIntervalMs: 0,
+      timeoutMs: 1_000,
+    });
 
     expect(result).toEqual({
       text: "Here's my concrete execution environment.",
       stopReason: "end_turn",
     });
-    expect(messageCalls).toBeGreaterThanOrEqual(5);
+    expect(messageCalls).toBe(3);
+    expect(retrievedRunIds).toEqual(["run-requested", "run-continuation"]);
   });
 });

--- a/src/headless-environment-response.ts
+++ b/src/headless-environment-response.ts
@@ -1,0 +1,155 @@
+import type { Message as LettaMessage } from "@letta-ai/letta-client/resources/agents/messages";
+import type { StopReasonType } from "@letta-ai/letta-client/resources/runs/runs";
+import type { Backend } from "@/backend";
+
+function pageItems<T>(page: unknown): T[] {
+  if (Array.isArray(page)) return page as T[];
+  if (page && typeof page === "object") {
+    const maybePage = page as {
+      getPaginatedItems?: () => T[];
+      items?: T[];
+    };
+    if (typeof maybePage.getPaginatedItems === "function") {
+      return maybePage.getPaginatedItems();
+    }
+    if (Array.isArray(maybePage.items)) {
+      return maybePage.items;
+    }
+  }
+  return [];
+}
+
+function extractMessageText(message: LettaMessage): string {
+  const content = (message as { content?: unknown }).content;
+  if (typeof content === "string") return content;
+  if (Array.isArray(content)) {
+    return content
+      .map((part) => {
+        if (
+          part &&
+          typeof part === "object" &&
+          "type" in part &&
+          part.type === "text" &&
+          "text" in part &&
+          typeof part.text === "string"
+        ) {
+          return part.text;
+        }
+        return "";
+      })
+      .filter(Boolean)
+      .join("\n");
+  }
+  return "";
+}
+
+function isAssistantMessage(message: LettaMessage): boolean {
+  return (
+    (message as { message_type?: string }).message_type === "assistant_message"
+  );
+}
+
+function isUserMessage(message: LettaMessage): boolean {
+  return (message as { message_type?: string }).message_type === "user_message";
+}
+
+function messageRunId(message: LettaMessage | undefined): string | null {
+  if (!message) return null;
+  const runId = (message as { run_id?: unknown }).run_id;
+  return typeof runId === "string" && runId.length > 0 ? runId : null;
+}
+
+function messageSequenceId(message: LettaMessage): number | null {
+  const sequenceId = (message as { seq_id?: unknown }).seq_id;
+  return typeof sequenceId === "number" ? sequenceId : null;
+}
+
+export async function waitForEnvironmentAssistantMessage(params: {
+  backend: Backend;
+  agentId: string;
+  conversationId: string;
+  otid: string;
+  timeoutMs?: number;
+  pollIntervalMs?: number;
+}): Promise<{ text: string; stopReason: StopReasonType | null }> {
+  const timeoutMs = params.timeoutMs ?? 10 * 60_000;
+  const pollIntervalMs = params.pollIntervalMs ?? 1_000;
+  const deadline = Date.now() + timeoutMs;
+  let inputSequenceId: number | null = null;
+
+  while (Date.now() < deadline) {
+    const page =
+      params.conversationId === "default"
+        ? await params.backend.listAgentMessages(params.agentId, {
+            conversation_id: "default",
+            limit: 50,
+            order: "desc",
+          })
+        : await params.backend.listConversationMessages(params.conversationId, {
+            limit: 50,
+            order: "desc",
+          });
+
+    const messages = pageItems<LettaMessage>(page);
+    if (inputSequenceId === null) {
+      const inputMessage = messages.find(
+        (message) =>
+          isUserMessage(message) &&
+          (message as { otid?: unknown }).otid === params.otid,
+      );
+      inputSequenceId = inputMessage ? messageSequenceId(inputMessage) : null;
+    }
+
+    if (inputSequenceId !== null) {
+      const anchorSequenceId = inputSequenceId;
+      // Approval continuations get new run IDs, so use the input's OTID as the
+      // turn anchor and follow messages only until the next user turn begins.
+      const newerMessages = messages.filter((message) => {
+        const sequenceId = messageSequenceId(message);
+        return sequenceId !== null && sequenceId > anchorSequenceId;
+      });
+      const nextUserSequenceId = newerMessages.reduce<number | null>(
+        (closest, message) => {
+          if (!isUserMessage(message)) return closest;
+          const sequenceId = messageSequenceId(message);
+          if (sequenceId === null) return closest;
+          return closest === null || sequenceId < closest
+            ? sequenceId
+            : closest;
+        },
+        null,
+      );
+      const assistant = newerMessages
+        .filter((message) => {
+          const sequenceId = messageSequenceId(message);
+          return (
+            isAssistantMessage(message) &&
+            sequenceId !== null &&
+            (nextUserSequenceId === null || sequenceId < nextUserSequenceId)
+          );
+        })
+        .sort(
+          (a, b) => (messageSequenceId(b) ?? 0) - (messageSequenceId(a) ?? 0),
+        )[0];
+      const runId = messageRunId(assistant);
+      if (runId) {
+        const run = await params.backend.retrieveRun(runId);
+        if (
+          (run.status === "completed" ||
+            run.status === "failed" ||
+            run.status === "cancelled") &&
+          run.stop_reason !== "requires_approval"
+        ) {
+          const text = assistant ? extractMessageText(assistant).trim() : "";
+          if (text.length > 0) {
+            return { text, stopReason: run.stop_reason ?? null };
+          }
+        }
+      }
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
+  }
+
+  throw new Error("Timed out waiting for environment turn completion");
+}

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -6,7 +6,6 @@ import type {
 } from "@letta-ai/letta-client/resources/agents/agents";
 import type {
   ApprovalCreate,
-  Message as LettaMessage,
   Run,
 } from "@letta-ai/letta-client/resources/agents/messages";
 import type { StopReasonType } from "@letta-ai/letta-client/resources/runs/runs";
@@ -115,6 +114,7 @@ import {
   validateRegistryHandleOrThrow,
 } from "./cli/startup-flag-validation";
 import { SYSTEM_REMINDER_CLOSE, SYSTEM_REMINDER_OPEN } from "./constants";
+import { waitForEnvironmentAssistantMessage } from "./headless-environment-response";
 import { resolveHeadlessMemfsPolicy } from "./headless-memfs-policy";
 import {
   createHeadlessModAdapter,
@@ -375,7 +375,6 @@ export const __headlessTestUtils = {
   contentToTaskNotificationText,
   toBidirectionalQueuedInput,
   prepareHeadlessToolExecutionContext,
-  waitForEnvironmentAssistantMessage,
 };
 
 type ReflectionOverrides = {
@@ -701,151 +700,6 @@ async function writeFinalHeadlessStdout(text: string): Promise<void> {
     }
     process.stdout.write(text, () => resolve());
   });
-}
-
-function pageItems<T>(page: unknown): T[] {
-  if (Array.isArray(page)) return page as T[];
-  if (page && typeof page === "object") {
-    const maybePage = page as {
-      getPaginatedItems?: () => T[];
-      items?: T[];
-    };
-    if (typeof maybePage.getPaginatedItems === "function") {
-      return maybePage.getPaginatedItems();
-    }
-    if (Array.isArray(maybePage.items)) {
-      return maybePage.items;
-    }
-  }
-  return [];
-}
-
-function extractMessageText(message: LettaMessage): string {
-  const content = (message as { content?: unknown }).content;
-  if (typeof content === "string") return content;
-  if (Array.isArray(content)) {
-    return content
-      .map((part) => {
-        if (
-          part &&
-          typeof part === "object" &&
-          "type" in part &&
-          part.type === "text" &&
-          "text" in part &&
-          typeof part.text === "string"
-        ) {
-          return part.text;
-        }
-        return "";
-      })
-      .filter(Boolean)
-      .join("\n");
-  }
-  return "";
-}
-
-function isAssistantMessage(message: LettaMessage): boolean {
-  return (
-    (message as { message_type?: string }).message_type === "assistant_message"
-  );
-}
-
-function messageTime(message: LettaMessage): number {
-  const date =
-    (message as { date?: string; created_at?: string }).date ??
-    (message as { created_at?: string }).created_at;
-  return date ? new Date(date).getTime() : 0;
-}
-
-function agentLastRunCompletionMs(agent: AgentState): number | null {
-  const raw = (agent as { last_run_completion?: unknown }).last_run_completion;
-  if (typeof raw !== "string" || raw.length === 0) return null;
-  const ms = new Date(raw).getTime();
-  return Number.isFinite(ms) ? ms : null;
-}
-
-function agentLastStopReason(agent: AgentState): StopReasonType | null {
-  const raw = (agent as { last_stop_reason?: unknown }).last_stop_reason;
-  return typeof raw === "string" && raw.length > 0
-    ? (raw as StopReasonType)
-    : null;
-}
-
-async function waitForEnvironmentAssistantMessage(params: {
-  backend: ReturnType<typeof getBackend>;
-  agentId: string;
-  conversationId: string;
-  startedAtMs: number;
-  baselineLastRunCompletionMs?: number | null;
-  timeoutMs?: number;
-  pollIntervalMs?: number;
-}): Promise<{ text: string; stopReason: StopReasonType | null }> {
-  const timeoutMs = params.timeoutMs ?? 10 * 60_000;
-  const pollIntervalMs = params.pollIntervalMs ?? 1_000;
-  const deadline = Date.now() + timeoutMs;
-  let lastText = "";
-  let postCompletionStableCount = 0;
-  let observedCompletion = false;
-  let observedStopReason: StopReasonType | null = null;
-
-  while (Date.now() < deadline) {
-    const freshAgent = await params.backend.retrieveAgent(params.agentId);
-    const completionMs = agentLastRunCompletionMs(freshAgent);
-    const baselineCompletionMs = params.baselineLastRunCompletionMs ?? null;
-    const wasObservedCompletion = observedCompletion;
-    if (
-      completionMs !== null &&
-      (baselineCompletionMs === null || completionMs > baselineCompletionMs) &&
-      completionMs >= params.startedAtMs - 5_000
-    ) {
-      observedCompletion = true;
-      observedStopReason = agentLastStopReason(freshAgent);
-      if (!wasObservedCompletion) {
-        postCompletionStableCount = 0;
-      }
-    }
-
-    const page =
-      params.conversationId === "default"
-        ? await params.backend.listAgentMessages(params.agentId, {
-            conversation_id: "default",
-            limit: 50,
-            order: "desc",
-          })
-        : await params.backend.listConversationMessages(params.conversationId, {
-            limit: 50,
-            order: "desc",
-          });
-
-    const messages = pageItems<LettaMessage>(page);
-    const assistant = messages
-      .filter(
-        (message) =>
-          isAssistantMessage(message) &&
-          messageTime(message) >= params.startedAtMs - 2_000,
-      )
-      .sort((a, b) => messageTime(b) - messageTime(a))[0];
-
-    const text = assistant ? extractMessageText(assistant).trim() : "";
-    if (text.length > 0) {
-      if (text === lastText) {
-        if (observedCompletion) postCompletionStableCount += 1;
-      } else {
-        lastText = text;
-        postCompletionStableCount = observedCompletion ? 1 : 0;
-      }
-      if (observedCompletion && postCompletionStableCount >= 2) {
-        return { text, stopReason: observedStopReason };
-      }
-    }
-
-    await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
-  }
-
-  if (observedCompletion && lastText) {
-    return { text: lastText, stopReason: observedStopReason };
-  }
-  throw new Error("Timed out waiting for environment turn completion");
 }
 
 type ReplyEnvironmentMetadata =
@@ -2379,8 +2233,7 @@ ${SYSTEM_REMINDER_CLOSE}
       }
       await exitHeadless(1, "headless_environment_unsupported");
     }
-    const startedAtMs = Date.now();
-    const baselineLastRunCompletionMs = agentLastRunCompletionMs(agent);
+    const otid = randomUUID();
     await sendEnvironmentMessage(connectionId, {
       agentId: agent.id,
       conversationId,
@@ -2389,7 +2242,7 @@ ${SYSTEM_REMINDER_CLOSE}
           role: "user",
           content: contentParts,
           client_message_id: randomUUID(),
-          otid: randomUUID(),
+          otid,
         },
       ],
     });
@@ -2398,8 +2251,7 @@ ${SYSTEM_REMINDER_CLOSE}
       backend,
       agentId: agent.id,
       conversationId,
-      startedAtMs,
-      baselineLastRunCompletionMs,
+      otid,
     });
     const resultText = environmentResult.text;
     const stats = sessionStats.getSnapshot();


### PR DESCRIPTION
## Summary
- retain the OTID generated for environment-routed headless input
- anchor response polling to that exact persisted user message instead of agent-wide completion timestamps
- follow response runs across approval continuations while stopping at the next user turn
- return assistant text only after its own run reaches a terminal state

## Testing
- `bun test src/headless-environment-response.test.ts`
- `bun run check`
- `bun src/index.ts --conversation conv-c6157d85-4384-440b-bebc-e2fb73b79ad9 --environment cloud --output-format json -p 'Use Bash to print $AGENT_ID, $CONVERSATION_ID, and $PWD on separate lines. Reply with only those three lines.'`