### PR TITLE
fix(cron): isolate scheduled invocations by default

### DIFF
--- a/src/cli/subcommands/cron-scope.ts
+++ b/src/cli/subcommands/cron-scope.ts
@@ -1,0 +1,28 @@
+export function resolveCronAgentId(fromArgs?: string): string {
+  return fromArgs || process.env.LETTA_AGENT_ID || "";
+}
+
+function resolveConversationAlias(
+  fromArgs?: string,
+): string | null | undefined {
+  if (fromArgs !== "self") return fromArgs;
+  const current = process.env.LETTA_CONVERSATION_ID?.trim();
+  if (current) return current;
+  console.error(
+    "Error: --conversation self requires an active conversation (LETTA_CONVERSATION_ID is not set).",
+  );
+  return null;
+}
+
+export function resolveCronAddConversationTarget(
+  fromArgs?: string,
+): string | null {
+  const resolved = resolveConversationAlias(fromArgs);
+  return resolved === undefined ? "new" : resolved;
+}
+
+export function resolveCronConversationFilter(
+  fromArgs?: string,
+): string | null | undefined {
+  return resolveConversationAlias(fromArgs);
+}

--- a/src/cli/subcommands/cron.test.ts
+++ b/src/cli/subcommands/cron.test.ts
@@ -16,6 +16,7 @@ const originalConsoleError = console.error;
 const originalBaseUrl = process.env.LETTA_BASE_URL;
 const originalApiKey = process.env.LETTA_API_KEY;
 const originalRuntimeDeviceId = process.env.LETTA_RUNTIME_ENVIRONMENT_DEVICE_ID;
