### PR TITLE
fix(subagents): drop stale Claude-Code-derived tools (LS/MultiEdit/TodoWrite) from builtin subagents

### DIFF
--- a/src/agent/subagents/builtin/fork.md
+++ b/src/agent/subagents/builtin/fork.md
@@ -1,7 +1,7 @@
 ---
 name: fork
 description: Fork of the parent agent with full context and tools. Recommended to run in background (run_in_background: true).
-tools: Bash, TaskOutput, Edit, KillBash, LS, MultiEdit, Read, TodoWrite, Write
+tools: Bash, TaskCreate, TaskGet, TaskList, TaskOutput, TaskUpdate, Edit, KillBash, Read, Write
 model: inherit
 fork: true
 background: true

--- a/src/agent/subagents/builtin/general-purpose.md
+++ b/src/agent/subagents/builtin/general-purpose.md
@@ -1,7 +1,7 @@
 ---
 name: general-purpose
 description: Full-capability agent for research, planning, and implementation
-tools: Bash, TaskOutput, Edit, KillBash, LS, MultiEdit, Read, TodoWrite, Write
+tools: Bash, TaskCreate, TaskGet, TaskList, TaskOutput, TaskUpdate, Edit, KillBash, Read, Write
 model: inherit
 ---
 
@@ -17,7 +17,7 @@ You DO have access to the full conversation history before you were launched.
 
 ## Instructions
 
-- You have access to all tools (Read, Write, Edit, Bash, TodoWrite, etc.) — use Bash with `rg` / `find` for searching
+- You have access to all tools (Read, Write, Edit, Bash, TaskCreate/TaskUpdate, etc.) — use Bash with `rg` / `find` for searching
 - Break down complex tasks into steps
 - Search the codebase to understand existing patterns
 - Follow existing code conventions and style

--- a/src/tools/descriptions/BashOutput.md
+++ b/src/tools/descriptions/BashOutput.md
@@ -9,3 +9,4 @@
 - If you are repeatedly calling this tool waiting for a recurring pattern to appear ("tell me every time an ERROR line appears"), stop polling and use the Monitor tool instead: each stdout line is an event — you keep working and notifications arrive in the chat
 - Shell IDs can be found using the /bg command
 - If the accumulated output exceeds 30,000 characters, it will be truncated before being returned to you
+- Once the shell finishes you already have its output file path — it was returned when the command started, and repeated in the `<task-notification>` you receive on completion. For the full transcript at that point, prefer `Read` on that path over calling this tool again; reserve `BashOutput` for a shell that's still running.

--- a/src/tools/descriptions/TaskOutput.md
+++ b/src/tools/descriptions/TaskOutput.md
@@ -7,3 +7,4 @@
 - Use `block=false` for an immediate, non-blocking check of current status
 - Task IDs can be found using the /tasks command
 - Works with all task types: background shells, monitors, async agents, and remote sessions
+- Once a task completes you already have its output file path — it was returned when the task started, and repeated in the `<task-notification>` you receive on completion. For the full transcript at that point, prefer `Read` on that path over calling this tool again; reserve `TaskOutput` for blocking/waiting on a task that hasn't finished yet or for a quick status check.


### PR DESCRIPTION
## Summary

Cross-checked our tool implementations against the current Claude Code [tools reference](https://code.claude.com/docs/en/tools-reference), plus real strings extracted from the installed `claude` v2.1.229 binary for details not covered by the public docs.

### 1. Stale tool trio in builtin subagents

Claude Code has, over time, consolidated three tools that letta-code still had wired into its two most-used builtin subagents (`general-purpose`, `fork`):

- **`LS`** — no longer a live Claude Code tool; only survives in a legacy catch-all tool-name enum kept for backward-compatible permission-rule parsing. Directory listing goes through `Bash` (`ls`) instead.
- **`MultiEdit`** — same story; `Edit`'s own `replace_all` param already covers batched same-file replacements.
- **`TodoWrite`** — gated behind `CLAUDE_CODE_ENABLE_TASKS` in current Claude Code, disabled by default in favor of `TaskCreate`/`TaskGet`/`TaskList`/`TaskUpdate`. Confirmed in the binary that Claude Code explicitly suppresses the old TodoWrite reminder logic whenever the Task-list tool is present in the active toolset — they're designed as alternates, not meant to coexist.

Our own top-level agent toolset (`ANTHROPIC_DEFAULT_TOOLS` in `src/tools/manager.ts`) already made this exact transition: `LS`/`MultiEdit` are commented out there and `TodoWrite` is absent, with the `Task*` tools used instead. `general-purpose.md`/`fork.md` were left on the old toolkit.

**Fix:** replace `LS, MultiEdit, TodoWrite` with `TaskCreate, TaskGet, TaskList, TaskUpdate` in both subagents' `tools:` frontmatter, matching the parent agent's toolset. Also fixed a stray `TodoWrite` mention in `general-purpose.md`'s body instructions.

### 2. TaskOutput / BashOutput missing upstream's Read steering

The real Claude Code `TaskOutput` tool description currently starts with `"[Deprecated] — for bash and remote_agent tasks, prefer Read on the output file path; for local_agent tasks, use the Agent tool result directly"` (extracted from the binary; not yet reflected in public docs). Letta's `TaskOutput.md`/`BashOutput.md` never told the model this.

Letta already has the identical output-file mechanism: a background command/task's start message includes `Output file: <path>`, and every `<task-notification>` on completion ends with `Full transcript available at: <path>`. So once a task/shell has completed, calling `TaskOutput`/`BashOutput` again is redundant with just reading that path.

**Fix:** added a note to both descriptions pointing the model at `Read` on the output file path for the completed case. Deliberately did **not** mark them outright deprecated like upstream — unlike `Read`, both tools support blocking/waiting on a task that has*not* finished yet (`block`/`timeout`), which has no `Read`-based equivalent and is still a live, needed capability.

## Test plan

- [x] `bun test src/agent/subagent-builtins.test.ts src/agent/prompt-assets.test.ts src/agent/subagent-env-composition.test.ts` — 51 pass
- [x] `bun test src/tools/task-output.test.ts src/tools/bash-background-notification.test.ts src/tools/bash-background.test.ts` — 26 pass
- [x] `bun run check` — all 12 checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)