### PR TITLE
fix(local): use Ollama's served context window, not the GGUF maximum

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -395,6 +395,10 @@ jobs:
         run: curl -fsSL https://ollama.com/install.sh | sh
 
       - name: Start Ollama server
+        env:
+          # The full Letta Code prompt must fit so this provider smoke reaches
+          # inference instead of exercising the intentional truncation guard.
+          OLLAMA_CONTEXT_LENGTH: 32768
         run: |
           ollama serve > /tmp/ollama.log 2>&1 &
           for _ in $(seq 1 30); do

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -395,10 +395,6 @@ jobs:
         run: curl -fsSL https://ollama.com/install.sh | sh
 
       - name: Start Ollama server
-        env:
-          # The full Letta Code prompt must fit so this provider smoke reaches
-          # inference instead of exercising the intentional truncation guard.
-          OLLAMA_CONTEXT_LENGTH: 32768
         run: |
           ollama serve > /tmp/ollama.log 2>&1 &
           for _ in $(seq 1 30); do
@@ -415,11 +411,19 @@ jobs:
       - name: Pull model
         run: ollama pull "${{ matrix.model }}"
 
+      - name: Configure smoke model context
+        run: |
+          cat > /tmp/letta-ci-smoke.Modelfile <<'EOF'
+          FROM ${{ matrix.model }}
+          PARAMETER num_ctx 32768
+          EOF
+          ollama create letta-ci-smoke -f /tmp/letta-ci-smoke.Modelfile
+
       - name: Run Ollama provider smoke (connect + autodetect + round-trip)
         env:
           OLLAMA_BASE_URL: http://localhost:11434/v1
         run: |
-          bun run src/test-utils/headless-scenario.ts --backend local --model "ollama/${{ matrix.model }}" --output text --parallel on --smoke
+          bun run src/test-utils/headless-scenario.ts --backend local --model "ollama/letta-ci-smoke" --output text --parallel on --smoke
 
   reflection-headless:
     needs: [classify, check]

