### PR TITLE
fix(tools): match Claude Code line-number prefix in Read

### DIFF
--- a/src/tools/impl/read.ts
+++ b/src/tools/impl/read.ts
@@ -147,19 +147,19 @@ function formatWithLineNumbers(
   // Apply per-line character limit (Claude Code: 2000 chars/line)
   let linesWereTruncatedInLength = false;
   const formattedLines = selectedLines.map((line, index) => {
+    // `cat -n`-style prefix: flush-left line number + tab, matching Claude
+    // Code. The separator must stay a literal tab so the Edit tool's
+    // documented "line number + tab" prefix contract holds.
     const lineNumber = actualStartLine + index + 1;
-    const maxLineNumber = actualStartLine + selectedLines.length;
-    const padding = Math.max(1, maxLineNumber.toString().length);
-    const paddedNumber = lineNumber.toString().padStart(padding);
 
     // Truncate long lines
     if (line.length > LIMITS.READ_MAX_CHARS_PER_LINE) {
       linesWereTruncatedInLength = true;
       const truncated = line.slice(0, LIMITS.READ_MAX_CHARS_PER_LINE);
-      return `${paddedNumber}→${truncated}... [line truncated]`;
+      return `${lineNumber}\t${truncated}... [line truncated]`;
     }
 
-    return `${paddedNumber}→${line}`;
+    return `${lineNumber}\t${line}`;
   });
 
   let result = formattedLines.join("\n");

--- a/src/tools/read.test.ts
+++ b/src/tools/read.test.ts
@@ -45,9 +45,32 @@ describe("Read tool", () => {
 
     const result = await read({ file_path: file });
 
-    expect(result.content).toContain("1→Line 1");
-    expect(result.content).toContain("2→Line 2");
-    expect(result.content).toContain("3→Line 3");
+    expect(result.content).toContain("1\tLine 1");
+    expect(result.content).toContain("2\tLine 2");
+    expect(result.content).toContain("3\tLine 3");
+  });
+
+  test("separates line numbers from content with a tab, not an arrow", async () => {
+    testDir = new TestDirectory();
+    const file = testDir.createFile("separator.txt", "alpha\nbravo");
+
+    const result = await read({ file_path: file });
+
+    expect(result.content).not.toContain("→");
+    expect(result.content).toContain("1\talpha");
+  });
+
+  test("keeps line numbers flush-left without padding past nine lines", async () => {
+    testDir = new TestDirectory();
+    const lines = Array.from({ length: 12 }, (_, i) => `line${i + 1}`);
+    const file = testDir.createFile("padding.txt", lines.join("\n"));
+
+    const result = await read({ file_path: file });
+
+    // Claude Code emits `9\tline9` and `10\tline10` with no alignment padding.
+    expect(result.content).toContain("\n9\tline9");
+    expect(result.content).toContain("\n10\tline10");
+    expect(result.content).not.toContain(" 9\tline9");
   });
 
   test("respects offset parameter", async () => {


### PR DESCRIPTION
## Summary

`Read` emitted a right-aligned line number followed by `→` (U+2192). Claude Code emits a flush-left line number followed by a literal tab. Verified against Claude Code 2.1.228 on the same 12-line fixture:

```
letta-code (before)        Claude Code 2.1.228
 9→line9                   9<TAB>line9
10→line10                  10<TAB>line10
```

This is a correctness issue, not just cosmetics. Two tool descriptions already document the Claude Code format:

- `src/tools/descriptions/Edit.md:8` — "The line number prefix format is: spaces + line number + **tab**. Everything after that tab is the actual file content to match."
- `src/tools/descriptions/Read.md:12` / `ReadLSP.md:11` — "Results are returned using `cat -n` format".

`Edit` is exact string replacement with no regex or fuzzy fallback. Telling the model to strip up to a tab that `Read` never emits is how you get an `old_string` with a stray `→` or a swallowed leading space. This aligns the implementation with its own documented contract.

## Changes

- `src/tools/impl/read.ts` — emit `` `${lineNumber}\t${line}` ``; drop the `padStart` alignment. Applies to the truncated-line branch too.
- `src/tools/read.test.ts` — update the three existing prefix assertions; add regression tests asserting the separator is a tab and not `→`, and that numbers stay flush-left across the 9→10 digit boundary.

`ReadLSP` calls `baseRead` from `read.ts`, so it inherits the fix. Nothing parses the prefix with a regex, so there are no other consumers — the arrow appeared only in these two files.

Scoped to `Read`/`ReadLSP` per review. The Codex/Gemini read shims intentionally mirror their own upstreams and are untouched.

## Test plan

- [x] `bun test src/tools/read.test.ts` — 16 pass
- [x] `bun test src/tools/` — 738 pass, 0 fail
- [x] `bun run check` — 12/12
- [x] Byte-level verification via `cat -te`: output is `9^Iline9`, `10^Iline10`

👾 Generated with [Letta Code](https://letta.com)