### PR TITLE
feat(cli): teleport conversations between environments

### DIFF
--- a/scripts/source-file-size-baseline.json
+++ b/scripts/source-file-size-baseline.json
@@ -23,7 +23,7 @@
   "src/cli/subcommands/skills.ts": 1264,
   "src/headless.ts": 5105,
   "src/hooks/integration.test.ts": 1147,
-  "src/index.ts": 2773,
+  "src/index.ts": 2775,
   "src/mods/learning-harness.ts": 2434,
   "src/mods/mod-engine.test.ts": 2153,
   "src/mods/mod-engine.ts": 1838,
@@ -44,7 +44,7 @@
   "src/websocket/listener/commands/memory.ts": 1114,
   "src/websocket/listener/file-commands.ts": 1053,
   "src/websocket/listener/lifecycle.ts": 1051,
-  "src/websocket/listener/protocol-inbound.ts": 2264,
+  "src/websocket/listener/protocol-inbound.ts": 2258,
   "src/websocket/listener/protocol-outbound.ts": 1072,
   "src/websocket/listener/turn.ts": 1010
 }

--- a/src/backend/api/environments.test.ts
+++ b/src/backend/api/environments.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import {
   createAgentSandbox,
-  getRuntimeLastEnvironment,
   teleportToEnvironment,
 } from "@/backend/api/environments";
 import type { apiRequest } from "@/backend/api/request";
@@ -55,60 +54,6 @@ describe("Cloud sandbox environment resolution", () => {
     await createAgentSandbox("agent-1", { conversationId: "default" }, request);
 
     expect(bodies).toEqual([{}]);
-  });
-});
-
-describe("getRuntimeLastEnvironment", () => {
-  test("GETs the last environment for a conversation", async () => {
-    const calls: Array<{ method: string; path: string }> = [];
-    const request = (async (method: string, path: string): Promise<unknown> => {
-      calls.push({ method, path });
-      return {
-        environmentId: "env-prior",
-        deviceId: "device-prior",
-        connectionName: "Prior Laptop",
-        metadata: null,
-        status: "online",
-        isOnline: true,
-        lastSeenAt: 100,
-        lastUsedAt: 100,
-        source: "environment",
-      };
-    }) as typeof apiRequest;
-
-    const result = await getRuntimeLastEnvironment(
-      "agent-1",
-      "conv-1",
-      request,
-    );
-
-    expect(calls).toEqual([
-      {
-        method: "GET",
-        path: "/v1/environments/runtimes/agent-1/conv-1/last",
-      },
-    ]);
-    expect(result).toEqual({
-      environmentId: "env-prior",
-      deviceId: "device-prior",
-      connectionName: "Prior Laptop",
-      metadata: null,
-      status: "online",
-      isOnline: true,
-      lastSeenAt: 100,
-      lastUsedAt: 100,
-      source: "environment",
-    });
-  });
-
-  test("returns null when no prior environment exists", async () => {
-    const request = (async (): Promise<unknown> => null) as typeof apiRequest;
-    const result = await getRuntimeLastEnvironment(
-      "agent-1",
-      "conv-1",
-      request,
-    );
-    expect(result).toBeNull();
   });
 });
 

--- a/src/backend/api/environments.test.ts
+++ b/src/backend/api/environments.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from "bun:test";
-import { createAgentSandbox } from "@/backend/api/environments";
+import {
+  createAgentSandbox,
+  getRuntimeLastEnvironment,
+  teleportToEnvironment,
+} from "@/backend/api/environments";
 import type { apiRequest } from "@/backend/api/request";
 
 describe("Cloud sandbox environment resolution", () => {
@@ -51,5 +55,106 @@ describe("Cloud sandbox environment resolution", () => {
     await createAgentSandbox("agent-1", { conversationId: "default" }, request);
 
     expect(bodies).toEqual([{}]);
+  });
+});
+
+describe("getRuntimeLastEnvironment", () => {
+  test("GETs the last environment for a conversation", async () => {
+    const calls: Array<{ method: string; path: string }> = [];
+    const request = (async (method: string, path: string): Promise<unknown> => {
+      calls.push({ method, path });
+      return {
+        environmentId: "env-prior",
+        deviceId: "device-prior",
+        connectionName: "Prior Laptop",
+        metadata: null,
+        status: "online",
+        isOnline: true,
+        lastSeenAt: 100,
+        lastUsedAt: 100,
+        source: "environment",
+      };
+    }) as typeof apiRequest;
+
+    const result = await getRuntimeLastEnvironment(
+      "agent-1",
+      "conv-1",
+      request,
+    );
+
+    expect(calls).toEqual([
+      {
+        method: "GET",
+        path: "/v1/environments/runtimes/agent-1/conv-1/last",
+      },
+    ]);
+    expect(result).toEqual({
+      environmentId: "env-prior",
+      deviceId: "device-prior",
+      connectionName: "Prior Laptop",
+      metadata: null,
+      status: "online",
+      isOnline: true,
+      lastSeenAt: 100,
+      lastUsedAt: 100,
+      source: "environment",
+    });
+  });
+
+  test("returns null when no prior environment exists", async () => {
+    const request = (async (): Promise<unknown> => null) as typeof apiRequest;
+    const result = await getRuntimeLastEnvironment(
+      "agent-1",
+      "conv-1",
+      request,
+    );
+    expect(result).toBeNull();
+  });
+});
+
+describe("teleportToEnvironment", () => {
+  test("POSTs to the teleport endpoint with targetConnectionId and idempotencyKey", async () => {
+    const calls: Array<{
+      method: string;
+      path: string;
+      body?: Record<string, unknown>;
+    }> = [];
+    const request = (async (
+      method: string,
+      path: string,
+      body?: Record<string, unknown>,
+    ): Promise<unknown> => {
+      calls.push({ method, path, body });
+      return {
+        id: "teleport-1",
+        agentId: "agent-1",
+        conversationId: "conv-1",
+        sourceConnectionId: "conn-source",
+        targetConnectionId: "conn-target",
+        targetDeviceId: "device-target",
+        targetConnectionName: "Target",
+        status: "waiting_for_source",
+        error: null,
+        createdAt: 1,
+        updatedAt: 1,
+      };
+    }) as typeof apiRequest;
+
+    const result = await teleportToEnvironment(
+      "agent-1",
+      "conv-1",
+      "conn-target",
+      request,
+    );
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.method).toBe("POST");
+    expect(calls[0]?.path).toBe(
+      "/v1/environments/runtimes/agent-1/conv-1/teleport",
+    );
+    expect(calls[0]?.body?.targetConnectionId).toBe("conn-target");
+    expect(calls[0]?.body?.idempotencyKey).toEqual(expect.any(String));
+    expect(result.status).toBe("waiting_for_source");
+    expect(result.targetConnectionId).toBe("conn-target");
   });
 });

--- a/src/backend/api/environments.ts
+++ b/src/backend/api/environments.ts
@@ -231,33 +231,6 @@ export interface TeleportResponse {
   updatedAt: number;
 }
 
-export interface RuntimeLastEnvironmentResponse {
-  environmentId: string | null;
-  deviceId: string;
-  connectionName: string;
-  metadata: EnvironmentMetadata | null;
-  status: "online" | "offline" | "unreachable";
-  isOnline: boolean;
-  lastSeenAt: number | null;
-  lastUsedAt: number;
-  source: "environment" | "sandbox" | "unknown";
-}
-
-/**
- * Fetch the prior online environment for a conversation from Cloud.
- * Returns null when no prior environment is recorded.
- */
-export async function getRuntimeLastEnvironment(
-  agentId: string,
-  conversationId: string,
-  request: typeof apiRequest = apiRequest,
-): Promise<RuntimeLastEnvironmentResponse | null> {
-  return request<RuntimeLastEnvironmentResponse | null>(
-    "GET",
-    `/v1/environments/runtimes/${encodeURIComponent(agentId)}/${encodeURIComponent(conversationId)}/last`,
-  );
-}
-
 /**
  * Submit a teleport request to Cloud. Returns immediately after the 202
  * acceptance — the harness owns polling/yield after this returns.

--- a/src/backend/api/environments.ts
+++ b/src/backend/api/environments.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import { apiRequest } from "./request";
 
 export interface EnvironmentMetadata {
@@ -207,5 +208,72 @@ export async function resolveAgentSandboxConnectionId(
 
   throw new Error(
     `Timed out waiting for cloud sandbox ${sandbox.connectionName} to register${lastError instanceof Error ? `: ${lastError.message}` : ""}`,
+  );
+}
+
+export type TeleportStatus =
+  | "waiting_for_source"
+  | "starting_destination"
+  | "completed"
+  | "failed";
+
+export interface TeleportResponse {
+  id: string;
+  agentId: string;
+  conversationId: string;
+  sourceConnectionId: string;
+  targetConnectionId: string;
+  targetDeviceId: string;
+  targetConnectionName: string;
+  status: TeleportStatus;
+  error: string | null;
+  createdAt: number;
+  updatedAt: number;
+}
+
+export interface RuntimeLastEnvironmentResponse {
+  environmentId: string | null;
+  deviceId: string;
+  connectionName: string;
+  metadata: EnvironmentMetadata | null;
+  status: "online" | "offline" | "unreachable";
+  isOnline: boolean;
+  lastSeenAt: number | null;
+  lastUsedAt: number;
+  source: "environment" | "sandbox" | "unknown";
+}
+
+/**
+ * Fetch the prior online environment for a conversation from Cloud.
+ * Returns null when no prior environment is recorded.
+ */
+export async function getRuntimeLastEnvironment(
+  agentId: string,
+  conversationId: string,
+  request: typeof apiRequest = apiRequest,
+): Promise<RuntimeLastEnvironmentResponse | null> {
+  return request<RuntimeLastEnvironmentResponse | null>(
+    "GET",
+    `/v1/environments/runtimes/${encodeURIComponent(agentId)}/${encodeURIComponent(conversationId)}/last`,
+  );
+}
+
+/**
+ * Submit a teleport request to Cloud. Returns immediately after the 202
+ * acceptance — the harness owns polling/yield after this returns.
+ */
+export async function teleportToEnvironment(
+  agentId: string,
+  conversationId: string,
+  targetConnectionId: string,
+  request: typeof apiRequest = apiRequest,
+): Promise<TeleportResponse> {
+  return request<TeleportResponse>(
+    "POST",
+    `/v1/environments/runtimes/${encodeURIComponent(agentId)}/${encodeURIComponent(conversationId)}/teleport`,
+    {
+      targetConnectionId,
+      idempotencyKey: randomUUID(),
+    },
   );
 }

--- a/src/cli/subcommands/router.test.ts
+++ b/src/cli/subcommands/router.test.ts
@@ -159,7 +159,7 @@ describe("subcommand router", () => {
       expect(exitCode).toBe(0);
       expect(messages.join("\n")).toContain("letta teleport list");
       expect(messages.join("\n")).toContain("letta teleport cloud");
-      expect(messages.join("\n")).toContain("letta teleport back");
+      expect(messages.join("\n")).not.toContain("letta teleport back");
     } finally {
       console.log = originalLog;
     }

--- a/src/cli/subcommands/router.test.ts
+++ b/src/cli/subcommands/router.test.ts
@@ -146,6 +146,25 @@ describe("subcommand router", () => {
     }
   });
 