--- a/src/backend/dev/pi-model-factory.ts
+++ b/src/backend/dev/pi-model-factory.ts
@@ -554,8 +554,25 @@ export async function resolvePiModelForAgent(
   // restate the published values never clone. Base URL overrides apply only
   // to built-in catalog providers (managed endpoints and mods own their
   // base URLs end-to-end).
-  const contextWindow = numericSetting(modelSettings.context_window_limit);
-  const maxTokens = numericSetting(modelSettings.max_tokens);
+  const configuredContextWindow = numericSetting(
+    modelSettings.context_window_limit,
+  );
+  // Ollama selection persists architectural catalog values into settings.
+  // They must not inflate exact local-daemon serving truth. Other endpoints
+  // retain the existing explicit override escape hatch.
+  const isLocalOllama =
+    modelsRuntime.isBuiltInLocalOllamaProvider(runtimeProviderId);
+  const contextWindow =
+    configuredContextWindow && isLocalOllama
+      ? Math.min(configuredContextWindow, hookedModel.contextWindow)
+      : configuredContextWindow;
+  const configuredMaxTokens = numericSetting(modelSettings.max_tokens);
+  const maxTokens = isLocalOllama
+    ? Math.min(
+        configuredMaxTokens ?? hookedModel.maxTokens,
+        contextWindow ?? hookedModel.contextWindow,
+      )
+    : configuredMaxTokens;
   const allowBaseUrlOverride =
     !registeredProvider &&
     spec !== undefined &&

--- a/src/backend/dev/pi-model-factory.ts
+++ b/src/backend/dev/pi-model-factory.ts
@@ -113,6 +113,7 @@ export interface PiModelFactoryOptions {
   model?: string;
   localProviderAuthStorageDir?: string;
   preferredProviderType?: string;
+  abortSignal?: AbortSignal;
   /**
    * Per-backend pi-ai Models runtime. Runtime-managed providers (local
    * endpoints and mod registrations) resolve to the complete Model object
@@ -489,6 +490,7 @@ export async function resolvePiModelForAgent(
       runtimeProviderId,
       modelId,
       fallbackModelId,
+      options.abortSignal,
     );
   // The runtime is the sole credential source (stored records, ambient env
   // via the runtime's AuthContext aliases, per-credential OAuth request

--- a/src/backend/dev/pi-models-runtime.test.ts
+++ b/src/backend/dev/pi-models-runtime.test.ts
@@ -22,8 +22,7 @@ interface FakeOllamaModel {
 interface FakeOllamaServer {
   url: string;
   chatBodies: Array<Record<string, unknown>>;
-  loadBodies?: Array<Record<string, unknown>>;
-  setRuntimeContext?(modelId: string, contextLength: number | undefined): void;
+  setDefaultRuntimeContext?(modelId: string, contextLength: number): void;
   stop(): void;
 }
 
@@ -60,8 +59,13 @@ function sseChatResponse(modelId: string): Response {
 
 function startFakeOllama(models: FakeOllamaModel[]): FakeOllamaServer {
   const chatBodies: Array<Record<string, unknown>> = [];
-  const loadBodies: Array<Record<string, unknown>> = [];
   const runtimeContexts = new Map<string, number>();
+  const defaultRuntimeContexts = new Map(
+    models.map((model) => [
+      model.id,
+      Math.min(model.contextLength ?? 128000, 128000),
+    ]),
+  );
   const server = Bun.serve({
     port: 0,
     async fetch(request) {
@@ -81,13 +85,9 @@ function startFakeOllama(models: FakeOllamaModel[]): FakeOllamaServer {
       }
       if (url.pathname === "/api/generate") {
         const body = (await request.json()) as Record<string, unknown>;
-        loadBodies.push(body);
         const model = models.find((entry) => entry.id === body.model);
         if (!model) return new Response("not found", { status: 404 });
-        runtimeContexts.set(
-          model.id,
-          Math.min(model.contextLength ?? 128000, 128000),
-        );
+        runtimeContexts.set(model.id, defaultRuntimeContexts.get(model.id)!);
         return Response.json({ model: model.id, done: true });
       }
       if (url.pathname === "/api/show") {
@@ -117,10 +117,8 @@ function startFakeOllama(models: FakeOllamaModel[]): FakeOllamaServer {
   return {
     url: `http://localhost:${server.port}`,
     chatBodies,
-    loadBodies,
-    setRuntimeContext: (modelId, contextLength) => {
-      if (contextLength === undefined) runtimeContexts.delete(modelId);
-      else runtimeContexts.set(modelId, contextLength);
+    setDefaultRuntimeContext: (modelId, contextLength) => {
+      defaultRuntimeContexts.set(modelId, contextLength);
     },
     stop: () => server.stop(true),
   };
@@ -464,7 +462,7 @@ describe("LocalPiModelsRuntime + Ollama provider", () => {
       runtime.getModel("ollama", "qwen3.6:27b")!,
     );
 
-    server.setRuntimeContext?.("qwen3.6:27b", 8192);
+    server.setDefaultRuntimeContext?.("qwen3.6:27b", 8192);
     const resolvedAfterRuntimeChange = await resolvePiModelForAgent(
       "ollama/qwen3.6:27b",
       persisted ?? {},

--- a/src/backend/dev/pi-models-runtime.test.ts
+++ b/src/backend/dev/pi-models-runtime.test.ts
@@ -22,6 +22,8 @@ interface FakeOllamaModel {
 interface FakeOllamaServer {
   url: string;
   chatBodies: Array<Record<string, unknown>>;
+  loadBodies?: Array<Record<string, unknown>>;
+  setRuntimeContext?(modelId: string, contextLength: number | undefined): void;
   stop(): void;
 }
 
@@ -58,6 +60,8 @@ function sseChatResponse(modelId: string): Response {
 
 function startFakeOllama(models: FakeOllamaModel[]): FakeOllamaServer {
   const chatBodies: Array<Record<string, unknown>> = [];
+  const loadBodies: Array<Record<string, unknown>> = [];
+  const runtimeContexts = new Map<string, number>();
   const server = Bun.serve({
     port: 0,
     async fetch(request) {
@@ -66,6 +70,25 @@ function startFakeOllama(models: FakeOllamaModel[]): FakeOllamaServer {
         return Response.json({
           models: models.map((model) => ({ name: model.id })),
         });
+      }
+      if (url.pathname === "/api/ps") {
+        return Response.json({
+          models: [...runtimeContexts].map(([name, context_length]) => ({
+            name,
+            context_length,
+          })),
+        });
+      }
+      if (url.pathname === "/api/generate") {
+        const body = (await request.json()) as Record<string, unknown>;
+        loadBodies.push(body);
+        const model = models.find((entry) => entry.id === body.model);
+        if (!model) return new Response("not found", { status: 404 });
+        runtimeContexts.set(
+          model.id,
+          Math.min(model.contextLength ?? 128000, 128000),
+        );
+        return Response.json({ model: model.id, done: true });
       }
       if (url.pathname === "/api/show") {
         const body = (await request.json()) as { model: string };
@@ -94,6 +117,11 @@ function startFakeOllama(models: FakeOllamaModel[]): FakeOllamaServer {
   return {
     url: `http://localhost:${server.port}`,
     chatBodies,
+    loadBodies,
+    setRuntimeContext: (modelId, contextLength) => {
+      if (contextLength === undefined) runtimeContexts.delete(modelId);
+      else runtimeContexts.set(modelId, contextLength);
+    },
     stop: () => server.stop(true),
   };
 }
@@ -388,8 +416,6 @@ describe("LocalPiModelsRuntime + Ollama provider", () => {
       { provider_type: "anthropic" },
       { localProviderAuthStorageDir: storageDir, modelsRuntime: runtime },
     );
-    // The LET-10125 target invariant holds for built-ins too: with no
-    // effective overrides, the turn model IS the runtime-published instance.
     expect(resolved.model).toBe(
       runtime.getModel("anthropic", "claude-opus-4-8")!,
     );
@@ -420,15 +446,11 @@ describe("LocalPiModelsRuntime + Ollama provider", () => {
       {},
       { localProviderAuthStorageDir: storageDir, modelsRuntime: runtime },
     );
-    // The turn model is the exact Model instance the provider published for
-    // listing — the LET-10125 target invariant.
     expect(resolved.model).toBe(runtime.getModel("ollama", "qwen3.6:27b")!);
     expect(resolved.model.input).toEqual(["text", "image"]);
     expect(resolved.model.reasoning).toBe(true);
     expect(resolved.model.contextWindow).toBe(128000);
 
-    // Identity survives the real selection path: settings persisted from
-    // the published model (restating its values) must not force a clone.
     const persisted = localModelSettingsForHandle(
       "ollama/qwen3.6:27b",
       runtime,
@@ -442,14 +464,30 @@ describe("LocalPiModelsRuntime + Ollama provider", () => {
       runtime.getModel("ollama", "qwen3.6:27b")!,
     );
 
-    // /context-limit remains an explicit per-conversation escape hatch when
-    // the user's Ollama runtime is configured above the conservative default.
-    const resolvedWithExplicitContext = await resolvePiModelForAgent(
+    server.setRuntimeContext?.("qwen3.6:27b", 8192);
+    const resolvedAfterRuntimeChange = await resolvePiModelForAgent(
       "ollama/qwen3.6:27b",
-      { context_window_limit: 262144 },
+      persisted ?? {},
       { localProviderAuthStorageDir: storageDir, modelsRuntime: runtime },
     );
-    expect(resolvedWithExplicitContext.model.contextWindow).toBe(262144);
+    expect(resolvedAfterRuntimeChange.model.contextWindow).toBe(8192);
+    expect(runtime.getModel("ollama", "qwen3.6:27b")?.contextWindow).toBe(8192);
+
+    const resolvedWithLargerContext = await resolvePiModelForAgent(
+      "ollama/qwen3.6:27b",
+      { context_window_limit: 262144, max_tokens: 32000 },
+      { localProviderAuthStorageDir: storageDir, modelsRuntime: runtime },
+    );
+    expect(resolvedWithLargerContext.model.contextWindow).toBe(8192);
+    expect(resolvedWithLargerContext.model.maxTokens).toBe(8192);
+
+    const resolvedWithSmallerContext = await resolvePiModelForAgent(
+      "ollama/qwen3.6:27b",
+      { context_window_limit: 4096, max_tokens: 32000 },
+      { localProviderAuthStorageDir: storageDir, modelsRuntime: runtime },
+    );
+    expect(resolvedWithSmallerContext.model.contextWindow).toBe(4096);
+    expect(resolvedWithSmallerContext.model.maxTokens).toBe(4096);
   });
 
   test("vision model with no name marker keeps base64 image_url in the request payload", async () => {
@@ -595,7 +633,6 @@ describe("LocalPiModelsRuntime + Ollama provider", () => {
       "image",
     ]);
     expect(runtime.getModel("ollama", "model-a:1b")).toBeUndefined();
-    // Other providers are untouched by the Ollama connection change.
     expect(runtime.getModels("anthropic")[0]).toBe(builtinBefore[0]!);
     expect(runtime.getModels("anthropic")).toHaveLength(builtinBefore.length);
   });
@@ -650,6 +687,12 @@ describe("LocalPiModelsRuntime + Ollama provider", () => {
       runtime.getModel("llama-cpp", "/models/qwen3.6-27b.gguf")!,
     );
     expect(resolved.model.input).toEqual(["text", "image"]);
+    const withLargerContext = await resolvePiModelForAgent(
+      "llama.cpp//models/qwen3.6-27b.gguf",
+      { context_window_limit: 65536 },
+      { localProviderAuthStorageDir: storageDir, modelsRuntime: runtime },
+    );
+    expect(withLargerContext.model.contextWindow).toBe(65536);
   });
 
   test("unloaded llama.cpp router models preserve provider identity from listing through turns", async () => {
@@ -756,7 +799,7 @@ describe("LocalPiModelsRuntime + Ollama provider", () => {
     expect(runtime.getModels("ollama")).toHaveLength(0);
   });
 
-  test("refresh failure retains last-known models and turns still resolve", async () => {
+  test("refresh failure retains listings but turn resolution fails closed", async () => {
     const server = startFakeOllama([
       {
         id: "qwen3.6:27b",
@@ -779,13 +822,13 @@ describe("LocalPiModelsRuntime + Ollama provider", () => {
     expect(listed.some((model) => model.handle === "ollama/qwen3.6:27b")).toBe(
       true,
     );
-    // Turn resolution still finds the model without a live endpoint.
-    const resolved = await resolvePiModelForAgent(
-      "ollama/qwen3.6:27b",
-      {},
-      { localProviderAuthStorageDir: storageDir, modelsRuntime: runtime },
-    );
-    expect(resolved.model.input).toEqual(["text", "image"]);
+    await expect(
+      resolvePiModelForAgent(
+        "ollama/qwen3.6:27b",
+        {},
+        { localProviderAuthStorageDir: storageDir, modelsRuntime: runtime },
+      ),
+    ).rejects.toThrow(/Refusing to send the prompt/i);
   });
 
   test("OpenAI-compatible discovery publishes arbitrary IDs and turns use the same Model", async () => {

--- a/src/backend/dev/pi-models-runtime.ts
+++ b/src/backend/dev/pi-models-runtime.ts
@@ -35,6 +35,7 @@ import {
   createOllamaPiProvider,
   OLLAMA_CLOUD_PI_PROVIDER_ID,
   OLLAMA_PI_PROVIDER_ID,
+  resolveOllamaServedContext,
 } from "./pi-ollama-provider";
 import { createOpenAICompatiblePiProvider } from "./pi-openai-compatible-provider";
 import {
@@ -173,6 +174,18 @@ function connectionSignature(connection: LocalEndpointConnection): string {
   ].join(" ");
 }
 
+function withOllamaServedContext(
+  model: Model<Api>,
+  servedContext: number,
+): Model<Api> {
+  const contextWindow = servedContext;
+  const maxTokens = Math.min(model.maxTokens, contextWindow);
+  if (model.contextWindow === contextWindow && model.maxTokens === maxTokens) {
+    return model;
+  }
+  return { ...model, contextWindow, maxTokens };
+}
+
 /**
  * Per-local-backend pi-ai Models runtime: the source of truth for provider
  * registration, model lookup, refresh, and stream dispatch in the local turn
@@ -308,8 +321,49 @@ export class LocalPiModelsRuntime {
         ? this.models.getModel(providerId, fallbackModelId)
         : undefined);
     for (let attempt = 0; ; attempt++) {
+      // Re-check connection-backed provider registration on every retry. This
+      // prevents native preflight against one endpoint from being paired with
+      // auth or a catalog built from another endpoint after a concurrent write.
+      this.ensureManagedProviders(providerId);
       await this.invalidateOnCredentialChange();
       const auth = await this.models.getAuth(providerId);
+      const isLocalOllama = this.isBuiltInLocalOllamaProvider(providerId);
+      const ollamaConnection = isLocalOllama
+        ? resolveLocalEndpointConnection(providerId, this.storageDir)
+        : undefined;
+      const expectedEndpointSignature = isLocalOllama
+        ? this.endpointSignatures.get(providerId)
+        : undefined;
+      if (
+        ollamaConnection &&
+        connectionSignature(ollamaConnection) !== expectedEndpointSignature
+      ) {
+        if (attempt >= MAX_TURN_RESOLUTION_RETRIES) {
+          throw new Error(
+            `Connection for provider "${providerId}" changed repeatedly during turn resolution; retry the request.`,
+          );
+        }
+        continue;
+      }
+
+      let ollamaServedContext: number | undefined;
+      if (ollamaConnection) {
+        ollamaServedContext = await resolveOllamaServedContext({
+          baseURL: ollamaConnection.baseURL,
+          modelId,
+          ...(ollamaConnection.apiKey
+            ? { apiKey: ollamaConnection.apiKey }
+            : {}),
+          ...(this.fetchImpl ? { fetchImpl: this.fetchImpl } : {}),
+        });
+        try {
+          await this.refresh(providerId);
+        } catch {
+          // Exact serving truth is already known. Retained catalog capabilities
+          // remain usable, but their contextWindow does not.
+        }
+      }
+
       let model = lookup();
       if (!model) {
         try {
@@ -319,16 +373,31 @@ export class LocalPiModelsRuntime {
         }
         model = lookup();
       }
-      if (await this.credentialIdentityMovedSinceInvalidation(providerId)) {
+      const credentialMoved =
+        await this.credentialIdentityMovedSinceInvalidation(providerId);
+      const endpointMoved =
+        ollamaConnection !== undefined &&
+        (this.endpointSignatures.get(providerId) !==
+          expectedEndpointSignature ||
+          connectionSignature(
+            resolveLocalEndpointConnection(providerId, this.storageDir),
+          ) !== expectedEndpointSignature);
+      if (credentialMoved || endpointMoved) {
         if (attempt >= MAX_TURN_RESOLUTION_RETRIES) {
           throw new Error(
-            `Credentials for provider "${providerId}" changed repeatedly ` +
+            `${endpointMoved ? "Connection" : "Credentials"} for provider "${providerId}" changed repeatedly ` +
               "during turn resolution; retry the request.",
           );
         }
         continue;
       }
-      return { model, auth };
+      return {
+        model:
+          model && ollamaServedContext !== undefined
+            ? withOllamaServedContext(model, ollamaServedContext)
+            : model,
+        auth,
+      };
     }
   }
 
@@ -359,6 +428,14 @@ export class LocalPiModelsRuntime {
     return (
       getRegisteredPiProvider(providerId) !== undefined ||
       MANAGED_ENDPOINT_PROVIDERS.has(providerId)
+    );
+  }
+
+  /** Built-in local Ollama daemon, excluding mods that override its id. */
+  isBuiltInLocalOllamaProvider(providerId: string): boolean {
+    return (
+      providerId === OLLAMA_PI_PROVIDER_ID &&
+      getRegisteredPiProvider(providerId) === undefined
     );
   }
 

--- a/src/backend/dev/pi-models-runtime.ts
+++ b/src/backend/dev/pi-models-runtime.ts
@@ -33,6 +33,7 @@ import {
 import { createModPiProvider } from "./pi-mod-provider";
 import {
   createOllamaPiProvider,
+  normalizeOllamaModelId,
   OLLAMA_CLOUD_PI_PROVIDER_ID,
   OLLAMA_PI_PROVIDER_ID,
   resolveOllamaServedContext,
@@ -318,6 +319,9 @@ export class LocalPiModelsRuntime {
     this.ensureManagedProviders(providerId);
     const lookup = () =>
       this.models.getModel(providerId, modelId) ??
+      (this.isBuiltInLocalOllamaProvider(providerId)
+        ? this.models.getModel(providerId, normalizeOllamaModelId(modelId))
+        : undefined) ??
       (fallbackModelId
         ? this.models.getModel(providerId, fallbackModelId)
         : undefined);

--- a/src/backend/dev/pi-models-runtime.ts
+++ b/src/backend/dev/pi-models-runtime.ts
@@ -313,6 +313,7 @@ export class LocalPiModelsRuntime {
     providerId: string,
     modelId: string,
     fallbackModelId?: string,
+    abortSignal?: AbortSignal,
   ): Promise<{ model: Model<Api> | undefined; auth: AuthResult | undefined }> {
     this.ensureManagedProviders(providerId);
     const lookup = () =>
@@ -355,6 +356,7 @@ export class LocalPiModelsRuntime {
             ? { apiKey: ollamaConnection.apiKey }
             : {}),
           ...(this.fetchImpl ? { fetchImpl: this.fetchImpl } : {}),
+          ...(abortSignal ? { signal: abortSignal } : {}),
         });
         try {
           await this.refresh(providerId);

--- a/src/backend/dev/pi-ollama-provider.test.ts
+++ b/src/backend/dev/pi-ollama-provider.test.ts
@@ -3,7 +3,10 @@ import { testRefreshContext } from "@/test-utils/pi-refresh-context";
 import { localEndpointNativeBaseURL } from "./pi-local-endpoint-provider";
 import { resolvePiModelForAgent } from "./pi-model-factory";
 import { LocalPiModelsRuntime } from "./pi-models-runtime";
-import { createOllamaPiProvider } from "./pi-ollama-provider";
+import {
+  createOllamaPiProvider,
+  resolveOllamaServedContext,
+} from "./pi-ollama-provider";
 
 interface FakeOllamaState {
   tags: unknown;
@@ -79,6 +82,36 @@ describe("localEndpointNativeBaseURL", () => {
     expect(localEndpointNativeBaseURL("http://localhost:11434")).toBe(
       "http://localhost:11434",
     );
+  });
+});
+
+describe("resolveOllamaServedContext", () => {
+  test("cancels a pending model load with the turn", async () => {
+    const fetchImpl = (async (
+      input: string | URL | Request,
+      init?: RequestInit,
+    ) => {
+      if (!String(input).endsWith("/api/generate")) {
+        return Response.json({ models: [] });
+      }
+      return new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener(
+          "abort",
+          () => reject(init.signal?.reason ?? new Error("aborted")),
+          { once: true },
+        );
+      });
+    }) as typeof fetch;
+    const controller = new AbortController();
+    const pending = resolveOllamaServedContext({
+      baseURL: "http://localhost:11434",
+      modelId: "qwen3.6:27b",
+      fetchImpl,
+      signal: controller.signal,
+    });
+
+    controller.abort(new Error("turn cancelled"));
+    await expect(pending).rejects.toThrow("turn cancelled");
   });
 });
 

--- a/src/backend/dev/pi-ollama-provider.test.ts
+++ b/src/backend/dev/pi-ollama-provider.test.ts
@@ -6,6 +6,8 @@ import { createOllamaPiProvider } from "./pi-ollama-provider";
 interface FakeOllamaState {
   tags: unknown;
   show: Record<string, unknown>;
+  /** `GET /api/ps` payload; omitted means the endpoint answers 404. */
+  ps?: unknown;
   failTags?: boolean;
   failShowFor?: Set<string>;
   requests: string[];
@@ -18,6 +20,11 @@ function fakeOllamaFetch(state: FakeOllamaState): typeof fetch {
     if (url.endsWith("/api/tags")) {
       if (state.failTags) throw new Error("connection refused");
       return Response.json(state.tags);
+    }
+    if (url.endsWith("/api/ps")) {
+      if (state.ps === undefined)
+        return new Response("not found", { status: 404 });
+      return Response.json(state.ps);
     }
     if (url.endsWith("/api/show")) {
       const body = JSON.parse(String(init?.body)) as { model: string };
@@ -97,6 +104,103 @@ describe("createOllamaPiProvider", () => {
     expect(text?.input).toEqual(["text"]);
     expect(text?.reasoning).toBe(false);
     expect(text?.contextWindow).toBe(32768);
+  });
+
+  // Ollama serves OLLAMA_CONTEXT_LENGTH, not the GGUF maximum, and silently
+  // truncates anything longer. Publishing the architectural maximum makes the
+  // harness think it has room it does not have, so compaction never fires and
+  // the engine drops the front of the prompt — persona and memory included.
+  test("prefers the runtime window from /api/ps over GGUF metadata", async () => {
+    const state = qwenState();
+    state.ps = {
+      models: [{ name: "qwen3.6:27b", context_length: 32768 }],
+    };
+    const provider = createOllamaPiProvider({
+      baseURL: "http://localhost:11434",
+      fetchImpl: fakeOllamaFetch(state),
+    });
+    await provider.refreshModels?.(testRefreshContext());
+
+    expect(
+      provider.getModels().find((m) => m.id === "qwen3.6:27b")?.contextWindow,
+    ).toBe(32768);
+  });
+
+  test("applies a loaded model's window to models that are not loaded", async () => {
+    const state = qwenState();
+    // OLLAMA_CONTEXT_LENGTH is daemon-wide, so the one loaded model reveals the
+    // window the endpoint will serve for the other one too.
+    state.ps = { models: [{ name: "smol-text:3b", context_length: 8192 }] };
+    const provider = createOllamaPiProvider({
+      baseURL: "http://localhost:11434",
+      fetchImpl: fakeOllamaFetch(state),
+    });
+    await provider.refreshModels?.(testRefreshContext());
+
+    expect(
+      provider.getModels().find((m) => m.id === "qwen3.6:27b")?.contextWindow,
+    ).toBe(8192);
+  });
+
+  test("takes the smallest observed runtime window", async () => {
+    const state = qwenState();
+    // A model another client loaded with a large explicit num_ctx must not
+    // inflate what we assume the endpoint serves by default.
+    state.ps = {
+      models: [
+        { name: "other:7b", context_length: 131072 },
+        { name: "smol-text:3b", context_length: 16384 },
+      ],
+    };
+    const provider = createOllamaPiProvider({
+      baseURL: "http://localhost:11434",
+      fetchImpl: fakeOllamaFetch(state),
+    });
+    await provider.refreshModels?.(testRefreshContext());
+
+    expect(
+      provider.getModels().find((m) => m.id === "qwen3.6:27b")?.contextWindow,
+    ).toBe(16384);
+  });
+
+  test("falls back to GGUF metadata when /api/ps is unavailable", async () => {
+    const state = qwenState();
+    const provider = createOllamaPiProvider({
+      baseURL: "http://localhost:11434",
+      fetchImpl: fakeOllamaFetch(state),
+    });
+    await provider.refreshModels?.(testRefreshContext());
+
+    // 262144 in metadata, clamped by the harness default.
+    expect(
+      provider.getModels().find((m) => m.id === "qwen3.6:27b")?.contextWindow,
+    ).toBe(128000);
+  });
+
+  test("republishes when the runtime window changes without a digest change", async () => {
+    const state: FakeOllamaState = {
+      tags: { models: [{ name: "qwen3.6:27b", digest: "sha256-aaa" }] },
+      show: { "qwen3.6:27b": { capabilities: ["completion"] } },
+      ps: { models: [{ name: "qwen3.6:27b", context_length: 8192 }] },
+      requests: [],
+    };
+    const provider = createOllamaPiProvider({
+      baseURL: "http://localhost:11434",
+      fetchImpl: fakeOllamaFetch(state),
+    });
+    const refreshContext = testRefreshContext();
+    await provider.refreshModels?.(refreshContext);
+    expect(
+      provider.getModels().find((m) => m.id === "qwen3.6:27b")?.contextWindow,
+    ).toBe(8192);
+
+    // Daemon restarted with a larger OLLAMA_CONTEXT_LENGTH: same blob, new
+    // window. The digest fast-path must not pin the stale value.
+    state.ps = { models: [{ name: "qwen3.6:27b", context_length: 65536 }] };
+    await provider.refreshModels?.(refreshContext);
+    expect(
+      provider.getModels().find((m) => m.id === "qwen3.6:27b")?.contextWindow,
+    ).toBe(65536);
   });
 
   test("skips /api/show when the tag digest is unchanged", async () => {

--- a/src/backend/dev/pi-ollama-provider.test.ts
+++ b/src/backend/dev/pi-ollama-provider.test.ts
@@ -113,6 +113,38 @@ describe("resolveOllamaServedContext", () => {
     controller.abort(new Error("turn cancelled"));
     await expect(pending).rejects.toThrow("turn cancelled");
   });
+
+  test("cancels the required post-load status probe with the turn", async () => {
+    let statusStarted = () => {};
+    const started = new Promise<void>((resolve) => {
+      statusStarted = resolve;
+    });
+    const fetchImpl = (async (
+      input: string | URL | Request,
+      init?: RequestInit,
+    ) => {
+      if (String(input).endsWith("/api/generate")) return Response.json({});
+      statusStarted();
+      return new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener(
+          "abort",
+          () => reject(init.signal?.reason ?? new Error("aborted")),
+          { once: true },
+        );
+      });
+    }) as typeof fetch;
+    const controller = new AbortController();
+    const pending = resolveOllamaServedContext({
+      baseURL: "http://localhost:11434",
+      modelId: "qwen3.6:27b",
+      fetchImpl,
+      signal: controller.signal,
+    });
+
+    await started;
+    controller.abort(new Error("turn cancelled"));
+    await expect(pending).rejects.toThrow("turn cancelled");
+  });
 });
 
 describe("createOllamaPiProvider", () => {

--- a/src/backend/dev/pi-ollama-provider.test.ts
+++ b/src/backend/dev/pi-ollama-provider.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from "bun:test";
 import { testRefreshContext } from "@/test-utils/pi-refresh-context";
 import { localEndpointNativeBaseURL } from "./pi-local-endpoint-provider";
+import { resolvePiModelForAgent } from "./pi-model-factory";
+import { LocalPiModelsRuntime } from "./pi-models-runtime";
 import { createOllamaPiProvider } from "./pi-ollama-provider";
 
 interface FakeOllamaState {
@@ -126,10 +128,10 @@ describe("createOllamaPiProvider", () => {
     ).toBe(32768);
   });
 
-  test("applies a loaded model's window to models that are not loaded", async () => {
+  test("does not apply another loaded model's window as an endpoint default", async () => {
     const state = qwenState();
-    // OLLAMA_CONTEXT_LENGTH is daemon-wide, so the one loaded model reveals the
-    // window the endpoint will serve for the other one too.
+    // A client can load each model with a different num_ctx. `/api/ps` is
+    // authoritative only for the exact model identity in that record.
     state.ps = { models: [{ name: "smol-text:3b", context_length: 8192 }] };
     const provider = createOllamaPiProvider({
       baseURL: "http://localhost:11434",
@@ -139,28 +141,10 @@ describe("createOllamaPiProvider", () => {
 
     expect(
       provider.getModels().find((m) => m.id === "qwen3.6:27b")?.contextWindow,
-    ).toBe(8192);
-  });
-
-  test("takes the smallest observed runtime window", async () => {
-    const state = qwenState();
-    // A model another client loaded with a large explicit num_ctx must not
-    // inflate what we assume the endpoint serves by default.
-    state.ps = {
-      models: [
-        { name: "other:7b", context_length: 131072 },
-        { name: "smol-text:3b", context_length: 16384 },
-      ],
-    };
-    const provider = createOllamaPiProvider({
-      baseURL: "http://localhost:11434",
-      fetchImpl: fakeOllamaFetch(state),
-    });
-    await provider.refreshModels?.(testRefreshContext());
-
+    ).toBe(128000);
     expect(
-      provider.getModels().find((m) => m.id === "qwen3.6:27b")?.contextWindow,
-    ).toBe(16384);
+      provider.getModels().find((m) => m.id === "smol-text:3b")?.contextWindow,
+    ).toBe(8192);
   });
 
   test("falls back to GGUF metadata when /api/ps is unavailable", async () => {
@@ -321,6 +305,35 @@ describe("createOllamaPiProvider as Ollama Cloud", () => {
     expect(authHeaders.every((header) => header === "Bearer cloud-key")).toBe(
       true,
     );
+  });
+
+  test("turn resolution does not require local-daemon serving APIs", async () => {
+    const previousApiKey = process.env.OLLAMA_API_KEY;
+    process.env.OLLAMA_API_KEY = "cloud-key";
+    const state = qwenState();
+    const fetchImpl = fakeOllamaFetch(state);
+    const runtime = new LocalPiModelsRuntime({ fetchImpl });
+
+    try {
+      const resolved = await resolvePiModelForAgent(
+        "ollama-cloud/qwen3.6:27b",
+        {
+          provider_type: "ollama_cloud",
+          context_window_limit: 262144,
+        },
+        { modelsRuntime: runtime },
+      );
+      expect(resolved.model.contextWindow).toBe(262144);
+      expect(state.requests.some((url) => url.endsWith("/api/generate"))).toBe(
+        false,
+      );
+      // Catalog discovery may probe /api/ps best-effort and receive 404. Turn
+      // resolution must not require a local-daemon served-window result.
+      expect(state.requests.some((url) => url.endsWith("/api/ps"))).toBe(true);
+    } finally {
+      if (previousApiKey === undefined) delete process.env.OLLAMA_API_KEY;
+      else process.env.OLLAMA_API_KEY = previousApiKey;
+    }
   });
 });
 

--- a/src/backend/dev/pi-ollama-provider.ts
+++ b/src/backend/dev/pi-ollama-provider.ts
@@ -100,6 +100,7 @@ export interface ResolveOllamaServedContextOptions {
   modelId: string;
   apiKey?: string;
   fetchImpl?: typeof fetch;
+  signal?: AbortSignal;
 }
 
 async function fetchOllamaNative<T>(
@@ -108,12 +109,16 @@ async function fetchOllamaNative<T>(
   options: {
     apiKey?: string;
     body?: unknown;
+    signal?: AbortSignal;
     timeoutMs: number;
     consume(response: Response): Promise<T>;
   },
 ): Promise<T> {
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), options.timeoutMs);
+  const abort = () => controller.abort(options.signal?.reason);
+  if (options.signal?.aborted) abort();
+  else options.signal?.addEventListener("abort", abort, { once: true });
   try {
     const headers: Record<string, string> = { Accept: "application/json" };
     if (options.apiKey && options.apiKey !== "not-needed") {
@@ -137,14 +142,17 @@ async function fetchOllamaNative<T>(
     return await options.consume(response);
   } finally {
     clearTimeout(timeout);
+    options.signal?.removeEventListener("abort", abort);
   }
 }
 
 /**
  * Resolve turn-time serving truth for one exact Ollama model. Catalog metadata
- * cannot answer this for an unloaded model, so use Ollama's documented empty
- * generate request to load only the selected model, then require `/api/ps` to
- * report that exact identity before any real prompt is dispatched.
+ * cannot answer this for an unloaded model. A model already loaded by another
+ * client can also use that client's `num_ctx`, while our OpenAI-compatible
+ * request uses the daemon default. Use Ollama's documented empty generate
+ * request to load the selected model with the same default our turn will use,
+ * then require `/api/ps` to report that exact identity before dispatch.
  */
 export async function resolveOllamaServedContext(
   options: ResolveOllamaServedContextOptions,
@@ -155,6 +163,7 @@ export async function resolveOllamaServedContext(
   const runningContext = async (): Promise<number | undefined> => {
     const data = await fetchOllamaNative(fetchImpl, psURL, {
       ...(options.apiKey ? { apiKey: options.apiKey } : {}),
+      ...(options.signal ? { signal: options.signal } : {}),
       timeoutMs: OLLAMA_STATUS_TIMEOUT_MS,
       consume: (response) => response.json(),
     });
@@ -162,21 +171,15 @@ export async function resolveOllamaServedContext(
   };
 
   try {
-    const alreadyLoaded = await runningContext();
-    if (alreadyLoaded !== undefined) return alreadyLoaded;
-  } catch {
-    // A failed initial status probe does not make loading unsafe. The required
-    // post-load probe below is authoritative and fails closed.
-  }
-
-  try {
     await fetchOllamaNative(fetchImpl, `${nativeBaseURL}/api/generate`, {
       ...(options.apiKey ? { apiKey: options.apiKey } : {}),
-      body: { model: options.modelId, stream: false },
+      ...(options.signal ? { signal: options.signal } : {}),
+      body: { model: options.modelId, prompt: "", stream: false },
       timeoutMs: OLLAMA_MODEL_LOAD_TIMEOUT_MS,
       consume: (response) => response.text(),
     });
   } catch (error) {
+    if (options.signal?.aborted) throw options.signal.reason ?? error;
     throw new Error(
       `Unable to load Ollama model "${options.modelId}" to determine its served context window. ` +
         `Refusing to send the prompt because Ollama may silently truncate it. ` +

--- a/src/backend/dev/pi-ollama-provider.ts
+++ b/src/backend/dev/pi-ollama-provider.ts
@@ -9,6 +9,14 @@ import {
 export const OLLAMA_PI_PROVIDER_ID = "ollama";
 export const OLLAMA_CLOUD_PI_PROVIDER_ID = "ollama-cloud";
 
+/** Ollama assigns the `latest` tag when a model handle omits one. */
+export function normalizeOllamaModelId(modelId: string): string {
+  const leaf = modelId.slice(modelId.lastIndexOf("/") + 1);
+  return leaf.includes(":") || leaf.includes("@")
+    ? modelId
+    : `${modelId}:latest`;
+}
+
 export interface OllamaPiProviderOptions {
   /** Base URL as configured; `/v1` is appended/stripped as needed. */
   baseURL: string;
@@ -158,6 +166,7 @@ export async function resolveOllamaServedContext(
   options: ResolveOllamaServedContextOptions,
 ): Promise<number> {
   const fetchImpl = options.fetchImpl ?? fetch;
+  const modelId = normalizeOllamaModelId(options.modelId);
   const nativeBaseURL = localEndpointNativeBaseURL(options.baseURL);
   const psURL = `${nativeBaseURL}/api/ps`;
   const runningContext = async (): Promise<number | undefined> => {
@@ -167,21 +176,21 @@ export async function resolveOllamaServedContext(
       timeoutMs: OLLAMA_STATUS_TIMEOUT_MS,
       consume: (response) => response.json(),
     });
-    return parseOllamaRunningContexts(data).get(options.modelId);
+    return parseOllamaRunningContexts(data).get(modelId);
   };
 
   try {
     await fetchOllamaNative(fetchImpl, `${nativeBaseURL}/api/generate`, {
       ...(options.apiKey ? { apiKey: options.apiKey } : {}),
       ...(options.signal ? { signal: options.signal } : {}),
-      body: { model: options.modelId, prompt: "", stream: false },
+      body: { model: modelId, prompt: "", stream: false },
       timeoutMs: OLLAMA_MODEL_LOAD_TIMEOUT_MS,
       consume: (response) => response.text(),
     });
   } catch (error) {
     if (options.signal?.aborted) throw options.signal.reason ?? error;
     throw new Error(
-      `Unable to load Ollama model "${options.modelId}" to determine its served context window. ` +
+      `Unable to load Ollama model "${modelId}" to determine its served context window. ` +
         `Refusing to send the prompt because Ollama may silently truncate it. ` +
         `Check the Ollama endpoint, model installation, and available memory. (${error instanceof Error ? error.message : String(error)})`,
     );
@@ -193,14 +202,14 @@ export async function resolveOllamaServedContext(
   } catch (error) {
     if (options.signal?.aborted) throw options.signal.reason ?? error;
     throw new Error(
-      `Ollama loaded model "${options.modelId}", but /api/ps could not verify its served context window. ` +
+      `Ollama loaded model "${modelId}", but /api/ps could not verify its served context window. ` +
         `Refusing to send the prompt because Ollama may silently truncate it. ` +
         `Check that the endpoint supports /api/ps. (${error instanceof Error ? error.message : String(error)})`,
     );
   }
 
   throw new Error(
-    `Ollama did not report an exact served context window for loaded model "${options.modelId}" in /api/ps. ` +
+    `Ollama did not report an exact served context window for loaded model "${modelId}" in /api/ps. ` +
       `Refusing to send the prompt because Ollama may silently truncate it. ` +
       `Check the model name and Ollama server logs.`,
   );

--- a/src/backend/dev/pi-ollama-provider.ts
+++ b/src/backend/dev/pi-ollama-provider.ts
@@ -191,6 +191,7 @@ export async function resolveOllamaServedContext(
     const loadedContext = await runningContext();
     if (loadedContext !== undefined) return loadedContext;
   } catch (error) {
+    if (options.signal?.aborted) throw options.signal.reason ?? error;
     throw new Error(
       `Ollama loaded model "${options.modelId}", but /api/ps could not verify its served context window. ` +
         `Refusing to send the prompt because Ollama may silently truncate it. ` +

--- a/src/backend/dev/pi-ollama-provider.ts
+++ b/src/backend/dev/pi-ollama-provider.ts
@@ -54,9 +54,47 @@ function parseOllamaTags(data: unknown): OllamaTagEntry[] {
     .filter((entry): entry is OllamaTagEntry => entry !== undefined);
 }
 
+/**
+ * Runtime context windows from `GET /api/ps`, keyed by model id.
+ *
+ * `/api/show` reports the architectural maximum baked into the GGUF, which is
+ * what the model *could* support — not what the daemon will actually serve.
+ * Ollama serves `OLLAMA_CONTEXT_LENGTH` (or a per-request `num_ctx`, which the
+ * OpenAI-compatible surface we stream through does not accept) and silently
+ * truncates any prompt longer than that: no error, no warning, and the reported
+ * prompt token count reflects the post-truncation prompt. Publishing the GGUF
+ * maximum therefore hands the harness a window several times larger than
+ * reality, so compaction never fires and the oldest part of the prompt — the
+ * compiled system prompt carrying persona and memory — is dropped on the floor.
+ *
+ * `/api/ps` reports `context_length` per *loaded* model, which is the window
+ * the engine will actually serve for it. Prefer it whenever it is available.
+ */
+function parseOllamaRunningContexts(data: unknown): Map<string, number> {
+  const contexts = new Map<string, number>();
+  if (!data || typeof data !== "object") return contexts;
+  const models = (data as { models?: unknown }).models;
+  if (!Array.isArray(models)) return contexts;
+  for (const entry of models) {
+    if (!entry || typeof entry !== "object") continue;
+    const record = entry as {
+      name?: unknown;
+      model?: unknown;
+      context_length?: unknown;
+    };
+    const id = record.name ?? record.model;
+    const contextLength = record.context_length;
+    if (typeof id !== "string" || id.length === 0) continue;
+    if (typeof contextLength !== "number" || contextLength <= 0) continue;
+    contexts.set(id, contextLength);
+  }
+  return contexts;
+}
+
 function parseOllamaShow(
   modelId: string,
   data: unknown,
+  runtimeContextLength?: number,
 ): LocalEndpointModelMetadata {
   if (!data || typeof data !== "object") return { id: modelId };
   const record = data as { capabilities?: unknown; model_info?: unknown };
@@ -69,16 +107,22 @@ function parseOllamaShow(
     typeof modelInfo?.["general.architecture"] === "string"
       ? (modelInfo["general.architecture"] as string)
       : undefined;
-  const contextLength = architecture
+  const architecturalContextLength = architecture
     ? modelInfo?.[`${architecture}.context_length`]
     : undefined;
+  // Runtime window wins: it is what the daemon will serve. The GGUF maximum is
+  // only a fallback for models that are not currently loaded.
+  const contextLength =
+    runtimeContextLength ??
+    (typeof architecturalContextLength === "number" &&
+    architecturalContextLength > 0
+      ? architecturalContextLength
+      : undefined);
   return {
     id: modelId,
     vision: capabilities.includes("vision"),
     thinking: capabilities.includes("thinking"),
-    ...(typeof contextLength === "number" && contextLength > 0
-      ? { contextLength }
-      : {}),
+    ...(contextLength !== undefined ? { contextLength } : {}),
   };
 }
 
@@ -92,18 +136,40 @@ function parseOllamaShow(
 const ollamaDiscover: LocalEndpointDiscover = async (context) => {
   const tags = await context.fetchJson(`${context.nativeBaseURL}/api/tags`);
   const entries = parseOllamaTags(tags);
+  // Loaded-model runtime windows. Best-effort: an endpoint that does not serve
+  // /api/ps (or fails it) falls back to GGUF metadata, the previous behavior.
+  const runtimeContexts = await context
+    .fetchJson(`${context.nativeBaseURL}/api/ps`)
+    .then(parseOllamaRunningContexts)
+    .catch(() => new Map<string, number>());
+  // `OLLAMA_CONTEXT_LENGTH` is daemon-wide, so any loaded model reveals the
+  // window this endpoint serves to models that are not loaded yet. Take the
+  // smallest observed value: a model loaded with an explicit larger `num_ctx`
+  // by another client should not inflate what we assume for everything else.
+  const endpointDefaultContext =
+    runtimeContexts.size > 0
+      ? Math.min(...runtimeContexts.values())
+      : undefined;
   return Promise.all(
     entries.map(async ({ id: modelId, digest }) => {
       // /api/show reads GGUF metadata from disk, which can take seconds for
       // large models. The tag digest identifies the installed blob, so an
-      // unchanged digest means the last-known published Model is current.
+      // unchanged digest means the last-known published Model is current. The
+      // runtime window is part of the fingerprint because it changes without
+      // the blob changing — loading a model, or restarting the daemon with a
+      // different OLLAMA_CONTEXT_LENGTH, must republish the Model.
+      const runtimeContextLength =
+        runtimeContexts.get(modelId) ?? endpointDefaultContext;
+      const fingerprint = digest
+        ? `${digest}:${runtimeContextLength ?? "-"}`
+        : undefined;
       const known = context.lastKnown.get(modelId);
       if (
         known &&
-        digest &&
-        context.metadataFingerprints.get(modelId) === digest
+        fingerprint &&
+        context.metadataFingerprints.get(modelId) === fingerprint
       ) {
-        context.nextMetadataFingerprints.set(modelId, digest);
+        context.nextMetadataFingerprints.set(modelId, fingerprint);
         return known;
       }
       try {
@@ -111,8 +177,12 @@ const ollamaDiscover: LocalEndpointDiscover = async (context) => {
           `${context.nativeBaseURL}/api/show`,
           { body: { model: modelId } },
         );
-        if (digest) context.nextMetadataFingerprints.set(modelId, digest);
-        return context.buildModel(parseOllamaShow(modelId, show));
+        if (fingerprint) {
+          context.nextMetadataFingerprints.set(modelId, fingerprint);
+        }
+        return context.buildModel(
+          parseOllamaShow(modelId, show, runtimeContextLength),
+        );
       } catch {
         // Metadata fetch failed for this one model: keep its last-known
         // published Model rather than guessing capabilities. A never-seen

--- a/src/backend/dev/pi-ollama-provider.ts
+++ b/src/backend/dev/pi-ollama-provider.ts
@@ -3,6 +3,7 @@ import {
   createLocalEndpointPiProvider,
   type LocalEndpointDiscover,
   type LocalEndpointModelMetadata,
+  localEndpointNativeBaseURL,
 } from "./pi-local-endpoint-provider";
 
 export const OLLAMA_PI_PROVIDER_ID = "ollama";
@@ -70,7 +71,7 @@ function parseOllamaTags(data: unknown): OllamaTagEntry[] {
  * `/api/ps` reports `context_length` per *loaded* model, which is the window
  * the engine will actually serve for it. Prefer it whenever it is available.
  */
-function parseOllamaRunningContexts(data: unknown): Map<string, number> {
+export function parseOllamaRunningContexts(data: unknown): Map<string, number> {
   const contexts = new Map<string, number>();
   if (!data || typeof data !== "object") return contexts;
   const models = (data as { models?: unknown }).models;
@@ -89,6 +90,116 @@ function parseOllamaRunningContexts(data: unknown): Map<string, number> {
     contexts.set(id, contextLength);
   }
   return contexts;
+}
+
+const OLLAMA_STATUS_TIMEOUT_MS = 2_000;
+const OLLAMA_MODEL_LOAD_TIMEOUT_MS = 120_000;
+
+export interface ResolveOllamaServedContextOptions {
+  baseURL: string;
+  modelId: string;
+  apiKey?: string;
+  fetchImpl?: typeof fetch;
+}
+
+async function fetchOllamaNative<T>(
+  fetchImpl: typeof fetch,
+  url: string,
+  options: {
+    apiKey?: string;
+    body?: unknown;
+    timeoutMs: number;
+    consume(response: Response): Promise<T>;
+  },
+): Promise<T> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), options.timeoutMs);
+  try {
+    const headers: Record<string, string> = { Accept: "application/json" };
+    if (options.apiKey && options.apiKey !== "not-needed") {
+      headers.Authorization = `Bearer ${options.apiKey}`;
+    }
+    if (options.body !== undefined)
+      headers["Content-Type"] = "application/json";
+    const response = await fetchImpl(url, {
+      method: options.body === undefined ? "GET" : "POST",
+      headers,
+      ...(options.body === undefined
+        ? {}
+        : { body: JSON.stringify(options.body) }),
+      signal: controller.signal,
+    });
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+    }
+    // Keep the abort deadline active through body consumption and parsing.
+    // Fetch resolves at headers, while Ollama's load completes with the body.
+    return await options.consume(response);
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+/**
+ * Resolve turn-time serving truth for one exact Ollama model. Catalog metadata
+ * cannot answer this for an unloaded model, so use Ollama's documented empty
+ * generate request to load only the selected model, then require `/api/ps` to
+ * report that exact identity before any real prompt is dispatched.
+ */
+export async function resolveOllamaServedContext(
+  options: ResolveOllamaServedContextOptions,
+): Promise<number> {
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const nativeBaseURL = localEndpointNativeBaseURL(options.baseURL);
+  const psURL = `${nativeBaseURL}/api/ps`;
+  const runningContext = async (): Promise<number | undefined> => {
+    const data = await fetchOllamaNative(fetchImpl, psURL, {
+      ...(options.apiKey ? { apiKey: options.apiKey } : {}),
+      timeoutMs: OLLAMA_STATUS_TIMEOUT_MS,
+      consume: (response) => response.json(),
+    });
+    return parseOllamaRunningContexts(data).get(options.modelId);
+  };
+
+  try {
+    const alreadyLoaded = await runningContext();
+    if (alreadyLoaded !== undefined) return alreadyLoaded;
+  } catch {
+    // A failed initial status probe does not make loading unsafe. The required
+    // post-load probe below is authoritative and fails closed.
+  }
+
+  try {
+    await fetchOllamaNative(fetchImpl, `${nativeBaseURL}/api/generate`, {
+      ...(options.apiKey ? { apiKey: options.apiKey } : {}),
+      body: { model: options.modelId, stream: false },
+      timeoutMs: OLLAMA_MODEL_LOAD_TIMEOUT_MS,
+      consume: (response) => response.text(),
+    });
+  } catch (error) {
+    throw new Error(
+      `Unable to load Ollama model "${options.modelId}" to determine its served context window. ` +
+        `Refusing to send the prompt because Ollama may silently truncate it. ` +
+        `Check the Ollama endpoint, model installation, and available memory. (${error instanceof Error ? error.message : String(error)})`,
+    );
+  }
+
+  try {
+    const loadedContext = await runningContext();
+    if (loadedContext !== undefined) return loadedContext;
+  } catch (error) {
+    throw new Error(
+      `Ollama loaded model "${options.modelId}", but /api/ps could not verify its served context window. ` +
+        `Refusing to send the prompt because Ollama may silently truncate it. ` +
+        `Check that the endpoint supports /api/ps. (${error instanceof Error ? error.message : String(error)})`,
+    );
+  }
+
+  throw new Error(
+    `Ollama did not report an exact served context window for loaded model "${options.modelId}" in /api/ps. ` +
+      `Refusing to send the prompt because Ollama may silently truncate it. ` +
+      `Check the model name and Ollama server logs.`,
+  );
 }
 
 function parseOllamaShow(
@@ -142,14 +253,6 @@ const ollamaDiscover: LocalEndpointDiscover = async (context) => {
     .fetchJson(`${context.nativeBaseURL}/api/ps`)
     .then(parseOllamaRunningContexts)
     .catch(() => new Map<string, number>());
-  // `OLLAMA_CONTEXT_LENGTH` is daemon-wide, so any loaded model reveals the
-  // window this endpoint serves to models that are not loaded yet. Take the
-  // smallest observed value: a model loaded with an explicit larger `num_ctx`
-  // by another client should not inflate what we assume for everything else.
-  const endpointDefaultContext =
-    runtimeContexts.size > 0
-      ? Math.min(...runtimeContexts.values())
-      : undefined;
   return Promise.all(
     entries.map(async ({ id: modelId, digest }) => {
       // /api/show reads GGUF metadata from disk, which can take seconds for
@@ -158,8 +261,10 @@ const ollamaDiscover: LocalEndpointDiscover = async (context) => {
       // runtime window is part of the fingerprint because it changes without
       // the blob changing — loading a model, or restarting the daemon with a
       // different OLLAMA_CONTEXT_LENGTH, must republish the Model.
-      const runtimeContextLength =
-        runtimeContexts.get(modelId) ?? endpointDefaultContext;
+      // `/api/ps` is runtime truth only for the exact loaded model. Another
+      // model may have been loaded with a per-request num_ctx, so its value says
+      // nothing reliable about this artifact or the daemon default.
+      const runtimeContextLength = runtimeContexts.get(modelId);
       const fingerprint = digest
         ? `${digest}:${runtimeContextLength ?? "-"}`
         : undefined;

--- a/src/backend/dev/pi-stream-adapter.ts
+++ b/src/backend/dev/pi-stream-adapter.ts
@@ -396,9 +396,10 @@ function assertPromptFloorFitsContextWindow(
   const floorTokens = estimateProviderPromptFloorTokens(input);
   if (floorTokens <= contextWindow) return;
 
-  const remedy = model.provider?.startsWith("ollama")
-    ? `Raise the served window (for example OLLAMA_CONTEXT_LENGTH=${nextPowerOfTwoAtLeast(floorTokens)} ollama serve)`
-    : "Raise the engine's context window";
+  const remedy =
+    model.provider === "ollama"
+      ? `Raise the served window (for example OLLAMA_CONTEXT_LENGTH=${nextPowerOfTwoAtLeast(floorTokens)} ollama serve)`
+      : "Raise the engine's context window";
   throw new Error(
     `The system prompt and tool definitions need about ${floorTokens.toLocaleString()} tokens, ` +
       `but "${model.id}" is served with a ${contextWindow.toLocaleString()}-token context window. ` +

--- a/src/backend/dev/pi-stream-adapter.ts
+++ b/src/backend/dev/pi-stream-adapter.ts
@@ -49,6 +49,7 @@ import type {
 import {
   contextTokensFromUsage,
   estimateProviderContextTokens,
+  estimateProviderPromptFloorTokens,
   providerLettaChunk,
   providerLocalMessage,
   providerStreamPart,
@@ -371,6 +372,47 @@ function withAnthropicOutputEffort(
   };
 }
 
+/**
+ * Reject a turn whose irreducible prompt cannot fit the serving context window.
+ *
+ * Local engines truncate oversized prompts silently rather than erroring, so
+ * the failure mode is an agent that answers with its memory and persona
+ * quietly missing. Compaction cannot help here — the system prompt and tool
+ * definitions are not history — so surface it as an actionable error instead of
+ * shipping a request we know will be clipped.
+ */
+function assertPromptFloorFitsContextWindow(
+  input: ProviderTurnInput,
+  model: { id: string; provider?: string; contextWindow?: number },
+): void {
+  const contextWindow = model.contextWindow;
+  if (
+    typeof contextWindow !== "number" ||
+    !Number.isFinite(contextWindow) ||
+    contextWindow <= 0
+  ) {
+    return;
+  }
+  const floorTokens = estimateProviderPromptFloorTokens(input);
+  if (floorTokens <= contextWindow) return;
+
+  const remedy = model.provider?.startsWith("ollama")
+    ? `Raise the served window (for example OLLAMA_CONTEXT_LENGTH=${nextPowerOfTwoAtLeast(floorTokens)} ollama serve)`
+    : "Raise the engine's context window";
+  throw new Error(
+    `The system prompt and tool definitions need about ${floorTokens.toLocaleString()} tokens, ` +
+      `but "${model.id}" is served with a ${contextWindow.toLocaleString()}-token context window. ` +
+      `The engine would silently truncate the prompt, dropping memory and persona before the model sees them. ` +
+      `${remedy}, or reduce what the prompt carries (fewer installed skills, a smaller toolset).`,
+  );
+}
+
+function nextPowerOfTwoAtLeast(value: number): number {
+  let size = 8192;
+  while (size < value && size < 1_048_576) size *= 2;
+  return size;
+}
+
 function stringValue(value: unknown): string | undefined {
   return typeof value === "string" && value.length > 0 ? value : undefined;
 }
@@ -581,6 +623,7 @@ export class PiStreamAdapter implements ProviderStreamAdapter {
         modelsRuntime: this.modelsRuntime,
       },
     );
+    assertPromptFloorFitsContextWindow(input, resolved.model);
     const context: Context = {
       systemPrompt: input.systemPrompt ?? input.agent.system,
       messages: toPiMessages(input.uiMessages),

--- a/src/backend/dev/pi-stream-adapter.ts
+++ b/src/backend/dev/pi-stream-adapter.ts
@@ -591,6 +591,7 @@ export class PiStreamAdapter implements ProviderStreamAdapter {
       {
         localProviderAuthStorageDir: this.localProviderAuthStorageDir,
         modelsRuntime: this.modelsRuntime,
+        ...(this.abortSignal ? { abortSignal: this.abortSignal } : {}),
       },
     );
     const contextWindow = resolved.model.contextWindow;
@@ -622,6 +623,7 @@ export class PiStreamAdapter implements ProviderStreamAdapter {
       {
         localProviderAuthStorageDir: this.localProviderAuthStorageDir,
         modelsRuntime: this.modelsRuntime,
+        ...(this.abortSignal ? { abortSignal: this.abortSignal } : {}),
       },
     );
     assertPromptFloorFitsContextWindow(input, resolved.model);

--- a/src/backend/dev/provider-turn-executor.ts
+++ b/src/backend/dev/provider-turn-executor.ts
@@ -205,6 +205,22 @@ export function estimateProviderContextTokens(
 }
 
 /**
+ * Tokens the request cannot shed: the compiled system prompt plus the tool
+ * definitions. Compaction rewrites message history, so when this floor alone
+ * exceeds the serving context window there is no recovery — every turn would be
+ * truncated by the engine before the model ever sees the memory the system
+ * prompt carries. Callers use this to fail loudly instead.
+ */
+export function estimateProviderPromptFloorTokens(
+  input: ProviderTurnInput,
+): number {
+  return (
+    estimateSerializedTokens(input.systemPrompt ?? input.agent.system) +
+    estimateSerializedTokens(input.clientTools)
+  );
+}
+
+/**
  * Context pressure must be handled before the provider request, not only after
  * an overflow. pi-ai first makes an oversized request valid by shrinking its
  * output allowance to `contextWindow - estimatedContext - 4096`, floored at

--- a/src/backend/pi-stream-adapter-local-endpoint.test.ts
+++ b/src/backend/pi-stream-adapter-local-endpoint.test.ts
@@ -190,4 +190,83 @@ describe("PiStreamAdapter local endpoint payloads", () => {
       await closeServer(server);
     }
   });
+
+  // Local engines truncate an oversized prompt silently instead of erroring, so
+  // the visible symptom is an agent whose persona and memory have gone missing.
+  // Compaction cannot recover it — the system prompt and tool schemas are not
+  // history — so the turn must fail with something the user can act on.
+  test("refuses a turn whose system prompt cannot fit the served window", async () => {
+    let chatRequests = 0;
+    const server = createServer(async (req, res) => {
+      if (req.method === "GET" && req.url === "/api/tags") {
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ models: [{ name: "deepseek-r1:8b" }] }));
+        return;
+      }
+      if (req.method === "GET" && req.url === "/api/ps") {
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(
+          JSON.stringify({
+            models: [{ name: "deepseek-r1:8b", context_length: 4096 }],
+          }),
+        );
+        return;
+      }
+      if (req.method === "POST" && req.url === "/api/show") {
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ capabilities: ["completion"] }));
+        return;
+      }
+      if (req.method === "POST" && req.url === "/v1/chat/completions") {
+        chatRequests += 1;
+      }
+      res.writeHead(404);
+      res.end();
+    });
+
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      throw new Error("expected tcp server address");
+    }
+
+    const previousOllamaBaseUrl = process.env.OLLAMA_BASE_URL;
+    process.env.OLLAMA_BASE_URL = `http://127.0.0.1:${address.port}/v1`;
+    const storageDir = await mkdtemp(
+      join(tmpdir(), "pi-stream-context-floor-"),
+    );
+
+    try {
+      const baseInput = input();
+      await expect(
+        collectEvents(
+          new PiStreamAdapter({
+            localProviderAuthStorageDir: storageDir,
+          }).stream({
+            ...baseInput,
+            agent: {
+              ...baseInput.agent,
+              model: "ollama/deepseek-r1:8b",
+              model_settings: { provider_type: "ollama" },
+            },
+            // Roughly 25k tokens of system prompt against a 4k window.
+            systemPrompt: "x".repeat(100_000),
+          }),
+        ),
+      ).rejects.toThrow(/context window/i);
+
+      // The request must never reach the engine: sending it would mean handing
+      // over a prompt we already know will be clipped.
+      expect(chatRequests).toBe(0);
+    } finally {
+      if (previousOllamaBaseUrl === undefined) {
+        delete process.env.OLLAMA_BASE_URL;
+      } else {
+        process.env.OLLAMA_BASE_URL = previousOllamaBaseUrl;
+      }
+      await rm(storageDir, { recursive: true, force: true });
+      await closeServer(server);
+    }
+  });
 });

--- a/src/backend/pi-stream-adapter-local-endpoint.test.ts
+++ b/src/backend/pi-stream-adapter-local-endpoint.test.ts
@@ -213,7 +213,7 @@ describe("PiStreamAdapter local endpoint payloads", () => {
   // the visible symptom is an agent whose persona and memory have gone missing.
   // Compaction cannot recover it — the system prompt and tool schemas are not
   // history — so the turn must fail with something the user can act on.
-  test("loads an unloaded selected model and uses its exact served window", async () => {
+  test("loads an unloaded implicit-latest model and uses its exact served window", async () => {
     let chatRequests = 0;
     let psRequests = 0;
     const loadBodies: unknown[] = [];
@@ -224,7 +224,7 @@ describe("PiStreamAdapter local endpoint payloads", () => {
         res.writeHead(200, { "Content-Type": "application/json" });
         res.end(
           JSON.stringify({
-            models: [{ name: "deepseek-r1:8b" }, { name: "unselected:7b" }],
+            models: [{ name: "deepseek-r1:latest" }, { name: "unselected:7b" }],
           }),
         );
         return;
@@ -236,7 +236,7 @@ describe("PiStreamAdapter local endpoint payloads", () => {
         res.end(
           JSON.stringify({
             models: selectedLoaded
-              ? [{ name: "deepseek-r1:8b", context_length: 8192 }]
+              ? [{ name: "deepseek-r1:latest", context_length: 8192 }]
               : [],
           }),
         );
@@ -291,7 +291,7 @@ describe("PiStreamAdapter local endpoint payloads", () => {
             ...baseInput,
             agent: {
               ...baseInput.agent,
-              model: "ollama/deepseek-r1:8b",
+              model: "ollama/deepseek-r1",
               // Simulate the architectural value persisted at selection.
               model_settings: {
                 provider_type: "ollama",
@@ -307,15 +307,19 @@ describe("PiStreamAdapter local endpoint payloads", () => {
       // The request must never reach the engine: sending it would mean handing
       // over a prompt we already know will be clipped.
       expect(chatRequests).toBe(0);
-      expect(psRequests).toBeGreaterThanOrEqual(2);
-      expect(loadBodies).toEqual([
-        { model: "deepseek-r1:8b", prompt: "", stream: false },
-        { model: "deepseek-r1:8b", prompt: "", stream: false },
-      ]);
+      expect(psRequests).toBeGreaterThanOrEqual(1);
+      expect(loadBodies.length).toBeGreaterThanOrEqual(1);
+      expect(loadBodies).toEqual(
+        loadBodies.map(() => ({
+          model: "deepseek-r1:latest",
+          prompt: "",
+          stream: false,
+        })),
+      );
       expect(servingLifecycle[0]).toBe("generate");
       expect(
         servingLifecycle.filter((event) => event === "generate"),
-      ).toHaveLength(2);
+      ).toHaveLength(loadBodies.length);
       expect(servingLifecycle.at(-1)).toBe("ps");
     } finally {
       if (previousOllamaBaseUrl === undefined) {

--- a/src/backend/pi-stream-adapter-local-endpoint.test.ts
+++ b/src/backend/pi-stream-adapter-local-endpoint.test.ts
@@ -58,6 +58,7 @@ function input(): ProviderTurnInput {
 describe("PiStreamAdapter local endpoint payloads", () => {
   test("downgrades images through Pi-AI payload conversion for text-only local models", async () => {
     let capturedPayload: unknown;
+    let loaded = false;
     const server = createServer(async (req, res) => {
       // Native Ollama discovery endpoints: the runtime-managed provider
       // publishes models from /api/tags + /api/show instead of fabricating
@@ -65,6 +66,23 @@ describe("PiStreamAdapter local endpoint payloads", () => {
       if (req.method === "GET" && req.url === "/api/tags") {
         res.writeHead(200, { "Content-Type": "application/json" });
         res.end(JSON.stringify({ models: [{ name: "deepseek-r1:8b" }] }));
+        return;
+      }
+      if (req.method === "GET" && req.url === "/api/ps") {
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(
+          JSON.stringify({
+            models: loaded
+              ? [{ name: "deepseek-r1:8b", context_length: 128000 }]
+              : [],
+          }),
+        );
+        return;
+      }
+      if (req.method === "POST" && req.url === "/api/generate") {
+        loaded = true;
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ done: true }));
         return;
       }
       if (req.method === "POST" && req.url === "/api/show") {
@@ -195,21 +213,46 @@ describe("PiStreamAdapter local endpoint payloads", () => {
   // the visible symptom is an agent whose persona and memory have gone missing.
   // Compaction cannot recover it — the system prompt and tool schemas are not
   // history — so the turn must fail with something the user can act on.
-  test("refuses a turn whose system prompt cannot fit the served window", async () => {
+  test("loads an unloaded selected model and uses its exact served window", async () => {
     let chatRequests = 0;
+    let psRequests = 0;
+    const loadBodies: unknown[] = [];
+    const servingLifecycle: string[] = [];
+    let selectedLoaded = false;
     const server = createServer(async (req, res) => {
       if (req.method === "GET" && req.url === "/api/tags") {
         res.writeHead(200, { "Content-Type": "application/json" });
-        res.end(JSON.stringify({ models: [{ name: "deepseek-r1:8b" }] }));
+        res.end(
+          JSON.stringify({
+            models: [{ name: "deepseek-r1:8b" }, { name: "unselected:7b" }],
+          }),
+        );
         return;
       }
       if (req.method === "GET" && req.url === "/api/ps") {
+        psRequests += 1;
+        servingLifecycle.push("ps");
         res.writeHead(200, { "Content-Type": "application/json" });
         res.end(
           JSON.stringify({
-            models: [{ name: "deepseek-r1:8b", context_length: 4096 }],
+            models: selectedLoaded
+              ? [{ name: "deepseek-r1:8b", context_length: 8192 }]
+              : [],
           }),
         );
+        return;
+      }
+      if (req.method === "POST" && req.url === "/api/generate") {
+        servingLifecycle.push("generate");
+        const chunks: Buffer[] = [];
+        for await (const chunk of req) {
+          chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+        }
+        const body = JSON.parse(Buffer.concat(chunks).toString("utf8"));
+        loadBodies.push(body);
+        selectedLoaded = true;
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ done: true }));
         return;
       }
       if (req.method === "POST" && req.url === "/api/show") {
@@ -243,14 +286,19 @@ describe("PiStreamAdapter local endpoint payloads", () => {
         collectEvents(
           new PiStreamAdapter({
             localProviderAuthStorageDir: storageDir,
+            onContextPressure: async () => null,
           }).stream({
             ...baseInput,
             agent: {
               ...baseInput.agent,
               model: "ollama/deepseek-r1:8b",
-              model_settings: { provider_type: "ollama" },
+              // Simulate the architectural value persisted at selection.
+              model_settings: {
+                provider_type: "ollama",
+                context_window_limit: 128000,
+              },
             },
-            // Roughly 25k tokens of system prompt against a 4k window.
+            // Roughly 25k tokens of system prompt against the observed 8k window.
             systemPrompt: "x".repeat(100_000),
           }),
         ),
@@ -259,6 +307,9 @@ describe("PiStreamAdapter local endpoint payloads", () => {
       // The request must never reach the engine: sending it would mean handing
       // over a prompt we already know will be clipped.
       expect(chatRequests).toBe(0);
+      expect(psRequests).toBeGreaterThanOrEqual(2);
+      expect(loadBodies).toEqual([{ model: "deepseek-r1:8b", stream: false }]);
+      expect(servingLifecycle.slice(0, 3)).toEqual(["ps", "generate", "ps"]);
     } finally {
       if (previousOllamaBaseUrl === undefined) {
         delete process.env.OLLAMA_BASE_URL;
@@ -269,4 +320,103 @@ describe("PiStreamAdapter local endpoint payloads", () => {
       await closeServer(server);
     }
   });
+
+  for (const failure of [
+    "load",
+    "post-load status",
+    "post-load missing model",
+  ] as const) {
+    test(`fails closed when selected-model ${failure} fails`, async () => {
+      let chatRequests = 0;
+      let psRequests = 0;
+      const server = createServer(async (req, res) => {
+        if (req.method === "GET" && req.url === "/api/tags") {
+          res.writeHead(200, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ models: [{ name: "deepseek-r1:8b" }] }));
+          return;
+        }
+        if (req.method === "GET" && req.url === "/api/ps") {
+          psRequests += 1;
+          if (failure === "post-load status" && psRequests > 1) {
+            res.writeHead(503);
+            res.end("status unavailable");
+            return;
+          }
+          res.writeHead(200, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ models: [] }));
+          return;
+        }
+        if (req.method === "POST" && req.url === "/api/generate") {
+          if (failure === "load") {
+            res.writeHead(503);
+            res.end("load failed");
+          } else {
+            res.writeHead(200, { "Content-Type": "application/json" });
+            res.end(JSON.stringify({ done: true }));
+          }
+          return;
+        }
+        if (req.method === "POST" && req.url === "/api/show") {
+          res.writeHead(200, { "Content-Type": "application/json" });
+          res.end(
+            JSON.stringify({
+              capabilities: ["completion"],
+              model_info: {
+                "general.architecture": "llama",
+                "llama.context_length": 128000,
+              },
+            }),
+          );
+          return;
+        }
+        if (req.method === "POST" && req.url === "/v1/chat/completions") {
+          chatRequests += 1;
+        }
+        res.writeHead(404);
+        res.end();
+      });
+
+      server.listen(0, "127.0.0.1");
+      await once(server, "listening");
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        throw new Error("expected tcp server address");
+      }
+      const previousOllamaBaseUrl = process.env.OLLAMA_BASE_URL;
+      process.env.OLLAMA_BASE_URL = `http://127.0.0.1:${address.port}/v1`;
+      const storageDir = await mkdtemp(
+        join(tmpdir(), "pi-stream-ollama-fail-"),
+      );
+
+      try {
+        const baseInput = input();
+        await expect(
+          collectEvents(
+            new PiStreamAdapter({
+              localProviderAuthStorageDir: storageDir,
+            }).stream({
+              ...baseInput,
+              agent: {
+                ...baseInput.agent,
+                model: "ollama/deepseek-r1:8b",
+                model_settings: {
+                  provider_type: "ollama",
+                  context_window_limit: 128000,
+                },
+              },
+            }),
+          ),
+        ).rejects.toThrow(/Refusing to send the prompt/i);
+        expect(chatRequests).toBe(0);
+      } finally {
+        if (previousOllamaBaseUrl === undefined) {
+          delete process.env.OLLAMA_BASE_URL;
+        } else {
+          process.env.OLLAMA_BASE_URL = previousOllamaBaseUrl;
+        }
+        await rm(storageDir, { recursive: true, force: true });
+        await closeServer(server);
+      }
+    });
+  }
 });

--- a/src/backend/pi-stream-adapter-local-endpoint.test.ts
+++ b/src/backend/pi-stream-adapter-local-endpoint.test.ts
@@ -308,8 +308,15 @@ describe("PiStreamAdapter local endpoint payloads", () => {
       // over a prompt we already know will be clipped.
       expect(chatRequests).toBe(0);
       expect(psRequests).toBeGreaterThanOrEqual(2);
-      expect(loadBodies).toEqual([{ model: "deepseek-r1:8b", stream: false }]);
-      expect(servingLifecycle.slice(0, 3)).toEqual(["ps", "generate", "ps"]);
+      expect(loadBodies).toEqual([
+        { model: "deepseek-r1:8b", prompt: "", stream: false },
+        { model: "deepseek-r1:8b", prompt: "", stream: false },
+      ]);
+      expect(servingLifecycle[0]).toBe("generate");
+      expect(
+        servingLifecycle.filter((event) => event === "generate"),
+      ).toHaveLength(2);
+      expect(servingLifecycle.at(-1)).toBe("ps");
     } finally {
       if (previousOllamaBaseUrl === undefined) {
         delete process.env.OLLAMA_BASE_URL;

--- a/src/test-utils/headless-scenario.ts
+++ b/src/test-utils/headless-scenario.ts
@@ -212,6 +212,18 @@ async function runCLI(args: Args): Promise<RunResult> {
     "--yolo",
     "--new-agent",
   ];
+  if (args.smoke) {
+    // This lane verifies provider discovery and one inference round-trip. Keep
+    // unrelated harness context out so CPU-only local models finish reliably.
+    cliArgs.push(
+      "--tools=",
+      "--no-skills",
+      "--no-mods",
+      "--no-system-info-reminder",
+      "--system-custom",
+      "You are a provider smoke test. Follow the requested response format exactly.",
+    );
+  }
   if (args.backend === "api") {
     // Skip the memfs pull to keep CI startup fast; agents are still
     // memfs-enabled (non-memfs agents are no longer supported).


### PR DESCRIPTION
## Problem

Ollama can serve a smaller context window than the model metadata reports. Ollama truncates an oversized prompt without an error. The truncation can remove the system prompt that contains persona and memory.

The original patch read `/api/ps` during model discovery. It still failed on the first turn after a cold start. It also treated another loaded model as proof of the selected model's context window.

## Changes

For each turn against the built-in local Ollama provider, Letta Code now:

1. Sends an empty request to native `/api/generate` for the selected model. The request uses the daemon defaults that the following OpenAI-compatible request will use.
2. Reads `/api/ps` and requires a positive `context_length` for that exact model.
3. Uses the observed value for preflight compaction and provider dispatch.
4. Clamps persisted `context_window_limit` and `max_tokens` values to the observed window.
5. Refuses to send the prompt if loading or verification fails.

Untagged model handles are normalized to Ollama's canonical `:latest` form before loading, status matching, and catalog lookup.

The model-load request follows turn cancellation. Endpoint and credential changes during resolution cause a bounded retry or a closed failure.

This behavior applies only to the built-in local `ollama` provider. Ollama Cloud, mods that register `ollama`, LM Studio, llama.cpp, and OpenAI-compatible providers keep their existing behavior.

## Verification

Focused tests cover:

- a cold selected model, including an implicit `:latest` tag;
- a changed daemon default while the model is already loaded;
- stale persisted context and output limits;
- load, status, and missing-model failures;
- cancellation during load and during the required status probe;
- Ollama Cloud and llama.cpp controls.

Results:

- `38` focused tests pass.
- All `12` repository checks pass.
- Ollama `0.32.12` live test with `qwen3.8:latest`:
  - another client loaded the model with `num_ctx=8192`;
  - the default-options preflight reloaded it at `65536`;
  - the following `/v1/chat/completions` request kept `65536`.
- A real headless CLI smoke used the untagged `ollama/letta-ci-smoke` handle with a `4096`-token derived model and returned the expected `PONG` response.
- Every PR CI job passes, including the CPU-only Ollama smoke on `qwen2.5:1.5b`.

The full local unit run reached unrelated ambient-auth failures, one existing local-backend fixture failure, and a Bun `1.3.0` segmentation fault. PR CI runs the suite in a clean environment.

## Limit

Another client can still reload the same model between `/api/ps` and the chat request. Ollama does not provide an atomic read-and-dispatch operation for this path.

---
Overlord (`agent-c2adbf5c-8419-4211-8cd8-3740db164974`)

