### PR TITLE
fix(approvals): distinguish dropped tool args from model omission

### DIFF
--- a/src/cli/approval-classification.test.ts
+++ b/src/cli/approval-classification.test.ts
@@ -115,6 +115,63 @@ describe("classifyApprovals", () => {
     expect(denied?.permission.reason).toBe(denied?.denyReason);
   });
 
+  test("flags empty arguments as dropped in transit, not omitted by the model", async () => {
+    await loadTools();
+    permissionMode.setMode("unrestricted");
+    process.env.MEMORY_DIR = "/Users/test/.letta/agents/agent-1/memory";
+
+    const result = await classifyApprovals(
+      [
+        {
+          toolCallId: "call_empty_args",
+          toolName: "Bash",
+          toolArgs: "{}",
+        },
+      ],
+      {
+        requireArgsForAutoApprove: true,
+        workingDirectory: "/Users/test/.letta/agents/agent-1/memory",
+      },
+    );
+
+    expect(result.autoDenied).toHaveLength(1);
+    const [denied] = result.autoDenied;
+    expect(denied?.missingRequiredArgs).toEqual(["command", "description"]);
+    expect(denied?.denyReason).toContain("arrived with empty arguments");
+    expect(denied?.denyReason).toContain("Do not resend an identical call");
+  });
+
+  test("flags unparseable arguments as truncated in transit", async () => {
+    await loadTools();
+    permissionMode.setMode("unrestricted");
+    process.env.MEMORY_DIR = "/Users/test/.letta/agents/agent-1/memory";
+
+    // Shape of a payload truncated mid-string on the way to the client.
+    const truncated = '{"command":"echo hello';
+
+    const result = await classifyApprovals(
+      [
+        {
+          toolCallId: "call_truncated_args",
+          toolName: "Bash",
+          toolArgs: truncated,
+        },
+      ],
+      {
+        requireArgsForAutoApprove: true,
+        workingDirectory: "/Users/test/.letta/agents/agent-1/memory",
+      },
+    );
+
+    expect(result.autoDenied).toHaveLength(1);
+    const [denied] = result.autoDenied;
+    expect(denied?.parsedArgs).toEqual({});
+    expect(denied?.denyReason).toContain(
+      `The raw arguments (${truncated.length} chars) were not valid JSON`,
+    );
+    expect(denied?.denyReason).toContain("Do not resend an identical call");
+  });
+
   test("reports missing exec_command cmd as validation error before auto-allow", async () => {
     await loadSpecificTools(["exec_command"]);
     permissionMode.setMode("unrestricted");

--- a/src/cli/helpers/approval-classification.ts
+++ b/src/cli/helpers/approval-classification.ts
@@ -1,6 +1,7 @@
 import type { ApprovalContext } from "@/permissions/analyzer";
 import { checkToolPermission, getToolSchema } from "@/tools/manager";
 import type { PermissionModeState } from "@/tools/permission-mode-state";
+import { debugWarn } from "@/utils/debug";
 import { safeJsonParseOr } from "./safe-json-parse";
 import type { ApprovalRequest } from "./stream-processor";
 
@@ -56,12 +57,69 @@ function formatMissingRequiredArgsReason(
   toolName: string,
   parsedArgs: Record<string, unknown>,
   missingRequiredArgs: string[],
+  argsParse?: ParsedToolArgs,
 ): string {
   const received = Object.keys(parsedArgs).join(", ");
-  return (
+  const base =
     `${toolName} tool missing required parameter${missingRequiredArgs.length > 1 ? "s" : ""}: ` +
-    `${missingRequiredArgs.join(", ")}. Received parameters: ${received}`
-  );
+    `${missingRequiredArgs.join(", ")}. Received parameters: ${received}`;
+
+  // No arguments at all reached the client. That is almost never the model
+  // omitting them: the payload was dropped or truncated in transit. Say so,
+  // otherwise the model "fixes" a call that was already correct and retries
+  // byte-identically until it burns the turn budget.
+  if (argsParse?.parseFailed) {
+    return (
+      `${base}. The raw arguments (${argsParse.rawLength} chars) were not valid JSON, ` +
+      `so they were lost or truncated in transit. Do not resend an identical call - ` +
+      `re-issue it with the arguments restructured (e.g. write long payloads to a file first).`
+    );
+  }
+  if (argsParse?.argsEmpty) {
+    return (
+      `${base}. The tool call arrived with empty arguments, which usually means they were ` +
+      `dropped in transit rather than omitted by you. Do not resend an identical call - ` +
+      `re-issue it with the arguments restructured (e.g. write long payloads to a file first).`
+    );
+  }
+  return base;
+}
+
+type ParsedToolArgs = {
+  parsedArgs: Record<string, unknown>;
+  /** Raw arguments were non-empty but could not be parsed as JSON. */
+  parseFailed: boolean;
+  /** Raw arguments were absent, empty, or parsed to an object with no keys. */
+  argsEmpty: boolean;
+  rawLength: number;
+};
+
+function parseToolArgs(rawArgs: string | undefined): ParsedToolArgs {
+  const raw = rawArgs ?? "";
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    return {
+      parsedArgs: {},
+      parseFailed: false,
+      argsEmpty: true,
+      rawLength: 0,
+    };
+  }
+  const parsed = safeJsonParseOr<Record<string, unknown> | null>(trimmed, null);
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return {
+      parsedArgs: {},
+      parseFailed: true,
+      argsEmpty: false,
+      rawLength: raw.length,
+    };
+  }
+  return {
+    parsedArgs: parsed,
+    parseFailed: false,
+    argsEmpty: Object.keys(parsed).length === 0,
+    rawLength: raw.length,
+  };
 }
 
 export async function classifyApprovals<TContext = ApprovalContext | null>(
@@ -89,10 +147,15 @@ export async function classifyApprovals<TContext = ApprovalContext | null>(
       continue;
     }
 
-    const parsedArgs = safeJsonParseOr<Record<string, unknown>>(
-      approval.toolArgs || "{}",
-      {},
-    );
+    const argsParse = parseToolArgs(approval.toolArgs);
+    const parsedArgs = argsParse.parsedArgs;
+    if (argsParse.parseFailed) {
+      debugWarn(
+        "approval-classification",
+        `Tool call ${approval.toolCallId} (${toolName}) had unparseable arguments ` +
+          `(${argsParse.rawLength} chars); treating as empty`,
+      );
+    }
 
     if (opts.requireArgsForAutoApprove) {
       const missingRequiredArgs = await getMissingRequiredArgs(
@@ -107,6 +170,7 @@ export async function classifyApprovals<TContext = ApprovalContext | null>(
               toolName,
               parsedArgs,
               missingRequiredArgs,
+              argsParse,
             );
         autoDenied.push({
           approval,


### PR DESCRIPTION
Follow-up to a production incident where three consecutive `Bash` calls were auto-denied with `missing required parameters: command, description` and the model retried byte-identically each time.

## What actually happened

The model emitted full, valid arguments (confirmed in the provider trace: 1781 / 1958 / 1511 chars, all parseable). The args were destroyed server-side, and the persisted approval request carried `arguments = "{}"`. The client then correctly observed empty args and told the model it had forgotten `command` — which the model knew it had not, so it resent the same call. Three times.

The server-side root cause is separate (`_safe_load_tool_call_str` truncating any argument string containing an adjacent close-brace/open-brace pair, a hack predating native parallel tool calls) and needs its own fix in letta-cloud. This PR is the client-side half: make the failure legible instead of blaming the model.

## Change

- `classifyApprovals` now distinguishes three argument shapes: parsed fine, arrived empty, and arrived non-empty but unparseable. Previously `safeJsonParseOr(toolArgs || "{}", {})` collapsed all three into `{}`.
- Deny reasons for the empty and unparseable cases say the payload was lost in transit and instruct the model to restructure rather than resend an identical call. The normal missing-parameter message is unchanged.
- A `debugWarn` fires when a non-empty argument string fails to parse, so silent arg loss leaves a trace.

No behavior change to permission decisions — only the reason text and a debug log.

## Test plan

- [x] `bun test src/cli/approval-classification.test.ts` (13 pass, includes two new regression tests: empty `{}` payload, truncated payload)
- [x] `bun test src/agent/check-approval.test.ts`
- [x] `bun run check`

👾 Generated with [Letta Code](https://letta.com)