### PR TITLE
feat(app-server): add runtime workspace sandboxes

### DIFF
--- a/scripts/source-file-size-baseline.json
+++ b/scripts/source-file-size-baseline.json
@@ -44,7 +44,7 @@
   "src/websocket/listener/commands/memory.ts": 1114,
   "src/websocket/listener/file-commands.ts": 1053,
   "src/websocket/listener/lifecycle.ts": 1051,
-  "src/websocket/listener/protocol-inbound.ts": 2258,
+  "src/websocket/listener/protocol-inbound.ts": 2244,
   "src/websocket/listener/protocol-outbound.ts": 1072,
   "src/websocket/listener/turn.ts": 1010
 }

--- a/src/permissions/checker.ts
+++ b/src/permissions/checker.ts
@@ -15,6 +15,7 @@ import {
   modToolApprovalPolicy,
 } from "@/mods/tool-registry";
 import type { ModContext } from "@/mods/types";
+import { getRuntimeContext } from "@/runtime-context";
 import type { PermissionModeState } from "@/tools/permission-mode-state";
 import {
   canonicalToolName,
@@ -40,6 +41,7 @@ import type {
   PermissionRules,
   PermissionTraceEvent,
 } from "./types";
+import { evaluateWorkspaceSandboxGuard } from "./workspace-sandbox";
 
 /**
  * Tools that don't require approval within working directory
@@ -312,6 +314,24 @@ function checkPermissionForEngine(
   const sessionRules = sessionPermissions.getRules();
   const workingDirectoryTools =
     engine === "v2" ? WORKING_DIRECTORY_TOOLS_V2 : WORKING_DIRECTORY_TOOLS_V1;
+
+  const workspaceGuardResult = evaluateWorkspaceSandboxGuard(
+    permissionToolName,
+    toolArgs,
+    workingDirectory,
+    getRuntimeContext()?.workspaceSandbox,
+  );
+  if (workspaceGuardResult) {
+    traceEvent(trace, "workspace-sandbox", workspaceGuardResult.reason);
+    return {
+      result: {
+        decision: "deny",
+        matchedRule: workspaceGuardResult.matchedRule,
+        reason: workspaceGuardResult.reason,
+      },
+      trace,
+    };
+  }
 
   // Cross-agent guard — when enabled, denies any tool call targeting another
   // agent's memory unless that agent is in the allowed set. Unbypassable by

--- a/src/permissions/workspace-sandbox.test.ts
+++ b/src/permissions/workspace-sandbox.test.ts
@@ -1,0 +1,163 @@
+import { expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { checkPermission } from "@/permissions/checker";
+import {
+  buildWorkspaceSandboxPolicy,
+  evaluateWorkspaceSandboxGuard,
+  resolveWorkspaceSandbox,
+} from "@/permissions/workspace-sandbox";
+import { runWithRuntimeContext } from "@/runtime-context";
+import type { SandboxAvailability } from "@/sandbox/availability";
+
+const SEATBELT: SandboxAvailability = { backend: "seatbelt", reason: "test" };
+
+function fixture(): {
+  base: string;
+  isolationRoot: string;
+  root: string;
+  peer: string;
+} {
+  const base = mkdtempSync(join(tmpdir(), "workspace-sandbox-"));
+  const isolationRoot = join(base, "runs");
+  const root = join(isolationRoot, "run-a");
+  const peer = join(isolationRoot, "run-b");
+  mkdirSync(root, { recursive: true });
+  mkdirSync(peer, { recursive: true });
+  return { base, isolationRoot, root, peer };
+}
+
+test("resolves a workspace inside its isolation root", () => {
+  const dirs = fixture();
+  try {
+    expect(
+      resolveWorkspaceSandbox(
+        { root: dirs.root, isolationRoot: dirs.isolationRoot },
+        { availability: SEATBELT },
+      ),
+    ).toEqual({ root: dirs.root, isolationRoot: dirs.isolationRoot });
+  } finally {
+    rmSync(dirs.base, { recursive: true, force: true });
+  }
+});
+
+test("fails closed without a kernel backend", () => {
+  const dirs = fixture();
+  try {
+    expect(() =>
+      resolveWorkspaceSandbox(
+        { root: dirs.root, isolationRoot: dirs.isolationRoot },
+        { availability: { backend: null, reason: "unavailable" } },
+      ),
+    ).toThrow("requires a kernel sandbox backend");
+  } finally {
+    rmSync(dirs.base, { recursive: true, force: true });
+  }
+});
+
+test("builds a write-restricted policy that hides peer workspaces", () => {
+  const dirs = fixture();
+  try {
+    expect(
+      buildWorkspaceSandboxPolicy({
+        root: dirs.root,
+        isolationRoot: dirs.isolationRoot,
+      }),
+    ).toEqual({
+      baseWritableRoots: [],
+      deniedRoots: [dirs.isolationRoot],
+      readonlyRoots: [],
+      writableRoots: [dirs.root],
+      restrictWrites: true,
+    });
+  } finally {
+    rmSync(dirs.base, { recursive: true, force: true });
+  }
+});
+
+test("allows own writes and broad reads but denies peer access", () => {
+  const dirs = fixture();
+  const sandbox = { root: dirs.root, isolationRoot: dirs.isolationRoot };
+  try {
+    expect(
+      evaluateWorkspaceSandboxGuard(
+        "Write",
+        { file_path: join(dirs.root, "memory.md") },
+        dirs.root,
+        sandbox,
+      ),
+    ).toBeNull();
+    expect(
+      evaluateWorkspaceSandboxGuard(
+        "Read",
+        { file_path: "/etc/hosts" },
+        dirs.root,
+        sandbox,
+      ),
+    ).toBeNull();
+    expect(
+      evaluateWorkspaceSandboxGuard(
+        "Read",
+        { file_path: join(dirs.peer, "memory.md") },
+        dirs.root,
+        sandbox,
+      )?.matchedRule,
+    ).toBe("workspace sandbox");
+    expect(
+      evaluateWorkspaceSandboxGuard(
+        "Write",
+        { file_path: join(dirs.base, "outside.md") },
+        dirs.root,
+        sandbox,
+      )?.matchedRule,
+    ).toBe("workspace sandbox");
+  } finally {
+    rmSync(dirs.base, { recursive: true, force: true });
+  }
+});
+
+test("follows symlinks before allowing a write", () => {
+  const dirs = fixture();
+  const link = join(dirs.root, "peer-link");
+  symlinkSync(dirs.peer, link);
+  try {
+    expect(
+      evaluateWorkspaceSandboxGuard(
+        "Write",
+        { file_path: join(link, "memory.md") },
+        dirs.root,
+        { root: dirs.root, isolationRoot: dirs.isolationRoot },
+      )?.matchedRule,
+    ).toBe("workspace sandbox");
+  } finally {
+    rmSync(dirs.base, { recursive: true, force: true });
+  }
+});
+
+test("the permission checker cannot override a workspace denial", () => {
+  const dirs = fixture();
+  try {
+    const result = runWithRuntimeContext(
+      {
+        workspaceSandbox: {
+          root: dirs.root,
+          isolationRoot: dirs.isolationRoot,
+        },
+      },
+      () =>
+        checkPermission(
+          "Write",
+          { file_path: join(dirs.peer, "memory.md") },
+          { allow: ["Write(**)"], deny: [], ask: [] },
+          dirs.root,
+        ),
+    );
+    expect(result).toMatchObject({
+      decision: "deny",
+      matchedRule: "workspace sandbox",
+    });
+  } finally {
+    rmSync(dirs.base, { recursive: true, force: true });
+  }
+});

--- a/src/permissions/workspace-sandbox.test.ts
+++ b/src/permissions/workspace-sandbox.test.ts
@@ -3,6 +3,7 @@ import { mkdirSync, mkdtempSync, rmSync, symlinkSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { checkPermission } from "@/permissions/checker";
+import { canonicalizeRoot } from "@/permissions/sandbox-policy";
 import {
   buildWorkspaceSandboxPolicy,
   evaluateWorkspaceSandboxGuard,
@@ -19,10 +20,12 @@ function fixture(): {
   root: string;
   peer: string;
 } {
-  const base = mkdtempSync(join(tmpdir(), "workspace-sandbox-"));
-  const isolationRoot = join(base, "runs");
-  const root = join(isolationRoot, "run-a");
-  const peer = join(isolationRoot, "run-b");
+  const base = canonicalizeRoot(
+    mkdtempSync(join(tmpdir(), "workspace-sandbox-")),
+  );
+  const isolationRoot = canonicalizeRoot(join(base, "runs"));
+  const root = canonicalizeRoot(join(isolationRoot, "run-a"));
+  const peer = canonicalizeRoot(join(isolationRoot, "run-b"));
   mkdirSync(root, { recursive: true });
   mkdirSync(peer, { recursive: true });
   return { base, isolationRoot, root, peer };

--- a/src/permissions/workspace-sandbox.ts
+++ b/src/permissions/workspace-sandbox.ts
@@ -1,0 +1,137 @@
+import { statSync } from "node:fs";
+import { isAbsolute, resolve } from "node:path";
+
+import type { RuntimeWorkspaceSandbox } from "@/runtime-context";
+import {
+  detectSandboxBackend,
+  type SandboxAvailability,
+} from "@/sandbox/availability";
+import { buildFsSandboxPolicy, type FsSandboxPolicy } from "@/sandbox/policy";
+import { canonicalToolName, isShellToolName } from "./canonical";
+import { extractApplyPatchPaths, extractFilePath } from "./cross-agent-guard";
+import { canonicalizeRoot } from "./sandbox-policy";
+
+type ToolArgs = Record<string, unknown>;
+
+export interface WorkspaceSandboxInput {
+  root: string;
+  isolationRoot: string;
+}
+
+export function resolveWorkspaceSandbox(
+  input: WorkspaceSandboxInput,
+  options: { availability?: SandboxAvailability } = {},
+): RuntimeWorkspaceSandbox {
+  if (!isAbsolute(input.root) || !isAbsolute(input.isolationRoot)) {
+    throw new Error("workspace sandbox paths must be absolute");
+  }
+  const root = canonicalizeRoot(input.root);
+  const isolationRoot = canonicalizeRoot(input.isolationRoot);
+  if (!statSync(root, { throwIfNoEntry: false })?.isDirectory()) {
+    throw new Error("workspace sandbox root must be an existing directory");
+  }
+  if (!statSync(isolationRoot, { throwIfNoEntry: false })?.isDirectory()) {
+    throw new Error(
+      "workspace sandbox isolation root must be an existing directory",
+    );
+  }
+  if (root === isolationRoot || !root.startsWith(`${isolationRoot}/`)) {
+    throw new Error("workspace sandbox root must be inside its isolation root");
+  }
+  const availability = options.availability ?? detectSandboxBackend();
+  if (!availability.backend) {
+    throw new Error(
+      `workspace sandbox requires a kernel sandbox backend (${availability.reason})`,
+    );
+  }
+  return { root, isolationRoot };
+}
+
+export function buildWorkspaceSandboxPolicy(
+  sandbox: RuntimeWorkspaceSandbox,
+): FsSandboxPolicy {
+  return buildFsSandboxPolicy({
+    deniedRoots: [sandbox.isolationRoot],
+    writableRoots: [sandbox.root],
+    restrictWrites: true,
+  });
+}
+
+function targetPaths(
+  toolName: string,
+  toolArgs: ToolArgs,
+  workingDirectory: string,
+): string[] {
+  if (isShellToolName(toolName)) return [];
+  const rawPaths: string[] = [];
+  if (
+    toolName === "ApplyPatch" ||
+    toolName === "apply_patch" ||
+    toolName === "memory_apply_patch"
+  ) {
+    if (typeof toolArgs.input === "string") {
+      rawPaths.push(...extractApplyPatchPaths(toolArgs.input));
+    }
+  } else {
+    const filePath = extractFilePath(toolArgs);
+    if (filePath) rawPaths.push(filePath);
+    if (
+      ["Glob", "Grep", "ListDir"].includes(canonicalToolName(toolName)) &&
+      typeof toolArgs.pattern === "string" &&
+      isAbsolute(toolArgs.pattern)
+    ) {
+      rawPaths.push(toolArgs.pattern);
+    }
+  }
+  return rawPaths.map((path) =>
+    canonicalizeRoot(isAbsolute(path) ? path : resolve(workingDirectory, path)),
+  );
+}
+
+function isWithin(path: string, root: string): boolean {
+  return path === root || path.startsWith(`${root}/`);
+}
+
+function isRecursiveTool(toolName: string): boolean {
+  return ["Glob", "Grep", "ListDir"].includes(canonicalToolName(toolName));
+}
+
+function isWriteTool(toolName: string): boolean {
+  return (
+    ["Write", "Edit"].includes(canonicalToolName(toolName)) ||
+    toolName === "ApplyPatch" ||
+    toolName === "apply_patch" ||
+    toolName === "memory_apply_patch"
+  );
+}
+
+export interface WorkspaceSandboxGuardResult {
+  matchedRule: "workspace sandbox";
+  reason: string;
+}
+
+export function evaluateWorkspaceSandboxGuard(
+  toolName: string,
+  toolArgs: ToolArgs,
+  workingDirectory: string,
+  sandbox?: RuntimeWorkspaceSandbox,
+): WorkspaceSandboxGuardResult | null {
+  if (!sandbox || isShellToolName(toolName)) return null;
+  const paths = targetPaths(toolName, toolArgs, workingDirectory);
+  for (const path of paths) {
+    const insideWorkspace = isWithin(path, sandbox.root);
+    const entersIsolationTree =
+      isWithin(path, sandbox.isolationRoot) ||
+      (isRecursiveTool(toolName) && isWithin(sandbox.isolationRoot, path));
+    if (
+      (isWriteTool(toolName) && !insideWorkspace) ||
+      (entersIsolationTree && !insideWorkspace)
+    ) {
+      return {
+        matchedRule: "workspace sandbox",
+        reason: `Permission denied by workspace sandbox: ${path} is outside ${sandbox.root}`,
+      };
+    }
+  }
+  return null;
+}

--- a/src/runtime-context.ts
+++ b/src/runtime-context.ts
@@ -9,6 +9,13 @@ export type RuntimePermissionMode =
   | "unrestricted"
   | "strict";
 
+export interface RuntimeWorkspaceSandbox {
+  /** Runtime-owned writable workspace. */
+  root: string;
+  /** Parent tree whose peer workspaces must stay hidden. */
+  isolationRoot: string;
+}
+
 export interface RuntimeContextSnapshot {
   /** Listener transport connection that owns the current turn, when present. */
   connectionId?: string | null;
@@ -28,6 +35,7 @@ export interface RuntimeContextSnapshot {
   workingDirectoryRecoveredFrom?: string | null;
   toolContextId?: string | null;
   permissionMode?: RuntimePermissionMode;
+  workspaceSandbox?: RuntimeWorkspaceSandbox;
 }
 
 const runtimeContextStorage = new AsyncLocalStorage<RuntimeContextSnapshot>();

--- a/src/tools/impl/shell-sandbox.test.ts
+++ b/src/tools/impl/shell-sandbox.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "bun:test";
-import { homedir } from "node:os";
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { getLocalBackendCrossAgentTreeRoot } from "@/backend/local/paths";
@@ -7,6 +8,7 @@ import {
   canonicalizeRoot,
   getDefaultAgentsTreeRoot,
 } from "@/permissions/sandbox-policy";
+import { runWithRuntimeContext } from "@/runtime-context";
 import type { SandboxAvailability } from "@/sandbox/availability";
 import { SANDBOX_ENV_VAR } from "@/sandbox/policy";
 import { SANDBOX_EXEC_PATH } from "@/sandbox/seatbelt";
@@ -32,6 +34,32 @@ test("no-op when the flag is off", () => {
   const result = applyShellSandbox(LAUNCHER, REPO_CWD, {}, SEATBELT);
   expect(result.backend).toBeNull();
   expect(result.launcher).toBe(LAUNCHER);
+});
+
+test("runtime workspace sandbox is fail-closed and does not need the global flag", () => {
+  const base = mkdtempSync(join(tmpdir(), "shell-workspace-sandbox-"));
+  const isolationRoot = join(base, "runs");
+  const root = join(isolationRoot, "run-a");
+  mkdirSync(root, { recursive: true });
+  try {
+    const result = runWithRuntimeContext(
+      { workspaceSandbox: { root, isolationRoot } },
+      () => applyShellSandbox(LAUNCHER, root, {}, SEATBELT),
+    );
+    expect(result.backend).toBe("seatbelt");
+    expect(result.env[SANDBOX_ENV_VAR]).toBe("seatbelt");
+    expect(defineValue(result.launcher, "-DDENIED_0=")).toBe(isolationRoot);
+    expect(defineValue(result.launcher, "-DWRITABLE_0=")).toBe(root);
+    expect(result.launcher[2]).toContain("(deny file-write*");
+
+    expect(() =>
+      runWithRuntimeContext({ workspaceSandbox: { root, isolationRoot } }, () =>
+        applyShellSandbox(LAUNCHER, root, {}, NO_BACKEND),
+      ),
+    ).toThrow("requires a kernel sandbox backend");
+  } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
 });
 
 test("no-op when already inside a sandbox (no nested sandbox-exec)", () => {

--- a/src/tools/impl/shell-sandbox.test.ts
+++ b/src/tools/impl/shell-sandbox.test.ts
@@ -48,8 +48,12 @@ test("runtime workspace sandbox is fail-closed and does not need the global flag
     );
     expect(result.backend).toBe("seatbelt");
     expect(result.env[SANDBOX_ENV_VAR]).toBe("seatbelt");
-    expect(defineValue(result.launcher, "-DDENIED_0=")).toBe(isolationRoot);
-    expect(defineValue(result.launcher, "-DWRITABLE_0=")).toBe(root);
+    expect(defineValue(result.launcher, "-DDENIED_0=")).toBe(
+      canonicalizeRoot(isolationRoot),
+    );
+    expect(defineValue(result.launcher, "-DWRITABLE_0=")).toBe(
+      canonicalizeRoot(root),
+    );
     expect(result.launcher[2]).toContain("(deny file-write*");
 
     expect(() =>

--- a/src/tools/impl/shell-sandbox.ts
+++ b/src/tools/impl/shell-sandbox.ts
@@ -3,7 +3,15 @@ import {
   buildCrossAgentSandboxPolicy,
   deriveSelfAgentRootsForTrees,
 } from "@/permissions/sandbox-policy";
-import type { SandboxAvailability } from "@/sandbox/availability";
+import {
+  buildWorkspaceSandboxPolicy,
+  resolveWorkspaceSandbox,
+} from "@/permissions/workspace-sandbox";
+import { getRuntimeContext } from "@/runtime-context";
+import {
+  detectSandboxBackend,
+  type SandboxAvailability,
+} from "@/sandbox/availability";
 import { SANDBOX_ENV_VAR, type SandboxBackend } from "@/sandbox/policy";
 import { wrapLauncher } from "@/sandbox/wrap";
 
@@ -51,6 +59,37 @@ export function applyShellSandbox(
   availability?: SandboxAvailability,
 ): ShellSandboxResult {
   const unchanged: ShellSandboxResult = { launcher, env, backend: null };
+
+  const requestedWorkspaceSandbox = getRuntimeContext()?.workspaceSandbox;
+  if (requestedWorkspaceSandbox) {
+    const available = availability ?? detectSandboxBackend();
+    const backend = available.backend;
+    if (!backend) {
+      throw new Error(
+        `workspace sandbox requires a kernel sandbox backend (${available.reason})`,
+      );
+    }
+    const workspaceSandbox = resolveWorkspaceSandbox(
+      requestedWorkspaceSandbox,
+      { availability: available },
+    );
+    const wrapped = wrapLauncher(
+      launcher,
+      buildWorkspaceSandboxPolicy(workspaceSandbox),
+      {
+        backend,
+        bwrapPath: available.bwrapPath,
+      },
+    );
+    if (!wrapped || wrapped.length === 0) {
+      throw new Error("workspace sandbox failed to wrap shell command");
+    }
+    return {
+      launcher: wrapped,
+      env: { ...env, [SANDBOX_ENV_VAR]: backend },
+      backend,
+    };
+  }
 
   // The gate short-circuits on the flag before any host probe, so the
   // sandbox-off hot path stays a no-op. When it returns a context it has already

--- a/src/tools/manager.ts
+++ b/src/tools/manager.ts
@@ -1260,10 +1260,10 @@ export async function checkToolPermission(
       permissionMode: effectivePermissionModeState?.mode ?? null,
       workingDirectory: effectiveWorkingDirectory,
     });
-
   const permissions = await loadPermissions(effectiveWorkingDirectory);
   return runWithRuntimeContext(
     {
+      ...(context?.runtimeContext ?? {}),
       ...(effectiveAgentId ? { agentId: effectiveAgentId } : {}),
       workingDirectory: effectiveWorkingDirectory,
       permissionMode: effectivePermissionModeState?.mode,

--- a/src/tools/toolset.ts
+++ b/src/tools/toolset.ts
@@ -364,6 +364,7 @@ export async function prepareToolExecutionContextForScope(params: {
   permissionModeState?: PermissionModeState;
   skillsDirectory?: string;
   skillSources?: SkillSource[];
+  workspaceSandbox?: RuntimeContextSnapshot["workspaceSandbox"];
   cachedAgent?: AgentState | null;
   modContext?: ModContext;
   modEvents?: ModEvents;
@@ -385,6 +386,7 @@ export async function prepareToolExecutionContextForScope(params: {
     permissionModeState,
     skillsDirectory,
     skillSources,
+    workspaceSandbox,
     cachedAgent,
     modContext,
     modEvents,
@@ -466,6 +468,7 @@ export async function prepareToolExecutionContextForScope(params: {
       workingDirectory,
       ...(skillsDirectory !== undefined ? { skillsDirectory } : {}),
       ...(skillSources !== undefined ? { skillSources } : {}),
+      ...(workspaceSandbox !== undefined ? { workspaceSandbox } : {}),
     },
   });
   return { ...result, agent: agent as AgentState };

--- a/src/types/app-server-info.ts
+++ b/src/types/app-server-info.ts
@@ -20,6 +20,7 @@ export interface AppServerInfoResponseMessage {
     conversation_management: boolean;
     memory_management: boolean;
     runtime_start: boolean;
+    runtime_workspace_sandbox?: boolean;
     runtime_external_tools_update?: boolean;
     split_channels: boolean;
   };
@@ -56,6 +57,8 @@ export function isAppServerInfoResponseMessage(
     typeof capabilityRecord.conversation_management === "boolean" &&
     typeof capabilityRecord.memory_management === "boolean" &&
     typeof capabilityRecord.runtime_start === "boolean" &&
+    (capabilityRecord.runtime_workspace_sandbox === undefined ||
+      typeof capabilityRecord.runtime_workspace_sandbox === "boolean") &&
     (capabilityRecord.runtime_external_tools_update === undefined ||
       typeof capabilityRecord.runtime_external_tools_update === "boolean") &&
     typeof capabilityRecord.split_channels === "boolean"

--- a/src/types/protocol_v2.ts
+++ b/src/types/protocol_v2.ts
@@ -765,7 +765,6 @@ export interface RuntimeStartClientInfo {
   title?: string;
   version?: string;
 }
-
 export interface RuntimeStartCommand {
   type: "runtime_start";
   /** Echoed back in the response for request correlation. */
@@ -784,6 +783,7 @@ export interface RuntimeStartCommand {
   cwd?: string | null;
   /** Initial permission mode for this runtime scope. */
   mode?: DevicePermissionMode;
+  workspace_sandbox?: { root: string; isolation_root: string };
   skill_sources?: readonly ("bundled" | "global" | "agent" | "project")[];
   /** Preserve the current override when skill_sources is omitted. */ preserve_skill_sources?: boolean;
   /** Optional client metadata for diagnostics/future protocol negotiation. */

--- a/src/websocket/listener/commands/app-server-info.test.ts
+++ b/src/websocket/listener/commands/app-server-info.test.ts
@@ -46,6 +46,7 @@ describe("app-server info protocol", () => {
         conversation_management: true,
         memory_management: true,
         runtime_start: true,
+        runtime_workspace_sandbox: true,
         runtime_external_tools_update: true,
         split_channels: false,
       },

--- a/src/websocket/listener/commands/app-server-info.ts
+++ b/src/websocket/listener/commands/app-server-info.ts
@@ -33,6 +33,7 @@ export function buildAppServerInfoResponse(
       conversation_management: true,
       memory_management: true,
       runtime_start: true,
+      runtime_workspace_sandbox: true,
       runtime_external_tools_update: true,
       split_channels: false,
     },

--- a/src/websocket/listener/commands/runtime-start.ts
+++ b/src/websocket/listener/commands/runtime-start.ts
@@ -11,6 +11,8 @@ import { createAgentWithBaseToolsRecovery } from "@/agent/create";
 import { DEFAULT_CREATED_AGENT_BASE_TOOLS } from "@/agent/create-agent-request";
 import { type ConversationUpdateBody, getBackend } from "@/backend";
 import { migratePermissionMode } from "@/permissions/mode";
+import { canonicalizeRoot } from "@/permissions/sandbox-policy";
+import { resolveWorkspaceSandbox } from "@/permissions/workspace-sandbox";
 import { settingsManager } from "@/settings-manager";
 import type { RuntimeScope, RuntimeStartCommand } from "@/types/protocol_v2";
 import { subscribeListenerConnection } from "@/websocket/listener/connection";
@@ -22,6 +24,7 @@ import {
   persistPermissionModeMapForRuntime,
 } from "@/websocket/listener/permission-mode";
 import { isRuntimeStartCommand } from "@/websocket/listener/protocol-inbound";
+import { assertRuntimeWorkspaceSandboxChangeAllowed } from "@/websocket/listener/runtime-workspace-sandbox";
 import type {
   ConversationRuntime,
   ListenerConnectionId,
@@ -290,6 +293,33 @@ async function applyRuntimeStartState(
   scope: RuntimeScope,
   scopedRuntime: ConversationRuntime,
 ): Promise<void> {
+  const workspaceSandbox = parsed.workspace_sandbox
+    ? resolveWorkspaceSandbox({
+        root: parsed.workspace_sandbox.root,
+        isolationRoot: parsed.workspace_sandbox.isolation_root,
+      })
+    : undefined;
+  const requestedWorkingDirectory =
+    parsed.cwd ??
+    workspaceSandbox?.root ??
+    getBootWorkingDirectory(context.runtime);
+  const canonicalWorkingDirectory = canonicalizeRoot(requestedWorkingDirectory);
+  if (
+    workspaceSandbox &&
+    canonicalWorkingDirectory !== workspaceSandbox.root &&
+    !canonicalWorkingDirectory.startsWith(`${workspaceSandbox.root}/`)
+  ) {
+    throw new Error(
+      "runtime_start cwd must be inside the workspace sandbox root",
+    );
+  }
+  assertRuntimeWorkspaceSandboxChangeAllowed(
+    context.runtime,
+    scopedRuntime,
+    workspaceSandbox,
+  );
+  scopedRuntime.workspaceSandbox = workspaceSandbox;
+
   if (
     parsed.skill_sources === undefined &&
     parsed.preserve_skill_sources !== true
@@ -319,12 +349,12 @@ async function applyRuntimeStartState(
     persistPermissionModeMapForRuntime(context.runtime);
   }
 
-  if (parsed.cwd !== undefined) {
+  if (parsed.cwd !== undefined || workspaceSandbox) {
     await switchConversationWorkingDirectory({
       runtime: context.runtime,
       agentId: scope.agent_id,
       conversationId: scope.conversation_id,
-      workingDirectory: parsed.cwd ?? getBootWorkingDirectory(context.runtime),
+      workingDirectory: requestedWorkingDirectory,
       emitStatus: false,
       statusRuntime: scopedRuntime,
       statusSocket: context.socket,

--- a/src/websocket/listener/protocol-inbound.test.ts
+++ b/src/websocket/listener/protocol-inbound.test.ts
@@ -192,6 +192,10 @@ describe("agent/conversation management protocol-inbound validators", () => {
       conversation_source_tags: ["channel:slack"],
       cwd: "/tmp/project",
       mode: "acceptEdits",
+      workspace_sandbox: {
+        root: "/tmp/runs/run-1",
+        isolation_root: "/tmp/runs",
+      },
       skill_sources: [],
       preserve_skill_sources: true,
       client_info: { name: "test", title: "Test", version: "1.0.0" },

--- a/src/websocket/listener/protocol-inbound.ts
+++ b/src/websocket/listener/protocol-inbound.ts
@@ -131,6 +131,12 @@ import {
   isStringRecord,
 } from "./protocol-validation";
 import {
+  isRuntimeStartClientInfo,
+  isRuntimeStartCreateAgentOptions,
+  isRuntimeStartCreateConversationOptions,
+  isRuntimeStartWorkspaceSandbox,
+} from "./runtime-start-validation";
+import {
   isTeleportContinuePayload,
   parseTeleportCommand,
 } from "./teleport-protocol-inbound";
@@ -493,28 +499,6 @@ function isDevicePermissionMode(value: unknown): boolean {
   );
 }
 
-function isRuntimeStartCreateAgentOptions(value: unknown): boolean {
-  if (!isObjectRecord(value)) return false;
-  return (
-    isObjectRecord(value.body) &&
-    (value.pin_global === undefined || typeof value.pin_global === "boolean") &&
-    (value.memfs === undefined || typeof value.memfs === "boolean")
-  );
-}
-
-function isRuntimeStartCreateConversationOptions(value: unknown): boolean {
-  if (!isObjectRecord(value)) return false;
-  return value.body === undefined || isObjectRecord(value.body);
-}
-function isRuntimeStartClientInfo(value: unknown): boolean {
-  if (!isObjectRecord(value)) return false;
-  return (
-    typeof value.name === "string" &&
-    (value.title === undefined || typeof value.title === "string") &&
-    (value.version === undefined || typeof value.version === "string")
-  );
-}
-
 export function isRuntimeStartCommand(
   value: unknown,
 ): value is RuntimeStartCommand {
@@ -534,6 +518,8 @@ export function isRuntimeStartCommand(
       isStringArray(c.conversation_source_tags)) &&
     (c.cwd === undefined || c.cwd === null || typeof c.cwd === "string") &&
     (c.mode === undefined || isDevicePermissionMode(c.mode)) &&
+    (c.workspace_sandbox === undefined ||
+      isRuntimeStartWorkspaceSandbox(c.workspace_sandbox)) &&
     (c.skill_sources === undefined || isSkillSourceArray(c.skill_sources)) &&
     (c.preserve_skill_sources === undefined ||
       typeof c.preserve_skill_sources === "boolean") &&

--- a/src/websocket/listener/runtime-start-validation.ts
+++ b/src/websocket/listener/runtime-start-validation.ts
@@ -1,0 +1,35 @@
+function isObjectRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+export function isRuntimeStartCreateAgentOptions(value: unknown): boolean {
+  if (!isObjectRecord(value)) return false;
+  return (
+    isObjectRecord(value.body) &&
+    (value.pin_global === undefined || typeof value.pin_global === "boolean") &&
+    (value.memfs === undefined || typeof value.memfs === "boolean")
+  );
+}
+
+export function isRuntimeStartCreateConversationOptions(
+  value: unknown,
+): boolean {
+  if (!isObjectRecord(value)) return false;
+  return value.body === undefined || isObjectRecord(value.body);
+}
+
+export function isRuntimeStartClientInfo(value: unknown): boolean {
+  if (!isObjectRecord(value)) return false;
+  return (
+    typeof value.name === "string" &&
+    (value.title === undefined || typeof value.title === "string") &&
+    (value.version === undefined || typeof value.version === "string")
+  );
+}
+
+export function isRuntimeStartWorkspaceSandbox(value: unknown): boolean {
+  if (!isObjectRecord(value)) return false;
+  return (
+    typeof value.root === "string" && typeof value.isolation_root === "string"
+  );
+}

--- a/src/websocket/listener/runtime-workspace-sandbox.test.ts
+++ b/src/websocket/listener/runtime-workspace-sandbox.test.ts
@@ -1,0 +1,30 @@
+import { expect, test } from "bun:test";
+import { __listenClientTestUtils } from "@/websocket/listen-client";
+import { createConversationRuntime } from "./runtime";
+import { assertRuntimeWorkspaceSandboxChangeAllowed } from "./runtime-workspace-sandbox";
+
+test("rejects changing the workspace sandbox on an active runtime", () => {
+  const listener = __listenClientTestUtils.createListenerRuntime();
+  const runtime = createConversationRuntime(listener, "agent-1", "conv-1");
+  runtime.workspaceSandbox = {
+    root: "/tmp/runs/run-a",
+    isolationRoot: "/tmp/runs",
+  };
+  listener.connectionIdsByRuntimeKey.set(runtime.key, new Set(["sdk-1"]));
+
+  expect(() =>
+    assertRuntimeWorkspaceSandboxChangeAllowed(listener, runtime, {
+      root: "/tmp/runs/run-b",
+      isolationRoot: "/tmp/runs",
+    }),
+  ).toThrow(
+    "runtime_start cannot change the workspace sandbox for an active runtime",
+  );
+  expect(() =>
+    assertRuntimeWorkspaceSandboxChangeAllowed(
+      listener,
+      runtime,
+      runtime.workspaceSandbox,
+    ),
+  ).not.toThrow();
+});

--- a/src/websocket/listener/runtime-workspace-sandbox.ts
+++ b/src/websocket/listener/runtime-workspace-sandbox.ts
@@ -1,0 +1,18 @@
+import type { RuntimeWorkspaceSandbox } from "@/runtime-context";
+import type { ConversationRuntime, ListenerRuntime } from "./types";
+
+export function assertRuntimeWorkspaceSandboxChangeAllowed(
+  listener: ListenerRuntime,
+  runtime: ConversationRuntime,
+  next: RuntimeWorkspaceSandbox | undefined,
+): void {
+  const current = runtime.workspaceSandbox;
+  const changed =
+    current?.root !== next?.root ||
+    current?.isolationRoot !== next?.isolationRoot;
+  if (changed && listener.connectionIdsByRuntimeKey.has(runtime.key)) {
+    throw new Error(
+      "runtime_start cannot change the workspace sandbox for an active runtime",
+    );
+  }
+}

--- a/src/websocket/listener/runtime.test.ts
+++ b/src/websocket/listener/runtime.test.ts
@@ -108,4 +108,23 @@ describe("conversation runtime eviction and worktree watcher idle stop", () => {
     expect(evictConversationRuntimeIfIdle(runtime)).toBe(false);
     expect(listener.conversationRuntimes.has(runtime.key)).toBe(true);
   });
+
+  test("a subscribed workspace sandbox survives between session turns", () => {
+    const listener = __listenClientTestUtils.createListenerRuntime();
+    const runtime = createConversationRuntime(
+      listener,
+      AGENT_ID,
+      CONVERSATION_ID,
+    );
+    runtime.workspaceSandbox = {
+      root: "/tmp/runs/run-a",
+      isolationRoot: "/tmp/runs",
+    };
+    listener.connectionIdsByRuntimeKey.set(runtime.key, new Set(["sdk-1"]));
+
+    expect(evictConversationRuntimeIfIdle(runtime)).toBe(false);
+
+    listener.connectionIdsByRuntimeKey.delete(runtime.key);
+    expect(evictConversationRuntimeIfIdle(runtime)).toBe(true);
+  });
 });

--- a/src/websocket/listener/runtime.ts
+++ b/src/websocket/listener/runtime.ts
@@ -168,7 +168,9 @@ export function evictConversationRuntimeIfIdle(
     runtime.pendingInterruptedContext !== null ||
     (runtime.pendingInterruptedToolCallIds?.length ?? 0) > 0 ||
     runtime.queuedMessagesByItemId.size > 0 ||
-    runtime.queueRuntime?.length > 0
+    runtime.queueRuntime?.length > 0 ||
+    (runtime.workspaceSandbox !== undefined &&
+      runtime.listener.connectionIdsByRuntimeKey.has(runtime.key))
   ) {
     return false;
   }
@@ -253,6 +255,7 @@ export function createConversationRuntime(
     agentId: normalizedAgentId,
     conversationId: normalizedConversationId,
     skillSources: listener.skillSourcesByConversation.get(runtimeKey)?.slice(),
+    workspaceSandbox: undefined,
     activeConnectionId: null,
     turnLifecycle,
     messageQueue: Promise.resolve(),

--- a/src/websocket/listener/turn-setup.ts
+++ b/src/websocket/listener/turn-setup.ts
@@ -290,6 +290,7 @@ export async function prepareListenerTurn(params: {
     permissionModeState,
     skillsDirectory: listenerOptions?.skillsDirectory,
     skillSources: runtime.skillSources,
+    workspaceSandbox: runtime.workspaceSandbox,
     cachedAgent,
     modContext: createListenerAgentModContext(agentId),
     modAdapters,

--- a/src/websocket/listener/types.ts
+++ b/src/websocket/listener/types.ts
@@ -17,6 +17,7 @@ import type {
   QueueRuntime,
 } from "@/queue/queue-runtime";
 import type { SharedReminderState } from "@/reminders/state";
+import type { RuntimeWorkspaceSandbox } from "@/runtime-context";
 import type { ToolsetName, ToolsetPreference } from "@/tools/toolset";
 import type {
   ApprovalResponseBody,
@@ -202,6 +203,8 @@ export type ConversationRuntime = {
   conversationId: string;
   /** Runtime-scoped SDK override. Undefined uses the process defaults. */
   skillSources: SkillSource[] | undefined;
+  /** Explicit runtime filesystem boundary for shared app-server sessions. */
+  workspaceSandbox: RuntimeWorkspaceSandbox | undefined;
   /** Connection currently executing this conversation's turn, if client-owned. */
   activeConnectionId: ListenerConnectionId | null;
   turnLifecycle: TurnLifecycle;


### PR DESCRIPTION
## Summary
- add a capability-gated `runtime_start.workspace_sandbox` scope for shared app-server runtimes
- enforce peer-workspace read isolation and workspace-only writes through the existing kernel sandbox backends
- carry the scope through turn tool contexts and reject sandbox changes on active runtimes

## Validation
- `bun run check`
- focused sandbox and app-server protocol tests (98 passing)

Linear: LET-10975