### PR TITLE
fix(worktree): support Windows long paths

### DIFF
--- a/scripts/source-file-size-baseline.json
+++ b/scripts/source-file-size-baseline.json
@@ -35,7 +35,6 @@
   "src/providers/chatgpt-usage-service.ts": 1112,
   "src/settings-manager.test.ts": 1635,
   "src/settings-manager.ts": 2102,
-  "src/tools/impl/enter-worktree.ts": 1034,
   "src/tools/manager.ts": 2994,
   "src/tools/tool-execution-context.test.ts": 1138,
   "src/types/protocol_v2.ts": 2876,

--- a/scripts/source-file-size-baseline.json
+++ b/scripts/source-file-size-baseline.json
@@ -35,6 +35,7 @@
   "src/providers/chatgpt-usage-service.ts": 1112,
   "src/settings-manager.test.ts": 1635,
   "src/settings-manager.ts": 2102,
+  "src/tools/impl/enter-worktree.ts": 1034,
   "src/tools/manager.ts": 2994,
   "src/tools/tool-execution-context.test.ts": 1138,
   "src/types/protocol_v2.ts": 2876,

--- a/src/tools/enter-worktree.test.ts
+++ b/src/tools/enter-worktree.test.ts
@@ -16,8 +16,14 @@ import {
   runWithRuntimeContext,
 } from "@/runtime-context";
 import { settingsManager } from "@/settings-manager";
-import { enter_worktree } from "@/tools/impl/enter-worktree";
-import { addWindowsPathLengthHint } from "@/tools/impl/worktree-git";
+import {
+  enter_worktree,
+  rollbackWorktreeCreation,
+} from "@/tools/impl/enter-worktree";
+import {
+  addWindowsPathLengthHint,
+  withLongPaths,
+} from "@/tools/impl/worktree-git";
 import {
   clearToolsWithLock,
   executeTool,
@@ -921,5 +927,57 @@ describe("EnterWorktree tool", () => {
     );
 
     expect(message).not.toContain("Windows path-length issue");
+  });
+
+  test("withLongPaths injects -c core.longpaths=true on win32 only", () => {
+    const base = ["worktree", "add", "--no-track", "-b", "br", "/p", "HEAD"];
+    const win = withLongPaths(base, "win32");
+    expect(win).toEqual(["-c", "core.longpaths=true", ...base]);
+    const linux = withLongPaths(base, "linux");
+    expect(linux).toEqual(base);
+    const mac = withLongPaths(base, "darwin");
+    expect(mac).toEqual(base);
+  });
+
+  test("rollbackWorktreeCreation removes a registered worktree and its branch", async () => {
+    const repo = await trackRepo();
+    const worktreesDir = path.join(repo, ".letta", "worktrees");
+    await mkdir(worktreesDir, { recursive: true });
+    const worktreePath = path.join(worktreesDir, "partial");
+    const branchName = "letta/partial-rollback-test";
+    git(
+      ["worktree", "add", "--no-track", "-b", branchName, worktreePath, "HEAD"],
+      repo,
+    );
+
+    // Confirm partial state exists before rollback.
+    // git porcelain output uses forward slashes on all platforms.
+    const fwdSlash = (p: string) => p.replace(/\\/g, "/");
+    expect(git(["branch", "--list", branchName], repo).trim()).not.toBe("");
+    expect(git(["worktree", "list", "--porcelain"], repo)).toContain(
+      fwdSlash(worktreePath),
+    );
+
+    await rollbackWorktreeCreation({
+      repoRoot: repo,
+      worktreePath,
+      branchName,
+    });
+
+    expect(git(["branch", "--list", branchName], repo).trim()).toBe("");
+    expect(git(["worktree", "list", "--porcelain"], repo)).not.toContain(
+      fwdSlash(worktreePath),
+    );
+  });
+
+  test("rollbackWorktreeCreation is idempotent when nothing exists", async () => {
+    const repo = await trackRepo();
+    await expect(
+      rollbackWorktreeCreation({
+        repoRoot: repo,
+        worktreePath: path.join(repo, ".letta", "worktrees", "never-created"),
+        branchName: "letta/never-created-abc12345",
+      }),
+    ).resolves.toBeUndefined();
   });
 });

