### PR TITLE
feat(reflection): honor server cutover flag

### DIFF
--- a/src/backend/api/reflection.test.ts
+++ b/src/backend/api/reflection.test.ts
@@ -1,10 +1,34 @@
 import { describe, expect, test } from "bun:test";
 import {
+  retrieveCloudReflectionConfig,
   updateCloudReflectionConfig,
   updateCloudReflectionConversationProgress,
 } from "./reflection";
 
 describe("Cloud reflection API", () => {
+  test("retrieves the agent config", async () => {
+    const calls: Array<{ method: string; path: string }> = [];
+    const config = {
+      agent_id: "agent/1",
+      enabled: true,
+      min_turn_count: 25,
+      cutover: true,
+      created_at: "2026-08-13T00:00:00.000Z",
+      updated_at: "2026-08-13T00:00:00.000Z",
+    };
+    const request = async <T>(method: string, path: string): Promise<T> => {
+      calls.push({ method, path });
+      return config as unknown as T;
+    };
+
+    await expect(
+      retrieveCloudReflectionConfig("agent/1", request),
+    ).resolves.toEqual(config);
+    expect(calls).toEqual([
+      { method: "GET", path: "/v1/agents/agent%2F1/reflection" },
+    ]);
+  });
+
   test("patches the agent config endpoint", async () => {
     const calls: Array<{
       method: string;

--- a/src/backend/api/reflection.ts
+++ b/src/backend/api/reflection.ts
@@ -1,5 +1,14 @@
 import { type ApiRequestMethod, apiRequest } from "./request";
 
+export interface CloudReflectionConfig {
+  agent_id: string;
+  enabled: boolean;
+  min_turn_count: number;
+  cutover?: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
 export interface UpdateCloudReflectionConfigInput {
   enabled: boolean;
   min_turn_count: number;
@@ -17,6 +26,13 @@ type ReflectionApiRequest = <T>(
 
 function agentPath(agentId: string): string {
   return `/v1/agents/${encodeURIComponent(agentId)}`;
+}
+
+export async function retrieveCloudReflectionConfig(
+  agentId: string,
+  request: ReflectionApiRequest = apiRequest,
+): Promise<CloudReflectionConfig> {
+  return request("GET", `${agentPath(agentId)}/reflection`);
 }
 
 export async function updateCloudReflectionConfig(

--- a/src/cli/helpers/reflection-launcher.test.ts
+++ b/src/cli/helpers/reflection-launcher.test.ts
@@ -101,6 +101,17 @@ describe("shouldRunQueuedReflectionLaunch", () => {
 });
 
 describe("launchReflectionSubagent", () => {
+  test("skips client-side reflection after server cutover", async () => {
+    const isCutover = mock(async () => true);
+
+    const result = await launchReflectionSubagent(queuedLaunchOptions(), {
+      isCutover,
+    });
+
+    expect(result).toEqual({ launched: false, reason: "cutover" });
+    expect(isCutover).toHaveBeenCalledWith("agent-1");
+  });
+
   test("skips before payload and worktree creation when parent memory is dirty", async () => {
     const originalLocalBackend = process.env.LETTA_LOCAL_BACKEND_EXPERIMENTAL;
     const originalLocalBackendDir = process.env.LETTA_LOCAL_BACKEND_DIR;
@@ -120,6 +131,7 @@ describe("launchReflectionSubagent", () => {
 
       const result = await launchReflectionSubagent(
         queuedLaunchOptions({ agentId }),
+        { isCutover: async () => false },
       );
 
       expect(result).toEqual({ launched: false, reason: "parent_dirty" });
@@ -144,6 +156,9 @@ describe("launchReflectionSubagent", () => {
 
 describe("getReflectionLaunchSkippedMessage", () => {
   test("formats parent-dirty and listener-specific skipped reasons", () => {
+    expect(getReflectionLaunchSkippedMessage("cutover")).toContain(
+      "managed by Letta Cloud",
+    );
     expect(getReflectionLaunchSkippedMessage("parent_dirty")).toContain(
       "uncommitted changes",
     );

--- a/src/cli/helpers/reflection-launcher.ts
+++ b/src/cli/helpers/reflection-launcher.ts
@@ -1,4 +1,7 @@
-import { getScopedMemoryFilesystemRoot } from "@/agent/memory-filesystem";
+import {
+  getScopedMemoryFilesystemRoot,
+  isLettaCloud,
+} from "@/agent/memory-filesystem";
 import {
   buildReflectionIntegrationMemoryScope,
   buildReflectionMemoryScope,
@@ -13,6 +16,7 @@ import {
 } from "@/agent/memory-worktree";
 import { getSubagents } from "@/agent/subagent-state";
 import { getBackend } from "@/backend";
+import { retrieveCloudReflectionConfig } from "@/backend/api/reflection";
 import {
   getReflectionSettings,
   type ReflectionSettings,
@@ -67,6 +71,7 @@ export type ReflectionLaunchTriggerSource =
 
 export type ReflectionLaunchSkippedReason =
   | "memfs_disabled"
+  | "cutover"
   | "already_active"
   | "parent_dirty"
   | "no_payload"
@@ -77,6 +82,8 @@ export function getReflectionLaunchSkippedMessage(
   surface: "cli" | "listener" = "cli",
 ): string | undefined {
   switch (reason) {
+    case "cutover":
+      return "Reflection is managed by Letta Cloud for this agent.";
     case "already_active":
       return surface === "listener"
         ? "A reflection agent is already running for this conversation."
@@ -606,8 +613,27 @@ export async function finalizeReflectionMemoryWorktreeLaunch(params: {
   };
 }
 
+async function isReflectionCutover(agentId: string): Promise<boolean> {
+  try {
+    if (!(await isLettaCloud())) return false;
+    const config = await retrieveCloudReflectionConfig(agentId);
+    return config.cutover === true;
+  } catch (error) {
+    debugWarn(
+      "memory",
+      `Failed to check Cloud reflection cutover: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+    return false;
+  }
+}
+
 export async function launchReflectionSubagent(
   options: ReflectionLaunchOptions,
+  dependencies: {
+    isCutover?: (agentId: string) => Promise<boolean>;
+  } = {},
 ): Promise<ReflectionLaunchResult> {
   const {
     agentId,
@@ -624,6 +650,14 @@ export async function launchReflectionSubagent(
 
   if (!memfsEnabled) {
     return { launched: false, reason: "memfs_disabled" };
+  }
+
+  if (await (dependencies.isCutover ?? isReflectionCutover)(agentId)) {
+    debugLog(
+      "memory",
+      `Skipping reflection launch (${triggerSource}) because server-side reflection owns this agent`,
+    );
+    return { launched: false, reason: "cutover" };
   }
 
   if (!tryReserveReflectionLaunch(agentId)) {


### PR DESCRIPTION
## Summary
- retrieve the server-side reflection config before launching a client reflection
- skip local reflection work when the config has `cutover: true`
- preserve existing behavior when the config is unavailable or comes from an older server

Depends on letta-ai/letta-cloud#14395.

## Test plan
- [x] `bun test src/backend/api/reflection.test.ts`
- [x] `bun test src/cli/helpers/reflection-launcher.test.ts`
- [x] `bun run check`

👾 Generated with [Letta Code](https://letta.com)