### PR TITLE
fix(providers): honor optional token-limit metadata from OpenAI-compatible model lists

### DIFF
--- a/src/backend/dev/pi-local-endpoint-provider.ts
+++ b/src/backend/dev/pi-local-endpoint-provider.ts
@@ -82,17 +82,53 @@ export function localEndpointOpenAIBaseURL(baseURL: string): string {
   return trimmed.endsWith("/v1") ? trimmed : `${trimmed}/v1`;
 }
 
-export function modelIdsFromOpenAICompatibleList(data: unknown): string[] {
+export interface OpenAICompatibleListEntry {
+  id: string;
+  /** Provider-advertised input limit from GET /v1/models, when valid. */
+  maxInputTokens?: number;
+  /** Provider-advertised output limit from GET /v1/models, when valid. */
+  maxOutputTokens?: number;
+}
+
+function isPositiveInteger(value: unknown): value is number {
+  return typeof value === "number" && Number.isInteger(value) && value > 0;
+}
+
+/**
+ * Parse an OpenAI-compatible GET /v1/models list, keeping each entry's
+ * optional limit metadata. Positive-integer limits are kept per field;
+ * malformed values (booleans, strings, zero, negatives, NaN/Infinity) are
+ * ignored so callers fall back per-field to last-known or harness defaults.
+ */
+export function openAICompatibleListEntries(
+  data: unknown,
+): OpenAICompatibleListEntry[] {
   if (!data || typeof data !== "object") return [];
   const records = (data as { data?: unknown }).data;
   if (!Array.isArray(records)) return [];
-  return records
-    .map((entry) => {
-      if (!entry || typeof entry !== "object") return undefined;
-      const id = (entry as { id?: unknown }).id;
-      return typeof id === "string" && id.length > 0 ? id : undefined;
-    })
-    .filter((id): id is string => id !== undefined);
+  const entries: OpenAICompatibleListEntry[] = [];
+  for (const record of records) {
+    if (!record || typeof record !== "object") continue;
+    const raw = record as {
+      id?: unknown;
+      max_input_tokens?: unknown;
+      max_output_tokens?: unknown;
+    };
+    if (typeof raw.id !== "string" || raw.id.length === 0) continue;
+    const entry: OpenAICompatibleListEntry = { id: raw.id };
+    if (isPositiveInteger(raw.max_input_tokens)) {
+      entry.maxInputTokens = raw.max_input_tokens;
+    }
+    if (isPositiveInteger(raw.max_output_tokens)) {
+      entry.maxOutputTokens = raw.max_output_tokens;
+    }
+    entries.push(entry);
+  }
+  return entries;
+}
+
+export function modelIdsFromOpenAICompatibleList(data: unknown): string[] {
+  return openAICompatibleListEntries(data).map((entry) => entry.id);
 }
 
 /**

--- a/src/backend/dev/pi-openai-compatible-provider.test.ts
+++ b/src/backend/dev/pi-openai-compatible-provider.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, test } from "bun:test";
 import { testRefreshContext } from "@/test-utils/pi-refresh-context";
-import { createOpenAICompatiblePiProvider } from "./pi-openai-compatible-provider";
+import {
+  createOpenAICompatiblePiProvider,
+  openAICompatibleTokenLimitRecord,
+  setOpenAICompatibleTokenLimits,
+} from "./pi-openai-compatible-provider";
+import { OPENAI_COMPATIBLE_PI_PROVIDER_ID } from "./pi-provider-registry";
 
 interface FakeOpenAIState {
   models?: unknown[];
@@ -161,5 +166,70 @@ describe("createOpenAICompatiblePiProvider", () => {
     expect(
       provider.getModels().find((m) => m.id === "changing")?.maxTokens,
     ).toBe(40000);
+  });
+});
+
+describe("openai-compatible token-limit sidecar", () => {
+  const PROVIDER_ID = OPENAI_COMPATIBLE_PI_PROVIDER_ID;
+
+  function makeProvider(models: unknown[]) {
+    return createOpenAICompatiblePiProvider({
+      baseURL: "http://127.0.0.1:9999",
+      fetchImpl: fakeOpenAIFetch({ models }),
+    });
+  }
+
+  test("exposes advertised and effective limits side by side", async () => {
+    setOpenAICompatibleTokenLimits(PROVIDER_ID, []);
+    const provider = makeProvider([
+      {
+        id: "oversized-272k",
+        object: "model",
+        max_input_tokens: 272000,
+        max_output_tokens: 200000,
+      },
+    ]);
+    await provider.refreshModels?.(testRefreshContext());
+    const record = openAICompatibleTokenLimitRecord(
+      PROVIDER_ID,
+      "oversized-272k",
+    );
+    // The caller can tell the endpoint reported 272k/200k while the harness
+    // ceiling produced the effective 128k window and cap.
+    expect(record?.advertisedContextLength).toBe(272000);
+    expect(record?.effectiveContextWindow).toBe(128000);
+    expect(record?.advertisedMaxOutputTokens).toBe(200000);
+    expect(record?.effectiveMaxTokens).toBe(128000);
+  });
+
+  test("keeps unadvertised fields undefined instead of inventing them", async () => {
+    setOpenAICompatibleTokenLimits(PROVIDER_ID, []);
+    const provider = makeProvider([{ id: "bare", object: "model" }]);
+    await provider.refreshModels?.(testRefreshContext());
+    const record = openAICompatibleTokenLimitRecord(PROVIDER_ID, "bare");
+    expect(record?.advertisedContextLength).toBeUndefined();
+    expect(record?.advertisedMaxOutputTokens).toBeUndefined();
+    // Effective values still exist — the harness defaults the Model ships with.
+    expect(record?.effectiveContextWindow).toBe(128000);
+    expect(typeof record?.effectiveMaxTokens).toBe("number");
+  });
+
+  test("refresh drops records for models the endpoint no longer lists", async () => {
+    setOpenAICompatibleTokenLimits(PROVIDER_ID, []);
+    const provider = makeProvider([
+      { id: "kept", object: "model" },
+      { id: "dropped", object: "model" },
+    ]);
+    await provider.refreshModels?.(testRefreshContext());
+    expect(
+      openAICompatibleTokenLimitRecord(PROVIDER_ID, "dropped"),
+    ).toBeDefined();
+
+    const second = makeProvider([{ id: "kept", object: "model" }]);
+    await second.refreshModels?.(testRefreshContext());
+    expect(openAICompatibleTokenLimitRecord(PROVIDER_ID, "kept")).toBeDefined();
+    expect(
+      openAICompatibleTokenLimitRecord(PROVIDER_ID, "dropped"),
+    ).toBeUndefined();
   });
 });

--- a/src/backend/dev/pi-openai-compatible-provider.test.ts
+++ b/src/backend/dev/pi-openai-compatible-provider.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, test } from "bun:test";
+import { testRefreshContext } from "@/test-utils/pi-refresh-context";
+import { createOpenAICompatiblePiProvider } from "./pi-openai-compatible-provider";
+
+interface FakeOpenAIState {
+  models?: unknown[];
+  fail?: boolean;
+}
+
+function fakeOpenAIFetch(state: FakeOpenAIState): typeof fetch {
+  return (async (input: string | URL | Request) => {
+    const url = String(input);
+    if (url.endsWith("/v1/models")) {
+      if (state.fail) throw new Error("connection refused");
+      return Response.json({ object: "list", data: state.models ?? [] });
+    }
+    return new Response("not found", { status: 404 });
+  }) as typeof fetch;
+}
+
+describe("createOpenAICompatiblePiProvider", () => {
+  test("publishes provider-advertised token limits from /v1/models", async () => {
+    const provider = createOpenAICompatiblePiProvider({
+      baseURL: "http://127.0.0.1:9999",
+      fetchImpl: fakeOpenAIFetch({
+        models: [
+          {
+            id: "small-30k",
+            object: "model",
+            max_input_tokens: 30000,
+            max_output_tokens: 16384,
+          },
+          {
+            id: "mid-100k",
+            object: "model",
+            max_input_tokens: 100000,
+            max_output_tokens: 40000,
+          },
+          {
+            id: "oversized-272k",
+            object: "model",
+            max_input_tokens: 272000,
+            max_output_tokens: 128000,
+          },
+        ],
+      }),
+    });
+    await provider.refreshModels?.(testRefreshContext());
+
+    const models = provider.getModels();
+    const small = models.find((m) => m.id === "small-30k");
+    expect(small?.contextWindow).toBe(30000);
+    expect(small?.maxTokens).toBe(16384);
+    const mid = models.find((m) => m.id === "mid-100k");
+    expect(mid?.contextWindow).toBe(100000);
+    expect(mid?.maxTokens).toBe(40000);
+    // Oversized windows stay clamped to the harness default cap.
+    const oversized = models.find((m) => m.id === "oversized-272k");
+    expect(oversized?.contextWindow).toBe(128000);
+    expect(oversized?.maxTokens).toBe(128000);
+  });
+
+  test("ignores malformed limit fields", async () => {
+    const provider = createOpenAICompatiblePiProvider({
+      baseURL: "http://127.0.0.1:9999",
+      fetchImpl: fakeOpenAIFetch({
+        models: [
+          {
+            id: "malformed",
+            object: "model",
+            max_input_tokens: true,
+            max_output_tokens: "16384",
+          },
+          {
+            id: "zero-limits",
+            object: "model",
+            max_input_tokens: 0,
+            max_output_tokens: 0,
+          },
+          {
+            id: "negative",
+            object: "model",
+            max_input_tokens: -5,
+            max_output_tokens: -1,
+          },
+          {
+            id: "fractional",
+            object: "model",
+            max_input_tokens: 1.5,
+            max_output_tokens: 2.5,
+          },
+        ],
+      }),
+    });
+    await provider.refreshModels?.(testRefreshContext());
+
+    const models = provider.getModels();
+    for (const id of ["malformed", "zero-limits", "negative", "fractional"]) {
+      const model = models.find((m) => m.id === id);
+      expect(model?.contextWindow).toBe(128000);
+      expect(model?.maxTokens).toBe(32000);
+    }
+  });
+
+  test("falls back per-field when only one limit is advertised", async () => {
+    const provider = createOpenAICompatiblePiProvider({
+      baseURL: "http://127.0.0.1:9999",
+      fetchImpl: fakeOpenAIFetch({
+        models: [
+          { id: "input-only", object: "model", max_input_tokens: 60000 },
+          { id: "output-only", object: "model", max_output_tokens: 20000 },
+        ],
+      }),
+    });
+    await provider.refreshModels?.(testRefreshContext());
+
+    const models = provider.getModels();
+    const inputOnly = models.find((m) => m.id === "input-only");
+    expect(inputOnly?.contextWindow).toBe(60000);
+    expect(inputOnly?.maxTokens).toBe(32000);
+    const outputOnly = models.find((m) => m.id === "output-only");
+    expect(outputOnly?.contextWindow).toBe(128000);
+    expect(outputOnly?.maxTokens).toBe(20000);
+  });
+
+  test("refresh updates limits when the provider changes its advertised values", async () => {
+    const state: FakeOpenAIState = {
+      models: [
+        {
+          id: "changing",
+          object: "model",
+          max_input_tokens: 30000,
+          max_output_tokens: 16384,
+        },
+      ],
+    };
+    const provider = createOpenAICompatiblePiProvider({
+      baseURL: "http://127.0.0.1:9999",
+      fetchImpl: fakeOpenAIFetch(state),
+    });
+    await provider.refreshModels?.(testRefreshContext());
+    expect(
+      provider.getModels().find((m) => m.id === "changing")?.contextWindow,
+    ).toBe(30000);
+    expect(
+      provider.getModels().find((m) => m.id === "changing")?.maxTokens,
+    ).toBe(16384);
+
+    state.models = [
+      {
+        id: "changing",
+        object: "model",
+        max_input_tokens: 100000,
+        max_output_tokens: 40000,
+      },
+    ];
+    await provider.refreshModels?.(testRefreshContext());
+    expect(
+      provider.getModels().find((m) => m.id === "changing")?.contextWindow,
+    ).toBe(100000);
+    expect(
+      provider.getModels().find((m) => m.id === "changing")?.maxTokens,
+    ).toBe(40000);
+  });
+});

--- a/src/backend/dev/pi-openai-compatible-provider.ts
+++ b/src/backend/dev/pi-openai-compatible-provider.ts
@@ -13,14 +13,65 @@ export interface OpenAICompatiblePiProviderOptions {
   discoveryTimeoutMs?: number;
 }
 
+/**
+ * Sidecar record for one discovered model. The published pi-ai `Model`
+ * carries only the effective (post-policy) values; this record keeps the
+ * provider-advertised inputs next to them so callers can tell whether a
+ * value came from the endpoint or from the harness ceiling.
+ */
+export interface OpenAICompatibleTokenLimitRecord {
+  /** Endpoint-reported `max_input_tokens`, when present and valid. */
+  advertisedContextLength?: number;
+  /** Endpoint-reported `max_output_tokens`, when present and valid. */
+  advertisedMaxOutputTokens?: number;
+  /** Context window published on the Model after the harness cap policy. */
+  effectiveContextWindow: number;
+  /** Output cap published on the Model after the harness policy. */
+  effectiveMaxTokens: number;
+}
+
+// Provider+model keyed sidecar — deliberately module-scoped instead of new
+// fields on the external pi-ai `Model` type. Each successful refresh replaces
+// the provider's whole slice, so records for models the endpoint no longer
+// lists disappear with it.
+const openAICompatibleTokenLimits = new Map<
+  string,
+  Map<string, OpenAICompatibleTokenLimitRecord>
+>();
+
+/** Replaces the sidecar slice for one provider id. */
+export function setOpenAICompatibleTokenLimits(
+  providerId: string,
+  records: ReadonlyArray<
+    OpenAICompatibleTokenLimitRecord & { modelId: string }
+  >,
+): void {
+  const slice = new Map<string, OpenAICompatibleTokenLimitRecord>();
+  for (const record of records) {
+    const { modelId, ...limits } = record;
+    slice.set(modelId, limits);
+  }
+  openAICompatibleTokenLimits.set(providerId, slice);
+}
+
+/** Reads the sidecar record for one provider+model pair, when fresh. */
+export function openAICompatibleTokenLimitRecord(
+  providerId: string,
+  modelId: string,
+): OpenAICompatibleTokenLimitRecord | undefined {
+  return openAICompatibleTokenLimits.get(providerId)?.get(modelId);
+}
+
 const openAICompatibleDiscover: LocalEndpointDiscover = async (context) => {
   const list = await context.fetchJson(`${context.openAIBaseURL}/models`);
-  return openAICompatibleListEntries(list).map((entry) => {
+  const records: Array<OpenAICompatibleTokenLimitRecord & { modelId: string }> =
+    [];
+  const models = openAICompatibleListEntries(list).map((entry) => {
     // Optional max_input_tokens / max_output_tokens are authoritative per
     // field; when a field is absent or malformed, fall back to the
     // last-known model value, then to the shared harness defaults.
     const previous = context.lastKnown.get(entry.id);
-    return context.buildModel({
+    const model = context.buildModel({
       id: entry.id,
       ...(entry.maxInputTokens !== undefined
         ? { contextLength: entry.maxInputTokens }
@@ -33,7 +84,20 @@ const openAICompatibleDiscover: LocalEndpointDiscover = async (context) => {
           ? { maxTokens: previous.maxTokens }
           : {}),
     });
+    // Effective values are read back off the built Model so the sidecar can
+    // never drift from what turn requests actually use; the clamp itself
+    // stays an explicit buildModel policy, not duplicated arithmetic here.
+    records.push({
+      modelId: entry.id,
+      advertisedContextLength: entry.maxInputTokens,
+      advertisedMaxOutputTokens: entry.maxOutputTokens,
+      effectiveContextWindow: model.contextWindow,
+      effectiveMaxTokens: model.maxTokens,
+    });
+    return model;
   });
+  setOpenAICompatibleTokenLimits(OPENAI_COMPATIBLE_PI_PROVIDER_ID, records);
+  return models;
 };
 
 /**

--- a/src/backend/dev/pi-openai-compatible-provider.ts
+++ b/src/backend/dev/pi-openai-compatible-provider.ts
@@ -2,7 +2,7 @@ import type { Provider } from "@earendil-works/pi-ai";
 import {
   createLocalEndpointPiProvider,
   type LocalEndpointDiscover,
-  modelIdsFromOpenAICompatibleList,
+  openAICompatibleListEntries,
 } from "./pi-local-endpoint-provider";
 import { OPENAI_COMPATIBLE_PI_PROVIDER_ID } from "./pi-provider-registry";
 
@@ -15,16 +15,32 @@ export interface OpenAICompatiblePiProviderOptions {
 
 const openAICompatibleDiscover: LocalEndpointDiscover = async (context) => {
   const list = await context.fetchJson(`${context.openAIBaseURL}/models`);
-  return modelIdsFromOpenAICompatibleList(list).map(
-    (modelId) =>
-      context.lastKnown.get(modelId) ?? context.buildModel({ id: modelId }),
-  );
+  return openAICompatibleListEntries(list).map((entry) => {
+    // Optional max_input_tokens / max_output_tokens are authoritative per
+    // field; when a field is absent or malformed, fall back to the
+    // last-known model value, then to the shared harness defaults.
+    const previous = context.lastKnown.get(entry.id);
+    return context.buildModel({
+      id: entry.id,
+      ...(entry.maxInputTokens !== undefined
+        ? { contextLength: entry.maxInputTokens }
+        : previous
+          ? { contextLength: previous.contextWindow }
+          : {}),
+      ...(entry.maxOutputTokens !== undefined
+        ? { maxTokens: entry.maxOutputTokens }
+        : previous
+          ? { maxTokens: previous.maxTokens }
+          : {}),
+    });
+  });
 };
 
 /**
  * Dynamic provider for an arbitrary OpenAI-compatible Chat Completions API.
- * The endpoint's /v1/models response owns model identity; capabilities remain
- * conservative because the OpenAI model-list schema does not report them.
+ * The endpoint's /v1/models response owns model identity and, when present,
+ * its optional per-model limit metadata; capabilities stay conservative
+ * wherever the model list does not report them.
  */
 export function createOpenAICompatiblePiProvider(
   options: OpenAICompatiblePiProviderOptions,


### PR DESCRIPTION
## Summary

The dynamic OpenAI-compatible provider (LETTA_LOCAL_BACKEND_EXPERIMENTAL / pi local endpoint) discarded the optional per-model limit metadata from GET /v1/models, so models behind OpenAI-compatible gateways (LiteLLM 1.90+, LM Studio, etc.) always got the harness fallback 128k/32k — even when the provider advertised accurate max_input_tokens / max_output_tokens. This is the local-backend analog of the bug class in #3802 (whose Cloud server half lives in the archived letta-ai/letta repo).

**Fix:** parse each /v1/models entry with defensive per-field validation (positive integers only; booleans, strings, zero, negatives, and NaN/Infinity are ignored), feed both limits to the shared model builder, and fall back per-field — last-known model value first, then the conservative harness defaults. Oversized windows remain clamped by the existing harness cap; provider refresh now updates both fields.

## Verification

- New tests in src/backend/dev/pi-openai-compatible-provider.test.ts (4 cases): advertised limits are published (30k/16,384 and 100k/40k accurate; 272k/128k clamped); malformed fields ignored (fallback 128k/32k); per-field fallback when only one limit is advertised; refresh updates limits when the provider changes them.
- Pre-fix: 3 of the 4 new tests fail against the previous implementation (1 pass / 3 fail); post-fix 4/4 pass.
- bun run check: 12/12 checks pass; sibling dev-provider tests 53/53 pass; local-backend + local-model-config tests 40/40 pass.

## AI Disclosure

- [ ] This pull request was written entirely by a human
- [x] This pull request was written with AI assistance and reviewed and edited by a human
- [x] I have read the [AI Policy](https://github.com/letta-ai/letta-code/blob/main/AI_POLICY.md) and agree to its terms

## AI Tool(s) Used

DeepSeek (AI-assisted development) operating on behalf of the submitting human. Extent: proposed the fix approach and regression tests; the implementation was written and verified step-by-step in the human's environment (bun test, bun run check) and reviewed line-by-line by the submitter.

## Human Verification

I have reviewed and understand every change in this pull request and take responsibility for its correctness.
