### PR TITLE
fix(tools): emit tool_end for text-only structured tool results

### DIFF
--- a/src/tools/manager.ts
+++ b/src/tools/manager.ts
@@ -79,6 +79,7 @@ import {
 } from "./secret-substitution";
 import { TOOL_DEFINITIONS, type ToolName } from "./tool-definitions";
 import { TOOL_PERMISSIONS } from "./tool-permissions";
+import { toolReturnText } from "./tool-return-text";
 
 export const TOOL_NAMES = Object.keys(TOOL_DEFINITIONS) as ToolName[];
 
@@ -2861,9 +2862,8 @@ export async function executeTool(
     ? getExecutionContextById(options.toolContextId)
     : undefined;
   const modEvents = context?.modEvents;
-  if (!modEvents || typeof res.toolReturn !== "string") {
-    return res;
-  }
+  const textOutput = toolReturnText(res.toolReturn);
+  if (!modEvents || textOutput === null) return res;
 
   const executionScope = context?.runtimeContext
     ? buildExecutionRuntimeContextSnapshot({
@@ -2890,7 +2890,7 @@ export async function executeTool(
     toolCallId: options?.toolCallId,
     toolName: name,
     status: res.status,
-    output: res.toolReturn,
+    output: textOutput,
   });
 
   return override

--- a/src/tools/tool-end-event.test.ts
+++ b/src/tools/tool-end-event.test.ts
@@ -1,0 +1,62 @@
+import { afterAll, describe, expect, test } from "bun:test";
+import {
+  clearTools,
+  executeTool,
+  loadSpecificTools,
+  prepareCurrentToolExecutionContext,
+} from "@/tools/manager";
+
+// Regression for #3828: text-only structured tool results (e.g. Bash output
+// returned as content parts) must still emit the mod `tool_end` lifecycle
+// event. Previously only plain-string returns triggered it.
+describe("tool_end for structured text results", () => {
+  afterAll(() => {
+    clearTools();
+  });
+
+  test("emits tool_end for text-only Bash results", async () => {
+    await loadSpecificTools(["Bash"]);
+    let endEvents = 0;
+
+    const prepared = await prepareCurrentToolExecutionContext({
+      modEvents: {
+        async emit(name, _event) {
+          if (name === "tool_end") endEvents += 1;
+          return { diagnostics: [], handlerCount: 0, name, results: [] };
+        },
+      },
+    });
+
+    const result = await executeTool(
+      "Bash",
+      { command: "echo tool-end-repro" },
+      { toolContextId: prepared.contextId },
+    );
+
+    expect(result.status).toBe("success");
+    expect(endEvents).toBe(1);
+  });
+
+  test("emits tool_end for plain-string results", async () => {
+    await loadSpecificTools(["Read"]);
+    let endEvents = 0;
+
+    const prepared = await prepareCurrentToolExecutionContext({
+      modEvents: {
+        async emit(name, _event) {
+          if (name === "tool_end") endEvents += 1;
+          return { diagnostics: [], handlerCount: 0, name, results: [] };
+        },
+      },
+    });
+
+    const result = await executeTool(
+      "Read",
+      { file_path: "README.md" },
+      { toolContextId: prepared.contextId },
+    );
+
+    expect(result.status).toBe("success");
+    expect(endEvents).toBe(1);
+  });
+});

--- a/src/tools/tool-return-text.ts
+++ b/src/tools/tool-return-text.ts
@@ -1,0 +1,27 @@
+import type {
+  ImageContent,
+  TextContent,
+} from "@letta-ai/letta-client/resources/agents/messages";
+
+export type ToolReturnContent = string | Array<TextContent | ImageContent>;
+
+/**
+ * Extract plain text from a tool return when it is purely textual.
+ *
+ * Tool results can be either a plain string or an array of content parts.
+ * Returns the string verbatim for string returns, the concatenated text of
+ * text-only part arrays, and null when any non-text (e.g. image) part is
+ * present so callers can fall back to non-text presentation paths.
+ */
+export function toolReturnText(toolReturn: ToolReturnContent): string | null {
+  if (typeof toolReturn === "string") {
+    return toolReturn;
+  }
+  if (toolReturn.some((block) => block.type !== "text")) {
+    return null;
+  }
+  return toolReturn
+    .filter((block): block is TextContent => block.type === "text")
+    .map((block) => block.text)
+    .join("");
+}


### PR DESCRIPTION
## Summary

Fixes #3828: `tool_end` was silently skipped for text-only structured tool results.

**Root cause:** `executeTool` in `src/tools/manager.ts` gated the mod `tool_end` event on `typeof res.toolReturn === "string"`. Tools like Bash can return structured content parts (an array of `TextContent | ImageContent`), so even purely textual results (e.g. Bash output) never emitted `tool_end`, breaking mod lifecycle observers.

**Fix:** extract plain text via a new `toolReturnText()` helper (`src/tools/tool-return-text.ts`): plain strings pass through verbatim, text-only part arrays are concatenated, and returns containing any non-text (e.g. image) part still skip the event. `executeTool` emits the extracted text as the event output.

## Verification

- New regression tests in `src/tools/tool-end-event.test.ts`: Bash structured-text result emits `tool_end`; plain-string result (Read) still emits `tool_end`.
- Pre-fix: the Bash test fails (1 fail / 1 pass). Post-fix: 2/2 pass.
- `bun test $(find src/tools -name "*.test.ts" | grep -v integration-tests)`: 754 pass / 0 fail across 84 files.
- `bun run check`: 12/12 checks pass (biome, typescript, cycles, boundaries, source-file-size ratchet — `manager.ts` stays at its 2,994-line baseline).

## AI Disclosure

- [ ] This pull request was written entirely by a human
- [x] This pull request was written with AI assistance and reviewed and edited by a human
- [x] I have read the [AI Policy](https://github.com/letta-ai/letta-code/blob/main/AI_POLICY.md) and agree to its terms

## AI Tool(s) Used

DeepSeek (AI-assisted development) operating on behalf of the submitting human. Extent: proposed the fix approach and test cases; the implementation was written and verified step-by-step in the human's environment (`bun test`, `bun run check`) and reviewed line-by-line by the submitter.

## Human Verification

I have reviewed and understand every change in this pull request and take responsibility for its correctness.
