### PR TITLE
fix(channels): preserve proactive Slack thread continuity

### DIFF
--- a/scripts/source-file-size-baseline.json
+++ b/scripts/source-file-size-baseline.json
@@ -46,5 +46,5 @@
   "src/websocket/listener/lifecycle.ts": 1051,
   "src/websocket/listener/protocol-inbound.ts": 2264,
   "src/websocket/listener/protocol-outbound.ts": 1072,
-  "src/websocket/listener/turn.ts": 1010
+  "src/websocket/listener/turn.ts": 1009
 }

--- a/src/channels/gateway-core.test.ts
+++ b/src/channels/gateway-core.test.ts
@@ -664,6 +664,66 @@ test("publishes hundreds of routed runtime tools without runtime_start", async (
   gateway.close();
 });
 
+test("publishes process-owned runtime tools without retaining gateway runtimes", async () => {
+  const client = new FakeClient();
+  const { hooks } = makeHooks();
+  const gateway = new ChannelGateway(client, hooks);
+
+  for (let index = 0; index < 350; index += 1) {
+    const runtime = {
+      agent_id: "agent-1",
+      conversation_id: `conv-schedule-${index}`,
+    };
+    expect(await gateway.publishRuntimeTools(runtime)).toBe(true);
+    await gateway.releaseRuntimeTools(runtime);
+  }
+
+  expect(client.runtimeToolUpdates).toHaveLength(700);
+  expect(
+    client.runtimeToolUpdates.filter(
+      (update) => update.external_tools.length === 0,
+    ),
+  ).toHaveLength(350);
+  expect(client.startedRuntimes).toHaveLength(0);
+  expect(gateway.getKnownRuntimes()).toHaveLength(0);
+  gateway.close();
+});
+
+test("does not release tools owned by a gateway runtime", async () => {
+  const client = new FakeClient();
+  const { hooks } = makeHooks();
+  const gateway = new ChannelGateway(client, hooks);
+
+  await gateway.registerRuntime(TEST_RUNTIME);
+  expect(await gateway.publishRuntimeTools(TEST_RUNTIME)).toBe(false);
+  await gateway.releaseRuntimeTools(TEST_RUNTIME);
+
+  expect(client.startedRuntimes).toHaveLength(1);
+  expect(client.runtimeToolUpdates).toHaveLength(0);
+  gateway.close();
+});
+
+test("does not release tools after the turn creates a routed source", async () => {
+  const client = new FakeClient();
+  const { hooks } = makeHooks();
+  const gateway = new ChannelGateway(client, hooks);
+  const runtime = {
+    agent_id: "agent-1",
+    conversation_id: "conv-schedule-1",
+  };
+
+  expect(await gateway.publishRuntimeTools(runtime)).toBe(true);
+  await gateway.releaseRuntimeTools(runtime, [
+    makeSource({
+      agentId: runtime.agent_id,
+      conversationId: runtime.conversation_id,
+    }),
+  ]);
+
+  expect(client.runtimeToolUpdates).toHaveLength(1);
+  gateway.close();
+});
+
 test("runtime registration removes MessageChannel when no route remains", async () => {
   const client = new FakeClient();
   const { hooks } = makeHooks({ buildExternalTool: async () => null });

--- a/src/channels/gateway-core.ts
+++ b/src/channels/gateway-core.ts
@@ -369,6 +369,50 @@ export class ChannelGateway {
     });
   }
 
