### PR TITLE
fix(model-handles): avoid double-prefixing provider-prefixed model handles

### DIFF
--- a/src/agent/model-handles.ts
+++ b/src/agent/model-handles.ts
@@ -188,6 +188,15 @@ export function resolveModelHandleFromLlmConfig(
   if (endpointType) {
     const normalizedModel = normalizeModelHandleForRegistry(model) ?? model;
     const modelProvider = providerPrefix(normalizedModel);
+    const endpointHandleProvider =
+      modelHandleProviderForEndpointType(endpointType);
+    // A handle that already carries the provider this endpoint type maps to
+    // is already normalized. Prepending the provider again produced doubled
+    // prefixes (e.g. chatgpt-oss/chatgpt-oss/<model>) while the provider mod
+    // was still loading during agent startup.
+    if (modelProvider && modelProvider === endpointHandleProvider) {
+      return normalizeKnownModelHandle(normalizedModel);
+    }
     if (
       modelProvider &&
       isKnownModelProviderPrefix(modelProvider) &&
@@ -196,9 +205,7 @@ export function resolveModelHandleFromLlmConfig(
       return normalizeKnownModelHandle(normalizedModel);
     }
 
-    return normalizeKnownModelHandle(
-      `${modelHandleProviderForEndpointType(endpointType)}/${model}`,
-    );
+    return normalizeKnownModelHandle(`${endpointHandleProvider}/${model}`);
   }
 
   const normalizedModel = normalizeKnownModelHandle(model);

--- a/src/backend/local/local-model-normalization.test.ts
+++ b/src/backend/local/local-model-normalization.test.ts
@@ -85,6 +85,16 @@ describe("local model normalization", () => {
     }
   });
 
+  test("does not double-prefix a handle already carrying the endpoint provider", () => {
+    // Regression for #3844: before the mod registers the provider, the
+    // endpoint-type normalization prepended the provider a second time.
+    expect(
+      normalizeLocalModelHandle("chatgpt-oss/gpt-5.6-sol", {
+        provider_type: "chatgpt-oss",
+      }),
+    ).toBe("chatgpt-oss/gpt-5.6-sol");
+  });
+
   test("preserves handles owned by registered provider mods", () => {
     registerPiProvider("custom-provider", {
       baseUrl: "http://localhost:8000/v1",


### PR DESCRIPTION
## Summary

Fixes #3844: persisted local-agent model handles can be normalized before the mod that registers their provider has loaded. resolveModelHandleFromLlmConfig only recognized provider prefixes in its static known-provider tables, so a handle like chatgpt-oss/gpt-5.6-sol (provider chatgpt-oss registered by a mod) fell through to the legacy fallback, which prepended the provider a second time: chatgpt-oss/chatgpt-oss/gpt-5.6-sol.

A handle that already carries the provider the endpoint type maps to is now treated as already normalized, so the fallback never double-prefixes — regardless of whether the provider mod has finished loading.

Resubmission of #3857, which the contribution-policy bot auto-closed for a missing disclosure checkbox; branch content is unchanged and now includes the full disclosure sections.

## Verification

- New regression case in src/backend/local/local-model-normalization.test.ts: a chatgpt-oss/chatgpt-oss-style double prefix is no longer produced for chatgpt-oss/gpt-5.6-sol with provider_type: chatgpt-oss.
- Pre-fix FAIL verified: the new test fails against the previous implementation (7 pass / 1 fail); post-fix 8/8 pass.
- bun run check: 12/12 checks pass (biome, typescript, cycles, boundaries, coverage, etc.).

## AI Disclosure

- [ ] This pull request was written entirely by a human
- [x] This pull request was written with AI assistance and reviewed and edited by a human
- [x] I have read the [AI Policy](https://github.com/letta-ai/letta-code/blob/main/AI_POLICY.md) and agree to its terms

## AI Tool(s) Used

DeepSeek (AI-assisted development) operating on behalf of the submitting human. Extent: proposed the fix and regression test; the implementation was written and verified step-by-step in the human's environment (bun test, bun run check) and reviewed line-by-line by the submitter.

## Human Verification

I have reviewed and understand every change in this pull request and take responsibility for its correctness.
