### PR TITLE
fix(tasks): align TaskUpdate with Anthropic

### DIFF
--- a/src/tools/descriptions/TaskGet.md
+++ b/src/tools/descriptions/TaskGet.md
@@ -6,8 +6,7 @@ Returns the full task record, including `subject`, `description`, `status`, `own
 
 ## Notes
 
-- Works on soft-deleted tasks (`status: "deleted"`) too — `TaskGet` returns the record even though `TaskList` hides it by default.
-- Errors if the task ID doesn't exist.
+- Errors if the task ID doesn't exist or was deleted.
 
 ## Example
 

--- a/src/tools/descriptions/TaskList.md
+++ b/src/tools/descriptions/TaskList.md
@@ -2,7 +2,7 @@
 
 List all tasks in the current session, in creation order.
 
-Soft-deleted tasks (`status: "deleted"`) are excluded from the output. Use `TaskGet` with a specific ID to retrieve a deleted task.
+Tasks removed with `status: "deleted"` are excluded from the output and cannot be retrieved.
 
 ## When to use
 

--- a/src/tools/descriptions/TaskUpdate.md
+++ b/src/tools/descriptions/TaskUpdate.md
@@ -1,51 +1,74 @@
-# TaskUpdate
+Use this tool to update a task in the task list.
 
-Partially update a single task. Only the fields you pass will change; everything else stays intact.
+## When to Use This Tool
 
-## Status transitions
+**Mark tasks as resolved:**
+- When you have completed the work described in a task
+- When a task is no longer needed or has been superseded
+- IMPORTANT: Always mark your assigned tasks as resolved when you finish them
+- After resolving, call TaskList to find your next task
 
-Use the `status` field to move a task through its lifecycle:
+- ONLY mark a task as completed when you have FULLY accomplished it
+- If you encounter errors, blockers, or cannot finish, keep the task as in_progress
+- When blocked, create a new task describing what needs to be resolved
+- Never mark a task as completed if:
+  - Tests are failing
+  - Implementation is partial
+  - You encountered unresolved errors
+  - You couldn't find necessary files or dependencies
 
-- `pending` — not started
-- `in_progress` — actively being worked on (keep only ONE task in this state at a time)
-- `completed` — finished
-- `deleted` — soft-delete; excluded from `TaskList` but still fetchable via `TaskGet`
+**Delete tasks:**
+- When a task is no longer relevant or was created in error
+- Setting status to `deleted` permanently removes the task
 
-Mark a task `completed` **only** when it's fully done — tests pass, implementation is complete, no unresolved errors. If blocked, leave it `in_progress` and create a new task for the blocker (then wire it up via `addBlockedBy`).
+**Update task details:**
+- When requirements change or become clearer
+- When establishing dependencies between tasks
 
-## Editable fields
+## Fields You Can Update
 
-- `subject`, `description`, `activeForm` — full replacements
-- `owner` — assign a string owner (free-form)
-- `addBlocks` — append task IDs that **this task blocks** (they can't start until this one finishes)
-- `addBlockedBy` — append task IDs that **block this task** (they must finish first)
-- `metadata` — merged into existing metadata (existing keys preserved; matching keys overwritten)
+- **status**: The task status (see Status Workflow below)
+- **subject**: Change the task title (imperative form, e.g., "Run tests")
+- **description**: Change the task description
+- **activeForm**: Present continuous form shown in spinner when in_progress (e.g., "Running tests")
+- **owner**: Change the task owner (agent name)
+- **metadata**: Merge metadata keys into the task (set a key to null to delete it)
+- **addBlocks**: Mark tasks that cannot start until this one completes
+- **addBlockedBy**: Mark tasks that must complete before this one can start
 
-## Best practices
+## Status Workflow
 
-- Update status in real-time as you work — don't batch status changes at the end
-- Exactly ONE task should be `in_progress` at any given time
-- Only use `status: "deleted"` when a task is no longer relevant; prefer completion when possible
-- When adding dependencies, call `TaskList` first to verify the referenced IDs exist
+Status progresses: `pending` → `in_progress` → `completed`
 
-## Example
+Use `deleted` to permanently remove a task.
 
+## Staleness
+
+Make sure to read a task's latest state using `TaskGet` before updating it.
+
+## Examples
+
+Mark task as in progress when starting work:
+```json
+{"taskId": "1", "status": "in_progress"}
 ```
-TaskUpdate({
-  taskId: "task_3",
-  status: "in_progress",
-  owner: "agent-abc123"
-})
 
-TaskUpdate({
-  taskId: "task_3",
-  addBlockedBy: ["task_1", "task_2"]
-})
-
-TaskUpdate({
-  taskId: "task_3",
-  status: "completed"
-})
+Mark task as completed after finishing work:
+```json
+{"taskId": "1", "status": "completed"}
 ```
 
-Returns the updated task record.
+Delete a task:
+```json
+{"taskId": "1", "status": "deleted"}
+```
+
+Claim a task by setting owner:
+```json
+{"taskId": "1", "owner": "my-name"}
+```
+
+Set up task dependencies:
+```json
+{"taskId": "2", "addBlockedBy": ["1"]}
+```

--- a/src/tools/impl/task-update.ts
+++ b/src/tools/impl/task-update.ts
@@ -15,7 +15,7 @@ interface TaskUpdateArgs {
   owner?: string;
   addBlocks?: string[];
   addBlockedBy?: string[];
-  metadata?: Record<string, string>;
+  metadata?: Record<string, unknown>;
 }
 
 const VALID_STATUSES: readonly TaskStatus[] = [
@@ -64,13 +64,6 @@ export async function task_update(args: TaskUpdateArgs): Promise<TaskRecord> {
       Array.isArray(args.metadata)
     ) {
       throw new Error("TaskUpdate: 'metadata' must be an object");
-    }
-    for (const [k, v] of Object.entries(args.metadata)) {
-      if (typeof v !== "string") {
-        throw new Error(
-          `TaskUpdate: metadata['${k}'] must be a string, received ${typeof v}`,
-        );
-      }
     }
   }
 

--- a/src/tools/impl/tasks/store.ts
+++ b/src/tools/impl/tasks/store.ts
@@ -22,7 +22,7 @@ export interface TaskRecord {
   blocks: string[];
   /** IDs of tasks that block this task */
   blockedBy: string[];
-  metadata: Record<string, string>;
+  metadata: Record<string, unknown>;
   createdAt: number;
   updatedAt: number;
 }
@@ -37,16 +37,9 @@ function nextTaskId(): string {
 }
 
 function cloneMetadata(
-  meta: Record<string, string> | undefined,
-): Record<string, string> {
-  if (!meta) return {};
-  const out: Record<string, string> = {};
-  for (const [k, v] of Object.entries(meta)) {
-    if (typeof k === "string" && typeof v === "string") {
-      out[k] = v;
-    }
-  }
-  return out;
+  meta: Record<string, unknown> | undefined,
+): Record<string, unknown> {
+  return meta ? { ...meta } : {};
 }
 
 function dedupe(values: string[]): string[] {
@@ -84,16 +77,11 @@ export function getTask(taskId: string): TaskRecord | undefined {
   return t ? { ...t } : undefined;
 }
 
-export interface ListTasksOptions {
-  includeDeleted?: boolean;
-}
-
-export function listTasks(options: ListTasksOptions = {}): TaskRecord[] {
+export function listTasks(): TaskRecord[] {
   const out: TaskRecord[] = [];
   for (const id of insertionOrder) {
     const t = tasks.get(id);
     if (!t) continue;
-    if (!options.includeDeleted && t.status === "deleted") continue;
     out.push({ ...t });
   }
   return out;
@@ -108,7 +96,7 @@ export interface UpdateTaskInput {
   owner?: string;
   addBlocks?: string[];
   addBlockedBy?: string[];
-  metadata?: Record<string, string>;
+  metadata?: Record<string, unknown>;
 }
 
 export class TaskNotFoundError extends Error {
@@ -136,15 +124,24 @@ export function updateTask(input: UpdateTaskInput): TaskRecord {
     existing.blockedBy = dedupe([...existing.blockedBy, ...input.addBlockedBy]);
   }
   if (input.metadata) {
-    // Merge (not replace) so partial updates don't clobber existing keys.
-    existing.metadata = {
-      ...existing.metadata,
-      ...cloneMetadata(input.metadata),
-    };
+    // Merge partial updates; null removes an existing metadata key.
+    for (const [key, value] of Object.entries(input.metadata)) {
+      if (value === null) {
+        delete existing.metadata[key];
+      } else {
+        existing.metadata[key] = value;
+      }
+    }
   }
   existing.updatedAt = Date.now();
 
-  return { ...existing };
+  const updated = { ...existing };
+  if (existing.status === "deleted") {
+    tasks.delete(input.taskId);
+    const orderIndex = insertionOrder.indexOf(input.taskId);
+    if (orderIndex !== -1) insertionOrder.splice(orderIndex, 1);
+  }
+  return updated;
 }
 
 /** Test-only hook to reset state between unit tests. */

--- a/src/tools/schemas/TaskUpdate.json
+++ b/src/tools/schemas/TaskUpdate.json
@@ -1,56 +1,51 @@
 {
-  "type": "object",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
   "properties": {
-    "taskId": {
-      "type": "string",
-      "description": "The ID of the task to update (e.g. \"task_1\")."
+    "activeForm": {
+      "description": "Present continuous form shown in spinner when in_progress (e.g. \"Running tests\")",
+      "type": "string"
+    },
+    "addBlockedBy": {
+      "description": "Task IDs that block this task",
+      "items": { "type": "string" },
+      "type": "array"
+    },
+    "addBlocks": {
+      "description": "Task IDs that this task blocks",
+      "items": { "type": "string" },
+      "type": "array"
+    },
+    "description": {
+      "description": "New description for the task",
+      "type": "string"
+    },
+    "metadata": {
+      "additionalProperties": {},
+      "description": "Metadata keys to merge into the task. Set a key to null to delete it.",
+      "propertyNames": { "type": "string" },
+      "type": "object"
+    },
+    "owner": {
+      "description": "New owner for the task",
+      "type": "string"
     },
     "status": {
       "anyOf": [
-        {
-          "type": "string",
-          "enum": ["pending", "in_progress", "completed"]
-        },
-        {
-          "type": "string",
-          "const": "deleted"
-        }
+        { "enum": ["pending", "in_progress", "completed"], "type": "string" },
+        { "const": "deleted", "type": "string" }
       ],
-      "description": "New status. Use 'deleted' to soft-delete the task (it will be excluded from TaskList but remains fetchable via TaskGet)."
+      "description": "New status for the task"
     },
     "subject": {
-      "type": "string",
-      "description": "Replacement subject."
+      "description": "New subject for the task",
+      "type": "string"
     },
-    "description": {
-      "type": "string",
-      "description": "Replacement description."
-    },
-    "activeForm": {
-      "type": "string",
-      "description": "Replacement active form."
-    },
-    "owner": {
-      "type": "string",
-      "description": "Assign an owner (free-form string, e.g. agent id or human name)."
-    },
-    "addBlocks": {
-      "type": "array",
-      "items": { "type": "string" },
-      "description": "Task IDs to append to this task's 'blocks' list (tasks that cannot start until this one finishes)."
-    },
-    "addBlockedBy": {
-      "type": "array",
-      "items": { "type": "string" },
-      "description": "Task IDs to append to this task's 'blockedBy' list (tasks that must finish before this one can start)."
-    },
-    "metadata": {
-      "type": "object",
-      "description": "Metadata keys to merge into the existing metadata bag (existing keys are preserved; matching keys are overwritten).",
-      "additionalProperties": { "type": "string" }
+    "taskId": {
+      "description": "The ID of the task to update",
+      "type": "string"
     }
   },
   "required": ["taskId"],
-  "additionalProperties": false,
-  "$schema": "http://json-schema.org/draft-07/schema#"
+  "type": "object"
 }

--- a/src/tools/task-crud.test.ts
+++ b/src/tools/task-crud.test.ts
@@ -4,8 +4,19 @@ import { task_get } from "@/tools/impl/task-get";
 import { task_list } from "@/tools/impl/task-list";
 import { task_update } from "@/tools/impl/task-update";
 import { _resetTaskStoreForTests } from "@/tools/impl/tasks/store";
+import TaskUpdateSchema from "@/tools/schemas/TaskUpdate.json";
 
 describe("Task CRUD family", () => {
+  test("TaskUpdate schema matches the Anthropic metadata contract", () => {
+    expect(TaskUpdateSchema.required).toEqual(["taskId"]);
+    expect(TaskUpdateSchema.properties.metadata.additionalProperties).toEqual(
+      {},
+    );
+    expect(TaskUpdateSchema.properties.metadata.propertyNames).toEqual({
+      type: "string",
+    });
+  });
+
   beforeEach(() => {
     _resetTaskStoreForTests();
   });
@@ -78,16 +89,18 @@ describe("Task CRUD family", () => {
     expect(tasks.map((t) => t.subject)).toEqual(["a", "b", "c"]);
   });
 
-  test("TaskList excludes soft-deleted tasks but TaskGet still returns them", async () => {
+  test("TaskUpdate permanently deletes tasks", async () => {
     const a = await task_create({ subject: "a", description: "aa" });
     await task_create({ subject: "b", description: "bb" });
-    await task_update({ taskId: a.taskId, status: "deleted" });
+    const deleted = await task_update({
+      taskId: a.taskId,
+      status: "deleted",
+    });
 
+    expect(deleted.status).toBe("deleted");
     const { tasks } = await task_list({});
     expect(tasks.map((t) => t.subject)).toEqual(["b"]);
-
-    const deleted = await task_get({ taskId: a.taskId });
-    expect(deleted.status).toBe("deleted");
+    await expect(task_get({ taskId: a.taskId })).rejects.toThrow(/not found/);
   });
 
   test("TaskUpdate transitions status through lifecycle", async () => {
@@ -127,7 +140,7 @@ describe("Task CRUD family", () => {
     expect(b2.blockedBy).toEqual([a.taskId]);
   });
 
-  test("TaskUpdate merges metadata rather than replacing", async () => {
+  test("TaskUpdate merges arbitrary metadata and deletes null keys", async () => {
     const t = await task_create({
       subject: "x",
       description: "y",
@@ -136,9 +149,20 @@ describe("Task CRUD family", () => {
 
     const updated = await task_update({
       taskId: t.taskId,
-      metadata: { b: "overwritten", c: "3" },
+      metadata: {
+        a: null,
+        b: "overwritten",
+        count: 3,
+        flags: ["ready"],
+        details: { source: "review" },
+      },
     });
-    expect(updated.metadata).toEqual({ a: "1", b: "overwritten", c: "3" });
+    expect(updated.metadata).toEqual({
+      b: "overwritten",
+      count: 3,
+      flags: ["ready"],
+      details: { source: "review" },
+    });
   });
 
   test("TaskUpdate sets owner, subject, description, activeForm", async () => {


### PR DESCRIPTION
## Summary
- replace the TaskUpdate guidance and JSON schema with the Anthropic contract
- make `deleted` permanently remove tasks and update TaskGet/TaskList guidance accordingly
- support arbitrary metadata values and null-based key deletion

## Test plan
- [x] `bun test src/tools/task-crud.test.ts`
- [x] `bun run check`

👾 Generated with [Letta Code](https://letta.com)