+  test("routes teleport help", async () => {
+    const messages: string[] = [];
+    const originalLog = console.log;
+    console.log = (message?: unknown) => {
+      messages.push(String(message));
+    };
+
+    try {
+      const exitCode = await runSubcommand(["teleport", "help"]);
+
+      expect(exitCode).toBe(0);
+      expect(messages.join("\n")).toContain("letta teleport list");
+      expect(messages.join("\n")).toContain("letta teleport cloud");
+      expect(messages.join("\n")).toContain("letta teleport back");
+    } finally {
+      console.log = originalLog;
+    }
+  });
+
   test("identifies backend-aware subcommands for early backend selection", () => {
     expect(subcommandNeedsEarlyBackendMode("app-server")).toBe(true);
     expect(subcommandNeedsEarlyBackendMode("connect")).toBe(true);
@@ -156,6 +175,7 @@ describe("subcommand router", () => {
     expect(subcommandNeedsEarlyBackendMode("memory")).toBe(true);
     expect(subcommandNeedsEarlyBackendMode("mods")).toBe(true);
     expect(subcommandNeedsEarlyBackendMode("sandbox")).toBe(true);
+    expect(subcommandNeedsEarlyBackendMode("teleport")).toBe(true);
     expect(subcommandNeedsEarlyBackendMode("version")).toBe(false);
     expect(subcommandNeedsEarlyBackendMode("backend")).toBe(false);
     expect(subcommandNeedsEarlyBackendMode(undefined)).toBe(false);

--- a/src/cli/subcommands/router.ts
+++ b/src/cli/subcommands/router.ts
@@ -15,6 +15,7 @@ import { asLegacyAppServerCommand, runServerSubcommand } from "./server";
 import { runSetupSubcommand } from "./setup";
 import { runSharedMemorySubcommand } from "./shared-memory";
 import { runInstallSubcommand, runSkillsSubcommand } from "./skills";
+import { runTeleportSubcommand } from "./teleport";
 import { runTrajectoriesSubcommand } from "./trajectories";
 
 async function runUpdateSubcommand(): Promise<number> {
@@ -51,6 +52,7 @@ export function subcommandNeedsEarlyBackendMode(
     case "server":
     case "shared-memory":
     case "skills":
+    case "teleport":
       return true;
     default:
       return false;
@@ -89,6 +91,8 @@ export async function runSubcommand(argv: string[]): Promise<number | null> {
       return runModsSubcommand(rest);
     case "sandbox":
       return runSandboxSubcommand(rest);
+    case "teleport":
+      return runTeleportSubcommand(rest);
     case "server":
       return runServerSubcommand(rest);
     case "remote": // alias

--- a/src/cli/subcommands/teleport.test.ts
+++ b/src/cli/subcommands/teleport.test.ts
@@ -1,0 +1,552 @@
+import { describe, expect, test } from "bun:test";
+import type { apiRequest } from "@/backend/api/request";
+import { ApiRequestError } from "@/backend/api/request";
+import {
+  formatTeleportApiError,
+  resolveTeleportSession,
+  runTeleportSubcommand,
+} from "@/cli/subcommands/teleport";
+
+const CLOUD_ENV = {
+  LETTA_AGENT_ID: "agent-1",
+  LETTA_CONVERSATION_ID: "conv-1",
+};
+
+async function withEnvironment<T>(
+  values: Record<string, string | undefined>,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const previous = new Map<string, string | undefined>();
+  for (const [key, value] of Object.entries(values)) {
+    previous.set(key, process.env[key]);
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+  try {
+    return await fn();
+  } finally {
+    for (const [key, value] of previous) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  }
+}
+
+function captureOutput(): {
+  messages: string[];
+  errors: string[];
+  restore: () => void;
+} {
+  const messages: string[] = [];
+  const errors: string[] = [];
+  const originalLog = console.log;
+  const originalError = console.error;
+  console.log = (message?: unknown) => {
+    messages.push(String(message));
+  };
+  console.error = (message?: unknown) => {
+    errors.push(String(message));
+  };
+  return {
+    messages,
+    errors,
+    restore: () => {
+      console.log = originalLog;
+      console.error = originalError;
+    },
+  };
+}
+
+describe("teleport subcommand", () => {
+  test("prints help and returns 0", async () => {
+    const out = captureOutput();
+    try {
+      const exitCode = await runTeleportSubcommand(["--help"]);
+      expect(exitCode).toBe(0);
+      expect(out.messages.join("\n")).toContain("letta teleport list");
+      expect(out.messages.join("\n")).toContain("letta teleport cloud");
+      expect(out.messages.join("\n")).toContain("letta teleport back");
+    } finally {
+      out.restore();
+    }
+  });
+
+  test("prints help for help action", async () => {
+    const out = captureOutput();
+    try {
+      const exitCode = await runTeleportSubcommand(["help"]);
+      expect(exitCode).toBe(0);
+      expect(out.messages.join("\n")).toContain("letta teleport");
+    } finally {
+      out.restore();
+    }
+  });
+
+  test("prefers active shell session over fallback", () => {
+    expect(
+      resolveTeleportSession(CLOUD_ENV, {
+        agentId: "agent-fallback",
+        conversationId: "conv-fallback",
+      }),
+    ).toEqual({ agentId: "agent-1", conversationId: "conv-1" });
+  });
+
+  test("rejects local agents", () => {
+    expect(() =>
+      resolveTeleportSession(
+        {
+          LETTA_AGENT_ID: "agent-local-1",
+          LETTA_CONVERSATION_ID: "conv-1",
+        },
+        null,
+      ),
+    ).toThrow("requires a Letta Cloud agent");
+  });
+
+  test("rejects virtual default conversation", () => {
+    expect(() =>
+      resolveTeleportSession(
+        {
+          LETTA_AGENT_ID: "agent-1",
+          LETTA_CONVERSATION_ID: "default",
+        },
+        null,
+      ),
+    ).toThrow("requires an active conversation");
+  });
+
+  test("rejects virtual new conversation", () => {
+    expect(() =>
+      resolveTeleportSession(
+        {
+          LETTA_AGENT_ID: "agent-1",
+          LETTA_CONVERSATION_ID: "new",
+        },
+        null,
+      ),
+    ).toThrow("requires an active conversation");
+  });
+
+  test("throws when no session is available", () => {
+    expect(() => resolveTeleportSession({}, null)).toThrow(
+      "No active agent conversation found",
+    );
+  });
+
+  test("list prints accessible online environments as JSON", async () => {
+    const out = captureOutput();
+    try {
+      const exitCode = await runTeleportSubcommand(["list"], {
+        initializeSettings: async () => {},
+        listEnvironments: async (options) => {
+          expect(options).toEqual({ limit: 100, onlineOnly: true });
+          return {
+            connections: [
+              {
+                id: "env-1",
+                connectionId: "conn-1",
+                deviceId: "device-1",
+                connectionName: "Laptop",
+                organizationId: "org-1",
+                podId: null,
+                connectedAt: null,
+                lastHeartbeat: Date.now(),
+                lastSeenAt: Date.now(),
+                firstSeenAt: Date.now(),
+              },
+            ],
+            hasNextPage: false,
+          };
+        },
+      });
+
+      expect(exitCode).toBe(0);
+      const parsed = JSON.parse(out.messages[0] ?? "{}");
+      expect(parsed.connections).toEqual([
+        {
+          deviceId: "device-1",
+          connectionName: "Laptop",
+          connectionId: "conn-1",
+        },
+      ]);
+      expect(parsed.hasNextPage).toBe(false);
+    } finally {
+      out.restore();
+    }
+  });
+
+  test("cloud resolves sandbox and submits teleport", async () => {
+    const out = captureOutput();
+    const teleportCalls: Array<{
+      agentId: string;
+      conversationId: string;
+      targetConnectionId: string;
+    }> = [];
+    try {
+      const exitCode = await withEnvironment(CLOUD_ENV, () =>
+        runTeleportSubcommand(["cloud"], {
+          initializeSettings: async () => {},
+          getLastSession: () => null,
+          resolveAgentSandboxConnectionId: async (agentId, options) => {
+            expect(agentId).toBe("agent-1");
+            expect(options?.conversationId).toBe("conv-1");
+            return {
+              connectionId: "sandbox-conn-1",
+              environment: {} as never,
+            };
+          },
+          teleportToEnvironment: async (
+            agentId,
+            conversationId,
+            targetConnectionId,
+          ) => {
+            teleportCalls.push({ agentId, conversationId, targetConnectionId });
+            return {
+              id: "teleport-1",
+              agentId: "agent-1",
+              conversationId: "conv-1",
+              sourceConnectionId: "source-conn",
+              targetConnectionId: "sandbox-conn-1",
+              targetDeviceId: "device-sandbox",
+              targetConnectionName: "Cloud",
+              status: "waiting_for_source",
+              error: null,
+              createdAt: 1,
+              updatedAt: 1,
+            };
+          },
+        }),
+      );
+
+      expect(exitCode).toBe(0);
+      expect(teleportCalls).toEqual([
+        {
+          agentId: "agent-1",
+          conversationId: "conv-1",
+          targetConnectionId: "sandbox-conn-1",
+        },
+      ]);
+      const parsed = JSON.parse(out.messages[0] ?? "{}");
+      expect(parsed.status).toBe("waiting_for_source");
+      expect(parsed.targetConnectionId).toBe("sandbox-conn-1");
+    } finally {
+      out.restore();
+    }
+  });
+
+  test("back resolves last environment and submits teleport", async () => {
+    const out = captureOutput();
+    const teleportCalls: Array<{ targetConnectionId: string }> = [];
+    try {
+      const exitCode = await withEnvironment(CLOUD_ENV, () =>
+        runTeleportSubcommand(["back"], {
+          initializeSettings: async () => {},
+          getLastSession: () => null,
+          getRuntimeLastEnvironment: async (agentId, conversationId) => {
+            expect(agentId).toBe("agent-1");
+            expect(conversationId).toBe("conv-1");
+            return {
+              environmentId: "env-prior",
+              deviceId: "device-prior",
+              connectionName: "Prior Laptop",
+              metadata: null,
+              status: "online",
+              isOnline: true,
+              lastSeenAt: 100,
+              lastUsedAt: 100,
+              source: "environment",
+            };
+          },
+          resolveEnvironmentConnectionId: async (selector) => {
+            expect(selector).toBe("device-prior");
+            return {
+              connectionId: "conn-prior",
+              environment: {} as never,
+            };
+          },
+          teleportToEnvironment: async (
+            _agentId,
+            _conversationId,
+            targetConnectionId,
+          ) => {
+            teleportCalls.push({ targetConnectionId });
+            return {
+              id: "teleport-2",
+              agentId: "agent-1",
+              conversationId: "conv-1",
+              sourceConnectionId: "source-conn",
+              targetConnectionId: "conn-prior",
+              targetDeviceId: "device-prior",
+              targetConnectionName: "Prior Laptop",
+              status: "starting_destination",
+              error: null,
+              createdAt: 1,
+              updatedAt: 1,
+            };
+          },
+        }),
+      );
+
+      expect(exitCode).toBe(0);
+      expect(teleportCalls).toEqual([{ targetConnectionId: "conn-prior" }]);
+      const parsed = JSON.parse(out.messages[0] ?? "{}");
+      expect(parsed.status).toBe("starting_destination");
+      expect(parsed.targetConnectionName).toBe("Prior Laptop");
+    } finally {
+      out.restore();
+    }
+  });
+
+  test("back errors when no prior environment exists", async () => {
+    const out = captureOutput();
+    try {
+      const exitCode = await withEnvironment(CLOUD_ENV, () =>
+        runTeleportSubcommand(["back"], {
+          initializeSettings: async () => {},
+          getLastSession: () => null,
+          getRuntimeLastEnvironment: async () => null,
+        }),
+      );
+
+      expect(exitCode).toBe(1);
+      expect(out.errors[0]).toContain("No prior environment found");
+    } finally {
+      out.restore();
+    }
+  });
+
+  test("back errors when the prior environment is offline", async () => {
+    const out = captureOutput();
+    try {
+      const exitCode = await withEnvironment(CLOUD_ENV, () =>
+        runTeleportSubcommand(["back"], {
+          initializeSettings: async () => {},
+          getLastSession: () => null,
+          getRuntimeLastEnvironment: async () => ({
+            environmentId: "env-prior",
+            deviceId: "device-prior",
+            connectionName: "Prior Laptop",
+            metadata: null,
+            status: "offline",
+            isOnline: false,
+            lastSeenAt: 100,
+            lastUsedAt: 100,
+            source: "environment",
+          }),
+        }),
+      );
+
+      expect(exitCode).toBe(1);
+      expect(out.errors[0]).toContain("offline");
+    } finally {
+      out.restore();
+    }
+  });
+
+  test("friendly selector resolves environment and submits teleport", async () => {
+    const out = captureOutput();
+    const teleportCalls: Array<{ targetConnectionId: string }> = [];
+    try {
+      const exitCode = await withEnvironment(CLOUD_ENV, () =>
+        runTeleportSubcommand(["my-laptop"], {
+          initializeSettings: async () => {},
+          getLastSession: () => null,
+          resolveEnvironmentConnectionId: async (selector) => {
+            expect(selector).toBe("my-laptop");
+            return {
+              connectionId: "conn-laptop",
+              environment: {} as never,
+            };
+          },
+          teleportToEnvironment: async (
+            _agentId,
+            _conversationId,
+            targetConnectionId,
+          ) => {
+            teleportCalls.push({ targetConnectionId });
+            return {
+              id: "teleport-3",
+              agentId: "agent-1",
+              conversationId: "conv-1",
+              sourceConnectionId: "source-conn",
+              targetConnectionId: "conn-laptop",
+              targetDeviceId: "device-laptop",
+              targetConnectionName: "my-laptop",
+              status: "completed",
+              error: null,
+              createdAt: 1,
+              updatedAt: 1,
+            };
+          },
+        }),
+      );
+
+      expect(exitCode).toBe(0);
+      expect(teleportCalls).toEqual([{ targetConnectionId: "conn-laptop" }]);
+      const parsed = JSON.parse(out.messages[0] ?? "{}");
+      expect(parsed.status).toBe("completed");
+    } finally {
+      out.restore();
+    }
+  });
+
+  test("POST shape includes targetConnectionId and idempotencyKey", async () => {
+    const out = captureOutput();
+    const requestCalls: Array<{
+      method: string;
+      path: string;
+      body?: Record<string, unknown>;
+    }> = [];
+    const mockRequest = (async (
+      method: string,
+      path: string,
+      body?: Record<string, unknown>,
+    ) => {
+      requestCalls.push({ method, path, body });
+      return {
+        id: "teleport-4",
+        agentId: "agent-1",
+        conversationId: "conv-1",
+        sourceConnectionId: "source-conn",
+        targetConnectionId: "conn-target",
+        targetDeviceId: "device-target",
+        targetConnectionName: "Target",
+        status: "waiting_for_source",
+        error: null,
+        createdAt: 1,
+        updatedAt: 1,
+      };
+    }) as typeof apiRequest;
+
+    try {
+      const exitCode = await withEnvironment(CLOUD_ENV, () =>
+        runTeleportSubcommand(["my-target"], {
+          initializeSettings: async () => {},
+          getLastSession: () => null,
+          resolveEnvironmentConnectionId: async () => ({
+            connectionId: "conn-target",
+            environment: {} as never,
+          }),
+          teleportToEnvironment: async (
+            agentId,
+            conversationId,
+            targetConnectionId,
+          ) => {
+            // Use the mock request to verify body shape
+            return mockRequest(
+              "POST",
+              `/v1/environments/runtimes/${agentId}/${conversationId}/teleport`,
+              { targetConnectionId, idempotencyKey: "test-uuid" },
+            );
+          },
+        }),
+      );
+
+      expect(exitCode).toBe(0);
+      expect(requestCalls).toHaveLength(1);
+      expect(requestCalls[0]?.method).toBe("POST");
+      expect(requestCalls[0]?.path).toContain("/teleport");
+      expect(requestCalls[0]?.body).toHaveProperty("targetConnectionId");
+      expect(requestCalls[0]?.body).toHaveProperty("idempotencyKey");
+    } finally {
+      out.restore();
+    }
+  });
+
+  test("returns immediately after 202 without polling", async () => {
+    const out = captureOutput();
+    let teleportCallCount = 0;
+    try {
+      const exitCode = await withEnvironment(CLOUD_ENV, () =>
+        runTeleportSubcommand(["cloud"], {
+          initializeSettings: async () => {},
+          getLastSession: () => null,
+          resolveAgentSandboxConnectionId: async () => ({
+            connectionId: "conn-sandbox",
+            environment: {} as never,
+          }),
+          teleportToEnvironment: async () => {
+            teleportCallCount++;
+            return {
+              id: "teleport-5",
+              agentId: "agent-1",
+              conversationId: "conv-1",
+              sourceConnectionId: "source-conn",
+              targetConnectionId: "conn-sandbox",
+              targetDeviceId: "device-sandbox",
+              targetConnectionName: "Cloud",
+              status: "waiting_for_source",
+              error: null,
+              createdAt: 1,
+              updatedAt: 1,
+            };
+          },
+        }),
+      );
+
+      expect(exitCode).toBe(0);
+      expect(teleportCallCount).toBe(1);
+      const parsed = JSON.parse(out.messages[0] ?? "{}");
+      expect(parsed.status).toBe("waiting_for_source");
+    } finally {
+      out.restore();
+    }
+  });
+
+  test("formats API error with concrete message from response body", async () => {
+    const out = captureOutput();
+    try {
+      const exitCode = await withEnvironment(CLOUD_ENV, () =>
+        runTeleportSubcommand(["cloud"], {
+          initializeSettings: async () => {},
+          getLastSession: () => null,
+          resolveAgentSandboxConnectionId: async () => ({
+            connectionId: "conn-sandbox",
+            environment: {} as never,
+          }),
+          teleportToEnvironment: async () => {
+            throw new ApiRequestError(
+              'API error (409): {"errorCode":"TELEPORT_CONFLICT","message":"A teleport is already in progress"}',
+              409,
+              JSON.stringify({
+                errorCode: "TELEPORT_CONFLICT",
+                message: "A teleport is already in progress",
+              }),
+            );
+          },
+        }),
+      );
+
+      expect(exitCode).toBe(1);
+      expect(out.errors[0]).toBe("Error: A teleport is already in progress");
+    } finally {
+      out.restore();
+    }
+  });
+
+  test("formats API error with errorCode when message is absent", () => {
+    const error = new ApiRequestError(
+      "API error (400): {}",
+      400,
+      JSON.stringify({ errorCode: "INVALID_TARGET" }),
+    );
+    expect(formatTeleportApiError(error)).toBe("INVALID_TARGET");
+  });
+
+  test("falls back to raw response text for unparseable body", () => {
+    const error = new ApiRequestError(
+      "API error (500): internal server error",
+      500,
+      "internal server error",
+    );
+    expect(formatTeleportApiError(error)).toBe(
+      "API error (500): internal server error",
+    );
+  });
+
+  test("formats generic errors with message", () => {
+    expect(formatTeleportApiError(new Error("something went wrong"))).toBe(
+      "something went wrong",
+    );
+  });
+});

--- a/src/cli/subcommands/teleport.test.ts
+++ b/src/cli/subcommands/teleport.test.ts
@@ -65,7 +65,10 @@ describe("teleport subcommand", () => {
       expect(exitCode).toBe(0);
       expect(out.messages.join("\n")).toContain("letta teleport list");
       expect(out.messages.join("\n")).toContain("letta teleport cloud");
-      expect(out.messages.join("\n")).toContain("letta teleport back");
+      expect(out.messages.join("\n")).not.toContain("letta teleport back");
+      expect(out.messages.join("\n")).toContain(
+        "Desktop Local is not a teleport target yet",
+      );
     } finally {
       out.restore();
     }
@@ -133,7 +136,7 @@ describe("teleport subcommand", () => {
     );
   });
 
-  test("list prints accessible online environments as JSON", async () => {
+  test("list prints accessible online remote environments as JSON", async () => {
     const out = captureOutput();
     try {
       const exitCode = await runTeleportSubcommand(["list"], {
@@ -142,6 +145,18 @@ describe("teleport subcommand", () => {
           expect(options).toEqual({ limit: 100, onlineOnly: true });
           return {
             connections: [
+              {
+                id: "local-env",
+                connectionId: "local-1",
+                deviceId: "local-device",
+                connectionName: "Desktop Local",
+                organizationId: "local",
+                podId: "local",
+                connectedAt: null,
+                lastHeartbeat: Date.now(),
+                lastSeenAt: Date.now(),
+                firstSeenAt: Date.now(),
+              },
               {
                 id: "env-1",
                 connectionId: "conn-1",
@@ -234,110 +249,52 @@ describe("teleport subcommand", () => {
     }
   });
 
-  test("back resolves last environment and submits teleport", async () => {
-    const out = captureOutput();
-    const teleportCalls: Array<{ targetConnectionId: string }> = [];
-    try {
-      const exitCode = await withEnvironment(CLOUD_ENV, () =>
-        runTeleportSubcommand(["back"], {
-          initializeSettings: async () => {},
-          getLastSession: () => null,
-          getRuntimeLastEnvironment: async (agentId, conversationId) => {
-            expect(agentId).toBe("agent-1");
-            expect(conversationId).toBe("conv-1");
-            return {
-              environmentId: "env-prior",
-              deviceId: "device-prior",
-              connectionName: "Prior Laptop",
-              metadata: null,
-              status: "online",
-              isOnline: true,
-              lastSeenAt: 100,
-              lastUsedAt: 100,
-              source: "environment",
-            };
-          },
-          resolveEnvironmentConnectionId: async (selector) => {
-            expect(selector).toBe("device-prior");
-            return {
-              connectionId: "conn-prior",
-              environment: {} as never,
-            };
-          },
-          teleportToEnvironment: async (
-            _agentId,
-            _conversationId,
-            targetConnectionId,
-          ) => {
-            teleportCalls.push({ targetConnectionId });
-            return {
-              id: "teleport-2",
-              agentId: "agent-1",
-              conversationId: "conv-1",
-              sourceConnectionId: "source-conn",
-              targetConnectionId: "conn-prior",
-              targetDeviceId: "device-prior",
-              targetConnectionName: "Prior Laptop",
-              status: "starting_destination",
-              error: null,
-              createdAt: 1,
-              updatedAt: 1,
-            };
-          },
-        }),
-      );
-
-      expect(exitCode).toBe(0);
-      expect(teleportCalls).toEqual([{ targetConnectionId: "conn-prior" }]);
-      const parsed = JSON.parse(out.messages[0] ?? "{}");
-      expect(parsed.status).toBe("starting_destination");
-      expect(parsed.targetConnectionName).toBe("Prior Laptop");
-    } finally {
-      out.restore();
-    }
-  });
-
-  test("back errors when no prior environment exists", async () => {
+  test("back explains that return teleport is not supported yet", async () => {
     const out = captureOutput();
     try {
       const exitCode = await withEnvironment(CLOUD_ENV, () =>
         runTeleportSubcommand(["back"], {
           initializeSettings: async () => {},
           getLastSession: () => null,
-          getRuntimeLastEnvironment: async () => null,
         }),
       );
 
       expect(exitCode).toBe(1);
-      expect(out.errors[0]).toContain("No prior environment found");
+      expect(out.errors[0]).toContain("Teleport back is not supported yet");
     } finally {
       out.restore();
     }
   });
 
-  test("back errors when the prior environment is offline", async () => {
+  test("rejects Desktop Local as an explicit environment target", async () => {
     const out = captureOutput();
     try {
       const exitCode = await withEnvironment(CLOUD_ENV, () =>
-        runTeleportSubcommand(["back"], {
+        runTeleportSubcommand(["caren-mac.local"], {
           initializeSettings: async () => {},
           getLastSession: () => null,
-          getRuntimeLastEnvironment: async () => ({
-            environmentId: "env-prior",
-            deviceId: "device-prior",
-            connectionName: "Prior Laptop",
-            metadata: null,
-            status: "offline",
-            isOnline: false,
-            lastSeenAt: 100,
-            lastUsedAt: 100,
-            source: "environment",
+          resolveEnvironmentConnectionId: async () => ({
+            connectionId: "local-1",
+            environment: {
+              id: "local-env",
+              connectionId: "local-1",
+              deviceId: "local-device",
+              connectionName: "caren-mac.local",
+              organizationId: "local",
+              podId: "local",
+              connectedAt: null,
+              lastHeartbeat: Date.now(),
+              lastSeenAt: Date.now(),
+              firstSeenAt: Date.now(),
+            },
           }),
         }),
       );
 
       expect(exitCode).toBe(1);
-      expect(out.errors[0]).toContain("offline");
+      expect(out.errors[0]).toContain(
+        "Desktop Local is not a teleport target yet",
+      );
     } finally {
       out.restore();
     }

--- a/src/cli/subcommands/teleport.test.ts
+++ b/src/cli/subcommands/teleport.test.ts
@@ -169,6 +169,18 @@ describe("teleport subcommand", () => {
                 lastSeenAt: Date.now(),
                 firstSeenAt: Date.now(),
               },
+              {
+                id: "env-offline",
+                connectionId: null,
+                deviceId: "device-offline",
+                connectionName: "Offline Laptop",
+                organizationId: "org-1",
+                podId: null,
+                connectedAt: null,
+                lastHeartbeat: null,
+                lastSeenAt: Date.now(),
+                firstSeenAt: Date.now(),
+              },
             ],
             hasNextPage: false,
           };

--- a/src/cli/subcommands/teleport.ts
+++ b/src/cli/subcommands/teleport.ts
@@ -2,6 +2,7 @@ import { parseArgs } from "node:util";
 import { isLocalAgentId } from "@/agent/agent-id";
 import {
   type EnvironmentConnection,
+  isEnvironmentOnline,
   listEnvironments,
   resolveAgentSandboxConnectionId,
   resolveEnvironmentConnectionId,
@@ -182,7 +183,11 @@ export async function runTeleportSubcommand(
       const list = deps.listEnvironments ?? listEnvironments;
       const result = await list({ limit: 100, onlineOnly: true });
       const connections = result.connections
-        .filter(isTeleportableRemoteEnvironment)
+        .filter(
+          (environment) =>
+            isEnvironmentOnline(environment) &&
+            isTeleportableRemoteEnvironment(environment),
+        )
         .map(formatEnvironmentForList);
       console.log(JSON.stringify({ ...result, connections }, null, 2));
       return 0;

--- a/src/cli/subcommands/teleport.ts
+++ b/src/cli/subcommands/teleport.ts
@@ -1,0 +1,233 @@
+import { parseArgs } from "node:util";
+import { isLocalAgentId } from "@/agent/agent-id";
+import {
+  type EnvironmentConnection,
+  getRuntimeLastEnvironment,
+  listEnvironments,
+  resolveAgentSandboxConnectionId,
+  resolveEnvironmentConnectionId,
+  teleportToEnvironment,
+} from "@/backend/api/environments";
+import { ApiRequestError } from "@/backend/api/request";
+import { type SessionRef, settingsManager } from "@/settings-manager";
+
+interface TeleportSubcommandDeps {
+  initializeSettings?: () => Promise<void>;
+  getLastSession?: () => SessionRef | null;
+  listEnvironments?: typeof listEnvironments;
+  resolveEnvironmentConnectionId?: typeof resolveEnvironmentConnectionId;
+  resolveAgentSandboxConnectionId?: typeof resolveAgentSandboxConnectionId;
+  getRuntimeLastEnvironment?: typeof getRuntimeLastEnvironment;
+  teleportToEnvironment?: typeof teleportToEnvironment;
+}
+
+const TELEPORT_OPTIONS = {
+  help: { type: "boolean", short: "h" },
+} as const;
+
+function printUsage(): void {
+  console.log(
+    `
+Usage:
+  letta teleport list
+  letta teleport cloud
+  letta teleport back
+  letta teleport <environment>
+
+Notes:
+  - Operates on the current agent/conversation from LETTA_AGENT_ID /
+    LETTA_CONVERSATION_ID (or AGENT_ID / CONVERSATION_ID), falling back to the
+    last active session.
+  - Requires a Letta Cloud agent and a non-virtual conversation.
+  - list: prints accessible online environments as JSON.
+  - cloud: teleports to the agent's Cloud sandbox.
+  - back: teleports to the last online prior environment.
+  - <environment>: teleports to a specific environment by name, device-id,
+    connection-id, or environment id.
+  - Output is JSON only.
+`.trim(),
+  );
+}
+
+function parseTeleportArgs(argv: string[]) {
+  return parseArgs({
+    args: argv,
+    options: TELEPORT_OPTIONS,
+    strict: true,
+    allowPositionals: true,
+  });
+}
+
+function getEnvironmentSession(env: NodeJS.ProcessEnv): SessionRef | null {
+  const agentId = (env.LETTA_AGENT_ID || env.AGENT_ID || "").trim();
+  const conversationId = (
+    env.LETTA_CONVERSATION_ID ||
+    env.CONVERSATION_ID ||
+    ""
+  ).trim();
+  if (!agentId && !conversationId) return null;
+  if (!agentId || !conversationId) {
+    throw new Error(
+      "Both agent and conversation context are required when either is set",
+    );
+  }
+  return { agentId, conversationId };
+}
+
+export function resolveTeleportSession(
+  env: NodeJS.ProcessEnv,
+  fallback: SessionRef | null,
+): SessionRef {
+  const session = getEnvironmentSession(env) ?? fallback;
+  if (!session) {
+    throw new Error("No active agent conversation found");
+  }
+  if (isLocalAgentId(session.agentId)) {
+    throw new Error("Teleport requires a Letta Cloud agent");
+  }
+  if (
+    !session.conversationId ||
+    session.conversationId === "default" ||
+    session.conversationId === "new"
+  ) {
+    throw new Error("Teleport requires an active conversation");
+  }
+  return session;
+}
+
+/**
+ * Parse an API error response body `{errorCode, message}` and return a
+ * concrete, human-readable message. Falls back to the raw response text
+ * when the body is not valid JSON or doesn't match the expected shape.
+ */
+export function formatTeleportApiError(error: unknown): string {
+  if (error instanceof ApiRequestError) {
+    try {
+      const body = JSON.parse(error.responseText) as {
+        errorCode?: string;
+        message?: string;
+      };
+      if (typeof body.message === "string" && body.message.length > 0) {
+        return body.message;
+      }
+      if (typeof body.errorCode === "string" && body.errorCode.length > 0) {
+        return body.errorCode;
+      }
+    } catch {
+      // Fall through to raw response text
+    }
+    return `API error (${error.status}): ${error.responseText}`;
+  }
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return String(error);
+}
+
+function formatEnvironmentForList(
+  environment: EnvironmentConnection,
+): Record<string, unknown> {
+  return {
+    deviceId: environment.deviceId,
+    connectionName: environment.connectionName,
+    connectionId: environment.connectionId ?? null,
+  };
+}
+
+async function initializeTeleportSettings(): Promise<void> {
+  await settingsManager.initialize();
+  await settingsManager.loadLocalProjectSettings();
+}
+
+export async function runTeleportSubcommand(
+  argv: string[],
+  deps: TeleportSubcommandDeps = {},
+): Promise<number> {
+  let parsed: ReturnType<typeof parseTeleportArgs>;
+  try {
+    parsed = parseTeleportArgs(argv);
+  } catch (error) {
+    console.error(`Error: ${error instanceof Error ? error.message : error}`);
+    printUsage();
+    return 1;
+  }
+
+  const [action] = parsed.positionals;
+  if (parsed.values.help || !action || action === "help") {
+    printUsage();
+    return 0;
+  }
+
+  const knownActions = ["list", "cloud", "back"];
+  const isEnvironmentSelector = !knownActions.includes(action);
+
+  try {
+    await (deps.initializeSettings ?? initializeTeleportSettings)();
+
+    if (action === "list") {
+      const list = deps.listEnvironments ?? listEnvironments;
+      const result = await list({ limit: 100, onlineOnly: true });
+      const connections = result.connections.map(formatEnvironmentForList);
+      console.log(JSON.stringify({ ...result, connections }, null, 2));
+      return 0;
+    }
+
+    // cloud, back, and <environment> all need a valid session
+    const session = resolveTeleportSession(
+      process.env,
+      (
+        deps.getLastSession ?? (() => settingsManager.getEffectiveLastSession())
+      )(),
+    );
+
+    let targetConnectionId: string;
+
+    if (action === "cloud") {
+      const resolve =
+        deps.resolveAgentSandboxConnectionId ?? resolveAgentSandboxConnectionId;
+      const result = await resolve(session.agentId, {
+        conversationId: session.conversationId,
+      });
+      targetConnectionId = result.connectionId;
+    } else if (action === "back") {
+      const getLast =
+        deps.getRuntimeLastEnvironment ?? getRuntimeLastEnvironment;
+      const lastEnv = await getLast(session.agentId, session.conversationId);
+      if (!lastEnv) {
+        throw new Error("No prior environment found to teleport back to");
+      }
+      if (!lastEnv.isOnline) {
+        throw new Error(
+          `Prior environment "${lastEnv.connectionName}" is offline`,
+        );
+      }
+      // Verify it's online via resolveEnvironmentConnectionId
+      const resolve =
+        deps.resolveEnvironmentConnectionId ?? resolveEnvironmentConnectionId;
+      const resolved = await resolve(lastEnv.deviceId);
+      targetConnectionId = resolved.connectionId;
+    } else if (isEnvironmentSelector) {
+      const resolve =
+        deps.resolveEnvironmentConnectionId ?? resolveEnvironmentConnectionId;
+      const resolved = await resolve(action);
+      targetConnectionId = resolved.connectionId;
+    } else {
+      console.error(`Unknown action: ${action}`);
+      printUsage();
+      return 1;
+    }
+
+    const teleport = deps.teleportToEnvironment ?? teleportToEnvironment;
+    const result = await teleport(
+      session.agentId,
+      session.conversationId,
+      targetConnectionId,
+    );
+    // Submit-and-exit immediately after 202; the harness owns yield
+    console.log(JSON.stringify(result, null, 2));
+    return 0;
+  } catch (error) {
+    console.error(`Error: ${formatTeleportApiError(error)}`);
+    return 1;
+  }
+}

--- a/src/cli/subcommands/teleport.ts
+++ b/src/cli/subcommands/teleport.ts
@@ -2,7 +2,6 @@ import { parseArgs } from "node:util";
 import { isLocalAgentId } from "@/agent/agent-id";
 import {
   type EnvironmentConnection,
-  getRuntimeLastEnvironment,
   listEnvironments,
   resolveAgentSandboxConnectionId,
   resolveEnvironmentConnectionId,
@@ -17,7 +16,6 @@ interface TeleportSubcommandDeps {
   listEnvironments?: typeof listEnvironments;
   resolveEnvironmentConnectionId?: typeof resolveEnvironmentConnectionId;
   resolveAgentSandboxConnectionId?: typeof resolveAgentSandboxConnectionId;
-  getRuntimeLastEnvironment?: typeof getRuntimeLastEnvironment;
   teleportToEnvironment?: typeof teleportToEnvironment;
 }
 
@@ -31,7 +29,6 @@ function printUsage(): void {
 Usage:
   letta teleport list
   letta teleport cloud
-  letta teleport back
   letta teleport <environment>
 
 Notes:
@@ -39,11 +36,12 @@ Notes:
     LETTA_CONVERSATION_ID (or AGENT_ID / CONVERSATION_ID), falling back to the
     last active session.
   - Requires a Letta Cloud agent and a non-virtual conversation.
-  - list: prints accessible online environments as JSON.
+  - list: prints accessible online remote environments as JSON.
   - cloud: teleports to the agent's Cloud sandbox.
-  - back: teleports to the last online prior environment.
-  - <environment>: teleports to a specific environment by name, device-id,
-    connection-id, or environment id.
+  - <environment>: teleports to a specific remote environment by name,
+    device-id, connection-id, or environment id.
+  - Desktop Local is not a teleport target yet. Use the Desktop environment
+    picker to switch back to Local.
   - Output is JSON only.
 `.trim(),
   );
@@ -134,6 +132,25 @@ function formatEnvironmentForList(
   };
 }
 
+function isTeleportableRemoteEnvironment(
+  environment: EnvironmentConnection,
+): boolean {
+  return (
+    environment.organizationId !== "local" &&
+    !environment.connectionId?.startsWith("local-")
+  );
+}
+
+function assertTeleportableRemoteEnvironment(
+  environment: EnvironmentConnection,
+): void {
+  if (!isTeleportableRemoteEnvironment(environment)) {
+    throw new Error(
+      "Desktop Local is not a teleport target yet. Use the Desktop environment picker to switch back to Local.",
+    );
+  }
+}
+
 async function initializeTeleportSettings(): Promise<void> {
   await settingsManager.initialize();
   await settingsManager.loadLocalProjectSettings();
@@ -158,21 +175,20 @@ export async function runTeleportSubcommand(
     return 0;
   }
 
-  const knownActions = ["list", "cloud", "back"];
-  const isEnvironmentSelector = !knownActions.includes(action);
-
   try {
     await (deps.initializeSettings ?? initializeTeleportSettings)();
 
     if (action === "list") {
       const list = deps.listEnvironments ?? listEnvironments;
       const result = await list({ limit: 100, onlineOnly: true });
-      const connections = result.connections.map(formatEnvironmentForList);
+      const connections = result.connections
+        .filter(isTeleportableRemoteEnvironment)
+        .map(formatEnvironmentForList);
       console.log(JSON.stringify({ ...result, connections }, null, 2));
       return 0;
     }
 
-    // cloud, back, and <environment> all need a valid session
+    // cloud and <environment> both need a valid session
     const session = resolveTeleportSession(
       process.env,
       (
@@ -190,31 +206,15 @@ export async function runTeleportSubcommand(
       });
       targetConnectionId = result.connectionId;
     } else if (action === "back") {
-      const getLast =
-        deps.getRuntimeLastEnvironment ?? getRuntimeLastEnvironment;
-      const lastEnv = await getLast(session.agentId, session.conversationId);
-      if (!lastEnv) {
-        throw new Error("No prior environment found to teleport back to");
-      }
-      if (!lastEnv.isOnline) {
-        throw new Error(
-          `Prior environment "${lastEnv.connectionName}" is offline`,
-        );
-      }
-      // Verify it's online via resolveEnvironmentConnectionId
-      const resolve =
-        deps.resolveEnvironmentConnectionId ?? resolveEnvironmentConnectionId;
-      const resolved = await resolve(lastEnv.deviceId);
-      targetConnectionId = resolved.connectionId;
-    } else if (isEnvironmentSelector) {
+      throw new Error(
+        "Teleport back is not supported yet. Use the Desktop environment picker to switch back to Local.",
+      );
+    } else {
       const resolve =
         deps.resolveEnvironmentConnectionId ?? resolveEnvironmentConnectionId;
       const resolved = await resolve(action);
+      assertTeleportableRemoteEnvironment(resolved.environment);
       targetConnectionId = resolved.connectionId;
-    } else {
-      console.error(`Unknown action: ${action}`);
-      printUsage();
-      return 1;
     }
 
     const teleport = deps.teleportToEnvironment ?? teleportToEnvironment;

--- a/src/index.ts
+++ b/src/index.ts
@@ -208,7 +208,7 @@ SUBCOMMANDS
   letta agents list [--query <text> | --name <name> | --tags <tags>]
   letta environments list [--online-only]
   letta environments current
-  letta teleport list|cloud|back|<environment>
+  letta teleport list|cloud|<environment>
   letta messages search --query <text> [--all-agents]
   letta messages list [--agent <id>]
   letta messages transcript --conversation <id> [--out <path>]

--- a/src/index.ts
+++ b/src/index.ts
@@ -181,6 +181,7 @@ USAGE
   letta memory ...      Memory filesystem subcommands
   letta agents ...      Agents subcommands (JSON-only)
   letta environments ... List available remote environments (JSON-only)
+  letta teleport ...    Move the current conversation between environments
   letta messages ...    Messages subcommands (JSON-only)
   letta mods ...        List and manage local mods
   letta sandbox ...     Transfer files to or from the current Cloud sandbox
@@ -207,6 +208,7 @@ SUBCOMMANDS
   letta agents list [--query <text> | --name <name> | --tags <tags>]
   letta environments list [--online-only]
   letta environments current
+  letta teleport list|cloud|back|<environment>
   letta messages search --query <text> [--all-agents]
   letta messages list [--agent <id>]
   letta messages transcript --conversation <id> [--out <path>]

--- a/src/types/protocol_v2.ts
+++ b/src/types/protocol_v2.ts
@@ -45,11 +45,13 @@ import type {
 } from "./external-tool-protocol";
 import type { RuntimeScope } from "./runtime-scope";
 import type { CronRunLogPage, CronTask } from "./schedule-protocol";
+import type * as TeleportProtocol from "./teleport-protocol";
 
 export type * from "./background-process-protocol";
 export type * from "./external-tool-protocol";
 export type * from "./runtime-scope";
 export type * from "./schedule-protocol";
+export type * from "./teleport-protocol";
 
 export type DmPolicy = "pairing" | "allowlist" | "open";
 
@@ -679,18 +681,14 @@ export interface InputCreateMessagePayload {
 export type InputApprovalResponsePayload = {
   kind: "approval_response";
 } & ApprovalResponseBody;
-
 export type InputPayload =
   | InputCreateMessagePayload
-  | InputApprovalResponsePayload;
+  | InputApprovalResponsePayload
+  | TeleportProtocol.InputTeleportContinuePayload;
 
 export interface InputCommand {
   type: "input";
-  /**
-   * Optional correlation id. When present, the listener acknowledges that the
-   * input was accepted into its normal dispatch/queue path without waiting for
-   * the turn to finish.
-   */
+  /** Correlates acknowledgement without waiting for the turn to finish. */
   request_id?: string;
   runtime: RuntimeScope;
   payload: InputPayload;
@@ -2688,6 +2686,7 @@ export type WsProtocolCommand =
   | AbortMessageCommand
   | SyncCommand
   | RuntimeStartCommand
+  | TeleportProtocol.TeleportProtocolCommand
   | RuntimeExternalToolsUpdateCommand
   | ExternalToolCallResponseCommand
   | TerminalSpawnCommand
@@ -2781,6 +2780,7 @@ export type WsProtocolCommandType = WsProtocolCommand["type"];
 export type WsProtocolMessage =
   | ControlRequest
   | InputAcceptedResponseMessage
+  | TeleportProtocol.TeleportProtocolMessage
   | ExecuteCommandResponseMessage
   | DeviceStatusUpdateMessage
   | LoopStatusUpdateMessage

--- a/src/types/teleport-protocol.ts
+++ b/src/types/teleport-protocol.ts
@@ -1,0 +1,67 @@
+import type { ApprovalCreate } from "@letta-ai/letta-client/resources/agents/messages";
+import type { RuntimeScope } from "./runtime-scope";
+
+export interface TeleportContinuation {
+  approvals: NonNullable<ApprovalCreate["approvals"]>;
+}
+
+export interface InputTeleportContinuePayload {
+  kind: "teleport_continue";
+  teleport_id: string;
+  source: {
+    device_id: string;
+    connection_name: string;
+  };
+  continuation?: TeleportContinuation;
+}
+
+export interface TeleportProbeCommand {
+  type: "teleport_probe";
+  request_id: string;
+  runtime: RuntimeScope;
+}
+
+export interface TeleportRequestCommand {
+  type: "teleport_request";
+  request_id: string;
+  teleport_id: string;
+  runtime: RuntimeScope;
+  target: {
+    connection_id: string;
+    device_id: string;
+    connection_name: string;
+  };
+}
+
+export interface TeleportFailedCommand {
+  type: "teleport_failed";
+  teleport_id: string;
+  runtime: RuntimeScope;
+  error: string;
+}
+
+export type TeleportProtocolCommand =
+  | TeleportProbeCommand
+  | TeleportRequestCommand
+  | TeleportFailedCommand;
+
+export interface TeleportProbeResponseMessage {
+  type: "teleport_probe_response";
+  request_id: string;
+  runtime: RuntimeScope;
+  supported: true;
+}
+
+export interface TeleportReadyMessage {
+  type: "teleport_ready";
+  teleport_id: string;
+  runtime: RuntimeScope;
+  success: boolean;
+  mode?: "standard" | "acceptEdits" | "unrestricted" | "strict";
+  continuation?: TeleportContinuation;
+  error?: string;
+}
+
+export type TeleportProtocolMessage =
+  | TeleportProbeResponseMessage
+  | TeleportReadyMessage;

--- a/src/websocket/listener/message-router.ts
+++ b/src/websocket/listener/message-router.ts
@@ -63,6 +63,11 @@ import {
 } from "./queue";
 import { emitLoopErrorNotice } from "./recoverable-notices";
 import { getActiveRuntime, safeEmitWsEvent } from "./runtime";
+import {
+  handleTeleportProbe,
+  handleTeleportRequest,
+  takeFailedTeleport,
+} from "./teleport";
 import type { ListenerTransport } from "./transport";
 import { handleIncomingMessage } from "./turn";
 import type {
@@ -269,6 +274,59 @@ export function createListenerMessageHandler(
         return;
       }
 
+      if (parsed.type === "teleport_probe") {
+        handleTeleportProbe(parsed, socket, safeSocketSend);
+        return;
+      }
+
+      if (parsed.type === "teleport_request") {
+        handleTeleportRequest({
+          listener: runtime,
+          command: parsed,
+          connectionId,
+        });
+        return;
+      }
+
+      if (parsed.type === "teleport_failed") {
+        const pending = takeFailedTeleport({
+          listener: runtime,
+          teleportId: parsed.teleport_id,
+          agentId: parsed.runtime.agent_id,
+          conversationId: parsed.runtime.conversation_id,
+        });
+        const approvals = pending?.continuation?.approvals;
+        if (pending && approvals && approvals.length > 0) {
+          const scopedRuntime = getOrCreateScopedRuntime(
+            runtime,
+            pending.agentId,
+            pending.conversationId,
+          );
+          runDetachedListenerTask("teleport_failed", async () => {
+            await processIncomingMessage(
+              {
+                type: "message",
+                connectionId: pending.connectionId,
+                agentId: pending.agentId,
+                conversationId: pending.conversationId,
+                messages: [
+                  {
+                    type: "approval",
+                    approvals,
+                    otid: crypto.randomUUID(),
+                  },
+                ],
+              },
+              socket,
+              scopedRuntime,
+              opts.onStatusChange,
+              pending.connectionId,
+            );
+          });
+        }
+        return;
+      }
+
       if (parsed.type === "external_tool_call_response") {
         handleExternalToolCallResponseCommand(runtime, connectionId, parsed);
         return;
@@ -380,6 +438,59 @@ export function createListenerMessageHandler(
         if (runtime !== getActiveRuntime() || runtime.intentionallyClosed) {
           console.log(`[Listen V2] Dropping input: runtime mismatch or closed`);
           acknowledgeInput(false, "Runtime is no longer active");
+          return;
+        }
+
+        if (parsed.payload.kind === "teleport_continue") {
+          const scopedRuntime = getOrCreateScopedRuntime(
+            runtime,
+            parsed.runtime.agent_id,
+            parsed.runtime.conversation_id,
+          );
+          const acceptedKey = `teleport:${parsed.payload.teleport_id}`;
+          const previousDisposition =
+            scopedRuntime.acceptedInputDispositions.get(acceptedKey);
+          if (previousDisposition) {
+            acknowledgeInput(true, undefined, previousDisposition);
+            return;
+          }
+
+          const approvals = parsed.payload.continuation?.approvals;
+          if (!approvals || approvals.length === 0) {
+            acknowledgeInput(true);
+            return;
+          }
+          if (scopedRuntime.isProcessing) {
+            acknowledgeInput(
+              false,
+              "Destination runtime is already processing",
+            );
+            return;
+          }
+
+          scopedRuntime.acceptedInputDispositions.set(acceptedKey, "started");
+          acknowledgeInput(true, undefined, "started");
+          runDetachedListenerTask("teleport_continue", async () => {
+            await processIncomingMessage(
+              {
+                type: "message",
+                connectionId,
+                agentId: parsed.runtime.agent_id,
+                conversationId: parsed.runtime.conversation_id,
+                messages: [
+                  {
+                    type: "approval",
+                    approvals,
+                    otid: crypto.randomUUID(),
+                  },
+                ],
+              },
+              socket,
+              scopedRuntime,
+              opts.onStatusChange,
+              connectionId,
+            );
+          });
           return;
         }
 

--- a/src/websocket/listener/protocol-ergonomics.test.ts
+++ b/src/websocket/listener/protocol-ergonomics.test.ts
@@ -131,6 +131,109 @@ describe("listener protocol ergonomics", () => {
     });
   });
 
+  test("teleport probe advertises listener support", async () => {
+    const runtime = __listenClientTestUtils.createListenerRuntime();
+    const sent: unknown[] = [];
+
+    await makeHandler(
+      runtime,
+      sent,
+    )(
+      Buffer.from(
+        JSON.stringify({
+          type: "teleport_probe",
+          request_id: "probe-1",
+          runtime: { agent_id: "agent-1", conversation_id: "conv-1" },
+        }),
+      ),
+    );
+
+    expect(sent).toContainEqual({
+      type: "teleport_probe_response",
+      request_id: "probe-1",
+      runtime: { agent_id: "agent-1", conversation_id: "conv-1" },
+      supported: true,
+    });
+  });
+
+  test("teleport continuation resumes with tool results and no user message", async () => {
+    const runtime = __listenClientTestUtils.createListenerRuntime();
+    const conversationRuntime =
+      __listenClientTestUtils.getOrCreateScopedRuntime(
+        runtime,
+        "agent-1",
+        "conv-1",
+      );
+    const sent: unknown[] = [];
+    const receivedIncoming: IncomingMessage[] = [];
+    const processIncomingMessage = mock(async (incoming: IncomingMessage) => {
+      receivedIncoming.push(incoming);
+    });
+    let detachedTask: Promise<void> | null = null;
+    __listenClientTestUtils.setActiveRuntime(runtime);
+
+    await makeHandler(runtime, sent, {
+      getParsedRuntimeScope: () => ({
+        agent_id: "agent-1",
+        conversation_id: "conv-1",
+      }),
+      getOrCreateScopedRuntime: () => conversationRuntime,
+      processIncomingMessage,
+      runDetachedListenerTask: (_name, task) => {
+        detachedTask = task();
+      },
+    })(
+      Buffer.from(
+        JSON.stringify({
+          type: "input",
+          request_id: "continue-1",
+          runtime: { agent_id: "agent-1", conversation_id: "conv-1" },
+          payload: {
+            kind: "teleport_continue",
+            teleport_id: "teleport-1",
+            source: {
+              device_id: "source-device",
+              connection_name: "Laptop",
+            },
+            continuation: {
+              approvals: [
+                {
+                  type: "tool",
+                  tool_call_id: "call-1",
+                  status: "success",
+                  tool_return: "done",
+                },
+              ],
+            },
+          },
+        }),
+      ),
+    );
+    await detachedTask;
+
+    expect(sent).toContainEqual({
+      type: "input_accepted",
+      request_id: "continue-1",
+      runtime: { agent_id: "agent-1", conversation_id: "conv-1" },
+      accepted: true,
+      disposition: "started",
+    });
+    const incoming = receivedIncoming[0];
+    expect(incoming?.messages).toHaveLength(1);
+    expect(incoming?.messages[0]).toMatchObject({
+      type: "approval",
+      approvals: [
+        {
+          type: "tool",
+          tool_call_id: "call-1",
+          status: "success",
+          tool_return: "done",
+        },
+      ],
+    });
+    expect(incoming?.messages.some((message) => "role" in message)).toBe(false);
+  });
+
   test("sync request_id gets a failure response when the listener is inactive", async () => {
     const runtime = __listenClientTestUtils.createListenerRuntime();
     const sent: unknown[] = [];

--- a/src/websocket/listener/protocol-inbound.test.ts
+++ b/src/websocket/listener/protocol-inbound.test.ts
@@ -65,6 +65,89 @@ describe("input protocol-inbound validators", () => {
       );
     }
   });
+
+  test("accepts a teleport continuation without a synthetic user message", () => {
+    const parsed = parseServerMessage(
+      Buffer.from(
+        JSON.stringify({
+          type: "input",
+          request_id: "continue-1",
+          runtime: { agent_id: "agent-1", conversation_id: "conv-1" },
+          payload: {
+            kind: "teleport_continue",
+            teleport_id: "teleport-1",
+            source: {
+              device_id: "source-device",
+              connection_name: "Laptop",
+            },
+            continuation: {
+              approvals: [
+                {
+                  type: "tool",
+                  tool_call_id: "call-1",
+                  status: "success",
+                  tool_return: "done",
+                },
+              ],
+            },
+          },
+        }),
+      ),
+    );
+
+    expect(parsed?.type).toBe("input");
+    if (parsed?.type === "input") {
+      expect(parsed.payload.kind).toBe("teleport_continue");
+    }
+  });
+
+  test("rejects a teleport continuation without source identity", () => {
+    const parsed = parseServerMessage(
+      Buffer.from(
+        JSON.stringify({
+          type: "input",
+          runtime: { agent_id: "agent-1", conversation_id: "conv-1" },
+          payload: {
+            kind: "teleport_continue",
+            teleport_id: "teleport-1",
+          },
+        }),
+      ),
+    );
+
+    expect(parsed?.type).toBe("__invalid_input");
+  });
+});
+
+describe("teleport protocol-inbound validators", () => {
+  test.each([
+    {
+      type: "teleport_probe",
+      request_id: "probe-1",
+      runtime: { agent_id: "agent-1", conversation_id: "conv-1" },
+    },
+    {
+      type: "teleport_request",
+      request_id: "teleport-1",
+      teleport_id: "teleport-1",
+      runtime: { agent_id: "agent-1", conversation_id: "conv-1" },
+      target: {
+        connection_id: "target-connection",
+        device_id: "target-device",
+        connection_name: "Cloud",
+      },
+    },
+    {
+      type: "teleport_failed",
+      teleport_id: "teleport-1",
+      runtime: { agent_id: "agent-1", conversation_id: "conv-1" },
+      error: "Target failed to start",
+    },
+  ])("accepts $type", (message) => {
+    expect(parseServerMessage(Buffer.from(JSON.stringify(message)))?.type).toBe(
+      message.type,
+    );
+  });
 });
 
 describe("update model protocol-inbound validator", () => {

--- a/src/websocket/listener/protocol-inbound.ts
+++ b/src/websocket/listener/protocol-inbound.ts
@@ -124,17 +124,22 @@ import {
   isAppServerInfoCommand,
   isConversationForkCommand,
 } from "./management-protocol-inbound";
+import {
+  isObjectRecord,
+  isRuntimeScope,
+  isStringArray,
+  isStringRecord,
+} from "./protocol-validation";
+import {
+  isTeleportContinuePayload,
+  parseTeleportCommand,
+} from "./teleport-protocol-inbound";
 import type { InvalidInputCommand, ParsedServerMessage } from "./types";
 
 export type ServerLifecycleMessage = {
   type: "pong";
 };
 
-function isStringArray(value: unknown): value is string[] {
-  return (
-    Array.isArray(value) && value.every((item) => typeof item === "string")
-  );
-}
 const TOOLSET_PREFERENCES = new Set([
   "auto",
   "codex",
@@ -152,32 +157,6 @@ function isClientToolsetConfig(value: unknown): value is ClientToolsetConfig {
       (typeof value.base === "string" &&
         TOOLSET_PREFERENCES.has(value.base))) &&
     (value.include === undefined || isStringArray(value.include))
-  );
-}
-
-function isStringRecord(value: unknown): value is Record<string, string> {
-  return (
-    !!value &&
-    typeof value === "object" &&
-    !Array.isArray(value) &&
-    Object.values(value).every((item) => typeof item === "string")
-  );
-}
-
-function isObjectRecord(value: unknown): value is Record<string, unknown> {
-  return !!value && typeof value === "object" && !Array.isArray(value);
-}
-
-function isRuntimeScope(value: unknown): value is RuntimeScope {
-  if (!value || typeof value !== "object") {
-    return false;
-  }
-  const candidate = value as { agent_id?: unknown; conversation_id?: unknown };
-  return (
-    typeof candidate.agent_id === "string" &&
-    candidate.agent_id.length > 0 &&
-    typeof candidate.conversation_id === "string" &&
-    candidate.conversation_id.length > 0
   );
 }
 
@@ -235,6 +214,9 @@ function isInputCommand(value: unknown): value is InputCommand {
   }
   if (payload.kind === "approval_response") {
     return isValidApprovalResponseBody(payload);
+  }
+  if (payload.kind === "teleport_continue") {
+    return isTeleportContinuePayload(payload);
   }
   return false;
 }
@@ -392,6 +374,16 @@ function getInvalidInputReason(value: unknown): {
         runtime: candidate.runtime,
         reason:
           "Protocol violation: input.kind=approval_response requires payload.request_id and either payload.decision or payload.error",
+      };
+    }
+    return null;
+  }
+  if (payload.kind === "teleport_continue") {
+    if (!isTeleportContinuePayload(payload)) {
+      return {
+        runtime: candidate.runtime,
+        reason:
+          "Protocol violation: input.kind=teleport_continue requires teleport_id, source, and optional continuation.approvals[]",
       };
     }
     return null;
@@ -2152,6 +2144,8 @@ export function parseServerMessage(
     if (legacyInput) {
       return legacyInput;
     }
+    const teleportCommand = parseTeleportCommand(parsed);
+    if (teleportCommand) return teleportCommand;
     if (
       isInputCommand(parsed) ||
       isChangeDeviceStateCommand(parsed) ||

--- a/src/websocket/listener/protocol-validation.ts
+++ b/src/websocket/listener/protocol-validation.ts
@@ -1,0 +1,35 @@
+import type { RuntimeScope } from "@/types/runtime-scope";
+
+export function isStringArray(value: unknown): value is string[] {
+  return (
+    Array.isArray(value) && value.every((item) => typeof item === "string")
+  );
+}
+
+export function isStringRecord(
+  value: unknown,
+): value is Record<string, string> {
+  return (
+    !!value &&
+    typeof value === "object" &&
+    !Array.isArray(value) &&
+    Object.values(value).every((item) => typeof item === "string")
+  );
+}
+
+export function isObjectRecord(
+  value: unknown,
+): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+export function isRuntimeScope(value: unknown): value is RuntimeScope {
+  if (!value || typeof value !== "object") return false;
+  const candidate = value as { agent_id?: unknown; conversation_id?: unknown };
+  return (
+    typeof candidate.agent_id === "string" &&
+    candidate.agent_id.length > 0 &&
+    typeof candidate.conversation_id === "string" &&
+    candidate.conversation_id.length > 0
+  );
+}

--- a/src/websocket/listener/teleport-protocol-inbound.ts
+++ b/src/websocket/listener/teleport-protocol-inbound.ts
@@ -1,0 +1,49 @@
+import type {
+  InputTeleportContinuePayload,
+  TeleportProtocolCommand,
+} from "@/types/teleport-protocol";
+import { isObjectRecord, isRuntimeScope } from "./protocol-validation";
+
+export function isTeleportContinuePayload(
+  value: unknown,
+): value is InputTeleportContinuePayload {
+  if (!isObjectRecord(value) || !isObjectRecord(value.source)) return false;
+  return (
+    value.kind === "teleport_continue" &&
+    typeof value.teleport_id === "string" &&
+    value.teleport_id.length > 0 &&
+    typeof value.source.device_id === "string" &&
+    typeof value.source.connection_name === "string" &&
+    (value.continuation === undefined ||
+      (isObjectRecord(value.continuation) &&
+        Array.isArray(value.continuation.approvals)))
+  );
+}
+
+export function parseTeleportCommand(
+  value: unknown,
+): TeleportProtocolCommand | null {
+  if (!isObjectRecord(value) || !isRuntimeScope(value.runtime)) return null;
+  if (value.type === "teleport_probe" && typeof value.request_id === "string") {
+    return value as unknown as TeleportProtocolCommand;
+  }
+  if (
+    value.type === "teleport_request" &&
+    typeof value.request_id === "string" &&
+    typeof value.teleport_id === "string" &&
+    isObjectRecord(value.target) &&
+    typeof value.target.connection_id === "string" &&
+    typeof value.target.device_id === "string" &&
+    typeof value.target.connection_name === "string"
+  ) {
+    return value as unknown as TeleportProtocolCommand;
+  }
+  if (
+    value.type === "teleport_failed" &&
+    typeof value.teleport_id === "string" &&
+    typeof value.error === "string"
+  ) {
+    return value as unknown as TeleportProtocolCommand;
+  }
+  return null;
+}

--- a/src/websocket/listener/teleport.ts
+++ b/src/websocket/listener/teleport.ts
@@ -1,0 +1,246 @@
+import type WebSocket from "ws";
+import type {
+  TeleportContinuation,
+  TeleportProbeCommand,
+  TeleportReadyMessage,
+  TeleportRequestCommand,
+} from "@/types/protocol_v2";
+import { toListenerConnection } from "./connection";
+import { getOrCreateConversationPermissionModeStateRef } from "./permission-mode";
+import {
+  emitProtocolV2Message,
+  emitRuntimeStateUpdates,
+} from "./protocol-outbound";
+import { getConversationRuntime } from "./runtime";
+import { isListenerTransportOpen } from "./transport";
+import type { TurnFinishTransition, TurnLease } from "./turn-lifecycle";
+import type {
+  ConversationRuntime,
+  ListenerConnectionId,
+  ListenerRuntime,
+  PendingTeleport,
+} from "./types";
+
+type SafeSocketSend = (
+  socket: WebSocket,
+  payload: unknown,
+  errorType: string,
+  context: string,
+) => boolean;
+
+const TELEPORT_RECOVERY_TTL_MS = 5 * 60_000;
+
+function getPendingTeleports(
+  runtime: ListenerRuntime,
+): Map<string, PendingTeleport> {
+  runtime.pendingTeleports ??= new Map();
+  return runtime.pendingTeleports;
+}
+
+function findPendingTeleportForRuntime(
+  runtime: ListenerRuntime,
+  agentId: string,
+  conversationId: string,
+): PendingTeleport | null {
+  for (const pending of getPendingTeleports(runtime).values()) {
+    if (
+      pending.agentId === agentId &&
+      pending.conversationId === conversationId &&
+      pending.readyAt === undefined
+    ) {
+      return pending;
+    }
+  }
+  return null;
+}
+
+function sendTeleportReady(
+  runtime: ListenerRuntime,
+  pending: PendingTeleport,
+  input: { success: boolean; error?: string },
+): boolean {
+  const connection = runtime.connections.get(pending.connectionId);
+  if (!connection || !isListenerTransportOpen(connection.writer)) return false;
+
+  const mode = getOrCreateConversationPermissionModeStateRef(
+    runtime,
+    pending.agentId,
+    pending.conversationId,
+  ).mode;
+  const message: TeleportReadyMessage = {
+    type: "teleport_ready",
+    teleport_id: pending.teleportId,
+    runtime: {
+      agent_id: pending.agentId,
+      conversation_id: pending.conversationId,
+    },
+    success: input.success,
+    mode,
+    ...(pending.continuation ? { continuation: pending.continuation } : {}),
+    ...(input.error ? { error: input.error } : {}),
+  };
+  emitProtocolV2Message(
+    connection.writer,
+    runtime,
+    message,
+    message.runtime,
+    toListenerConnection(pending.connectionId),
+  );
+  return true;
+}
+
+function retainTeleportForRecovery(
+  runtime: ListenerRuntime,
+  pending: PendingTeleport,
+): void {
+  const timeout = setTimeout(() => {
+    const current = runtime.pendingTeleports?.get(pending.teleportId);
+    if (current === pending) {
+      runtime.pendingTeleports?.delete(pending.teleportId);
+    }
+  }, TELEPORT_RECOVERY_TTL_MS);
+  timeout.unref?.();
+}
+
+export function handleTeleportProbe(
+  command: TeleportProbeCommand,
+  socket: WebSocket,
+  safeSocketSend: SafeSocketSend,
+): void {
+  safeSocketSend(
+    socket,
+    {
+      type: "teleport_probe_response",
+      request_id: command.request_id,
+      runtime: command.runtime,
+      supported: true,
+    },
+    "teleport_probe_response",
+    "teleport_probe",
+  );
+}
+
+export function handleTeleportRequest(params: {
+  listener: ListenerRuntime;
+  command: TeleportRequestCommand;
+  connectionId: ListenerConnectionId;
+}): void {
+  const { listener, command, connectionId } = params;
+  const pendingTeleports = getPendingTeleports(listener);
+  const existing = pendingTeleports.get(command.teleport_id);
+  if (existing) {
+    if (existing.readyAt !== undefined) {
+      sendTeleportReady(listener, existing, { success: true });
+    }
+    return;
+  }
+
+  const pending: PendingTeleport = {
+    teleportId: command.teleport_id,
+    connectionId,
+    agentId: command.runtime.agent_id,
+    conversationId: command.runtime.conversation_id,
+    requestedAt: Date.now(),
+  };
+  const conflicting = findPendingTeleportForRuntime(
+    listener,
+    pending.agentId,
+    pending.conversationId,
+  );
+  if (conflicting) {
+    pendingTeleports.set(pending.teleportId, pending);
+    pending.readyAt = Date.now();
+    sendTeleportReady(listener, pending, {
+      success: false,
+      error: "Conversation already has a teleport pending",
+    });
+    retainTeleportForRecovery(listener, pending);
+    return;
+  }
+
+  pendingTeleports.set(pending.teleportId, pending);
+  const conversationRuntime = getConversationRuntime(
+    listener,
+    pending.agentId,
+    pending.conversationId,
+  );
+  if (!conversationRuntime?.isProcessing) {
+    if (sendTeleportReady(listener, pending, { success: true })) {
+      pending.readyAt = Date.now();
+      retainTeleportForRecovery(listener, pending);
+    }
+  }
+}
+
+export function claimPendingTeleportAtBoundary(params: {
+  listener: ListenerRuntime;
+  agentId: string;
+  conversationId: string;
+  continuation?: TeleportContinuation;
+}): PendingTeleport | null {
+  const pending = findPendingTeleportForRuntime(
+    params.listener,
+    params.agentId,
+    params.conversationId,
+  );
+  if (!pending) return null;
+  const connection = params.listener.connections.get(pending.connectionId);
+  if (!connection || !isListenerTransportOpen(connection.writer)) return null;
+  pending.readyAt = Date.now();
+  pending.continuation = params.continuation;
+  return pending;
+}
+
+export function emitClaimedTeleportReady(
+  listener: ListenerRuntime,
+  pending: PendingTeleport,
+): boolean {
+  const sent = sendTeleportReady(listener, pending, { success: true });
+  if (sent) {
+    retainTeleportForRecovery(listener, pending);
+  }
+  return sent;
+}
+
+export function finishTeleport(
+  runtime: ConversationRuntime,
+  lease: TurnLease,
+  pending: PendingTeleport,
+): TurnFinishTransition {
+  const transition = runtime.turnLifecycle.finish(lease, "cancelled");
+  if (!transition.finished) return transition;
+  emitRuntimeStateUpdates(runtime, {
+    agent_id: pending.agentId,
+    conversation_id: pending.conversationId,
+  });
+  emitClaimedTeleportReady(runtime.listener, pending);
+  return transition;
+}
+
+export function finishPendingTeleport(runtime: ConversationRuntime): void {
+  if (runtime.lastStopReason !== "end_turn" || !runtime.agentId) return;
+  const pending = claimPendingTeleportAtBoundary({
+    listener: runtime.listener,
+    agentId: runtime.agentId,
+    conversationId: runtime.conversationId,
+  });
+  if (pending) emitClaimedTeleportReady(runtime.listener, pending);
+}
+
+export function takeFailedTeleport(params: {
+  listener: ListenerRuntime;
+  teleportId: string;
+  agentId: string;
+  conversationId: string;
+}): PendingTeleport | null {
+  const pending = params.listener.pendingTeleports?.get(params.teleportId);
+  if (
+    !pending ||
+    pending.agentId !== params.agentId ||
+    pending.conversationId !== params.conversationId
+  ) {
+    return null;
+  }
+  params.listener.pendingTeleports?.delete(params.teleportId);
+  return pending;
+}

--- a/src/websocket/listener/turn-approval.ts
+++ b/src/websocket/listener/turn-approval.ts
@@ -52,6 +52,7 @@ import {
   sendApprovalContinuationWithRetry,
 } from "./send";
 import { injectQueuedSkillContent } from "./skill-injection";
+import { claimPendingTeleportAtBoundary } from "./teleport";
 import { isListenerTransportOpen, type ListenerTransport } from "./transport";
 import {
   createTurnInputState,
@@ -60,7 +61,7 @@ import {
 } from "./turn-input-state";
 import type { TurnLease } from "./turn-lifecycle";
 import { setTurnLoopStatus } from "./turn-status";
-import type { ConversationRuntime } from "./types";
+import type { ConversationRuntime, PendingTeleport } from "./types";
 
 type ApprovalTransportOpenResult = "open" | "interrupted";
 
@@ -106,6 +107,10 @@ export type ApprovalBranchResult =
       stream: Stream<LettaStreamingResponse>;
     } & ApprovalBranchProgress)
   | ({ kind: "interrupted" } & ApprovalBranchProgress)
+  | ({
+      kind: "teleport";
+      pendingTeleport: PendingTeleport;
+    } & ApprovalBranchProgress)
   | ({
       kind: "terminal";
       drainResult: Extract<
@@ -567,6 +572,31 @@ export async function handleApprovalStop(params: {
 
   if (shouldInterrupt()) {
     return interruptTermination();
+  }
+
+  const pendingTeleport = claimPendingTeleportAtBoundary({
+    listener: runtime.listener,
+    agentId,
+    conversationId,
+    continuation: { approvals: persistedExecutionResults },
+  });
+  if (pendingTeleport) {
+    clearPendingApprovalBatchIds(
+      runtime,
+      decisions.map((decision) => decision.approval),
+    );
+    return {
+      kind: "teleport",
+      pendingTeleport,
+      turnInput,
+      dequeuedBatchId,
+      pendingNormalizationInterruptedToolCallIds: [],
+      turnToolContextId,
+      lastExecutionResults,
+      lastExecutingToolCallIds,
+      lastNeedsUserInputToolCallIds,
+      lastApprovalContinuationAccepted: false,
+    };
   }
 
   let nextTurnInput = createTurnInputState([

--- a/src/websocket/listener/turn-lifecycle-integration.test.ts
+++ b/src/websocket/listener/turn-lifecycle-integration.test.ts
@@ -5,12 +5,14 @@ import {
   setConversationId,
   setCurrentAgentId,
 } from "@/agent/context";
+import { openListenerConnection } from "./connection";
 import { getOrCreateScopedRuntime } from "./conversation-runtime";
 import { createRuntime } from "./lifecycle";
 import { getOrCreateConversationPermissionModeStateRef } from "./permission-mode";
 import { shouldProcessInboundMessageDirectly } from "./queue";
 import { finalizeHandledRecoveryTurn } from "./recovery";
 import { clearConversationRuntimeState } from "./runtime";
+import { finishPendingTeleport, handleTeleportRequest } from "./teleport";
 import type { ListenerTransport } from "./transport";
 import { handleApprovalStop } from "./turn-approval";
 import { releaseListenerTurnContext } from "./turn-context";
@@ -23,6 +25,26 @@ function createOpenTransport(sentPayloads: string[] = []): ListenerTransport {
     isOpen: () => true,
     send: (payload: string) => sentPayloads.push(payload),
   };
+}
+
+function openTestConnection(
+  listener: ReturnType<typeof createRuntime>,
+  connectionId: string,
+): void {
+  openListenerConnection({
+    runtime: listener,
+    connectionId,
+    writer: createOpenTransport(),
+    options: {
+      connectionId,
+      wsUrl: "ws://test",
+      deviceId: "device-test",
+      connectionName: "Test",
+      onConnected: () => {},
+      onDisconnected: () => {},
+      onError: () => {},
+    },
+  });
 }
 
 async function waitForPendingApproval(
@@ -213,6 +235,107 @@ describe("listener turn lifecycle integration", () => {
     expect(result.kind).toBe("terminal");
     expect(waitForApprovalTransportOpen).toHaveBeenCalledTimes(0);
     expect(executeApprovalBatch).toHaveBeenCalledTimes(1);
+  });
+
+  test("teleport yields after persisting the current tool result", async () => {
+    const listener = createRuntime();
+    const runtime = getOrCreateScopedRuntime(listener, "agent-1", "conv-1");
+    const turnLease = runtime.turnLifecycle.begin({
+      origin: "message",
+      workingDirectory: process.cwd(),
+      initialStatus: "EXECUTING_CLIENT_SIDE_TOOL",
+    });
+    openTestConnection(listener, "cloud-relay");
+    handleTeleportRequest({
+      listener,
+      connectionId: "cloud-relay",
+      command: {
+        type: "teleport_request",
+        request_id: "teleport-1",
+        teleport_id: "teleport-1",
+        runtime: { agent_id: "agent-1", conversation_id: "conv-1" },
+        target: {
+          connection_id: "target-connection",
+          device_id: "target-device",
+          connection_name: "Cloud",
+        },
+      },
+    });
+    const approval = {
+      toolCallId: "call-teleport",
+      toolName: "Bash",
+      toolArgs: '{"command":"letta teleport cloud"}',
+    };
+    const sendApprovalContinuation = mock(async () => {
+      throw new Error("source must not start another model step");
+    });
+
+    const result = await startQuestionApproval(runtime, turnLease, {
+      approvals: [approval],
+      processOwnedTurn: true,
+      dependencies: {
+        classifyApprovals: async () => ({
+          autoAllowed: [{ approval, parsedArgs: {}, context: null }],
+          autoDenied: [],
+          needsUserInput: [],
+        }),
+        executeApprovalBatch: async () => [
+          {
+            type: "tool" as const,
+            tool_call_id: approval.toolCallId,
+            status: "success" as const,
+            tool_return: '{"status":"waiting_for_source"}',
+          },
+        ],
+        ensureSecretsHydrated: async () => {},
+        sendApprovalContinuation,
+      } as never,
+    });
+
+    expect(result.kind).toBe("teleport");
+    if (result.kind === "teleport") {
+      expect(result.pendingTeleport.continuation?.approvals).toEqual([
+        {
+          type: "tool",
+          tool_call_id: "call-teleport",
+          status: "success",
+          tool_return: '{"status":"waiting_for_source"}',
+        },
+      ]);
+    }
+    expect(sendApprovalContinuation).toHaveBeenCalledTimes(0);
+  });
+
+  test("a text-only turn becomes ready at its end-turn boundary", () => {
+    const listener = createRuntime();
+    const runtime = getOrCreateScopedRuntime(listener, "agent-1", "conv-1");
+    const lease = runtime.turnLifecycle.begin({
+      origin: "message",
+      workingDirectory: process.cwd(),
+    });
+    openTestConnection(listener, "cloud-relay");
+    handleTeleportRequest({
+      listener,
+      connectionId: "cloud-relay",
+      command: {
+        type: "teleport_request",
+        request_id: "teleport-text",
+        teleport_id: "teleport-text",
+        runtime: { agent_id: "agent-1", conversation_id: "conv-1" },
+        target: {
+          connection_id: "target-connection",
+          device_id: "target-device",
+          connection_name: "Cloud",
+        },
+      },
+    });
+
+    runtime.turnLifecycle.finish(lease, "end_turn");
+    finishPendingTeleport(runtime);
+
+    expect(listener.pendingTeleports?.get("teleport-text")?.readyAt).toEqual(
+      expect.any(Number),
+    );
   });
 
   // Guards the gate's polarity and its default. A relay turn's results must

--- a/src/websocket/listener/turn.ts
+++ b/src/websocket/listener/turn.ts
@@ -71,6 +71,7 @@ import {
 import { normalizeCwdAgentId } from "./scope";
 import { markAwaitingAcceptedApprovalContinuationRunId } from "./send";
 import { injectQueuedSkillContent } from "./skill-injection";
+import * as tp from "./teleport";
 import type { ListenerTransport } from "./transport";
 import { handleApprovalStop } from "./turn-approval";
 import { runListenerTurnCleanup } from "./turn-cleanup";
@@ -116,6 +117,7 @@ export async function handleIncomingMessage(
     );
   } finally {
     notifyTurnFinished(msg);
+    tp.finishPendingTeleport(runtime);
   }
 }
 
@@ -147,17 +149,15 @@ async function handleIncomingMessageInner(
     conversationId,
   );
 
+  let postStopApprovalRecoveryRetries = 0,
+    llmApiErrorRetries = 0,
+    emptyResponseRetries = 0,
+    lastApprovalContinuationAccepted = false,
+    activeDequeuedBatchId = dequeuedBatchId;
   const msgRunIds: string[] = [];
-  let postStopApprovalRecoveryRetries = 0;
-  let llmApiErrorRetries = 0;
-  let emptyResponseRetries = 0;
-  let lastApprovalContinuationAccepted = false;
-  let activeDequeuedBatchId = dequeuedBatchId;
-
   let lastExecutionResults: ApprovalResult[] | null = null;
   let lastExecutingToolCallIds: string[] = [];
   let lastNeedsUserInputToolCallIds: string[] = [];
-
   const turnLease =
     existingTurnLease ??
     runtime.turnLifecycle.begin({
@@ -167,17 +167,14 @@ async function handleIncomingMessageInner(
   if (connectionId) {
     runtime.activeConnectionId = connectionId;
   }
-  if (!runtime.turnLifecycle.isCurrent(turnLease)) {
+  if (!runtime.turnLifecycle.isCurrent(turnLease))
     throw new Error("Cannot continue a turn with a stale lifecycle lease");
-  }
   const turnAbortSignal = turnLease.signal;
   let finalizedByThisInvocation = false;
   const noteFinalization = (
     transition: ReturnType<typeof finishListenerTurn>,
   ) => {
-    if (transition.finished) {
-      finalizedByThisInvocation = true;
-    }
+    finalizedByThisInvocation ||= transition.finished;
     return transition;
   };
   const finishTurn = (options: Parameters<typeof finishListenerTurn>[2]) =>
@@ -355,7 +352,6 @@ async function handleIncomingMessageInner(
     let runId: string | undefined;
     const buffers = createBuffers(agentId);
     seedInboundUserTranscriptLines(buffers, inboundUserTranscriptLines);
-
     while (true) {
       runIdSent = false;
       let latestErrorText: string | null = null;
@@ -460,7 +456,6 @@ async function handleIncomingMessageInner(
         break;
       }
       lastApprovalContinuationAccepted = false;
-
       if (stopReason === "end_turn") {
         const transcriptLines = toLines(buffers);
         const completion = await completeSuccessfulListenerTurn({
@@ -852,6 +847,11 @@ async function handleIncomingMessageInner(
       lastApprovalContinuationAccepted =
         approvalResult.lastApprovalContinuationAccepted;
 
+      if (approvalResult.kind === "teleport") {
+        const pending = approvalResult.pendingTeleport;
+        noteFinalization(tp.finishTeleport(runtime, turnLease, pending));
+        return;
+      }
       if (approvalResult.kind === "interrupted") {
         if (runtime.turnLifecycle.isCurrent(turnLease)) {
           populateInterruptQueue(runtime, {

--- a/src/websocket/listener/types.ts
+++ b/src/websocket/listener/types.ts
@@ -27,6 +27,7 @@ import type {
   LoopStatus,
   RuntimeScope,
   StopReasonType,
+  TeleportContinuation,
   WsProtocolCommand,
 } from "@/types/protocol_v2";
 import type {
@@ -135,6 +136,16 @@ export interface PendingExternalToolCall {
   reject: (error: Error) => void;
   timeout: ReturnType<typeof setTimeout>;
 }
+
+export type PendingTeleport = {
+  teleportId: string;
+  connectionId: ListenerConnectionId;
+  agentId: string;
+  conversationId: string;
+  requestedAt: number;
+  readyAt?: number;
+  continuation?: TeleportContinuation;
+};
 
 export interface ModeChangePayload {
   mode: "standard" | "acceptEdits" | "unrestricted" | "strict";
@@ -367,6 +378,8 @@ export type ListenerRuntime = {
   /** Agent IDs whose cached secrets are stale and must re-fetch on the next hydration call. */
   secretsDirtyAgents: Set<string>;
   pendingExternalToolCalls: Map<string, PendingExternalToolCall>;
+  /** Source handoffs retained briefly so a failed destination can resume. */
+  pendingTeleports?: Map<string, PendingTeleport>;
   /**
    * Agent metadata warmups for listen-mode reminders. The cached promise is
    * reused while the listener stays connected so first-turn reminders can join


### PR DESCRIPTION
## Summary
- add `letta teleport list|cloud|<environment>` for the active conversation
- restrict discovery and explicit selectors to Cloud-registered remote targets; Desktop Local remains a manual picker action
- add the listener capability probe and handoff protocol
- yield after persisted tool results, resume without a synthetic user message, and recover on destination failure
- keep working directories device-local during handoff

## Test plan
- `bun test src/backend/api/environments.test.ts src/cli/subcommands/teleport.test.ts src/cli/subcommands/router.test.ts src/websocket/listener/protocol-inbound.test.ts src/websocket/listener/protocol-ergonomics.test.ts src/websocket/listener/turn-lifecycle-integration.test.ts`
- `bun run check`

Linear: [LET-10972](https://linear.app/letta/issue/LET-10972)