### PR TITLE
fix(cli): preserve pasted and space-containing secret values

### DIFF
--- a/src/cli/commands/registry.ts
+++ b/src/cli/commands/registry.ts
@@ -1,6 +1,7 @@
 // src/cli/commands/registry.ts
 // Registry of available CLI commands
 
+import { resolvePlaceholders } from "@/cli/helpers/paste-registry";
 import { handleMemoryRepositoryCommand } from "./memory-repository";
 import { handleSecretCommand } from "./secret";
 
@@ -13,6 +14,7 @@ type CommandHandlerResult =
 
 type CommandHandler = (
   args: string[],
+  rawInput?: string,
 ) => Promise<CommandHandlerResult> | CommandHandlerResult;
 
 interface Command {
@@ -365,7 +367,8 @@ export const commands: Record<string, Command> = {
     desc: "Manage secrets for shell commands",
     order: 33,
     args: "<set|list|unset> [key] [value]",
-    handler: (args: string[]) => handleSecretCommand(args),
+    handler: (args: string[], rawInput?: string) =>
+      handleSecretCommand(args, rawInput),
   },
   "/memory-repository": {
     desc: "Push this agent's memory repo to an additional git remote",
@@ -673,7 +676,12 @@ function normalizeCommandHandlerResult(result: CommandHandlerResult): {
 export async function executeCommand(
   input: string,
 ): Promise<CommandExecutionResult> {
-  const [command, ...args] = input.trim().split(/\s+/);
+  // Resolve paste placeholders up front so commands operate on the real
+  // pasted content, and keep the resolved text for handlers that need
+  // values verbatim (whitespace splitting cannot represent spaces or
+  // newlines inside a value, e.g. /secret set KEY <token with spaces>).
+  const resolvedInput = resolvePlaceholders(input).trim();
+  const [command, ...args] = resolvedInput.split(/\s+/);
 
   if (!command) {
     return {
@@ -699,7 +707,9 @@ export async function executeCommand(
   }
 
   try {
-    const result = normalizeCommandHandlerResult(await handler.handler(args));
+    const result = normalizeCommandHandlerResult(
+      await handler.handler(args, resolvedInput),
+    );
     return { success: true, ...result };
   } catch (error) {
     return {

--- a/src/cli/commands/secret.test.ts
+++ b/src/cli/commands/secret.test.ts
@@ -126,6 +126,43 @@ describe("/secret command", () => {
     });
   });
 
+  test("set stores values containing spaces verbatim from the resolved input", async () => {
+    retrieveAgentMock.mockResolvedValueOnce({
+      secrets: [{ key: "CLOUDFLARE_API_TOKEN", value: "cf-token" }],
+    });
+
+    const result = await handleSecretCommand(
+      ["set", "fly", "FlyV1"],
+      "/secret set fly FlyV1 macaroon-one macaroon-two",
+    );
+
+    expect(result.output).toBe("Secret '$FLY' set.");
+    expect(updateAgentMock).toHaveBeenCalledWith(AGENT_ID, {
+      secrets: {
+        CLOUDFLARE_API_TOKEN: "cf-token",
+        FLY: "FlyV1 macaroon-one macaroon-two",
+      },
+    });
+  });
+
+  test("set preserves newlines in multi-line pasted values", async () => {
+    const localAgentId = "agent-local-secret-command";
+    installLocalSecretStorage();
+    setCurrentAgentId(localAgentId);
+    clearSecretsCache(localAgentId);
+
+    const result = await handleSecretCommand(
+      ["set", "PRIVATE_KEY"],
+      "/secret set PRIVATE_KEY -----BEGIN KEY-----\nline2\n-----END KEY-----",
+    );
+
+    expect(result.output).toBe("Secret '$PRIVATE_KEY' set.");
+    expect(updateAgentMock).not.toHaveBeenCalled();
+    expect(loadSecrets(localAgentId)).toEqual({
+      PRIVATE_KEY: "-----BEGIN KEY-----\nline2\n-----END KEY-----",
+    });
+  });
+
   test("unset refreshes before checking whether the secret exists", async () => {
     retrieveAgentMock.mockResolvedValueOnce({
       secrets: [{ key: "CLOUDFLARE_API_TOKEN", value: "cf-token" }],

--- a/src/cli/commands/secret.ts
+++ b/src/cli/commands/secret.ts
@@ -24,14 +24,22 @@ export interface SecretCommandResult {
  */
 export async function handleSecretCommand(
   args: string[],
+  rawInput?: string,
 ): Promise<SecretCommandResult> {
-  const [subcommand, key, value] = args;
+  const [subcommand, key] = args;
 
   switch (subcommand) {
     case "set": {
       if (!key) {
         return { output: "Usage: /secret set KEY value" };
       }
+      // Values can contain spaces and newlines (e.g. "FlyV1 <token>" or a
+      // pasted private key). The whitespace-split args cannot reconstruct
+      // them, so recover the value verbatim from the resolved input.
+      const value =
+        rawInput !== undefined
+          ? rawInput.replace(/^\/secret\s+set\s+\S+\s*/, "")
+          : args.slice(2).join(" ");
       if (!value) {
         return {
           output:


### PR DESCRIPTION
## Summary

Fixes #3775: /secret set corrupted two kinds of secret values:

1. Pasted values — a long paste becomes a [Pasted text #N +M lines] display placeholder; the command path never resolved it, so /secret set stored the literal 7 characters [Pasted and reported success.
2. Values containing spaces — executeCommand splits arguments on whitespace and the handler read only the third argument, so a Fly token (FlyV1 <macaroon-bundle>) was stored as just FlyV1.

Changes:

- executeCommand now resolves paste placeholders on the input before dispatching, and passes the resolved input to handlers (rawInput, optional — existing handlers are unaffected).
- handleSecretCommand recovers the value verbatim from the resolved input when available (spaces and newlines preserved), falling back to args.slice(2).join(" ") for direct callers.

Resubmission of #3856, which the contribution-policy bot auto-closed for a missing disclosure checkbox; branch content is unchanged and now includes the full disclosure sections.

## Verification

- Two new cases in src/cli/commands/secret.test.ts: space-containing values stored verbatim via the resolved input; multi-line values (real newlines) stored intact in local secret storage.
- Pre-fix FAIL verified: both new tests fail with the previous implementation (9 pass / 2 fail); post-fix 11/11 pass.
- bun run check: 12/12 checks pass (biome, typescript, cycles, boundaries, coverage, etc.).

## AI Disclosure

- [ ] This pull request was written entirely by a human
- [x] This pull request was written with AI assistance and reviewed and edited by a human
- [x] I have read the [AI Policy](https://github.com/letta-ai/letta-code/blob/main/AI_POLICY.md) and agree to its terms

## AI Tool(s) Used

DeepSeek (AI-assisted development) operating on behalf of the submitting human. Extent: proposed the fix approach and test cases; the implementation was written and verified step-by-step in the human's environment (bun test, bun run check) and reviewed line-by-line by the submitter.

## Human Verification

I have reviewed and understand every change in this pull request and take responsibility for its correctness.
