### PR TITLE
fix(cli): hydrate persisted titles when resuming

### DIFF
--- a/src/agent/check-approval-resume-data.test.ts
+++ b/src/agent/check-approval-resume-data.test.ts
@@ -525,6 +525,7 @@ describe("getResumeData", () => {
     const sameDate = "2026-01-01T00:00:02.000Z";
     const conversationsRetrieve = mock(async () => ({
       in_context_message_ids: ["provider-msg-2"],
+      summary: "Persisted title",
     }));
     const conversationsList = mock(async () => ({
       getPaginatedItems: () => [
@@ -581,6 +582,7 @@ describe("getResumeData", () => {
       "tool_return_message",
       "assistant_message",
     ]);
+    expect(resume.conversation?.summary).toBe("Persisted title");
   });
 
   test("default conversation backfill orders equal-timestamp local tool messages before assistant text", async () => {

--- a/src/cli/app/AppCoordinator.tsx
+++ b/src/cli/app/AppCoordinator.tsx
@@ -49,6 +49,7 @@ import { getClient } from "@/backend/api/client";
 import { getBillingTier } from "@/backend/api/metadata";
 import { subscribePiProviderRegistry } from "@/backend/dev/pi-provider-mod-registry";
 import { useConversationTitleSync } from "@/cli/app/conversation-title-sync";
+import { resolveResumedConversationSummary } from "@/cli/app/resumed-conversation-summary";
 import {
   cancelActiveConnectOperation,
   isActiveConnectOperationCancellable,
@@ -350,6 +351,7 @@ export function App({
   agentId: initialAgentId,
   agentState: initialAgentState,
   conversationId: initialConversationId,
+  conversationSummary: initialConversationSummary = null,
   loadingState = "ready",
   continueSession = false,
   startupApproval = null,
@@ -402,11 +404,10 @@ export function App({
       : ("standard" as const);
     return shouldRecommendDefaultPrompt(agentState.system, memMode);
   }, [agentState]);
-
   const projectDirectory = process.cwd();
   const [conversationId, setConversationId] = useState(initialConversationId);
-  const [conversationSummary, setConversationSummary] = useState<string | null>(
-    null,
+  const [conversationSummary, setConversationSummary] = useState(
+    initialConversationSummary,
   );
   // Keep a ref to the current agentId for use in callbacks that need the latest value
   const agentIdRef = useRef(agentId);
@@ -4527,30 +4528,29 @@ export function App({
                   agentState,
                   action.conversationId,
                 );
-
+                const resumedSummary = resolveResumedConversationSummary(
+                  resumeData.conversation,
+                );
                 setConversationIdAndRef(action.conversationId);
                 setConversationAutoTitleEligibility(false);
-
+                setConversationSummary(resumedSummary ?? null);
                 pendingConversationSwitchRef.current = {
                   origin: "resume-selector",
                   conversationId: action.conversationId,
                   isDefault: action.conversationId === "default",
                   messageCount: resumeData.messageHistory.length,
+                  summary: resumedSummary,
                   messageHistory: resumeData.messageHistory,
                 };
-
                 settingsManager.persistSession(agentId, action.conversationId);
-
                 // Reset context tokens for new conversation
                 resetContextHistory(contextTrackerRef.current);
                 resetBootstrapReminderState();
-
                 if (resumeData.pendingApprovals.length > 0) {
                   await recoverRestoredPendingApprovals(
                     resumeData.pendingApprovals,
                   );
                 }
-
                 cmd.finish(
                   `Switched to conversation (${resumeData.messageHistory.length} messages)`,
                   true,

--- a/src/cli/app/AppView.tsx
+++ b/src/cli/app/AppView.tsx
@@ -95,6 +95,7 @@ import type { ToolsetName, ToolsetPreference } from "@/tools/toolset";
 import type { QueuedMessage } from "@/utils/message-queue-bridge";
 import { ExitStats } from "./ExitStats";
 import { uid } from "./ids";
+import { resolveResumedConversationSummary } from "./resumed-conversation-summary";
 import { StaticTranscript } from "./StaticTranscript";
 import type {
   ActiveOverlay,
@@ -1209,7 +1210,6 @@ export function AppView(props: AppViewProps) {
                     output: "Switching conversation...",
                     phase: "running",
                   });
-
                   try {
                     // Validate conversation exists BEFORE updating state
                     // (getResumeData throws 404/422 for non-existent conversations)
@@ -1218,12 +1218,14 @@ export function AppView(props: AppViewProps) {
                         agentState,
                         convId,
                       );
-
+                      const resumedSummary = resolveResumedConversationSummary(
+                        resumeData.conversation,
+                        selectorContext?.summary,
+                      );
                       // Only update state after validation succeeds
                       setConversationIdAndRef(convId);
                       setConversationAutoTitleEligibility(false);
-                      setConversationSummary(selectorContext?.summary ?? null);
-
+                      setConversationSummary(resumedSummary ?? null);
                       pendingConversationSwitchRef.current = {
                         origin: "resume-selector",
                         conversationId: convId,
@@ -1231,12 +1233,10 @@ export function AppView(props: AppViewProps) {
                         messageCount:
                           selectorContext?.messageCount ??
                           resumeData.messageHistory.length,
-                        summary: selectorContext?.summary,
+                        summary: resumedSummary,
                         messageHistory: resumeData.messageHistory,
                       };
-
                       settingsManager.persistSession(agentId, convId);
-
                       // Build success command with agent + conversation info
                       const currentAgentName =
                         agentState.name || "Unnamed Agent";
@@ -1483,29 +1483,29 @@ export function AppView(props: AppViewProps) {
                     output: "Switching conversation...",
                     phase: "running",
                   });
-
                   try {
                     if (agentState) {
                       const resumeData = await getResumeDataFromBackend(
                         agentState,
                         actualTargetConv,
                       );
-
+                      const resumedSummary = resolveResumedConversationSummary(
+                        resumeData.conversation,
+                      );
                       setConversationIdAndRef(actualTargetConv);
                       setConversationAutoTitleEligibility(false);
-
+                      setConversationSummary(resumedSummary ?? null);
                       pendingConversationSwitchRef.current = {
                         origin: "search",
                         conversationId: actualTargetConv,
                         isDefault: actualTargetConv === "default",
                         messageCount: resumeData.messageHistory.length,
+                        summary: resumedSummary,
                         messageHistory: resumeData.messageHistory,
                         searchQuery: searchContext?.query,
                         searchMessage: searchContext?.message,
                       };
-
                       settingsManager.persistSession(agentId, actualTargetConv);
-
                       const currentAgentName =
                         agentState.name || "Unnamed Agent";
                       const successOutput = [

--- a/src/cli/app/resumed-conversation-summary.test.ts
+++ b/src/cli/app/resumed-conversation-summary.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "bun:test";
+import { resolveResumedConversationSummary } from "./resumed-conversation-summary";
+
+describe("resolveResumedConversationSummary", () => {
+  test("uses the persisted conversation summary", () => {
+    expect(
+      resolveResumedConversationSummary({ summary: "  Persisted title  " }),
+    ).toBe("Persisted title");
+  });
+
+  test("preserves selector metadata when it is available", () => {
+    expect(
+      resolveResumedConversationSummary(
+        { summary: "Persisted title" },
+        "Selector title",
+      ),
+    ).toBe("Selector title");
+  });
+
+  test("falls back to the persisted summary when selector metadata is absent", () => {
+    expect(
+      resolveResumedConversationSummary({ summary: "Persisted title" }, null),
+    ).toBe("Persisted title");
+  });
+
+  test("omits blank persisted summaries", () => {
+    expect(
+      resolveResumedConversationSummary({ summary: "   " }),
+    ).toBeUndefined();
+  });
+});

--- a/src/cli/app/resumed-conversation-summary.ts
+++ b/src/cli/app/resumed-conversation-summary.ts
@@ -1,0 +1,10 @@
+type ConversationWithSummary = {
+  summary?: string | null;
+};
+
+export function resolveResumedConversationSummary(
+  conversation: ConversationWithSummary | null | undefined,
+  selectorSummary?: string | null,
+): string | undefined {
+  return selectorSummary ?? (conversation?.summary?.trim() || undefined);
+}

--- a/src/cli/app/submit-navigation-commands.ts
+++ b/src/cli/app/submit-navigation-commands.ts
@@ -11,6 +11,7 @@ import { CLI_GLYPHS } from "@/cli/helpers/glyphs";
 import type { ApprovalRequest } from "@/cli/helpers/stream";
 import { settingsManager } from "@/settings-manager";
 import { uid } from "./ids";
+import { resolveResumedConversationSummary } from "./resumed-conversation-summary";
 import type { ActiveOverlay, AppCommandRunner, StaticItem } from "./types";
 
 type SubmitCommandResult = { submitted: boolean };
@@ -35,6 +36,7 @@ type NavigationCommandContext = {
   setCommandRunning: (value: boolean) => void;
   setConversationAutoTitleEligibility: (enabled: boolean) => void;
   setConversationIdAndRef: (nextConversationId: string) => void;
+  setConversationSummary: (summary: string | null) => void;
   setLines: Dispatch<SetStateAction<Line[]>>;
   setSearchQuery: Dispatch<SetStateAction<string>>;
   setStaticItems: Dispatch<SetStateAction<StaticItem[]>>;
@@ -68,6 +70,7 @@ export async function handleNavigationCommand(
     setCommandRunning,
     setConversationAutoTitleEligibility,
     setConversationIdAndRef,
+    setConversationSummary,
     setLines,
     setSearchQuery,
     setStaticItems,
@@ -127,14 +130,19 @@ export async function handleNavigationCommand(
             targetConvId,
           );
 
+          const resumedSummary = resolveResumedConversationSummary(
+            resumeData.conversation,
+          );
           setConversationIdAndRef(targetConvId);
           setConversationAutoTitleEligibility(false);
+          setConversationSummary(resumedSummary ?? null);
 
           pendingConversationSwitchRef.current = {
             origin: "resume-direct",
             conversationId: targetConvId,
             isDefault: targetConvId === "default",
             messageCount: resumeData.messageHistory.length,
+            summary: resumedSummary,
             messageHistory: resumeData.messageHistory,
           };
 

--- a/src/cli/app/types.ts
+++ b/src/cli/app/types.ts
@@ -33,6 +33,7 @@ export type AppProps = {
   agentId: string;
   agentState?: AgentState | null;
   conversationId: string; // Required: created at startup
+  conversationSummary?: string | null;
   loadingState?: AppLoadingState;
   continueSession?: boolean;
   startupApproval?: ApprovalRequest | null; // Deprecated: use startupApprovals

--- a/src/cli/app/use-conversation-switching.ts
+++ b/src/cli/app/use-conversation-switching.ts
@@ -59,6 +59,7 @@ import { debugLog, debugWarn } from "@/utils/debug";
 import { LLM_API_ERROR_MAX_RETRIES } from "./constants";
 import { uid } from "./ids";
 import { getPreferredAgentModelHandle } from "./model-config";
+import { resolveResumedConversationSummary } from "./resumed-conversation-summary";
 import type {
   ActiveOverlay,
   AppCommandRunner,
@@ -369,16 +370,20 @@ export function useConversationSwitching(ctx: ConversationSwitchingContext) {
           conversationId,
         );
 
+        const resumedSummary = resolveResumedConversationSummary(
+          resumeData.conversation,
+        );
         await maybeCarryOverActiveConversationModel(conversationId);
         setConversationIdAndRef(conversationId);
         setConversationAutoTitleEligibility(false);
-        setConversationSummary(null);
+        setConversationSummary(resumedSummary ?? null);
 
         pendingConversationSwitchRef.current = {
           origin: "fork",
           conversationId,
           isDefault: false,
           messageCount: resumeData.messageHistory.length,
+          summary: resumedSummary,
           messageHistory: resumeData.messageHistory,
         };
 

--- a/src/cli/app/use-submit-handler.ts
+++ b/src/cli/app/use-submit-handler.ts
@@ -2533,7 +2533,6 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
           }
           return { submitted: true };
         }
-
         // Special handling for /agents command - routed through navigation commands.
         const navigationCommandResult = await handleNavigationCommand(trimmed, {
           agentId,
@@ -2553,6 +2552,7 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
           setCommandRunning,
           setConversationAutoTitleEligibility,
           setConversationIdAndRef,
+          setConversationSummary,
           setLines,
           setSearchQuery,
           setStaticItems,

--- a/src/index.ts
+++ b/src/index.ts
@@ -2720,12 +2720,12 @@ async function main(): Promise<void> {
         fileAutocompleteFdPath,
       });
     }
-
     return React.createElement(App, {
       key: `${agentId}:${conversationId}`,
       agentId,
       agentState,
       conversationId,
+      conversationSummary: resumeData?.conversation?.summary?.trim() || null,
       loadingState: appLoadingState,
       continueSession: isResumingSession,
       startupApproval: resumeData?.pendingApproval ?? null,


### PR DESCRIPTION
Overlord (agent-c2adbf5c-8419-4211-8cd8-3740db164974)

## Summary

- Initialize the active TUI title from the retrieved conversation summary.
- Apply the same summary fallback to direct, queued, selector, search, and fork resume paths.
- Preserve selector summary metadata when it is available.

Closes #3843.

## Before

A resumed conversation could have a persisted summary while the terminal title displayed its conversation ID.

## After

Each changed resume path sets `conversationSummary` from the retrieved conversation record. Blank summaries still use the existing fallback behavior.

## Validation

- `bun test src/cli/app/resumed-conversation-summary.test.ts src/agent/check-approval-resume-data.test.ts`
- `bun run check`
- Live TUI startup with a titled conversation displayed the persisted title.

## Limits

This change does not modify the live title update flow from #3837.
