### PR TITLE
perf(cli): lazily initialize shiki highlighter [LET-10986]

### DIFF
--- a/src/cli/components/SyntaxHighlightedCommand.tsx
+++ b/src/cli/components/SyntaxHighlightedCommand.tsx
@@ -42,11 +42,8 @@ import { createJavaScriptRegexEngine } from "shiki/engine/javascript";
 import { colors } from "./colors";
 import { Text } from "./Text";
 
-// Created lazily on first highlight: building the highlighter parses TextMate
-// grammars for every language below (~150-250ms of CPU), which would otherwise
-// run at module load on every process start — including non-TUI paths like
-// `letta --version` and the sandbox listener (`letta remote`) that never
-// render a code block.
+// Created lazily on first highlight: grammar parsing costs ~150-250ms of CPU,
+// which shouldn't run at module load on every process start.
 let shikiHighlighter: ReturnType<typeof createHighlighterCoreSync> | null =
   null;
 

--- a/src/cli/components/SyntaxHighlightedCommand.tsx
+++ b/src/cli/components/SyntaxHighlightedCommand.tsx
@@ -42,47 +42,60 @@ import { createJavaScriptRegexEngine } from "shiki/engine/javascript";
 import { colors } from "./colors";
 import { Text } from "./Text";
 
-const shikiHighlighter = createHighlighterCoreSync({
-  themes: [catppuccinMocha, catppuccinLatte],
-  langs: [
-    bashLang,
-    cLang,
-    cppLang,
-    csharpLang,
-    cssLang,
-    diffLang,
-    dockerLang,
-    goLang,
-    graphqlLang,
-    htmlLang,
-    iniLang,
-    javaLang,
-    javascriptLang,
-    jsonLang,
-    kotlinLang,
-    lessLang,
-    luaLang,
-    makeLang,
-    markdownLang,
-    perlLang,
-    phpLang,
-    pythonLang,
-    rLang,
-    rubyLang,
-    rustLang,
-    scalaLang,
-    scssLang,
-    sqlLang,
-    swiftLang,
-    tomlLang,
-    tsxLang,
-    typescriptLang,
-    wasmLang,
-    xmlLang,
-    yamlLang,
-  ],
-  engine: createJavaScriptRegexEngine(),
-});
+// Created lazily on first highlight: building the highlighter parses TextMate
+// grammars for every language below (~150-250ms of CPU), which would otherwise
+// run at module load on every process start — including non-TUI paths like
+// `letta --version` and the sandbox listener (`letta remote`) that never
+// render a code block.
+let shikiHighlighter: ReturnType<typeof createHighlighterCoreSync> | null =
+  null;
+
+function getShikiHighlighter(): ReturnType<typeof createHighlighterCoreSync> {
+  if (shikiHighlighter === null) {
+    shikiHighlighter = createHighlighterCoreSync({
+      themes: [catppuccinMocha, catppuccinLatte],
+      langs: [
+        bashLang,
+        cLang,
+        cppLang,
+        csharpLang,
+        cssLang,
+        diffLang,
+        dockerLang,
+        goLang,
+        graphqlLang,
+        htmlLang,
+        iniLang,
+        javaLang,
+        javascriptLang,
+        jsonLang,
+        kotlinLang,
+        lessLang,
+        luaLang,
+        makeLang,
+        markdownLang,
+        perlLang,
+        phpLang,
+        pythonLang,
+        rLang,
+        rubyLang,
+        rustLang,
+        scalaLang,
+        scssLang,
+        sqlLang,
+        swiftLang,
+        tomlLang,
+        tsxLang,
+        typescriptLang,
+        wasmLang,
+        xmlLang,
+        yamlLang,
+      ],
+      engine: createJavaScriptRegexEngine(),
+    });
+  }
+  return shikiHighlighter;
+}
 const BASH_LANGUAGE = "bash";
 const FIRST_LINE_PROMPT = "$";
 const PROMPT_COLUMN_WIDTH = 2;
@@ -292,7 +305,7 @@ export function highlightCode(
   language: string,
 ): StyledSpan[][] | undefined {
   try {
-    const result = shikiHighlighter.codeToTokens(code, {
+    const result = getShikiHighlighter().codeToTokens(code, {
       lang: language,
       theme:
         colors.shellSyntax === colors.shellSyntaxLight


### PR DESCRIPTION
## Summary

`SyntaxHighlightedCommand.tsx` builds its shiki highlighter at module scope, which parses TextMate grammars for ~35 languages (bash → wasm) on **every process start** — before argv is even read. A CPU profile of `letta --version` attributes ~200ms of its ~520ms to grammar parsing (`collectExternalReferencesInRules`, `addLanguage`), all for a code path that never renders a code block.

This memoizes highlighter construction behind `getShikiHighlighter()`: only the first actual `highlightCode()` call pays the parse.

## Who benefits

- `letta --version` / `--help` and any headless invocation
- **Sandbox listeners** (`letta remote`) — this is ~250ms of the ~1.6s cold listener boot on cloud sandbox CPUs (part of the letta-cloud send-latency work)
- Subagent spawns that never render TUI code blocks

Interactive TUI sessions pay the same cost, deferred to first code-block render (one-time, inside a render that already does layout — imperceptible).

## Measurements

| | before | after |
|---|---|---|
| `letta --version` (M-series) | 0.52s | 0.39s (-25%) |

Remaining startup cost is V8 parse of the 36MB bundle (compile-cache territory, separate effort).

## Notes

- Deliberately NOT dynamic `import()` splitting — imports stay static, bundle unchanged, no chunk-loading failure modes. Only the eager *execution* moves.
- `createHighlighterCoreSync` is synchronous → memoization has no async race.
- If construction ever threw, it previously crashed at import; now it degrades to unhighlighted text via `highlightCode`'s existing try/catch.

## Test plan

- [x] `markdown-display-code-highlighting.test.tsx` passes (exercises `highlightCode` via the lazy path)
- [x] Typecheck: no new errors (77 pre-existing on main, unrelated)
- [x] Rebuilt bundle, verified `--version` output + timing
- [ ] CI

👾 Generated with [Letta Code](https://letta.com)