+  /** Publish tools for a listener-owned turn without subscribing to its stream. */
+  async publishRuntimeTools(
+    runtime: RuntimeScope,
+    sources: ChannelTurnSource[] = [],
+  ): Promise<boolean> {
+    return await this.enqueueRegistration(async () => {
+      if (this.states.has(runtimeKey(runtime))) return false;
+      const tool = await this.hooks.buildExternalTool(runtime, sources);
+      const response = await this.client.runtimeExternalToolsUpdate({
+        updates: [
+          {
+            runtimes: [runtime],
+            external_tools: tool ? [{ tools: [tool] }] : [],
+          },
+        ],
+      });
+      if (!response.success) {
+        throw new Error(
+          response.error ?? "Failed to publish channel runtime tools",
+        );
+      }
+      return tool !== null;
+    });
+  }
+
+  async releaseRuntimeTools(
+    runtime: RuntimeScope,
+    routedSources: ChannelTurnSource[] = [],
+  ): Promise<void> {
+    await this.enqueueRegistration(async () => {
+      if (routedSources.length > 0 || this.states.has(runtimeKey(runtime))) {
+        return;
+      }
+      const response = await this.client.runtimeExternalToolsUpdate({
+        updates: [{ runtimes: [runtime], external_tools: [] }],
+      });
+      if (!response.success) {
+        throw new Error(
+          response.error ?? "Failed to release channel runtime tools",
+        );
+      }
+    });
+  }
+
   async submitApprovalResponse(
     runtime: RuntimeScope,
     response: ApprovalResponseBody,

--- a/src/channels/gateway-local.ts
+++ b/src/channels/gateway-local.ts
@@ -98,7 +98,10 @@ async function executeChannelServiceCommand(
 }
 
 async function executeGatewayServiceCommand(
-  request: Exclude<ServiceCommandRequest, { kind: "register_runtime" }>,
+  request: Exclude<
+    ServiceCommandRequest,
+    { kind: "publish_runtime_tools" | "release_runtime_tools" }
+  >,
 ): Promise<ServiceCommandResponse> {
   if (request.kind === "protocol") {
     return {
@@ -609,13 +612,23 @@ export async function startLocalChannelGateway(
     executeCommand: async (command) => {
       let result: ServiceCommandResponse;
       try {
-        if (command.kind === "register_runtime") {
+        if (command.kind === "publish_runtime_tools") {
           const sources = registry.resolveTurnSourcesForScope(
             command.runtime.agent_id,
             command.runtime.conversation_id,
           );
-          await gateway.registerRuntime(command.runtime, sources);
-          result = { kind: "runtime_registered" };
+          const transient = await gateway.publishRuntimeTools(
+            command.runtime,
+            sources,
+          );
+          result = { kind: "runtime_tools_published", transient };
+        } else if (command.kind === "release_runtime_tools") {
+          const sources = registry.resolveTurnSourcesForScope(
+            command.runtime.agent_id,
+            command.runtime.conversation_id,
+          );
+          await gateway.releaseRuntimeTools(command.runtime, sources);
+          result = { kind: "runtime_tools_released" };
         } else {
           result = await executeGatewayServiceCommand(command);
         }

--- a/src/channels/gateway-local.ts
+++ b/src/channels/gateway-local.ts
@@ -98,7 +98,7 @@ async function executeChannelServiceCommand(
 }
 
 async function executeGatewayServiceCommand(
-  request: ServiceCommandRequest,
+  request: Exclude<ServiceCommandRequest, { kind: "register_runtime" }>,
 ): Promise<ServiceCommandResponse> {
   if (request.kind === "protocol") {
     return {
@@ -241,13 +241,8 @@ export async function startLocalChannelGateway(
           }
         : null;
     },
-    buildExternalTool: async (runtime) => {
-      return buildGatewayMessageChannelTool(
-        registry.resolveTurnSourcesForScope(
-          runtime.agent_id,
-          runtime.conversation_id,
-        ),
-      );
+    buildExternalTool: async (runtime, sources) => {
+      return buildGatewayMessageChannelTool(sources, runtime);
     },
     executeExternalTool: async (request, sources, idempotencyScope) => {
       if (request.tool_name !== "MessageChannel" || !request.runtime) {
@@ -612,9 +607,18 @@ export async function startLocalChannelGateway(
   registry.setReady();
   return {
     executeCommand: async (command) => {
-      let result: Awaited<ReturnType<typeof executeGatewayServiceCommand>>;
+      let result: ServiceCommandResponse;
       try {
-        result = await executeGatewayServiceCommand(command);
+        if (command.kind === "register_runtime") {
+          const sources = registry.resolveTurnSourcesForScope(
+            command.runtime.agent_id,
+            command.runtime.conversation_id,
+          );
+          await gateway.registerRuntime(command.runtime, sources);
+          result = { kind: "runtime_registered" };
+        } else {
+          result = await executeGatewayServiceCommand(command);
+        }
       } catch (error) {
         routedRuntimeRegistrationRefresher.requestRefresh();
         throw error;

--- a/src/channels/message-channel-gateway-tool.test.ts
+++ b/src/channels/message-channel-gateway-tool.test.ts
@@ -1,6 +1,70 @@
-import { expect, test } from "bun:test";
+import { afterEach, expect, test } from "bun:test";
+import {
+  __testOverrideLoadChannelAccounts,
+  __testOverrideSaveChannelAccounts,
+  clearChannelAccountStores,
+  upsertChannelAccount,
+} from "@/channels/accounts";
+import { ChannelRegistry, getChannelRegistry } from "@/channels/registry";
+import type { ChannelAdapter } from "@/channels/types";
 import { buildGatewayMessageChannelTool } from "./message-channel-gateway-tool";
 
-test("does not build MessageChannel without an eligible route", async () => {
+afterEach(async () => {
+  await getChannelRegistry()?.stopAll();
+  clearChannelAccountStores();
+  __testOverrideLoadChannelAccounts(null);
+  __testOverrideSaveChannelAccounts(null);
+});
+
+test("does not build MessageChannel without an eligible route or proactive account", async () => {
   expect(await buildGatewayMessageChannelTool([])).toBeNull();
+});
+
+test("builds proactive Slack for a fresh conversation owned by the account agent", async () => {
+  __testOverrideLoadChannelAccounts(() => []);
+  __testOverrideSaveChannelAccounts(() => {});
+  const registry = new ChannelRegistry();
+  const adapter: ChannelAdapter = {
+    id: "slack:account-1",
+    channelId: "slack",
+    accountId: "account-1",
+    name: "Slack",
+    start: async () => {},
+    stop: async () => {},
+    isRunning: () => true,
+    sendMessage: async () => ({ messageId: "unused" }),
+    sendDirectReply: async () => {},
+  };
+  registry.registerAdapter(adapter);
+  upsertChannelAccount("slack", {
+    channel: "slack",
+    accountId: "account-1",
+    displayName: "Slack",
+    enabled: true,
+    dmPolicy: "pairing",
+    allowedUsers: [],
+    createdAt: "2026-08-13T00:00:00.000Z",
+    updatedAt: "2026-08-13T00:00:00.000Z",
+    mode: "socket",
+    botToken: "xoxb-test",
+    appToken: "xapp-test",
+    agentId: "agent-1",
+    defaultPermissionMode: "standard",
+  });
+
+  const tool = await buildGatewayMessageChannelTool([], {
+    agent_id: "agent-1",
+    conversation_id: "conv-schedule-1",
+  });
+  expect(tool).not.toBeNull();
+  expect(tool?.description).not.toContain(
+    "currently scoped to a routed external channel turn",
+  );
+
+  await expect(
+    buildGatewayMessageChannelTool([], {
+      agent_id: "agent-other",
+      conversation_id: "conv-schedule-2",
+    }),
+  ).resolves.toBeNull();
 });

--- a/src/channels/message-channel-gateway-tool.ts
+++ b/src/channels/message-channel-gateway-tool.ts
@@ -1,28 +1,44 @@
-import type { ExternalToolDefinitionPayload } from "@/types/app-server-protocol";
+import type {
+  ExternalToolDefinitionPayload,
+  RuntimeScope,
+} from "@/types/app-server-protocol";
 import { buildMessageChannelExternalToolDefinition } from "./message-channel-tool-definition";
 import { resolveLocalMessageChannelToolChannels } from "./message-tool";
+import { listEligibleProactiveSlackAccounts } from "./slack/proactive-accounts";
 import type { ChannelTurnSource } from "./types";
 
 export async function buildGatewayMessageChannelTool(
   sources: ChannelTurnSource[],
+  runtime?: RuntimeScope,
 ): Promise<ExternalToolDefinitionPayload | null> {
-  if (sources.length === 0) return null;
-
   const seen = new Set<string>();
-  const channels = sources
-    .map((source) => ({
-      channelId: source.channel,
-      accountId: source.accountId ?? null,
-    }))
-    .filter(({ channelId, accountId }) => {
-      const key = `${channelId}:${accountId ?? ""}`;
-      if (seen.has(key)) return false;
-      seen.add(key);
-      return true;
-    });
+  const channelScopes = (
+    sources.length > 0
+      ? sources.map((source) => ({
+          channelId: source.channel,
+          accountId: source.accountId ?? null,
+        }))
+      : runtime
+        ? listEligibleProactiveSlackAccounts({
+            agentId: runtime.agent_id,
+          }).map(({ account }) => ({
+            channelId: "slack",
+            accountId: account.accountId,
+          }))
+        : []
+  ).filter(({ channelId, accountId }) => {
+    const key = `${channelId}:${accountId ?? ""}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+  if (channelScopes.length === 0) return null;
+
   return buildMessageChannelExternalToolDefinition({
-    channels: await resolveLocalMessageChannelToolChannels({ channels }),
-    scoped: true,
+    channels: await resolveLocalMessageChannelToolChannels({
+      channels: channelScopes,
+    }),
+    scoped: sources.length > 0,
     allowProactiveTargets: true,
   });
 }

--- a/src/channels/message-channel-slack.test.ts
+++ b/src/channels/message-channel-slack.test.ts
@@ -6,7 +6,13 @@ import {
   upsertChannelAccount,
 } from "@/channels/accounts";
 import { ChannelRegistry, getChannelRegistry } from "@/channels/registry";
-import { clearAllRoutes, setRouteInMemory } from "@/channels/routing";
+import {
+  __testOverrideLoadRoutes,
+  __testOverrideSaveRoutes,
+  clearAllRoutes,
+  getRouteRaw,
+  setRouteInMemory,
+} from "@/channels/routing";
 import {
   __testOverrideLoadTargetStore,
   __testOverrideSaveTargetStore,
@@ -29,6 +35,8 @@ describe("MessageChannel Slack", () => {
     __testOverrideSaveChannelAccounts(null);
     __testOverrideLoadTargetStore(null);
     __testOverrideSaveTargetStore(null);
+    __testOverrideLoadRoutes(null);
+    __testOverrideSaveRoutes(null);
   });
 
   function installChannelStateTestOverrides(): void {
@@ -36,6 +44,8 @@ describe("MessageChannel Slack", () => {
     __testOverrideSaveChannelAccounts(() => {});
     __testOverrideLoadTargetStore(() => {});
     __testOverrideSaveTargetStore(() => {});
+    __testOverrideLoadRoutes(() => null);
+    __testOverrideSaveRoutes(() => {});
   }
 
   test("uses the routed account adapter for multi-account channels", async () => {
@@ -657,18 +667,6 @@ describe("MessageChannel Slack", () => {
       throw new Error("explicit target path should not consult routes");
     });
 
-    setRouteInMemory("slack", {
-      accountId: "account-1",
-      chatId: "C123",
-      chatType: "channel",
-      threadId: "1712790000.000050",
-      agentId: "agent-1",
-      conversationId: "default",
-      enabled: true,
-      createdAt: "2026-04-11T00:00:00.000Z",
-      updatedAt: "2026-04-11T00:00:00.000Z",
-    });
-
     upsertChannelAccount("slack", {
       channel: "slack",
       accountId: "account-1",
@@ -701,7 +699,7 @@ describe("MessageChannel Slack", () => {
       message: "hello proactive slack",
       parentScope: {
         agentId: "agent-1",
-        conversationId: "default",
+        conversationId: "conv-schedule-1",
       },
     });
 
@@ -715,7 +713,14 @@ describe("MessageChannel Slack", () => {
       threadId: null,
       parseMode: undefined,
       agentId: "agent-1",
-      conversationId: "default",
+      conversationId: "conv-schedule-1",
+    });
+    expect(
+      getRouteRaw("slack", "C999", "account-1", "slack-msg-proactive-1"),
+    ).toMatchObject({
+      agentId: "agent-1",
+      conversationId: "conv-schedule-1",
+      threadId: "slack-msg-proactive-1",
     });
   });
 
@@ -752,29 +757,6 @@ describe("MessageChannel Slack", () => {
 
     registry.registerAdapter(adapter1);
     registry.registerAdapter(adapter2);
-
-    setRouteInMemory("slack", {
-      accountId: "account-1",
-      chatId: "C123",
-      chatType: "channel",
-      threadId: "1712790000.000050",
-      agentId: "agent-1",
-      conversationId: "default",
-      enabled: true,
-      createdAt: "2026-04-11T00:00:00.000Z",
-      updatedAt: "2026-04-11T00:00:00.000Z",
-    });
-    setRouteInMemory("slack", {
-      accountId: "account-2",
-      chatId: "C124",
-      chatType: "channel",
-      threadId: "1712790000.000051",
-      agentId: "agent-1",
-      conversationId: "default",
-      enabled: true,
-      createdAt: "2026-04-11T00:00:00.000Z",
-      updatedAt: "2026-04-11T00:00:00.000Z",
-    });
 
     upsertChannelAccount("slack", {
       channel: "slack",
@@ -846,18 +828,6 @@ describe("MessageChannel Slack", () => {
 
     registry.registerAdapter(adapter);
 
-    setRouteInMemory("slack", {
-      accountId: "account-1",
-      chatId: "C123",
-      chatType: "channel",
-      threadId: "1712790000.000050",
-      agentId: "agent-1",
-      conversationId: "default",
-      enabled: true,
-      createdAt: "2026-04-11T00:00:00.000Z",
-      updatedAt: "2026-04-11T00:00:00.000Z",
-    });
-
     upsertChannelAccount("slack", {
       channel: "slack",
       accountId: "account-1",
@@ -870,7 +840,7 @@ describe("MessageChannel Slack", () => {
       mode: "socket",
       botToken: "xoxb-test-token",
       appToken: "xapp-test-token",
-      agentId: "agent-1",
+      agentId: "agent-other",
       defaultPermissionMode: "standard",
     });
 
@@ -878,7 +848,7 @@ describe("MessageChannel Slack", () => {
       action: "send",
       channel: "slack",
       target: "#eng",
-      accountId: "other-account",
+      accountId: "account-1",
       message: "hello proactive slack",
       parentScope: {
         agentId: "agent-1",
@@ -887,7 +857,7 @@ describe("MessageChannel Slack", () => {
     });
 
     expect(result).toBe(
-      'Error: Slack account "other-account" is not available for proactive sends in this agent scope.',
+      'Error: Slack account "account-1" is not available for proactive sends in this agent scope.',
     );
     expect(sendMessage).not.toHaveBeenCalled();
   });

--- a/src/channels/routed-runtime-registration.test.ts
+++ b/src/channels/routed-runtime-registration.test.ts
@@ -157,12 +157,43 @@ test("revokes a known runtime that lost its route before publication", async () 
       },
     },
     channelNames: ["slack"],
-    buildTool: async () => createTool(),
+    buildTool: async (sources) => (sources.length > 0 ? createTool() : null),
   });
 
   await refresher.refresh();
 
   expect(updates).toEqual([[{ runtimes: [runtime], external_tools: [] }]]);
+  refresher.close();
+});
+
+test("preserves proactive tools for known runtimes without routes", async () => {
+  __testOverrideLoadRoutes(() => null);
+  const updates: RuntimeExternalToolsUpdateGroup[][] = [];
+  const refresher = createRoutedRuntimeRegistrationRefresher({
+    registry: { resolveRoutedTurnSources: () => [] },
+    publisher: {
+      getKnownRuntimes: () => [runtime],
+      publish: async (nextUpdates) => {
+        updates.push([...nextUpdates]);
+      },
+    },
+    channelNames: ["slack"],
+    buildTool: async (sources, nextRuntime) =>
+      sources.length === 0 && nextRuntime.agent_id === "agent-1"
+        ? createTool("Proactive Slack")
+        : null,
+  });
+
+  await refresher.refresh();
+
+  expect(updates).toEqual([
+    [
+      {
+        runtimes: [runtime],
+        external_tools: [{ tools: [createTool("Proactive Slack")] }],
+      },
+    ],
+  ]);
   refresher.close();
 });
 

--- a/src/channels/routed-runtime-registration.ts
+++ b/src/channels/routed-runtime-registration.ts
@@ -24,6 +24,7 @@ interface RoutedRuntimeToolPublisher {
 
 type RoutedRuntimeToolBuilder = (
   sources: ChannelTurnSource[],
+  runtime: RuntimeScope,
 ) => Promise<ExternalToolDefinitionPayload | null>;
 
 type DesiredRuntimeRegistration = {
@@ -57,7 +58,11 @@ function groupSourcesByRuntime(
   return [...sourcesByRuntime.values()];
 }
 
-function toolScopeKey(sources: ChannelTurnSource[]): string {
+function toolScopeKey(
+  sources: ChannelTurnSource[],
+  runtime: RuntimeScope,
+): string {
+  if (sources.length === 0) return `proactive:${runtime.agent_id}`;
   return JSON.stringify(
     [
       ...new Set(
@@ -86,10 +91,10 @@ async function buildDesiredRegistrations(
   >();
   await Promise.all(
     groupedSources.map(async ({ runtime, sources }) => {
-      const scopeKey = toolScopeKey(sources);
+      const scopeKey = toolScopeKey(sources, runtime);
       let toolPromise = toolsByScope.get(scopeKey);
       if (!toolPromise) {
-        toolPromise = buildTool(sources);
+        toolPromise = buildTool(sources, runtime);
         toolsByScope.set(scopeKey, toolPromise);
       }
       const tool = await toolPromise;
@@ -104,17 +109,29 @@ async function buildDesiredRegistrations(
       });
     }),
   );
-  for (const runtime of knownRuntimes) {
-    const key = runtimeKey(runtime);
-    if (desired.has(key)) continue;
-    const externalTools: RuntimeStartExternalToolsGroup[] = [];
-    desired.set(key, {
-      runtime,
-      sources: [],
-      externalTools,
-      signature: JSON.stringify(externalTools),
-    });
-  }
+  await Promise.all(
+    knownRuntimes.map(async (runtime) => {
+      const key = runtimeKey(runtime);
+      if (desired.has(key)) return;
+      const sources: ChannelTurnSource[] = [];
+      const scopeKey = toolScopeKey(sources, runtime);
+      let toolPromise = toolsByScope.get(scopeKey);
+      if (!toolPromise) {
+        toolPromise = buildTool(sources, runtime);
+        toolsByScope.set(scopeKey, toolPromise);
+      }
+      const tool = await toolPromise;
+      const externalTools: RuntimeStartExternalToolsGroup[] = tool
+        ? [{ tools: [tool] }]
+        : [];
+      desired.set(key, {
+        runtime,
+        sources,
+        externalTools,
+        signature: JSON.stringify(externalTools),
+      });
+    }),
+  );
   return desired;
 }
 

--- a/src/channels/routed-runtime-registration.ts
+++ b/src/channels/routed-runtime-registration.ts
@@ -82,6 +82,15 @@ async function buildDesiredRegistrations(
   const groupedSources = groupSourcesByRuntime(
     registry.resolveRoutedTurnSources(),
   );
+  const sourcesByRuntime = new Map(
+    groupedSources.map((entry) => [runtimeKey(entry.runtime), entry]),
+  );
+  for (const runtime of knownRuntimes) {
+    const key = runtimeKey(runtime);
+    if (!sourcesByRuntime.has(key)) {
+      sourcesByRuntime.set(key, { runtime, sources: [] });
+    }
+  }
   const desired = new Map<string, DesiredRuntimeRegistration>();
   // Hundreds of conversations commonly share one channel/account capability
   // set. Resolve and serialize that schema once, then fan it out by runtime.
@@ -90,7 +99,7 @@ async function buildDesiredRegistrations(
     Promise<ExternalToolDefinitionPayload | null>
   >();
   await Promise.all(
-    groupedSources.map(async ({ runtime, sources }) => {
+    [...sourcesByRuntime.values()].map(async ({ runtime, sources }) => {
       const scopeKey = toolScopeKey(sources, runtime);
       let toolPromise = toolsByScope.get(scopeKey);
       if (!toolPromise) {
@@ -102,29 +111,6 @@ async function buildDesiredRegistrations(
         ? [{ tools: [tool] }]
         : [];
       desired.set(runtimeKey(runtime), {
-        runtime,
-        sources,
-        externalTools,
-        signature: JSON.stringify(externalTools),
-      });
-    }),
-  );
-  await Promise.all(
-    knownRuntimes.map(async (runtime) => {
-      const key = runtimeKey(runtime);
-      if (desired.has(key)) return;
-      const sources: ChannelTurnSource[] = [];
-      const scopeKey = toolScopeKey(sources, runtime);
-      let toolPromise = toolsByScope.get(scopeKey);
-      if (!toolPromise) {
-        toolPromise = buildTool(sources, runtime);
-        toolsByScope.set(scopeKey, toolPromise);
-      }
-      const tool = await toolPromise;
-      const externalTools: RuntimeStartExternalToolsGroup[] = tool
-        ? [{ tools: [tool] }]
-        : [];
-      desired.set(key, {
         runtime,
         sources,
         externalTools,

--- a/src/channels/slack/proactive-accounts.ts
+++ b/src/channels/slack/proactive-accounts.ts
@@ -1,9 +1,5 @@
-import {
-  getChannelAccount,
-  LEGACY_CHANNEL_ACCOUNT_ID,
-} from "@/channels/accounts";
+import { listChannelAccounts } from "@/channels/accounts";
 import { getChannelRegistry } from "@/channels/registry";
-import { getRoutesForChannel, loadRoutes } from "@/channels/routing";
 import type { ChannelAdapter, SlackChannelAccount } from "@/channels/types";
 import { isSlackChannelAccount } from "@/channels/types";
 
@@ -14,36 +10,16 @@ export interface EligibleProactiveSlackAccount {
 
 export function listEligibleProactiveSlackAccounts(params: {
   agentId: string;
-  conversationId: string;
 }): EligibleProactiveSlackAccount[] {
   const registry = getChannelRegistry();
   if (!registry) {
     return [];
   }
 
-  loadRoutes("slack");
-  const seen = new Set<string>();
-
   const eligible: EligibleProactiveSlackAccount[] = [];
-  for (const route of getRoutesForChannel("slack")) {
+  for (const account of listChannelAccounts("slack")) {
     if (
-      route.agentId !== params.agentId ||
-      route.conversationId !== params.conversationId ||
-      !route.enabled ||
-      route.outboundEnabled === false
-    ) {
-      continue;
-    }
-
-    const accountId = route.accountId ?? LEGACY_CHANNEL_ACCOUNT_ID;
-    if (seen.has(accountId)) {
-      continue;
-    }
-    seen.add(accountId);
-
-    const account = getChannelAccount("slack", accountId);
-    if (
-      !account ||
+      !account.enabled ||
       !isSlackChannelAccount(account) ||
       account.agentId !== params.agentId
     ) {
@@ -65,12 +41,10 @@ export function listEligibleProactiveSlackAccounts(params: {
 
 export function resolveEligibleProactiveSlackAccount(params: {
   agentId: string;
-  conversationId: string;
   accountId?: string | null;
 }): EligibleProactiveSlackAccount | string {
   const eligible = listEligibleProactiveSlackAccounts({
     agentId: params.agentId,
-    conversationId: params.conversationId,
   });
 
   if (params.accountId) {

--- a/src/channels/slack/proactive-route.test.ts
+++ b/src/channels/slack/proactive-route.test.ts
@@ -73,3 +73,20 @@ test("keeps an idempotent binding and refuses to overwrite a conflict", () => {
     conversationId: "conv-other",
   });
 });
+
+test("rolls back an in-memory binding when persistence fails", () => {
+  __testOverrideLoadRoutes(() => null);
+  __testOverrideSaveRoutes(() => {
+    throw new Error("disk unavailable");
+  });
+
+  expect(() => bindProactiveSlackThreadRoute(params)).toThrow(
+    "disk unavailable",
+  );
+  expect(
+    getRouteRaw("slack", params.chatId, params.accountId, params.rootMessageId),
+  ).toBeUndefined();
+
+  __testOverrideSaveRoutes(() => {});
+  expect(() => bindProactiveSlackThreadRoute(params)).not.toThrow();
+});

--- a/src/channels/slack/proactive-route.test.ts
+++ b/src/channels/slack/proactive-route.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, expect, test } from "bun:test";
+import { afterEach, expect, mock, test } from "bun:test";
 import {
   __testOverrideLoadRoutes,
   __testOverrideSaveRoutes,
@@ -6,7 +6,10 @@ import {
   getRouteRaw,
   setRouteInMemory,
 } from "@/channels/routing";
-import { bindProactiveSlackThreadRoute } from "./proactive-route";
+import {
+  bindProactiveSlackThreadRoute,
+  createProactiveSlackTransport,
+} from "./proactive-route";
 
 const params = {
   accountId: "account-1",
@@ -89,4 +92,50 @@ test("rolls back an in-memory binding when persistence fails", () => {
 
   __testOverrideSaveRoutes(() => {});
   expect(() => bindProactiveSlackThreadRoute(params)).not.toThrow();
+});
+
+test("reports a sent root as an error when its route cannot be persisted", async () => {
+  __testOverrideLoadRoutes(() => null);
+  __testOverrideSaveRoutes(() => {
+    throw new Error("disk unavailable");
+  });
+  const sendMessage = mock(async () => ({ messageId: params.rootMessageId }));
+  const transport = createProactiveSlackTransport({
+    adapter: {
+      id: "slack:account-1",
+      channelId: "slack",
+      accountId: params.accountId,
+      name: "Slack",
+      start: async () => {},
+      stop: async () => {},
+      isRunning: () => true,
+      sendMessage,
+      sendDirectReply: async () => {},
+    },
+    accountId: params.accountId,
+    target: {
+      chatId: params.chatId,
+      chatType: "channel",
+      threadId: null,
+    },
+    agentId: params.agentId,
+    conversationId: params.conversationId,
+  });
+
+  await expect(
+    transport.sendMessage({
+      channel: "slack",
+      accountId: params.accountId,
+      chatId: params.chatId,
+      text: "hello",
+      agentId: params.agentId,
+      conversationId: params.conversationId,
+    }),
+  ).rejects.toThrow(
+    `Slack accepted message ${params.rootMessageId}, but its thread route could not be persisted: disk unavailable`,
+  );
+  expect(sendMessage).toHaveBeenCalledTimes(1);
+  expect(
+    getRouteRaw("slack", params.chatId, params.accountId, params.rootMessageId),
+  ).toBeUndefined();
 });

--- a/src/channels/slack/proactive-route.test.ts
+++ b/src/channels/slack/proactive-route.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, expect, test } from "bun:test";
+import {
+  __testOverrideLoadRoutes,
+  __testOverrideSaveRoutes,
+  clearAllRoutes,
+  getRouteRaw,
+  setRouteInMemory,
+} from "@/channels/routing";
+import { bindProactiveSlackThreadRoute } from "./proactive-route";
+
+const params = {
+  accountId: "account-1",
+  chatId: "C123",
+  rootMessageId: "1712800000.000100",
+  agentId: "agent-1",
+  conversationId: "conv-schedule-1",
+};
+
+afterEach(() => {
+  clearAllRoutes();
+  __testOverrideLoadRoutes(null);
+  __testOverrideSaveRoutes(null);
+});
+
+function installRouteStorageOverrides(): void {
+  __testOverrideLoadRoutes(() => null);
+  __testOverrideSaveRoutes(() => {});
+}
+
+test("binds a proactive Slack root to its occurrence conversation", () => {
+  installRouteStorageOverrides();
+
+  bindProactiveSlackThreadRoute(params);
+
+  expect(
+    getRouteRaw("slack", params.chatId, params.accountId, params.rootMessageId),
+  ).toMatchObject({
+    accountId: params.accountId,
+    chatId: params.chatId,
+    chatType: "channel",
+    threadId: params.rootMessageId,
+    agentId: params.agentId,
+    conversationId: params.conversationId,
+    enabled: true,
+    outboundEnabled: true,
+  });
+});
+
+test("keeps an idempotent binding and refuses to overwrite a conflict", () => {
+  installRouteStorageOverrides();
+  bindProactiveSlackThreadRoute(params);
+  expect(() => bindProactiveSlackThreadRoute(params)).not.toThrow();
+
+  clearAllRoutes();
+  setRouteInMemory("slack", {
+    accountId: params.accountId,
+    chatId: params.chatId,
+    chatType: "channel",
+    threadId: params.rootMessageId,
+    agentId: "agent-other",
+    conversationId: "conv-other",
+    enabled: true,
+    createdAt: "2026-08-13T00:00:00.000Z",
+  });
+
+  expect(() => bindProactiveSlackThreadRoute(params)).toThrow(
+    "is already routed to agent-other/conv-other",
+  );
+  expect(
+    getRouteRaw("slack", params.chatId, params.accountId, params.rootMessageId),
+  ).toMatchObject({
+    agentId: "agent-other",
+    conversationId: "conv-other",
+  });
+});

--- a/src/channels/slack/proactive-route.ts
+++ b/src/channels/slack/proactive-route.ts
@@ -1,4 +1,14 @@
-import { addRoute, getRouteRaw, loadRoutes } from "@/channels/routing";
+import type {
+  ChannelMessageActionTransport,
+  ChannelResolvedMessageTarget,
+} from "@/channels/plugin-types";
+import {
+  addRoute,
+  getRouteRaw,
+  loadRoutes,
+  removeRouteInMemory,
+} from "@/channels/routing";
+import type { ChannelAdapter } from "@/channels/types";
 
 export interface BindProactiveSlackThreadRouteParams {
   accountId: string;
@@ -36,16 +46,67 @@ export function bindProactiveSlackThreadRoute(
   }
 
   const now = new Date().toISOString();
-  addRoute("slack", {
-    accountId: params.accountId,
-    chatId: params.chatId,
-    chatType: "channel",
-    threadId: params.rootMessageId,
-    agentId: params.agentId,
-    conversationId: params.conversationId,
-    enabled: true,
-    outboundEnabled: true,
-    createdAt: now,
-    updatedAt: now,
-  });
+  try {
+    addRoute("slack", {
+      accountId: params.accountId,
+      chatId: params.chatId,
+      chatType: "channel",
+      threadId: params.rootMessageId,
+      agentId: params.agentId,
+      conversationId: params.conversationId,
+      enabled: true,
+      outboundEnabled: true,
+      createdAt: now,
+      updatedAt: now,
+    });
+  } catch (error) {
+    removeRouteInMemory(
+      "slack",
+      params.chatId,
+      params.accountId,
+      params.rootMessageId,
+    );
+    throw error;
+  }
+}
+
+interface CreateProactiveSlackTransportParams {
+  adapter: ChannelAdapter;
+  accountId: string;
+  target: ChannelResolvedMessageTarget;
+  agentId: string;
+  conversationId: string;
+}
+
+export function createProactiveSlackTransport(
+  params: CreateProactiveSlackTransportParams,
+): ChannelMessageActionTransport {
+  return {
+    sendMessage: async (message) => {
+      const result = await params.adapter.sendMessage(message);
+      const isRootChannelPost =
+        params.target.chatType === "channel" &&
+        !message.threadId?.trim() &&
+        !message.replyToMessageId?.trim() &&
+        !message.reaction;
+      if (isRootChannelPost && result.messageId.trim()) {
+        try {
+          bindProactiveSlackThreadRoute({
+            accountId: params.accountId,
+            chatId: params.target.chatId,
+            rootMessageId: result.messageId,
+            agentId: params.agentId,
+            conversationId: params.conversationId,
+          });
+        } catch (error) {
+          console.error(
+            `[Channels] Failed to bind proactive Slack thread: ${
+              error instanceof Error ? error.message : String(error)
+            }`,
+          );
+        }
+      }
+      return result;
+    },
+  };
 }

--- a/src/channels/slack/proactive-route.ts
+++ b/src/channels/slack/proactive-route.ts
@@ -104,6 +104,9 @@ export function createProactiveSlackTransport(
               error instanceof Error ? error.message : String(error)
             }`,
           );
+          throw new Error(
+            `Slack accepted message ${result.messageId}, but its thread route could not be persisted: ${error instanceof Error ? error.message : String(error)}`,
+          );
         }
       }
       return result;

--- a/src/channels/slack/proactive-route.ts
+++ b/src/channels/slack/proactive-route.ts
@@ -1,0 +1,51 @@
+import { addRoute, getRouteRaw, loadRoutes } from "@/channels/routing";
+
+export interface BindProactiveSlackThreadRouteParams {
+  accountId: string;
+  chatId: string;
+  rootMessageId: string;
+  agentId: string;
+  conversationId: string;
+}
+
+/**
+ * Bind replies to a proactively posted Slack root back to the runtime that
+ * created it. Existing ownership is idempotent, but a conflicting route is
+ * never overwritten.
+ */
+export function bindProactiveSlackThreadRoute(
+  params: BindProactiveSlackThreadRouteParams,
+): void {
+  loadRoutes("slack");
+  const existing = getRouteRaw(
+    "slack",
+    params.chatId,
+    params.accountId,
+    params.rootMessageId,
+  );
+  if (existing) {
+    if (
+      existing.agentId === params.agentId &&
+      existing.conversationId === params.conversationId
+    ) {
+      return;
+    }
+    throw new Error(
+      `Slack thread ${params.accountId}/${params.chatId}/${params.rootMessageId} is already routed to ${existing.agentId}/${existing.conversationId}`,
+    );
+  }
+
+  const now = new Date().toISOString();
+  addRoute("slack", {
+    accountId: params.accountId,
+    chatId: params.chatId,
+    chatType: "channel",
+    threadId: params.rootMessageId,
+    agentId: params.agentId,
+    conversationId: params.conversationId,
+    enabled: true,
+    outboundEnabled: true,
+    createdAt: now,
+    updatedAt: now,
+  });
+}

--- a/src/cli/subcommands/cron-scope.ts
+++ b/src/cli/subcommands/cron-scope.ts
@@ -1,0 +1,28 @@
+export function resolveCronAgentId(fromArgs?: string): string {
+  return fromArgs || process.env.LETTA_AGENT_ID || "";
+}
+
+function resolveConversationAlias(
+  fromArgs?: string,
+): string | null | undefined {
+  if (fromArgs !== "self") return fromArgs;
+  const current = process.env.LETTA_CONVERSATION_ID?.trim();
+  if (current) return current;
+  console.error(
+    "Error: --conversation self requires an active conversation (LETTA_CONVERSATION_ID is not set).",
+  );
+  return null;
+}
+
+export function resolveCronAddConversationTarget(
+  fromArgs?: string,
+): string | null {
+  const resolved = resolveConversationAlias(fromArgs);
+  return resolved === undefined ? "new" : resolved;
+}
+
+export function resolveCronConversationFilter(
+  fromArgs?: string,
+): string | null | undefined {
+  return resolveConversationAlias(fromArgs);
+}

--- a/src/cli/subcommands/cron.test.ts
+++ b/src/cli/subcommands/cron.test.ts
@@ -16,6 +16,7 @@ const originalConsoleError = console.error;
 const originalBaseUrl = process.env.LETTA_BASE_URL;
 const originalApiKey = process.env.LETTA_API_KEY;
 const originalRuntimeDeviceId = process.env.LETTA_RUNTIME_ENVIRONMENT_DEVICE_ID;
+const originalConversationId = process.env.LETTA_CONVERSATION_ID;
 const originalLettaHome = process.env.LETTA_HOME;
 
 const addArgs = [
@@ -33,6 +34,12 @@ const addArgs = [
   "--conversation",
   "conversation-test",
 ];
+
+function withoutConversationArgument(args: string[]): string[] {
+  const index = args.indexOf("--conversation");
+  if (index < 0) return [...args];
+  return [...args.slice(0, index), ...args.slice(index + 2)];
+}
 
 function environment(deviceId: string) {
   const now = Date.now();
@@ -114,6 +121,7 @@ beforeEach(() => {
   process.env.LETTA_BASE_URL = "https://example.test";
   process.env.LETTA_API_KEY = "test-key";
   delete process.env.LETTA_RUNTIME_ENVIRONMENT_DEVICE_ID;
+  delete process.env.LETTA_CONVERSATION_ID;
   settingsManager.initialize = mock(
     async () => {},
   ) as typeof settingsManager.initialize;
@@ -144,6 +152,7 @@ afterEach(() => {
     ["LETTA_BASE_URL", originalBaseUrl],
     ["LETTA_API_KEY", originalApiKey],
     ["LETTA_RUNTIME_ENVIRONMENT_DEVICE_ID", originalRuntimeDeviceId],
+    ["LETTA_CONVERSATION_ID", originalConversationId],
     ["LETTA_HOME", originalLettaHome],
   ] as const) {
     if (value === undefined) delete process.env[key];
@@ -152,6 +161,89 @@ afterEach(() => {
 });
 
 describe("cron add execution targeting", () => {
+  test("Cloud schedules default to a new conversation per fire and ignore ambient conversation state", async () => {
+    process.env.LETTA_CONVERSATION_ID = "ambient-conversation";
+    const requests = installScheduleApi({});
+
+    expect(
+      await runCronSubcommand([
+        ...withoutConversationArgument(addArgs),
+        "--runner",
+        "cloud",
+      ]),
+    ).toBe(0);
+
+    expect(
+      requests.find((request) => request.method === "POST")?.body,
+    ).toMatchObject({ conversation_id: "new" });
+  });
+
+  test("local schedules default to a new conversation per fire and ignore ambient conversation state", async () => {
+    const home = mkdtempSync(join(tmpdir(), "letta-cron-conversation-test-"));
+    process.env.LETTA_HOME = home;
+    process.env.LETTA_CONVERSATION_ID = "ambient-conversation";
+    installScheduleApi({});
+    const logs: string[] = [];
+    console.log = mock((line: string) => {
+      logs.push(String(line));
+    });
+
+    try {
+      expect(
+        await runCronSubcommand([
+          ...withoutConversationArgument(addArgs),
+          "--runner",
+          "local",
+        ]),
+      ).toBe(0);
+
+      const output = JSON.parse(logs.join("")) as Record<string, unknown>;
+      expect(output.conversation_id).toBe("new");
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  test("--conversation self captures the current conversation", async () => {
+    process.env.LETTA_CONVERSATION_ID = "current-conversation";
+    const requests = installScheduleApi({});
+
+    expect(
+      await runCronSubcommand([
+        ...withoutConversationArgument(addArgs),
+        "--conversation",
+        "self",
+        "--runner",
+        "cloud",
+      ]),
+    ).toBe(0);
+
+    expect(
+      requests.find((request) => request.method === "POST")?.body,
+    ).toMatchObject({ conversation_id: "current-conversation" });
+  });
+
+  test("--conversation self fails without a current conversation", async () => {
+    const requests = installScheduleApi({});
+    const errors: string[] = [];
+    console.error = mock((line: string) => errors.push(String(line)));
+
+    expect(
+      await runCronSubcommand([
+        ...withoutConversationArgument(addArgs),
+        "--conversation",
+        "self",
+        "--runner",
+        "cloud",
+      ]),
+    ).toBe(1);
+
+    expect(errors).toContain(
+      "Error: --conversation self requires an active conversation (LETTA_CONVERSATION_ID is not set).",
+    );
+    expect(requests.some((request) => request.method === "POST")).toBe(false);
+  });
+
   test("default Cloud creation targets the current registered listener at the HTTP boundary", async () => {
     const requests = installScheduleApi({
       environments: { "device-persisted": environment("device-persisted") },

--- a/src/cli/subcommands/cron.ts
+++ b/src/cli/subcommands/cron.ts
@@ -60,6 +60,11 @@ import {
   validateTargetDevice,
 } from "./cron-runner";
 import {
+  resolveCronAddConversationTarget,
+  resolveCronAgentId,
+  resolveCronConversationFilter,
+} from "./cron-scope";
+import {
   ensureSettingsForCloud,
   printAmbiguousTaskName,
   resolveTaskName,
@@ -87,7 +92,9 @@ Add options:
   --once                 Fire once (with --at); default for --at
   --cron <expr>          Raw 5-field cron expression
   --agent <id>           Agent ID (defaults to LETTA_AGENT_ID)
-  --conversation <id>    Conversation ID (defaults to LETTA_CONVERSATION_ID or "default")
+  --conversation <id>    Conversation target (omit or "new" for a fresh
+                         conversation per fire; "self" for the current
+                         conversation; "default" for the agent default)
   --runner <runner>      Where the schedule lives and fires (normally omit:
                          the default keeps the schedule running where it was
                          created):
@@ -151,14 +158,6 @@ function parseCronArgs(argv: string[]) {
     strict: true,
     allowPositionals: true,
   });
-}
-
-function getAgentId(fromArgs?: string): string {
-  return fromArgs || process.env.LETTA_AGENT_ID || "";
-}
-
-function getConversationId(fromArgs?: string): string {
-  return fromArgs || process.env.LETTA_CONVERSATION_ID || "default";
 }
 
 // ── Runner resolution ───────────────────────────────────────────────
@@ -287,13 +286,14 @@ async function handleAdd(values: CronArgValues): Promise<number> {
     return 1;
   }
 
-  const agentId = getAgentId(values.agent);
+  const agentId = resolveCronAgentId(values.agent);
   if (!agentId) {
     console.error("Error: --agent or LETTA_AGENT_ID required.");
     return 1;
   }
 
-  const conversationId = getConversationId(values.conversation);
+  const conversationId = resolveCronAddConversationTarget(values.conversation);
+  if (conversationId === null) return 1;
 
   // Determine schedule type
   const everyValue = values.every;
@@ -564,7 +564,8 @@ async function handleList(values: CronArgValues): Promise<number> {
   }
 
   const agentId = values.agent || process.env.LETTA_AGENT_ID || undefined;
-  const conversationId = values.conversation || undefined;
+  const conversationId = resolveCronConversationFilter(values.conversation);
+  if (conversationId === null) return 1;
 
   const includeLocal = values.runner !== "cloud";
   const includeCloud = values.runner !== "local";
@@ -661,7 +662,7 @@ async function handleGet(
     return 1;
   }
 
-  const agentId = getAgentId(values.agent);
+  const agentId = resolveCronAgentId(values.agent);
 
   // Local store is a cheap file read; check it first unless --runner cloud.
   if (values.runner !== "cloud") {
@@ -769,7 +770,7 @@ async function handleRuns(values: CronArgValues): Promise<number> {
     return 1;
   }
 
-  const agentId = getAgentId(values.agent);
+  const agentId = resolveCronAgentId(values.agent);
   if (!agentId) {
     console.error(
       `Error: task ${id} not found locally, and --agent or LETTA_AGENT_ID is required to look up Cloud schedule runs.`,
@@ -829,7 +830,7 @@ async function handleDelete(
     }
   }
 
-  const agentId = getAgentId(values.agent);
+  const agentId = resolveCronAgentId(values.agent);
 
   // Cloud delete by ID (unless --runner local).
   if (values.runner !== "local") {
@@ -898,7 +899,7 @@ async function handleDelete(
 }
 
 async function handleDeleteAll(values: CronArgValues): Promise<number> {
-  const agentId = getAgentId(values.agent);
+  const agentId = resolveCronAgentId(values.agent);
   if (!agentId) {
     console.error("Error: --agent or LETTA_AGENT_ID required with --all.");
     return 1;

--- a/src/cron/cron-file.test.ts
+++ b/src/cron/cron-file.test.ts
@@ -98,6 +98,20 @@ describe("addTask", () => {
     expect(result.task.conversation_id).toBe("new");
   });
 
+  test("defaults an omitted conversation target to new", () => {
+    const input = makeInput();
+    delete input.conversation_id;
+
+    const result = addTask(input);
+
+    expect(result.task.conversation_id).toBe("new");
+  });
+
+  test("preserves an explicit default conversation target", () => {
+    const result = addTask(makeInput({ conversation_id: "default" }));
+    expect(result.task.conversation_id).toBe("default");
+  });
+
   test("creates a one-shot task", () => {
     const scheduledFor = new Date(Date.now() + 60000);
     const result = addTask(

--- a/src/cron/cron-file.ts
+++ b/src/cron/cron-file.ts
@@ -474,8 +474,8 @@ export interface AddTaskInput {
   agent_id: string;
   /**
    * Conversation target for scheduled fires.
-   * - omitted/"default": agent default conversation
-   * - "new": fresh conversation per fire
+   * - omitted/"new": fresh conversation per fire
+   * - "default": agent default conversation
    * - any other string: existing conversation id
    */
   conversation_id?: string;
@@ -500,7 +500,7 @@ export function addTask(input: AddTaskInput): AddTaskResult {
   return withLock(() => {
     const data = readCronFile();
     const agentId = input.agent_id;
-    const conversationId = input.conversation_id ?? "default";
+    const conversationId = input.conversation_id ?? "new";
 
     // Check per-agent active limit
     const activeCount = data.tasks.filter(

--- a/src/skills/builtin/scheduling-tasks/SKILL.md
+++ b/src/skills/builtin/scheduling-tasks/SKILL.md
@@ -31,7 +31,7 @@ The CLI reports its placement in the command output. If it warns that the schedu
 Two patterns cover most schedules:
 
 - **Fast follow-ups** ("check on the PR in 5m"): the default is right — same computer as the active conversation. If the session dies before it fires, the follow-up usually died with the task anyway.
-- **Recurring jobs** ("every Monday 11am, start the lunch order"): prefer durability. If the CLI warned that a recurring schedule is local, that's usually wrong for the user's intent — recreate it with `--runner cloud`, or `--computer` if the job needs a specific always-on computer. Also consider whether the job should post into a dedicated conversation rather than this one (continuity in one thread vs a fresh context per run).
+- **Recurring jobs** ("every Monday 11am, start the lunch order"): prefer durability. If the CLI warned that a recurring schedule is local, that's usually wrong for the user's intent — recreate it with `--runner cloud`, or `--computer` if the job needs a specific always-on computer. A fresh conversation per run is the default; pass a conversation explicitly when the job needs continuity in one thread.
 
 ## CLI Usage
 
@@ -64,7 +64,7 @@ letta cron add --name <short-name> --description <text> --prompt <text> <schedul
 | Flag | Description |
 |------|-------------|
 | `--agent <id>` | Agent ID (defaults to `LETTA_AGENT_ID` from the current shell/session) |
-| `--conversation <id>` | Conversation ID (defaults to `LETTA_CONVERSATION_ID` from the current shell/session, otherwise `"default"`) |
+| `--conversation <id>` | Conversation target: omit or pass `new` for a fresh conversation per fire; pass `self` for the current conversation; pass `default` for the agent default; or pass a concrete ID |
 | `--runner <runner>` | `cloud` or `local` — normally omit; see "Where Schedules Run" above |
 | `--computer <id>` | Execute on a specific connected computer — normally omit |
 | `--once` | Mark `--at` as one-shot (already the default for `--at`) |
@@ -97,7 +97,7 @@ For local run history, `--run-id <id>` selects one run. Cloud history ignores th
 
 If exact routing matters, pass both `--agent` and `--conversation` explicitly.
 
-`letta cron add` will otherwise fall back to `LETTA_AGENT_ID` and `LETTA_CONVERSATION_ID` from the current shell/session. Those values may be correct for the current chat, but they can also be inherited from surrounding tooling, another conversation, or an older shell.
+`letta cron add` falls back to `LETTA_AGENT_ID` for the agent. An omitted `--conversation` means `"new"`, so every fire gets a fresh conversation. Pass `--conversation self` to capture the current `LETTA_CONVERSATION_ID`, `--conversation default` for the agent default, or a concrete conversation ID.
 
 Safest pattern:
 
@@ -107,14 +107,14 @@ letta cron add \
   --description "Daily email summary in this conversation" \
   --prompt "Check the user's email and post a summary here." \
   --cron "0 10 * * *" \
-  --agent "$AGENT_ID" \
-  --conversation "$CONVERSATION_ID"
+  --agent "$LETTA_AGENT_ID" \
+  --conversation self
 ```
 
 Then verify the binding explicitly:
 
 ```bash
-letta cron list --agent "$AGENT_ID" --conversation "$CONVERSATION_ID"
+letta cron list --agent "$LETTA_AGENT_ID" --conversation self
 ```
 
 ### Deleting or Replacing Tasks
@@ -156,7 +156,9 @@ letta cron add \
   --name "deploy-check" \
   --description "One-time check on deployment status" \
   --prompt "Check the deployment status and report the result here." \
-  --at "in 30m"
+  --at "in 30m" \
+  --agent "$LETTA_AGENT_ID" \
+  --conversation self
 ```
 
 ### "Every weekday at 5pm, remind me to submit my timesheet" (user in UTC−7)
@@ -203,7 +205,7 @@ Include context about what the user originally asked for, so you can give a help
 - **Minimum granularity**: 1 minute. Intervals under 60 seconds are rounded up.
 - **Recurring tasks**: No longer auto-expire. They remain active until explicitly cancelled.
 - **One-shot cleanup (local runner)**: One-shot local tasks are garbage-collected 24 hours after firing.
-- **Default binding precedence**: `letta cron add` uses `--agent` / `--conversation` first, then falls back to `LETTA_AGENT_ID` / `LETTA_CONVERSATION_ID`, then finally uses `"default"` for the conversation if no env var is present.
+- **Default binding**: `letta cron add` uses `--agent` first, then `LETTA_AGENT_ID`. Omit `--conversation` for a fresh conversation per fire; use `--conversation self` to capture `LETTA_CONVERSATION_ID` explicitly.
 - **Local scheduler requirement**: Local schedules only fire while a Letta session is running on their computer; fires while no session runs are marked as missed. Cloud schedules fire from the cloud regardless.
 - **`--at` for specific times**: `--at "3:00pm"` schedules a one-shot. If the time has already passed today, it schedules for tomorrow.
 - **Cloud schedule creation failures are loud**: if creating a cloud schedule fails, no schedule is created — a failed create never silently becomes a local schedule. (The local placement for computers the cloud scheduler can't reach is decided before creation and reported in the output.)

--- a/src/tools/impl/message-channel.ts
+++ b/src/tools/impl/message-channel.ts
@@ -19,52 +19,10 @@ import {
   isSupportedChannelId,
   loadChannelPlugin,
 } from "@/channels/plugin-registry";
-import type {
-  ChannelMessageActionTransport,
-  ChannelResolvedMessageTarget,
-} from "@/channels/plugin-types";
 import { getChannelRegistry } from "@/channels/registry";
 import { resolveEligibleProactiveSlackAccount } from "@/channels/slack/proactive-accounts";
-import { bindProactiveSlackThreadRoute } from "@/channels/slack/proactive-route";
-import type { ChannelAdapter } from "@/channels/types";
+import { createProactiveSlackTransport } from "@/channels/slack/proactive-route";
 import type { ExternalToolCallResult } from "@/types/app-server-protocol";
-
-function createProactiveSlackTransport(params: {
-  adapter: ChannelAdapter;
-  accountId: string;
-  target: ChannelResolvedMessageTarget;
-  agentId: string;
-  conversationId: string;
-}): ChannelMessageActionTransport {
-  return {
-    sendMessage: async (message) => {
-      const result = await params.adapter.sendMessage(message);
-      const isRootChannelPost =
-        params.target.chatType === "channel" &&
-        !message.threadId?.trim() &&
-        !message.replyToMessageId?.trim() &&
-        !message.reaction;
-      if (isRootChannelPost && result.messageId.trim()) {
-        try {
-          bindProactiveSlackThreadRoute({
-            accountId: params.accountId,
-            chatId: params.target.chatId,
-            rootMessageId: result.messageId,
-            agentId: params.agentId,
-            conversationId: params.conversationId,
-          });
-        } catch (error) {
-          console.error(
-            `[Channels] Failed to bind proactive Slack thread: ${
-              error instanceof Error ? error.message : String(error)
-            }`,
-          );
-        }
-      }
-      return result;
-    },
-  };
-}
 
 function createLocalMessageChannelResolver(): MessageChannelExecutionResolver {
   return {

--- a/src/tools/impl/message-channel.ts
+++ b/src/tools/impl/message-channel.ts
@@ -19,9 +19,52 @@ import {
   isSupportedChannelId,
   loadChannelPlugin,
 } from "@/channels/plugin-registry";
+import type {
+  ChannelMessageActionTransport,
+  ChannelResolvedMessageTarget,
+} from "@/channels/plugin-types";
 import { getChannelRegistry } from "@/channels/registry";
 import { resolveEligibleProactiveSlackAccount } from "@/channels/slack/proactive-accounts";
+import { bindProactiveSlackThreadRoute } from "@/channels/slack/proactive-route";
+import type { ChannelAdapter } from "@/channels/types";
 import type { ExternalToolCallResult } from "@/types/app-server-protocol";
+
+function createProactiveSlackTransport(params: {
+  adapter: ChannelAdapter;
+  accountId: string;
+  target: ChannelResolvedMessageTarget;
+  agentId: string;
+  conversationId: string;
+}): ChannelMessageActionTransport {
+  return {
+    sendMessage: async (message) => {
+      const result = await params.adapter.sendMessage(message);
+      const isRootChannelPost =
+        params.target.chatType === "channel" &&
+        !message.threadId?.trim() &&
+        !message.replyToMessageId?.trim() &&
+        !message.reaction;
+      if (isRootChannelPost && result.messageId.trim()) {
+        try {
+          bindProactiveSlackThreadRoute({
+            accountId: params.accountId,
+            chatId: params.target.chatId,
+            rootMessageId: result.messageId,
+            agentId: params.agentId,
+            conversationId: params.conversationId,
+          });
+        } catch (error) {
+          console.error(
+            `[Channels] Failed to bind proactive Slack thread: ${
+              error instanceof Error ? error.message : String(error)
+            }`,
+          );
+        }
+      }
+      return result;
+    },
+  };
+}
 
 function createLocalMessageChannelResolver(): MessageChannelExecutionResolver {
   return {
@@ -64,7 +107,6 @@ function createLocalMessageChannelResolver(): MessageChannelExecutionResolver {
       }
       const eligibleAccount = resolveEligibleProactiveSlackAccount({
         agentId: params.scope.agentId,
-        conversationId: params.scope.conversationId,
         accountId: params.accountId,
       });
       if (typeof eligibleAccount === "string") return eligibleAccount;
@@ -82,7 +124,13 @@ function createLocalMessageChannelResolver(): MessageChannelExecutionResolver {
       return {
         accountId: eligibleAccount.account.accountId,
         target,
-        transport: eligibleAccount.adapter,
+        transport: createProactiveSlackTransport({
+          adapter: eligibleAccount.adapter,
+          accountId: eligibleAccount.account.accountId,
+          target,
+          agentId: params.scope.agentId,
+          conversationId: params.scope.conversationId,
+        }),
         messageActions,
       };
     },

--- a/src/types/protocol_v2.ts
+++ b/src/types/protocol_v2.ts
@@ -1611,8 +1611,8 @@ export interface CronAddCommand {
   agent_id: string;
   /**
    * Conversation target for scheduled fires.
-   * - omitted/"default": agent default conversation
-   * - "new": create a fresh conversation for every fire
+   * - omitted/"new": create a fresh conversation for every fire
+   * - "default": agent default conversation
    * - any other string: existing conversation id
    */
   conversation_id?: string;

--- a/src/types/service-protocol.ts
+++ b/src/types/service-protocol.ts
@@ -41,6 +41,7 @@ export function isChannelServiceCommandType(
 
 export type ServiceCommandRequest =
   | { kind: "protocol"; command: WsProtocolCommand }
+  | { kind: "register_runtime"; runtime: RuntimeScope }
   | {
       kind: "slash_command";
       command: "channels";
@@ -50,6 +51,7 @@ export type ServiceCommandRequest =
 
 export type ServiceCommandResponse =
   | { kind: "protocol"; messages: WsProtocolMessage[] }
+  | { kind: "runtime_registered" }
   | { kind: "text"; text: string };
 
 export type ServiceEvent = {

--- a/src/types/service-protocol.ts
+++ b/src/types/service-protocol.ts
@@ -41,7 +41,8 @@ export function isChannelServiceCommandType(
 
 export type ServiceCommandRequest =
   | { kind: "protocol"; command: WsProtocolCommand }
-  | { kind: "register_runtime"; runtime: RuntimeScope }
+  | { kind: "publish_runtime_tools"; runtime: RuntimeScope }
+  | { kind: "release_runtime_tools"; runtime: RuntimeScope }
   | {
       kind: "slash_command";
       command: "channels";
@@ -51,7 +52,8 @@ export type ServiceCommandRequest =
 
 export type ServiceCommandResponse =
   | { kind: "protocol"; messages: WsProtocolMessage[] }
-  | { kind: "runtime_registered" }
+  | { kind: "runtime_tools_published"; transient: boolean }
+  | { kind: "runtime_tools_released" }
   | { kind: "text"; text: string };
 
 export type ServiceEvent = {

--- a/src/websocket/listener/channel-runtime-tools.test.ts
+++ b/src/websocket/listener/channel-runtime-tools.test.ts
@@ -1,35 +1,48 @@
 import { expect, mock, test } from "bun:test";
-import { registerChannelRuntimeToolsForTurn } from "./channel-runtime-tools";
+import {
+  publishChannelRuntimeToolsForTurn,
+  releaseChannelRuntimeToolsForTurn,
+} from "./channel-runtime-tools";
 
 const runtime = {
   agent_id: "agent-1",
   conversation_id: "conv-schedule-1",
 };
 
-test("registers a runtime before channel tools are prepared", async () => {
+test("publishes runtime tools before channel tools are prepared", async () => {
   const serviceCommandHandler = mock(async () => ({
-    kind: "runtime_registered" as const,
+    kind: "runtime_tools_published" as const,
+    transient: true,
   }));
 
   await expect(
-    registerChannelRuntimeToolsForTurn({ serviceCommandHandler }, runtime),
+    publishChannelRuntimeToolsForTurn({ serviceCommandHandler }, runtime),
   ).resolves.toBe(true);
   expect(serviceCommandHandler).toHaveBeenCalledWith({
-    kind: "register_runtime",
+    kind: "publish_runtime_tools",
+    runtime,
+  });
+});
+
+test("releases tools that were published only for one turn", async () => {
+  const serviceCommandHandler = mock(async () => ({
+    kind: "runtime_tools_released" as const,
+  }));
+
+  await releaseChannelRuntimeToolsForTurn({ serviceCommandHandler }, runtime);
+  expect(serviceCommandHandler).toHaveBeenCalledWith({
+    kind: "release_runtime_tools",
     runtime,
   });
 });
 
 test("does not block turns when the channel gateway is absent or fails", async () => {
   await expect(
-    registerChannelRuntimeToolsForTurn(
-      { serviceCommandHandler: null },
-      runtime,
-    ),
+    publishChannelRuntimeToolsForTurn({ serviceCommandHandler: null }, runtime),
   ).resolves.toBe(false);
 
   await expect(
-    registerChannelRuntimeToolsForTurn(
+    publishChannelRuntimeToolsForTurn(
       {
         serviceCommandHandler: async () => {
           throw new Error("gateway unavailable");

--- a/src/websocket/listener/channel-runtime-tools.test.ts
+++ b/src/websocket/listener/channel-runtime-tools.test.ts
@@ -1,0 +1,41 @@
+import { expect, mock, test } from "bun:test";
+import { registerChannelRuntimeToolsForTurn } from "./channel-runtime-tools";
+
+const runtime = {
+  agent_id: "agent-1",
+  conversation_id: "conv-schedule-1",
+};
+
+test("registers a runtime before channel tools are prepared", async () => {
+  const serviceCommandHandler = mock(async () => ({
+    kind: "runtime_registered" as const,
+  }));
+
+  await expect(
+    registerChannelRuntimeToolsForTurn({ serviceCommandHandler }, runtime),
+  ).resolves.toBe(true);
+  expect(serviceCommandHandler).toHaveBeenCalledWith({
+    kind: "register_runtime",
+    runtime,
+  });
+});
+
+test("does not block turns when the channel gateway is absent or fails", async () => {
+  await expect(
+    registerChannelRuntimeToolsForTurn(
+      { serviceCommandHandler: null },
+      runtime,
+    ),
+  ).resolves.toBe(false);
+
+  await expect(
+    registerChannelRuntimeToolsForTurn(
+      {
+        serviceCommandHandler: async () => {
+          throw new Error("gateway unavailable");
+        },
+      },
+      runtime,
+    ),
+  ).resolves.toBe(false);
+});

--- a/src/websocket/listener/channel-runtime-tools.ts
+++ b/src/websocket/listener/channel-runtime-tools.ts
@@ -16,7 +16,7 @@ type ChannelRuntimeToolRegistrar = {
  * runtime before the listener snapshots its toolset. This is best-effort so a
  * channel subsystem failure never blocks an otherwise valid device turn.
  */
-export async function registerChannelRuntimeToolsForTurn(
+export async function publishChannelRuntimeToolsForTurn(
   listener: ChannelRuntimeToolRegistrar,
   runtime: RuntimeScope,
 ): Promise<boolean> {
@@ -24,19 +24,46 @@ export async function registerChannelRuntimeToolsForTurn(
   if (!handler) return false;
 
   try {
-    const response = await handler({ kind: "register_runtime", runtime });
-    if (response.kind === "runtime_registered") return true;
+    const response = await handler({ kind: "publish_runtime_tools", runtime });
+    if (response.kind === "runtime_tools_published") {
+      return response.transient;
+    }
     debugWarn(
       "listen",
-      `ChannelGateway returned an unexpected runtime registration response: ${response.kind}`,
+      `ChannelGateway returned an unexpected tool publication response: ${response.kind}`,
     );
   } catch (error) {
     debugWarn(
       "listen",
-      `Failed to register channel tools for ${runtime.agent_id}/${runtime.conversation_id}: ${
+      `Failed to publish channel tools for ${runtime.agent_id}/${runtime.conversation_id}: ${
         error instanceof Error ? error.message : String(error)
       }`,
     );
   }
   return false;
+}
+
+/** Remove tools that were published only for one listener-owned turn. */
+export async function releaseChannelRuntimeToolsForTurn(
+  listener: ChannelRuntimeToolRegistrar,
+  runtime: RuntimeScope,
+): Promise<void> {
+  const handler = listener.serviceCommandHandler;
+  if (!handler) return;
+
+  try {
+    const response = await handler({ kind: "release_runtime_tools", runtime });
+    if (response.kind === "runtime_tools_released") return;
+    debugWarn(
+      "listen",
+      `ChannelGateway returned an unexpected tool release response: ${response.kind}`,
+    );
+  } catch (error) {
+    debugWarn(
+      "listen",
+      `Failed to release channel tools for ${runtime.agent_id}/${runtime.conversation_id}: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+  }
 }

--- a/src/websocket/listener/channel-runtime-tools.ts
+++ b/src/websocket/listener/channel-runtime-tools.ts
@@ -1,0 +1,42 @@
+import type { RuntimeScope } from "@/types/app-server-protocol";
+import type {
+  ServiceCommandRequest,
+  ServiceCommandResponse,
+} from "@/types/service-protocol";
+import { debugWarn } from "@/utils/debug";
+
+type ChannelRuntimeToolRegistrar = {
+  serviceCommandHandler:
+    | ((request: ServiceCommandRequest) => Promise<ServiceCommandResponse>)
+    | null;
+};
+
+/**
+ * Give the process-owned channel gateway a chance to publish tools for a
+ * runtime before the listener snapshots its toolset. This is best-effort so a
+ * channel subsystem failure never blocks an otherwise valid device turn.
+ */
+export async function registerChannelRuntimeToolsForTurn(
+  listener: ChannelRuntimeToolRegistrar,
+  runtime: RuntimeScope,
+): Promise<boolean> {
+  const handler = listener.serviceCommandHandler;
+  if (!handler) return false;
+
+  try {
+    const response = await handler({ kind: "register_runtime", runtime });
+    if (response.kind === "runtime_registered") return true;
+    debugWarn(
+      "listen",
+      `ChannelGateway returned an unexpected runtime registration response: ${response.kind}`,
+    );
+  } catch (error) {
+    debugWarn(
+      "listen",
+      `Failed to register channel tools for ${runtime.agent_id}/${runtime.conversation_id}: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+  }
+  return false;
+}

--- a/src/websocket/listener/runtime.ts
+++ b/src/websocket/listener/runtime.ts
@@ -290,6 +290,7 @@ export function createConversationRuntime(
     currentToolsetPreference: "auto",
     currentLoadedTools: [],
     currentAvailableSkills: [],
+    transientChannelRuntimeTools: false,
     pendingApprovalBatchByToolCallId: new Map(),
     approvalMessageIdByToolCallId: new Map(),
     pendingInterruptedResults: null,

--- a/src/websocket/listener/turn-cleanup.test.ts
+++ b/src/websocket/listener/turn-cleanup.test.ts
@@ -1,0 +1,28 @@
+import { expect, mock, test } from "bun:test";
+import { getOrCreateScopedRuntime } from "./conversation-runtime";
+import { createRuntime } from "./lifecycle";
+import { runListenerTurnCleanup } from "./turn-cleanup";
+
+test("releases transient channel tools when turn finalization moved elsewhere", async () => {
+  const listener = createRuntime();
+  const runtime = getOrCreateScopedRuntime(listener, "agent-1", "conv-1");
+  const serviceCommandHandler = mock(async () => ({
+    kind: "runtime_tools_released" as const,
+  }));
+  listener.serviceCommandHandler = serviceCommandHandler;
+  runtime.transientChannelRuntimeTools = true;
+
+  await runListenerTurnCleanup({
+    runtime,
+    agentId: "agent-1",
+    normalizedAgentId: "agent-1",
+    conversationId: "conv-1",
+    finalized: false,
+  });
+
+  expect(serviceCommandHandler).toHaveBeenCalledWith({
+    kind: "release_runtime_tools",
+    runtime: { agent_id: "agent-1", conversation_id: "conv-1" },
+  });
+  expect(runtime.transientChannelRuntimeTools).toBe(false);
+});

--- a/src/websocket/listener/turn-cleanup.ts
+++ b/src/websocket/listener/turn-cleanup.ts
@@ -1,6 +1,7 @@
 import { runPostTurnMemorySync } from "@/reminders/memory-git-sync";
 import { enqueueMemoryGitSyncReminder } from "@/reminders/state";
 import { settingsManager } from "@/settings-manager";
+import { releaseChannelRuntimeToolsForTurn } from "./channel-runtime-tools";
 import {
   persistPermissionModeMapForRuntime,
   pruneConversationPermissionModeStateIfDefault,
@@ -13,8 +14,22 @@ export async function runListenerTurnCleanup(params: {
   agentId?: string | null;
   normalizedAgentId: string | null;
   conversationId: string;
+  finalized: boolean;
 }): Promise<void> {
-  const { runtime, agentId, normalizedAgentId, conversationId } = params;
+  const { runtime, agentId, normalizedAgentId, conversationId, finalized } =
+    params;
+
+  if (runtime.transientChannelRuntimeTools) {
+    if (agentId) {
+      await releaseChannelRuntimeToolsForTurn(runtime.listener, {
+        agent_id: agentId,
+        conversation_id: conversationId,
+      });
+    }
+    runtime.transientChannelRuntimeTools = false;
+  }
+
+  if (!finalized) return;
 
   pruneConversationPermissionModeStateIfDefault(
     runtime.listener,

--- a/src/websocket/listener/turn-setup.ts
+++ b/src/websocket/listener/turn-setup.ts
@@ -21,7 +21,7 @@ import { INTERACTIVE_USER_INPUT_TOOL_NAMES } from "@/tools/interactive-policy";
 import { prepareToolExecutionContextForScope } from "@/tools/toolset";
 import { debugWarn, isDebugEnabled } from "@/utils/debug";
 import { detectShellContext } from "@/utils/shell-context";
-import { registerChannelRuntimeToolsForTurn } from "./channel-runtime-tools";
+import { publishChannelRuntimeToolsForTurn } from "./channel-runtime-tools";
 import { getInboundImageFailureModes } from "./image-policy";
 import { consumeInterruptQueue } from "./interrupts";
 import {
@@ -270,10 +270,11 @@ export async function prepareListenerTurn(params: {
     runtime.listener,
     agentId,
   );
-  await registerChannelRuntimeToolsForTurn(runtime.listener, {
-    agent_id: agentId,
-    conversation_id: conversationId,
-  });
+  runtime.transientChannelRuntimeTools =
+    await publishChannelRuntimeToolsForTurn(runtime.listener, {
+      agent_id: agentId,
+      conversation_id: conversationId,
+    });
   if (isInterrupted()) {
     return { kind: "interrupted" };
   }

--- a/src/websocket/listener/turn-setup.ts
+++ b/src/websocket/listener/turn-setup.ts
@@ -21,6 +21,7 @@ import { INTERACTIVE_USER_INPUT_TOOL_NAMES } from "@/tools/interactive-policy";
 import { prepareToolExecutionContextForScope } from "@/tools/toolset";
 import { debugWarn, isDebugEnabled } from "@/utils/debug";
 import { detectShellContext } from "@/utils/shell-context";
+import { registerChannelRuntimeToolsForTurn } from "./channel-runtime-tools";
 import { getInboundImageFailureModes } from "./image-policy";
 import { consumeInterruptQueue } from "./interrupts";
 import {
@@ -269,6 +270,13 @@ export async function prepareListenerTurn(params: {
     runtime.listener,
     agentId,
   );
+  await registerChannelRuntimeToolsForTurn(runtime.listener, {
+    agent_id: agentId,
+    conversation_id: conversationId,
+  });
+  if (isInterrupted()) {
+    return { kind: "interrupted" };
+  }
   const listenerOptions = connectionId
     ? runtime.listener.connections.get(connectionId)?.options
     : runtime.listener.connections.values().next().value?.options;

--- a/src/websocket/listener/turn.ts
+++ b/src/websocket/listener/turn.ts
@@ -993,14 +993,13 @@ async function handleIncomingMessageInner(
     }
 
     try {
-      if (finalizedByThisInvocation) {
-        await runListenerTurnCleanup({
-          runtime,
-          agentId,
-          normalizedAgentId,
-          conversationId,
-        });
-      }
+      await runListenerTurnCleanup({
+        runtime,
+        agentId,
+        normalizedAgentId,
+        conversationId,
+        finalized: finalizedByThisInvocation,
+      });
     } finally {
       releaseListenerTurnContext({ runtime, agentId, conversationId });
     }

--- a/src/websocket/listener/types.ts
+++ b/src/websocket/listener/types.ts
@@ -218,6 +218,7 @@ export type ConversationRuntime = {
   currentToolsetPreference: ToolsetPreference;
   currentLoadedTools: string[];
   currentAvailableSkills: AvailableSkillSummary[];
+  transientChannelRuntimeTools: boolean;
   pendingApprovalBatchByToolCallId: Map<string, string>;
   /**
    * tool_call_id -> server-assigned id of the approval_request_message that


### PR DESCRIPTION
## Summary

- publish `MessageChannel` before a scheduled turn snapshots its tools without starting or subscribing a channel-gateway runtime
- remove turn-only tool registrations after completion, while retaining them when the turn creates a durable channel route
- expose proactive Slack for an agent-owned running account even when the conversation has no existing channel route
- bind each successful top-level Slack post to the concrete conversation that created it
- roll back failed route bindings and return a tool error when Slack accepts a post whose route cannot be saved

## Why

Fresh schedule conversations start without an inbound channel route. They therefore lacked `MessageChannel`; and when a proactive root was posted, the first Slack reply could provision a separate conversation instead of continuing the schedule occurrence.

Publishing the tool through `runtime_start` would also permanently subscribe the gateway to every fresh schedule conversation. This instead uses the external-tool update path and removes the registration when the turn finishes.

## Validation

- `bun test src/channels/gateway-core.test.ts src/channels/routed-runtime-registration.test.ts src/channels/message-channel-gateway-tool.test.ts src/channels/message-channel-gateway.test.ts src/channels/slack/proactive-route.test.ts src/websocket/listener/channel-runtime-tools.test.ts src/websocket/listener/turn-cleanup.test.ts src/websocket/listener/external-tools.test.ts` (61 passed)
- `bun run check` (12/12 passed)
- live scheduled-run-to-Slack smoke: two concrete conversations posted separate roots; replies to each root returned only to its originating conversation; no reply conversation was created

👾 Generated with [Letta Code](https://letta.com)
