### PR TITLE
fix(cli): load project settings for sandbox transfers

### DIFF
--- a/src/cli/subcommands/sandbox.test.ts
+++ b/src/cli/subcommands/sandbox.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
 import { resolve } from "node:path";
 import {
   resolveSandboxSession,
@@ -134,6 +136,37 @@ describe("sandbox subcommand", () => {
       expect(writes).toEqual([{ path: resolve("copy.txt"), data: [1, 2, 3] }]);
     } finally {
       console.log = originalLog;
+    }
+  });
+
+  test("loads project settings before production session resolution", async () => {
+    const workingDirectory = await mkdtemp(
+      `${tmpdir()}/letta-sandbox-settings-`,
+    );
+    const originalWorkingDirectory = process.cwd();
+    const originalLog = console.log;
+    console.log = () => {};
+    process.chdir(workingDirectory);
+    try {
+      const exitCode = await withEnvironment(CLOUD_ENV, () =>
+        runSandboxSubcommand(["upload", "note.txt"], {
+          isCloud: async () => true,
+          statLocalPath: async () => ({ isFile: () => true }),
+          readLocalFile: async () => Buffer.from("hello"),
+          ensureSandbox: async () => ({
+            sandboxId: "sandbox-1",
+            deviceId: "device-1",
+            connectionName: "Cloud",
+          }),
+          uploadFile: async () => ({ files: [] }),
+        }),
+      );
+
+      expect(exitCode).toBe(0);
+    } finally {
+      process.chdir(originalWorkingDirectory);
+      console.log = originalLog;
+      await rm(workingDirectory, { recursive: true, force: true });
     }
   });
 });

--- a/src/cli/subcommands/sandbox.ts
+++ b/src/cli/subcommands/sandbox.ts
@@ -89,6 +89,11 @@ export function resolveSandboxSession(
   return session;
 }
 
+async function initializeSandboxSettings(): Promise<void> {
+  await settingsManager.initialize();
+  await settingsManager.loadLocalProjectSettings();
+}
+
 export async function runSandboxSubcommand(
   argv: string[],
   deps: SandboxSubcommandDeps = {},
@@ -114,7 +119,7 @@ export async function runSandboxSubcommand(
   }
 
   try {
-    await (deps.initializeSettings ?? (() => settingsManager.initialize()))();
+    await (deps.initializeSettings ?? initializeSandboxSettings)();
     if (!(await (deps.isCloud ?? isLettaCloud)())) {
       throw new Error("Sandbox file transfer is only available on Letta Cloud");
     }


### PR DESCRIPTION
## Summary
- load current-project settings during sandbox subcommand initialization
- resolve the effective active session only after local settings are available
- cover the production initialization path without replacing `getLastSession`

## Testing
- `bun test src/cli/subcommands/sandbox.test.ts`
- `bun run check`
- live binary upload/download through `bun src/index.ts sandbox ...`
- `cmp` and SHA-256 matched for the 1,035-byte round trip

Fixes LET-10954