### PR TITLE
fix: remap unsupported minimal reasoning for GPT-5.6 [LET-11064]

### DIFF
--- a/src/agent/conversation-model-carryover.test.ts
+++ b/src/agent/conversation-model-carryover.test.ts
@@ -79,6 +79,22 @@ describe("conversation model carryover", () => {
     expect(carryover?.updateArgs?.context_window).not.toBe(128000);
   });
 
+  test("rewrites carried-over minimal reasoning for GPT-5.6 Sol", () => {
+    const carryover = buildConversationModelCarryoverUpdate({
+      rawModelHandle: "chatgpt-plus-pro/gpt-5.6-sol",
+      currentLlmConfig: {
+        model: "gpt-5.6-sol",
+        model_endpoint_type: "chatgpt_oauth",
+        reasoning_effort: "minimal",
+      } as LlmConfig,
+      activeConversationContextWindowLimit: null,
+    });
+
+    expect(carryover?.updateArgs).toMatchObject({
+      reasoning_effort: "none",
+    });
+  });
+
   test("uses centralized normalization for ChatGPT fast handles", () => {
     const carryover = buildConversationModelCarryoverUpdate({
       rawModelHandle: "chatgpt_oauth/gpt-5.5-fast",

--- a/src/agent/conversation-model-carryover.ts
+++ b/src/agent/conversation-model-carryover.ts
@@ -4,6 +4,7 @@ import {
   preservableContextWindow,
 } from "@/agent/model";
 import { normalizeKnownModelHandle } from "@/agent/model-handles";
+import { normalizeReasoningEffortForModel } from "@/utils/openai-reasoning-effort";
 
 type CarryoverLlmConfig = LlmConfig & {
   enable_reasoner?: boolean | null;
@@ -52,7 +53,10 @@ export function buildConversationModelCarryoverUpdate(params: {
   const updateArgs: Record<string, unknown> = {
     ...((modelInfo?.updateArgs as Record<string, unknown> | undefined) ?? {}),
   };
-  const reasoningEffort = carryoverLlmConfig?.reasoning_effort;
+  const reasoningEffort = normalizeReasoningEffortForModel(
+    modelHandle,
+    carryoverLlmConfig?.reasoning_effort,
+  );
   if (
     typeof reasoningEffort === "string" &&
     updateArgs.reasoning_effort === undefined

--- a/src/agent/modify-local.test.ts
+++ b/src/agent/modify-local.test.ts
@@ -60,6 +60,18 @@ describe("local model updates", () => {
     });
   });
 
+  test("rewrites unsupported minimal reasoning to none for GPT-5.6 Sol", () => {
+    expect(
+      __modifyTestUtils.buildModelSettings("openai-codex/gpt-5.6-sol", {
+        provider_type: "chatgpt_oauth",
+        reasoning_effort: "minimal",
+      }),
+    ).toMatchObject({
+      provider_type: "chatgpt_oauth",
+      reasoning: { reasoning_effort: "none" },
+    });
+  });
+
   test("stores GPT-5.6 max separately from xhigh for local providers", () => {
     expect(
       __modifyTestUtils.buildModelSettings("openai-codex/gpt-5.6-sol", {

--- a/src/agent/modify.ts
+++ b/src/agent/modify.ts
@@ -13,6 +13,7 @@ import { getBackend } from "@/backend";
 import { OPENAI_CODEX_PROVIDER_NAME } from "@/providers/openai-codex-provider";
 import { debugLog } from "@/utils/debug";
 import { OPENAI_COMPATIBLE_PROXY_UPDATE_ARG } from "@/utils/openai-endpoint";
+import { normalizeReasoningEffortForModel } from "@/utils/openai-reasoning-effort";
 import { isRecord } from "@/utils/type-guards";
 import { getModelContextWindow } from "./available-models";
 import { getModelInfo, type ModelReasoningSelection } from "./model";
@@ -107,7 +108,12 @@ function buildModelSettings(
       (openaiSettings as Record<string, unknown>).reasoning =
         updateArgs.reasoning_effort === null
           ? null
-          : { reasoning_effort: updateArgs.reasoning_effort };
+          : {
+              reasoning_effort: normalizeReasoningEffortForModel(
+                modelHandle,
+                String(updateArgs.reasoning_effort),
+              ),
+            };
     }
     const verbosity = updateArgs?.verbosity;
     if (verbosity === "low" || verbosity === "medium" || verbosity === "high") {
@@ -244,7 +250,12 @@ function buildModelSettings(
       (openaiProxySettings as Record<string, unknown>).reasoning =
         updateArgs.reasoning_effort === null
           ? null
-          : { reasoning_effort: updateArgs.reasoning_effort };
+          : {
+              reasoning_effort: normalizeReasoningEffortForModel(
+                modelHandle,
+                String(updateArgs.reasoning_effort),
+              ),
+            };
     }
     if (typeof updateArgs?.strict === "boolean") {
       (openaiProxySettings as Record<string, unknown>).strict =

--- a/src/backend/dev/pi-model-factory.ts
+++ b/src/backend/dev/pi-model-factory.ts
@@ -11,6 +11,7 @@ import {
   type LocalProviderTimeout,
   resolveLocalProviderTimeout,
 } from "@/backend/local/local-provider-timeout";
+import { normalizeReasoningEffortForModel } from "@/utils/openai-reasoning-effort";
 import { isRecord } from "@/utils/type-guards";
 import { LocalPiModelsRuntime } from "./pi-models-runtime";
 import {
@@ -67,6 +68,9 @@ function thinkingLevelSetting(
 ): ThinkingLevel | undefined {
   const effort = settingString(value);
   if (effort === "max") return preserveMax ? "max" : "xhigh";
+  // pi-ai's public ThinkingLevel currently omits `none`, but ChatGPT GPT-5.6
+  // accepts it and rejects the legacy `minimal` alias (LET-11064).
+  if (effort === "none") return "none" as ThinkingLevel;
   return effort === "minimal" ||
     effort === "low" ||
     effort === "medium" ||
@@ -94,10 +98,16 @@ export function reasoningForSettings(
     : undefined;
   const modelId = modelHandle?.slice(modelHandle.indexOf("/") + 1);
   const preserveMax = modelId?.startsWith("gpt-5.6") === true;
-  return (
-    thinkingLevelSetting(nestedReasoning?.reasoning_effort, preserveMax) ??
-    thinkingLevelSetting(modelSettings.effort, preserveMax) ??
-    thinkingLevelSetting(modelSettings.reasoning_effort, preserveMax)
+  const rawEffort =
+    nestedReasoning?.reasoning_effort ??
+    modelSettings.effort ??
+    modelSettings.reasoning_effort;
+  return thinkingLevelSetting(
+    normalizeReasoningEffortForModel(
+      modelHandle,
+      typeof rawEffort === "string" ? rawEffort : undefined,
+    ),
+    preserveMax,
   );
 }
 

--- a/src/backend/pi-model-factory.test.ts
+++ b/src/backend/pi-model-factory.test.ts
@@ -191,6 +191,12 @@ describe("pi model factory", () => {
           "openai-codex/gpt-5.6-sol",
         ),
       ).toBe("max");
+      expect(
+        reasoningForSettings(
+          { reasoning: { reasoning_effort: "minimal" } },
+          "openai-codex/gpt-5.6-sol",
+        ),
+      ).toBe("none" as "low");
     } finally {
       await rm(storageDir, { recursive: true, force: true });
     }

--- a/src/utils/openai-reasoning-effort.test.ts
+++ b/src/utils/openai-reasoning-effort.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from "bun:test";
+import { normalizeReasoningEffortForModel } from "@/utils/openai-reasoning-effort";
+
+describe("normalizeReasoningEffortForModel", () => {
+  test.each([
+    ["gpt-5.6-sol-1p-codexswic-ev3", "minimal", "none"],
+    ["gpt-5.6-sol", "minimal", "none"],
+    ["chatgpt-plus-pro/gpt-5.6-sol", "minimal", "none"],
+    ["openai-codex/gpt-5.6-sol-fast", "minimal", "none"],
+    ["gpt-5.5", "minimal", "none"],
+    ["gpt-5.5", "max", "xhigh"],
+    ["gpt-5.6-sol", "max", "max"],
+    ["gpt-5", "minimal", "minimal"],
+    ["custom-model", "minimal", "minimal"],
+  ])("normalizes %s effort %s to %s", (model, effort, expected) => {
+    expect(normalizeReasoningEffortForModel(model, effort)).toBe(expected);
+  });
+
+  test("passes through empty model and effort values", () => {
+    expect(normalizeReasoningEffortForModel(null, "minimal")).toBe("minimal");
+    expect(normalizeReasoningEffortForModel("gpt-5.6-sol", null)).toBeNull();
+    expect(
+      normalizeReasoningEffortForModel("gpt-5.6-sol", undefined),
+    ).toBeUndefined();
+  });
+});

--- a/src/utils/openai-reasoning-effort.ts
+++ b/src/utils/openai-reasoning-effort.ts
@@ -1,0 +1,48 @@
+const NONE_REASONING_MODEL_PREFIXES = [
+  "gpt-5.1",
+  "gpt-5.2",
+  "gpt-5.3",
+  "gpt-5.4",
+  "gpt-5.5",
+  "gpt-5.6",
+] as const;
+
+function openaiModelNameFromHandle(
+  modelHandleOrId: string | null | undefined,
+): string | null {
+  if (!modelHandleOrId) return null;
+  const trimmed = modelHandleOrId.trim().toLowerCase();
+  if (!trimmed) return null;
+  const slashIndex = trimmed.lastIndexOf("/");
+  const unprefixed =
+    slashIndex === -1 ? trimmed : trimmed.slice(slashIndex + 1);
+  return unprefixed.endsWith("-fast")
+    ? unprefixed.slice(0, -"-fast".length)
+    : unprefixed;
+}
+
+function supportsNoneReasoningEffort(model: string): boolean {
+  return NONE_REASONING_MODEL_PREFIXES.some(
+    (prefix) => model === prefix || model.startsWith(`${prefix}-`),
+  );
+}
+
+/**
+ * Repair legacy efforts that the selected model rejects on the wire.
+ * GPT-5.5/5.6 (including ChatGPT Sol aliases) do not accept `minimal`.
+ */
+export function normalizeReasoningEffortForModel(
+  modelHandleOrId: string | null | undefined,
+  effort: string | null | undefined,
+): string | null | undefined {
+  if (effort == null) return effort;
+  const model = openaiModelNameFromHandle(modelHandleOrId);
+  if (!model) return effort;
+  if (effort === "minimal" && supportsNoneReasoningEffort(model)) {
+    return "none";
+  }
+  if (effort === "max" && model.startsWith("gpt-5.5")) {
+    return "xhigh";
+  }
+  return effort;
+}


### PR DESCRIPTION
## Summary

ChatGPT Sol rejects `reasoning.effort=minimal` (`Supported values are: none, low, medium, high, xhigh, and max`). The cloud ChatGPT OAuth path already remaps this in letta-cloud ([LET-10997](https://linear.app/letta/issue/LET-10997)). LCD/LC could still persist or send `minimal` when carrying settings onto GPT-5.6 or talking to ChatGPT locally.

This adds `normalizeReasoningEffortForModel` and uses it when:
- building OpenAI / ChatGPT `model_settings`
- carrying conversation model config onto a new conversation
- mapping local pi-ai thinking levels for ChatGPT/OpenAI requests

`minimal` becomes `none` for GPT-5.1+ models that accept `none`. GPT-5 (base) and unknown models are unchanged.

Companion cloud PR: letta-ai/letta-cloud `caren/let-11064-minimal-reasoning-d3c0`.

## Verification

- `bun test src/utils/openai-reasoning-effort.test.ts src/agent/conversation-model-carryover.test.ts src/agent/modify-local.test.ts src/backend/pi-model-factory.test.ts` — 50 passed
- `tsc --noEmit` via pre-commit — passed
- layer-boundary check — passed

## AI Disclosure

- [ ] This pull request was written entirely by a human
- [x] This pull request was written with AI assistance and reviewed and edited by a human
- [x] I have read the [AI Policy](https://github.com/letta-ai/letta-code/blob/main/AI_POLICY.md) and agree to its terms

## AI Tool(s) Used

Cursor Grok 4.6 (cloud agent)

## Human Verification

I have reviewed and understand every change in this pull request and take responsibility for its correctness.