--- a/src/tools/enter-worktree.test.ts
+++ b/src/tools/enter-worktree.test.ts
@@ -16,12 +16,10 @@ import {
   runWithRuntimeContext,
 } from "@/runtime-context";
 import { settingsManager } from "@/settings-manager";
-import {
-  enter_worktree,
-  rollbackWorktreeCreation,
-} from "@/tools/impl/enter-worktree";
+import { enter_worktree } from "@/tools/impl/enter-worktree";
 import {
   addWindowsPathLengthHint,
+  rollbackWorktreeCreation,
   withLongPaths,
 } from "@/tools/impl/worktree-git";
 import {
@@ -979,5 +977,19 @@ describe("EnterWorktree tool", () => {
         branchName: "letta/never-created-abc12345",
       }),
     ).resolves.toBeUndefined();
+  });
+
+  test("rollbackWorktreeCreation preserves a branch without the target worktree", async () => {
+    const repo = await trackRepo();
+    const branchName = "letta/concurrent-branch-test";
+    git(["branch", branchName, "HEAD"], repo);
+
+    await rollbackWorktreeCreation({
+      repoRoot: repo,
+      worktreePath: path.join(repo, ".letta", "worktrees", "never-created"),
+      branchName,
+    });
+
+    expect(git(["branch", "--list", branchName], repo).trim()).not.toBe("");
   });
 });