+const originalConversationId = process.env.LETTA_CONVERSATION_ID;
 const originalLettaHome = process.env.LETTA_HOME;
 
 const addArgs = [
@@ -33,6 +34,12 @@ const addArgs = [
   "--conversation",
   "conversation-test",
 ];
+
+function withoutConversationArgument(args: string[]): string[] {
+  const index = args.indexOf("--conversation");
+  if (index < 0) return [...args];
+  return [...args.slice(0, index), ...args.slice(index + 2)];
+}
 
 function environment(deviceId: string) {
   const now = Date.now();
@@ -114,6 +121,7 @@ beforeEach(() => {
   process.env.LETTA_BASE_URL = "https://example.test";
   process.env.LETTA_API_KEY = "test-key";
   delete process.env.LETTA_RUNTIME_ENVIRONMENT_DEVICE_ID;
+  delete process.env.LETTA_CONVERSATION_ID;
   settingsManager.initialize = mock(
     async () => {},
   ) as typeof settingsManager.initialize;
@@ -144,6 +152,7 @@ afterEach(() => {
     ["LETTA_BASE_URL", originalBaseUrl],
     ["LETTA_API_KEY", originalApiKey],
     ["LETTA_RUNTIME_ENVIRONMENT_DEVICE_ID", originalRuntimeDeviceId],
+    ["LETTA_CONVERSATION_ID", originalConversationId],
     ["LETTA_HOME", originalLettaHome],
   ] as const) {
     if (value === undefined) delete process.env[key];
@@ -152,6 +161,49 @@ afterEach(() => {
 });
 
 describe("cron add execution targeting", () => {
+  test("Cloud schedules default to a new conversation per fire and ignore ambient conversation state", async () => {
+    process.env.LETTA_CONVERSATION_ID = "ambient-conversation";
+    const requests = installScheduleApi({});
+
+    expect(
+      await runCronSubcommand([
+        ...withoutConversationArgument(addArgs),
+        "--runner",
+        "cloud",
+      ]),
+    ).toBe(0);
+
+    expect(
+      requests.find((request) => request.method === "POST")?.body,
+    ).toMatchObject({ conversation_id: "new" });
+  });
+
+  test("local schedules default to a new conversation per fire and ignore ambient conversation state", async () => {
+    const home = mkdtempSync(join(tmpdir(), "letta-cron-conversation-test-"));
+    process.env.LETTA_HOME = home;
+    process.env.LETTA_CONVERSATION_ID = "ambient-conversation";
+    installScheduleApi({});
+    const logs: string[] = [];
+    console.log = mock((line: string) => {
+      logs.push(String(line));
+    });
+
+    try {
+      expect(
+        await runCronSubcommand([
+          ...withoutConversationArgument(addArgs),
+          "--runner",
+          "local",
+        ]),
+      ).toBe(0);
+
+      const output = JSON.parse(logs.join("")) as Record<string, unknown>;
+      expect(output.conversation_id).toBe("new");
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
   test("default Cloud creation targets the current registered listener at the HTTP boundary", async () => {
     const requests = installScheduleApi({
       environments: { "device-persisted": environment("device-persisted") },

--- a/src/cli/subcommands/cron.test.ts
+++ b/src/cli/subcommands/cron.test.ts
@@ -204,6 +204,46 @@ describe("cron add execution targeting", () => {
     }
   });
 
+  test("--conversation self captures the current conversation", async () => {
+    process.env.LETTA_CONVERSATION_ID = "current-conversation";
+    const requests = installScheduleApi({});
+
+    expect(
+      await runCronSubcommand([
+        ...withoutConversationArgument(addArgs),
+        "--conversation",
+        "self",
+        "--runner",
+        "cloud",
+      ]),
+    ).toBe(0);
+
+    expect(
+      requests.find((request) => request.method === "POST")?.body,
+    ).toMatchObject({ conversation_id: "current-conversation" });
+  });
+
+  test("--conversation self fails without a current conversation", async () => {
+    const requests = installScheduleApi({});
+    const errors: string[] = [];
+    console.error = mock((line: string) => errors.push(String(line)));
+
+    expect(
+      await runCronSubcommand([
+        ...withoutConversationArgument(addArgs),
+        "--conversation",
+        "self",
+        "--runner",
+        "cloud",
+      ]),
+    ).toBe(1);
+
+    expect(errors).toContain(
+      "Error: --conversation self requires an active conversation (LETTA_CONVERSATION_ID is not set).",
+    );
+    expect(requests.some((request) => request.method === "POST")).toBe(false);
+  });
+
   test("default Cloud creation targets the current registered listener at the HTTP boundary", async () => {
     const requests = installScheduleApi({
       environments: { "device-persisted": environment("device-persisted") },

--- a/src/cli/subcommands/cron.ts
+++ b/src/cli/subcommands/cron.ts
@@ -87,7 +87,7 @@ Add options:
   --once                 Fire once (with --at); default for --at
   --cron <expr>          Raw 5-field cron expression
   --agent <id>           Agent ID (defaults to LETTA_AGENT_ID)
-  --conversation <id>    Conversation ID (defaults to LETTA_CONVERSATION_ID or "default")
+  --conversation <id>    Conversation ID (omit for a fresh conversation per fire)
   --runner <runner>      Where the schedule lives and fires (normally omit:
                          the default keeps the schedule running where it was
                          created):
@@ -157,8 +157,8 @@ function getAgentId(fromArgs?: string): string {
   return fromArgs || process.env.LETTA_AGENT_ID || "";
 }
 
-function getConversationId(fromArgs?: string): string {
-  return fromArgs || process.env.LETTA_CONVERSATION_ID || "default";
+function getConversationTarget(fromArgs?: string): string {
+  return fromArgs || "new";
 }
 
 // ── Runner resolution ───────────────────────────────────────────────
@@ -293,7 +293,7 @@ async function handleAdd(values: CronArgValues): Promise<number> {
     return 1;
   }
 
-  const conversationId = getConversationId(values.conversation);
+  const conversationId = getConversationTarget(values.conversation);
 
   // Determine schedule type
   const everyValue = values.every;

--- a/src/cli/subcommands/cron.ts
+++ b/src/cli/subcommands/cron.ts
@@ -60,6 +60,11 @@ import {
   validateTargetDevice,
 } from "./cron-runner";
 import {
+  resolveCronAddConversationTarget,
+  resolveCronAgentId,
+  resolveCronConversationFilter,
+} from "./cron-scope";
+import {
   ensureSettingsForCloud,
   printAmbiguousTaskName,
   resolveTaskName,
@@ -87,7 +92,9 @@ Add options:
   --once                 Fire once (with --at); default for --at
   --cron <expr>          Raw 5-field cron expression
   --agent <id>           Agent ID (defaults to LETTA_AGENT_ID)
-  --conversation <id>    Conversation ID (omit for a fresh conversation per fire)
+  --conversation <id>    Conversation target (omit or "new" for a fresh
+                         conversation per fire; "self" for the current
+                         conversation; "default" for the agent default)
   --runner <runner>      Where the schedule lives and fires (normally omit:
                          the default keeps the schedule running where it was
                          created):
@@ -151,14 +158,6 @@ function parseCronArgs(argv: string[]) {
     strict: true,
     allowPositionals: true,
   });
-}
-
-function getAgentId(fromArgs?: string): string {
-  return fromArgs || process.env.LETTA_AGENT_ID || "";
-}
-
-function getConversationTarget(fromArgs?: string): string {
-  return fromArgs || "new";
 }
 
 // ── Runner resolution ───────────────────────────────────────────────
@@ -287,13 +286,14 @@ async function handleAdd(values: CronArgValues): Promise<number> {
     return 1;
   }
 
-  const agentId = getAgentId(values.agent);
+  const agentId = resolveCronAgentId(values.agent);
   if (!agentId) {
     console.error("Error: --agent or LETTA_AGENT_ID required.");
     return 1;
   }
 
-  const conversationId = getConversationTarget(values.conversation);
+  const conversationId = resolveCronAddConversationTarget(values.conversation);
+  if (conversationId === null) return 1;
 
   // Determine schedule type
   const everyValue = values.every;
@@ -564,7 +564,8 @@ async function handleList(values: CronArgValues): Promise<number> {
   }
 
   const agentId = values.agent || process.env.LETTA_AGENT_ID || undefined;
-  const conversationId = values.conversation || undefined;
+  const conversationId = resolveCronConversationFilter(values.conversation);
+  if (conversationId === null) return 1;
 
   const includeLocal = values.runner !== "cloud";
   const includeCloud = values.runner !== "local";
@@ -661,7 +662,7 @@ async function handleGet(
     return 1;
   }
 
-  const agentId = getAgentId(values.agent);
+  const agentId = resolveCronAgentId(values.agent);
 
   // Local store is a cheap file read; check it first unless --runner cloud.
   if (values.runner !== "cloud") {
@@ -769,7 +770,7 @@ async function handleRuns(values: CronArgValues): Promise<number> {
     return 1;
   }
 
-  const agentId = getAgentId(values.agent);
+  const agentId = resolveCronAgentId(values.agent);
   if (!agentId) {
     console.error(
       `Error: task ${id} not found locally, and --agent or LETTA_AGENT_ID is required to look up Cloud schedule runs.`,
@@ -829,7 +830,7 @@ async function handleDelete(
     }
   }
 
-  const agentId = getAgentId(values.agent);
+  const agentId = resolveCronAgentId(values.agent);
 
   // Cloud delete by ID (unless --runner local).
   if (values.runner !== "local") {
@@ -898,7 +899,7 @@ async function handleDelete(
 }
 
 async function handleDeleteAll(values: CronArgValues): Promise<number> {
-  const agentId = getAgentId(values.agent);
+  const agentId = resolveCronAgentId(values.agent);
   if (!agentId) {
     console.error("Error: --agent or LETTA_AGENT_ID required with --all.");
     return 1;

--- a/src/cron/cron-file.test.ts
+++ b/src/cron/cron-file.test.ts
@@ -98,6 +98,20 @@ describe("addTask", () => {
     expect(result.task.conversation_id).toBe("new");
   });
 
+  test("defaults an omitted conversation target to new", () => {
+    const input = makeInput();
+    delete input.conversation_id;
+
+    const result = addTask(input);
+
+    expect(result.task.conversation_id).toBe("new");
+  });
+
+  test("preserves an explicit default conversation target", () => {
+    const result = addTask(makeInput({ conversation_id: "default" }));
+    expect(result.task.conversation_id).toBe("default");
+  });
+
   test("creates a one-shot task", () => {
     const scheduledFor = new Date(Date.now() + 60000);
     const result = addTask(

--- a/src/cron/cron-file.test.ts
+++ b/src/cron/cron-file.test.ts
@@ -98,13 +98,13 @@ describe("addTask", () => {
     expect(result.task.conversation_id).toBe("new");
   });
 
-  test("defaults an omitted conversation target to new", () => {
+  test("defaults an omitted conversation target to default", () => {
     const input = makeInput();
     delete input.conversation_id;
 
     const result = addTask(input);
 
-    expect(result.task.conversation_id).toBe("new");
+    expect(result.task.conversation_id).toBe("default");
   });
 
   test("preserves an explicit default conversation target", () => {

--- a/src/cron/cron-file.test.ts
+++ b/src/cron/cron-file.test.ts
@@ -98,13 +98,13 @@ describe("addTask", () => {
     expect(result.task.conversation_id).toBe("new");
   });
 
-  test("defaults an omitted conversation target to default", () => {
+  test("defaults an omitted conversation target to new", () => {
     const input = makeInput();
     delete input.conversation_id;
 
     const result = addTask(input);
 
-    expect(result.task.conversation_id).toBe("default");
+    expect(result.task.conversation_id).toBe("new");
   });
 
   test("preserves an explicit default conversation target", () => {

--- a/src/cron/cron-file.ts
+++ b/src/cron/cron-file.ts
@@ -474,8 +474,8 @@ export interface AddTaskInput {
   agent_id: string;
   /**
    * Conversation target for scheduled fires.
-   * - omitted/"default": agent default conversation
-   * - "new": fresh conversation per fire
+   * - omitted/"new": fresh conversation per fire
+   * - "default": agent default conversation
    * - any other string: existing conversation id
    */
   conversation_id?: string;
@@ -500,7 +500,7 @@ export function addTask(input: AddTaskInput): AddTaskResult {
   return withLock(() => {
     const data = readCronFile();
     const agentId = input.agent_id;
-    const conversationId = input.conversation_id ?? "default";
+    const conversationId = input.conversation_id ?? "new";
 
     // Check per-agent active limit
     const activeCount = data.tasks.filter(

--- a/src/cron/cron-file.ts
+++ b/src/cron/cron-file.ts
@@ -474,8 +474,8 @@ export interface AddTaskInput {
   agent_id: string;
   /**
    * Conversation target for scheduled fires.
-   * - omitted/"new": fresh conversation per fire
-   * - "default": agent default conversation
+   * - omitted/"default": agent default conversation
+   * - "new": fresh conversation per fire
    * - any other string: existing conversation id
    */
   conversation_id?: string;
@@ -500,7 +500,7 @@ export function addTask(input: AddTaskInput): AddTaskResult {
   return withLock(() => {
     const data = readCronFile();
     const agentId = input.agent_id;
-    const conversationId = input.conversation_id ?? "new";
+    const conversationId = input.conversation_id ?? "default";
 
     // Check per-agent active limit
     const activeCount = data.tasks.filter(

--- a/src/skills/builtin/scheduling-tasks/SKILL.md
+++ b/src/skills/builtin/scheduling-tasks/SKILL.md
@@ -64,7 +64,7 @@ letta cron add --name <short-name> --description <text> --prompt <text> <schedul
 | Flag | Description |
 |------|-------------|
 | `--agent <id>` | Agent ID (defaults to `LETTA_AGENT_ID` from the current shell/session) |
-| `--conversation <id>` | Conversation target (omit for a fresh conversation per fire; pass `default` or a concrete ID for continuity) |
+| `--conversation <id>` | Conversation target: omit or pass `new` for a fresh conversation per fire; pass `self` for the current conversation; pass `default` for the agent default; or pass a concrete ID |
 | `--runner <runner>` | `cloud` or `local` — normally omit; see "Where Schedules Run" above |
 | `--computer <id>` | Execute on a specific connected computer — normally omit |
 | `--once` | Mark `--at` as one-shot (already the default for `--at`) |
@@ -97,7 +97,7 @@ For local run history, `--run-id <id>` selects one run. Cloud history ignores th
 
 If exact routing matters, pass both `--agent` and `--conversation` explicitly.
 
-`letta cron add` falls back to `LETTA_AGENT_ID` for the agent. An omitted `--conversation` means `"new"`, so every fire gets a fresh conversation; schedule creation ignores ambient `LETTA_CONVERSATION_ID`. Pass `--conversation default` or a concrete conversation ID when later work must return to one existing conversation.
+`letta cron add` falls back to `LETTA_AGENT_ID` for the agent. An omitted `--conversation` means `"new"`, so every fire gets a fresh conversation. Pass `--conversation self` to capture the current `LETTA_CONVERSATION_ID`, `--conversation default` for the agent default, or a concrete conversation ID.
 
 Safest pattern:
 
@@ -107,14 +107,14 @@ letta cron add \
   --description "Daily email summary in this conversation" \
   --prompt "Check the user's email and post a summary here." \
   --cron "0 10 * * *" \
-  --agent "$AGENT_ID" \
-  --conversation "$CONVERSATION_ID"
+  --agent "$LETTA_AGENT_ID" \
+  --conversation self
 ```
 
 Then verify the binding explicitly:
 
 ```bash
-letta cron list --agent "$AGENT_ID" --conversation "$CONVERSATION_ID"
+letta cron list --agent "$LETTA_AGENT_ID" --conversation self
 ```
 
 ### Deleting or Replacing Tasks
@@ -157,8 +157,8 @@ letta cron add \
   --description "One-time check on deployment status" \
   --prompt "Check the deployment status and report the result here." \
   --at "in 30m" \
-  --agent "$AGENT_ID" \
-  --conversation "$CONVERSATION_ID"
+  --agent "$LETTA_AGENT_ID" \
+  --conversation self
 ```
 
 ### "Every weekday at 5pm, remind me to submit my timesheet" (user in UTC−7)
@@ -205,7 +205,7 @@ Include context about what the user originally asked for, so you can give a help
 - **Minimum granularity**: 1 minute. Intervals under 60 seconds are rounded up.
 - **Recurring tasks**: No longer auto-expire. They remain active until explicitly cancelled.
 - **One-shot cleanup (local runner)**: One-shot local tasks are garbage-collected 24 hours after firing.
-- **Default binding**: `letta cron add` uses `--agent` first, then `LETTA_AGENT_ID`. It uses an explicit `--conversation` when provided; otherwise each fire gets a fresh conversation. Ambient `LETTA_CONVERSATION_ID` is ignored during schedule creation.
+- **Default binding**: `letta cron add` uses `--agent` first, then `LETTA_AGENT_ID`. Omit `--conversation` for a fresh conversation per fire; use `--conversation self` to capture `LETTA_CONVERSATION_ID` explicitly.
 - **Local scheduler requirement**: Local schedules only fire while a Letta session is running on their computer; fires while no session runs are marked as missed. Cloud schedules fire from the cloud regardless.
 - **`--at` for specific times**: `--at "3:00pm"` schedules a one-shot. If the time has already passed today, it schedules for tomorrow.
 - **Cloud schedule creation failures are loud**: if creating a cloud schedule fails, no schedule is created — a failed create never silently becomes a local schedule. (The local placement for computers the cloud scheduler can't reach is decided before creation and reported in the output.)

--- a/src/skills/builtin/scheduling-tasks/SKILL.md
+++ b/src/skills/builtin/scheduling-tasks/SKILL.md
@@ -31,7 +31,7 @@ The CLI reports its placement in the command output. If it warns that the schedu
 Two patterns cover most schedules:
 
 - **Fast follow-ups** ("check on the PR in 5m"): the default is right — same computer as the active conversation. If the session dies before it fires, the follow-up usually died with the task anyway.
-- **Recurring jobs** ("every Monday 11am, start the lunch order"): prefer durability. If the CLI warned that a recurring schedule is local, that's usually wrong for the user's intent — recreate it with `--runner cloud`, or `--computer` if the job needs a specific always-on computer. Also consider whether the job should post into a dedicated conversation rather than this one (continuity in one thread vs a fresh context per run).
+- **Recurring jobs** ("every Monday 11am, start the lunch order"): prefer durability. If the CLI warned that a recurring schedule is local, that's usually wrong for the user's intent — recreate it with `--runner cloud`, or `--computer` if the job needs a specific always-on computer. A fresh conversation per run is the default; pass a conversation explicitly when the job needs continuity in one thread.
 
 ## CLI Usage
 
@@ -64,7 +64,7 @@ letta cron add --name <short-name> --description <text> --prompt <text> <schedul
 | Flag | Description |
 |------|-------------|
 | `--agent <id>` | Agent ID (defaults to `LETTA_AGENT_ID` from the current shell/session) |
-| `--conversation <id>` | Conversation ID (defaults to `LETTA_CONVERSATION_ID` from the current shell/session, otherwise `"default"`) |
+| `--conversation <id>` | Conversation target (omit for a fresh conversation per fire; pass `default` or a concrete ID for continuity) |
 | `--runner <runner>` | `cloud` or `local` — normally omit; see "Where Schedules Run" above |
 | `--computer <id>` | Execute on a specific connected computer — normally omit |
 | `--once` | Mark `--at` as one-shot (already the default for `--at`) |
@@ -97,7 +97,7 @@ For local run history, `--run-id <id>` selects one run. Cloud history ignores th
 
 If exact routing matters, pass both `--agent` and `--conversation` explicitly.
 
-`letta cron add` will otherwise fall back to `LETTA_AGENT_ID` and `LETTA_CONVERSATION_ID` from the current shell/session. Those values may be correct for the current chat, but they can also be inherited from surrounding tooling, another conversation, or an older shell.
+`letta cron add` falls back to `LETTA_AGENT_ID` for the agent. An omitted `--conversation` means `"new"`, so every fire gets a fresh conversation; schedule creation ignores ambient `LETTA_CONVERSATION_ID`. Pass `--conversation default` or a concrete conversation ID when later work must return to one existing conversation.
 
 Safest pattern:
 
@@ -156,7 +156,9 @@ letta cron add \
   --name "deploy-check" \
   --description "One-time check on deployment status" \
   --prompt "Check the deployment status and report the result here." \
-  --at "in 30m"
+  --at "in 30m" \
+  --agent "$AGENT_ID" \
+  --conversation "$CONVERSATION_ID"
 ```
 
 ### "Every weekday at 5pm, remind me to submit my timesheet" (user in UTC−7)
@@ -203,7 +205,7 @@ Include context about what the user originally asked for, so you can give a help
 - **Minimum granularity**: 1 minute. Intervals under 60 seconds are rounded up.
 - **Recurring tasks**: No longer auto-expire. They remain active until explicitly cancelled.
 - **One-shot cleanup (local runner)**: One-shot local tasks are garbage-collected 24 hours after firing.
-- **Default binding precedence**: `letta cron add` uses `--agent` / `--conversation` first, then falls back to `LETTA_AGENT_ID` / `LETTA_CONVERSATION_ID`, then finally uses `"default"` for the conversation if no env var is present.
+- **Default binding**: `letta cron add` uses `--agent` first, then `LETTA_AGENT_ID`. It uses an explicit `--conversation` when provided; otherwise each fire gets a fresh conversation. Ambient `LETTA_CONVERSATION_ID` is ignored during schedule creation.
 - **Local scheduler requirement**: Local schedules only fire while a Letta session is running on their computer; fires while no session runs are marked as missed. Cloud schedules fire from the cloud regardless.
 - **`--at` for specific times**: `--at "3:00pm"` schedules a one-shot. If the time has already passed today, it schedules for tomorrow.
 - **Cloud schedule creation failures are loud**: if creating a cloud schedule fails, no schedule is created — a failed create never silently becomes a local schedule. (The local placement for computers the cloud scheduler can't reach is decided before creation and reported in the output.)

--- a/src/types/protocol_v2.ts
+++ b/src/types/protocol_v2.ts
@@ -1611,8 +1611,8 @@ export interface CronAddCommand {
   agent_id: string;
   /**
    * Conversation target for scheduled fires.
-   * - omitted/"default": agent default conversation
-   * - "new": create a fresh conversation for every fire
+   * - omitted/"new": create a fresh conversation for every fire
+   * - "default": agent default conversation
    * - any other string: existing conversation id
    */
   conversation_id?: string;


### PR DESCRIPTION
## Summary

- make an omitted conversation target create a fresh conversation for every fire across CLI and direct app-server callers
- keep explicit `default`, `new`, and concrete conversation IDs unchanged
- add `--conversation self` so an agent can explicitly capture its current `LETTA_CONVERSATION_ID`
- fail clearly when `self` is used outside an active conversation
- update the bundled scheduling guidance and examples

## Dependency

Stacked on #3820 so isolated Slack schedule occurrences can proactively post roots and own their follow-up threads. After #3820 merges, this PR can be retargeted to `main`.

## Validation

- `bun test src/cli/subcommands/cron.test.ts src/cron/cron-file.test.ts src/cron/scheduler.test.ts src/websocket/listen-client-protocol.test.ts` (212 passed)
- `bun run check` (12/12 passed)
- live recurring schedule fired twice and produced distinct conversations; each Slack root and its replies stayed in the corresponding occurrence

👾 Generated with [Letta Code](https://letta.com)