--- a/src/tools/impl/enter-worktree.ts
+++ b/src/tools/impl/enter-worktree.ts
@@ -35,6 +35,7 @@ import {
   resolvePrimaryWorktreeRoot,
   resolveRepoRoot,
   runGit,
+  withLongPaths,
 } from "./worktree-git.js";
 
 interface EnterWorktreeArgs {
@@ -831,6 +832,28 @@ async function enterExistingWorktree(params: {
   };
 }
 
+/**
+ * Removes a partially-created worktree registration and the branch that
+ * `git worktree add -b` would have created. Called when checkout fails
+ * mid-flight (e.g. Windows path-length errors) to avoid leaving stale git
+ * state that requires manual cleanup. Both operations allow failure so that
+ * missing registrations or branches are silently ignored.
+ */
+export async function rollbackWorktreeCreation(params: {
+  repoRoot: string;
+  worktreePath: string;
+  branchName: string;
+}): Promise<void> {
+  await runGit(
+    ["worktree", "remove", "--force", params.worktreePath],
+    params.repoRoot,
+    { allowFailure: true },
+  );
+  await runGit(["branch", "-D", params.branchName], params.repoRoot, {
+    allowFailure: true,
+  });
+}
+
 export async function enter_worktree(
   rawArgs: Record<string, unknown>,
 ): Promise<EnterWorktreeResult> {
@@ -903,18 +926,29 @@ export async function enter_worktree(
     // `--no-track` keeps the new branch from adopting the base ref (e.g.
     // origin/main) as its upstream, which would otherwise produce misleading
     // ahead/behind status and risk an accidental push to the base branch.
-    await runGit(
-      [
-        "worktree",
-        "add",
-        "--no-track",
-        "-b",
-        branchName,
-        worktreePath,
-        baseRef,
-      ],
-      repoRoot,
-    );
+    // On Windows, `-c core.longpaths=true` is injected for this invocation
+    // only so that tracked paths near the MAX_PATH limit can be checked out
+    // without touching global git config.
+    try {
+      await runGit(
+        withLongPaths([
+          "worktree",
+          "add",
+          "--no-track",
+          "-b",
+          branchName,
+          worktreePath,
+          baseRef,
+        ]),
+        repoRoot,
+      );
+    } catch (error) {
+      // The branch and/or worktree registration may have been created before
+      // the checkout failed (common with Windows path-length errors). Roll
+      // both back so the caller starts from a clean slate.
+      await rollbackWorktreeCreation({ repoRoot, worktreePath, branchName });
+      throw error;
+    }
 
     const normalizedWorktreePath = path.normalize(await realpath(worktreePath));
 

--- a/src/tools/impl/enter-worktree.ts
+++ b/src/tools/impl/enter-worktree.ts
@@ -27,6 +27,7 @@ import {
 } from "./enter-worktree-messages.js";
 import { switchRuntimeWorkingDirectory } from "./runtime-working-directory";
 import {
+  addManagedWorktree,
   formatGitFailure,
   gitRefExists,
   gitStdout,
@@ -35,7 +36,6 @@ import {
   resolvePrimaryWorktreeRoot,
   resolveRepoRoot,
   runGit,
-  withLongPaths,
 } from "./worktree-git.js";
 
 interface EnterWorktreeArgs {
@@ -832,28 +832,6 @@ async function enterExistingWorktree(params: {
   };
 }
 
-/**
- * Removes a partially-created worktree registration and the branch that
- * `git worktree add -b` would have created. Called when checkout fails
- * mid-flight (e.g. Windows path-length errors) to avoid leaving stale git
- * state that requires manual cleanup. Both operations allow failure so that
- * missing registrations or branches are silently ignored.
- */
-export async function rollbackWorktreeCreation(params: {
-  repoRoot: string;
-  worktreePath: string;
-  branchName: string;
-}): Promise<void> {
-  await runGit(
-    ["worktree", "remove", "--force", params.worktreePath],
-    params.repoRoot,
-    { allowFailure: true },
-  );
-  await runGit(["branch", "-D", params.branchName], params.repoRoot, {
-    allowFailure: true,
-  });
-}
-
 export async function enter_worktree(
   rawArgs: Record<string, unknown>,
 ): Promise<EnterWorktreeResult> {
@@ -923,32 +901,7 @@ export async function enter_worktree(
     }
 
     await mkdir(managedDir, { recursive: true });
-    // `--no-track` keeps the new branch from adopting the base ref (e.g.
-    // origin/main) as its upstream, which would otherwise produce misleading
-    // ahead/behind status and risk an accidental push to the base branch.
-    // On Windows, `-c core.longpaths=true` is injected for this invocation
-    // only so that tracked paths near the MAX_PATH limit can be checked out
-    // without touching global git config.
-    try {
-      await runGit(
-        withLongPaths([
-          "worktree",
-          "add",
-          "--no-track",
-          "-b",
-          branchName,
-          worktreePath,
-          baseRef,
-        ]),
-        repoRoot,
-      );
-    } catch (error) {
-      // The branch and/or worktree registration may have been created before
-      // the checkout failed (common with Windows path-length errors). Roll
-      // both back so the caller starts from a clean slate.
-      await rollbackWorktreeCreation({ repoRoot, worktreePath, branchName });
-      throw error;
-    }
+    await addManagedWorktree({ repoRoot, worktreePath, branchName, baseRef });
 
     const normalizedWorktreePath = path.normalize(await realpath(worktreePath));
 

--- a/src/tools/impl/worktree-git.test.ts
+++ b/src/tools/impl/worktree-git.test.ts
@@ -4,8 +4,10 @@ import { chmod, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import {
+  addManagedWorktree,
   buildNonInteractiveGitEnv,
   formatGitFailure,
+  rollbackWorktreeCreation,
   runGit,
 } from "@/tools/impl/worktree-git";
 
@@ -139,5 +141,81 @@ describe("worktree Git runner", () => {
       expect(Date.now() - startedAt).toBeLessThan(2000);
       await expectGitDescendantExited(failure);
     },
+  );
+
+  test.skipIf(process.platform !== "win32")(
+    "checks out tracked Windows paths beyond MAX_PATH",
+    async () => {
+      const repo = await mkdtemp(path.join(tmpdir(), "letta-longpaths-repo-"));
+      const worktreePath = await mkdtemp(
+        path.join(tmpdir(), "letta-longpaths-worktree-"),
+      );
+      await rm(worktreePath, { recursive: true });
+      tempDirs.push(repo, worktreePath);
+
+      await runGit(["init", "--quiet"], repo);
+      await runGit(["config", "user.email", "test@example.com"], repo);
+      await runGit(["config", "user.name", "Test User"], repo);
+      await writeFile(path.join(repo, "seed"), "long path");
+      const blob = (
+        await runGit(["hash-object", "-w", "seed"], repo)
+      ).stdout.trim();
+      const trackedPath = `${Array.from(
+        { length: 5 },
+        (_, index) => `segment-${index}-${"x".repeat(48)}`,
+      ).join("/")}/tracked.txt`;
+      await runGit(
+        [
+          "update-index",
+          "--add",
+          "--cacheinfo",
+          `100644,${blob},${trackedPath}`,
+        ],
+        repo,
+      );
+      const tree = (await runGit(["write-tree"], repo)).stdout.trim();
+      const commit = (
+        await runGit(["commit-tree", tree, "-m", "seed"], repo)
+      ).stdout.trim();
+      await runGit(["update-ref", "refs/heads/main", commit], repo);
+      await runGit(["config", "--local", "core.longpaths", "false"], repo);
+
+      let baseFailure = "";
+      try {
+        await runGit(
+          ["worktree", "add", "-b", "base-failure", worktreePath, "main"],
+          repo,
+        );
+      } catch (error) {
+        baseFailure = formatGitFailure(error);
+      }
+      expect(baseFailure).toContain("Filename too long");
+      await rollbackWorktreeCreation({
+        repoRoot: repo,
+        worktreePath,
+        branchName: "base-failure",
+      });
+
+      await addManagedWorktree({
+        repoRoot: repo,
+        worktreePath,
+        branchName: "fixed-checkout",
+        baseRef: "main",
+      });
+      expect((await runGit(["status", "--short"], worktreePath)).stdout).toBe(
+        "",
+      );
+      expect(
+        (
+          await runGit(["config", "--local", "--get", "core.longpaths"], repo)
+        ).stdout.trim(),
+      ).toBe("true");
+      await rollbackWorktreeCreation({
+        repoRoot: repo,
+        worktreePath,
+        branchName: "fixed-checkout",
+      });
+    },
+    30_000,
   );
 });

--- a/src/tools/impl/worktree-git.ts
+++ b/src/tools/impl/worktree-git.ts
@@ -199,6 +199,69 @@ export function withLongPaths(
   return platform === "win32" ? ["-c", "core.longpaths=true", ...args] : args;
 }
 
+export async function rollbackWorktreeCreation(params: {
+  repoRoot: string;
+  worktreePath: string;
+  branchName: string;
+}): Promise<void> {
+  // Only delete the branch when this path is registered to it. A concurrent
+  // caller can create the same branch after name allocation but before add.
+  const list = await runGit(
+    ["worktree", "list", "--porcelain", "-z"],
+    params.repoRoot,
+    { allowFailure: true },
+  );
+  const targetPath = path.resolve(params.worktreePath);
+  const targetBranch = `branch refs/heads/${params.branchName}`;
+  const ownsBranch = list.stdout.split("\0\0").some((entry) => {
+    const fields = entry.split("\0");
+    const worktree = fields.find((field) => field.startsWith("worktree "));
+    return (
+      worktree !== undefined &&
+      path.resolve(worktree.slice("worktree ".length)) === targetPath &&
+      fields.includes(targetBranch)
+    );
+  });
+
+  await runGit(
+    ["worktree", "remove", "--force", params.worktreePath],
+    params.repoRoot,
+    { allowFailure: true },
+  );
+  if (ownsBranch) {
+    await runGit(["branch", "-D", params.branchName], params.repoRoot, {
+      allowFailure: true,
+    });
+  }
+}
+
+export async function addManagedWorktree(params: {
+  repoRoot: string;
+  worktreePath: string;
+  branchName: string;
+  baseRef: string;
+}): Promise<void> {
+  try {
+    // Keep long-path support scoped to this checkout. Do not change user Git
+    // configuration to make a managed worktree fit on Windows.
+    await runGit(
+      withLongPaths([
+        "worktree",
+        "add",
+        "--no-track",
+        "-b",
+        params.branchName,
+        params.worktreePath,
+        params.baseRef,
+      ]),
+      params.repoRoot,
+    );
+  } catch (error) {
+    await rollbackWorktreeCreation(params);
+    throw error;
+  }
+}
+
 export function isPathWithin(child: string, parent: string): boolean {
   const resolvedChild = path.resolve(child);
   const resolvedParent = path.resolve(parent);

--- a/src/tools/impl/worktree-git.ts
+++ b/src/tools/impl/worktree-git.ts
@@ -186,6 +186,19 @@ export async function resolveDefaultBaseRef(repoRoot: string): Promise<string> {
     : "HEAD";
 }
 
+/**
+ * Prepends `-c core.longpaths=true` to git args on Windows so that
+ * `git worktree add` can check out repositories with long tracked paths
+ * without requiring a user-wide `core.longpaths` setting in global config.
+ * On other platforms the args are returned unchanged.
+ */
+export function withLongPaths(
+  args: string[],
+  platform: NodeJS.Platform = process.platform,
+): string[] {
+  return platform === "win32" ? ["-c", "core.longpaths=true", ...args] : args;
+}
+
 export function isPathWithin(child: string, parent: string): boolean {
   const resolvedChild = path.resolve(child);
   const resolvedParent = path.resolve(parent);

--- a/src/tools/impl/worktree-git.ts
+++ b/src/tools/impl/worktree-git.ts
@@ -199,6 +199,17 @@ export function withLongPaths(
   return platform === "win32" ? ["-c", "core.longpaths=true", ...args] : args;
 }
 
+async function enableRepoLongPaths(
+  repoRoot: string,
+  platform: NodeJS.Platform = process.platform,
+): Promise<void> {
+  if (platform === "win32") {
+    // The checkout override is not enough: later Git commands in the longer
+    // worktree must also accept the same paths. Keep the setting repo-local.
+    await runGit(["config", "--local", "core.longpaths", "true"], repoRoot);
+  }
+}
+
 export async function rollbackWorktreeCreation(params: {
   repoRoot: string;
   worktreePath: string;
@@ -241,9 +252,8 @@ export async function addManagedWorktree(params: {
   branchName: string;
   baseRef: string;
 }): Promise<void> {
+  await enableRepoLongPaths(params.repoRoot);
   try {
-    // Keep long-path support scoped to this checkout. Do not change user Git
-    // configuration to make a managed worktree fit on Windows.
     await runGit(
       withLongPaths([
         "worktree",


### PR DESCRIPTION
﻿Overlord (agent-c2adbf5c-8419-4211-8cd8-3740db164974)

## Summary

`EnterWorktree` can create a branch and worktree registration before a Windows checkout fails with `Filename too long`. The failed state then blocks a retry.

This change:

- enables `core.longpaths` in the repository before Windows worktree creation, without changing global Git configuration;
- removes a partial worktree registration after a failed checkout;
- deletes the branch only when that worktree path is registered to it, which preserves a branch created by another caller;
- keeps the shared creation and rollback logic outside the already-large `enter-worktree.ts` module.

## Before and after

Before, a tracked file whose absolute worktree path exceeded the Windows limit caused `git worktree add` to fail after Git had written partial state. A command-only override could complete checkout, but later plain Git commands still treated the long tracked file as deleted.

After, the managed checkout succeeds and a plain `git status` in the new worktree remains clean. Failed creation removes only state whose ownership can be proven.

## Validation

- Windows regression creates an index-only tracked path with a 288-character absolute checkout path.
- The base path fails with `Filename too long`.
- The managed path checks out successfully and plain `git status --short` is clean.
- Rollback tests cover registered state, missing state, and an unrelated existing branch.
- `bun test src/tools/enter-worktree.test.ts src/tools/impl/worktree-git.test.ts` — 31 passed, 2 platform-specific skips.
- `bun run check` — 12/12 checks passed.

## Limit

If Git creates only an unregistered branch before failing, rollback leaves that branch in place rather than risk deleting a branch created concurrently.

Closes #3883
