### PR TITLE
fix: label xhigh Extra High when catalog has a max tier [LET-11121]

### DIFF
--- a/src/agent/reasoning-effort-label.test.ts
+++ b/src/agent/reasoning-effort-label.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from "bun:test";
+import {
+  catalogHasDistinctMaxTier,
+  formatXhighEffortLabel,
+} from "@/agent/reasoning-effort-label";
+
+describe("catalogHasDistinctMaxTier", () => {
+  test("is true for GPT-5.6 Sol ChatGPT which has a max tier", () => {
+    expect(
+      catalogHasDistinctMaxTier({
+        modelLabel: "GPT-5.6 Sol (ChatGPT)",
+        modelHandle: "chatgpt-plus-pro/gpt-5.6-sol",
+      }),
+    ).toBe(true);
+  });
+
+  test("is false for Opus 4.6 which only exposes xhigh", () => {
+    expect(
+      catalogHasDistinctMaxTier({
+        modelLabel: "Opus 4.6",
+        modelHandle: "anthropic/claude-opus-4-6",
+      }),
+    ).toBe(false);
+  });
+
+  test("is true for Fable 5 and Opus 4.7+ which have a max tier", () => {
+    expect(catalogHasDistinctMaxTier({ modelLabel: "Fable 5" })).toBe(true);
+    expect(catalogHasDistinctMaxTier({ modelLabel: "Opus 4.7" })).toBe(true);
+    expect(catalogHasDistinctMaxTier({ modelLabel: "Opus 4.8" })).toBe(true);
+  });
+});
+
+describe("formatXhighEffortLabel", () => {
+  test("uses Extra High when max is a distinct tier", () => {
+    expect(formatXhighEffortLabel(true)).toBe("Extra High");
+  });
+
+  test("uses Max when xhigh is the top tier", () => {
+    expect(formatXhighEffortLabel(false)).toBe("Max");
+  });
+});

--- a/src/agent/reasoning-effort-label.ts
+++ b/src/agent/reasoning-effort-label.ts
@@ -1,0 +1,24 @@
+import { models } from "@/agent/model-catalog";
+
+/**
+ * LCD and the TUI show `xhigh` as Extra High only when the model also has a
+ * distinct `max` tier. Older catalogs that only expose `xhigh` still label it
+ * Max (Opus 4.6).
+ */
+export function catalogHasDistinctMaxTier(params: {
+  modelLabel?: string;
+  modelHandle?: string;
+}): boolean {
+  const { modelLabel, modelHandle } = params;
+  if (!modelLabel && !modelHandle) return false;
+
+  return models.some((model) => {
+    if (model.updateArgs?.reasoning_effort !== "max") return false;
+    if (modelHandle && model.handle === modelHandle) return true;
+    return Boolean(modelLabel && model.label === modelLabel);
+  });
+}
+
+export function formatXhighEffortLabel(hasDistinctMaxTier: boolean): string {
+  return hasDistinctMaxTier ? "Extra High" : "Max";
+}

--- a/src/cli/components/ModelReasoningSelector.tsx
+++ b/src/cli/components/ModelReasoningSelector.tsx
@@ -1,6 +1,7 @@
 import { Box, useInput } from "ink";
 import { useEffect, useMemo, useState } from "react";
 import type { ModelReasoningSelection } from "@/agent/model";
+import { formatXhighEffortLabel } from "@/agent/reasoning-effort-label";
 import { useTerminalWidth } from "@/cli/hooks/use-terminal-width";
 import { colors } from "./colors";
 import type { ModelSelectorSelection } from "./ModelSelector";
@@ -30,7 +31,7 @@ function formatEffortLabel(
 ): string {
   if (effort === null) return "Default";
   if (effort === "none") return "Off";
-  if (effort === "xhigh") return hasDistinctMaxTier ? "Extra-High" : "Max";
+  if (effort === "xhigh") return formatXhighEffortLabel(hasDistinctMaxTier);
   if (effort === "max") return "Max";
   if (effort === "minimal") return "Minimal";
   return effort.charAt(0).toUpperCase() + effort.slice(1);

--- a/src/websocket/listen-model-update.test.ts
+++ b/src/websocket/listen-model-update.test.ts
@@ -129,7 +129,7 @@ describe("listen-client model update status message", () => {
     expect(result.message).toBe("Model updated to Opus 4.6 (Max).");
   });
 
-  test("shows Extra-High for reasoning_effort xhigh on Fable and Opus 4.7+", () => {
+  test("shows Extra High for reasoning_effort xhigh on Fable and Opus 4.7+", () => {
     for (const modelLabel of ["Fable 5", "Opus 4.7", "Opus 4.8"]) {
       const result = __listenClientTestUtils.buildModelUpdateStatusMessage({
         modelLabel,
@@ -138,9 +138,35 @@ describe("listen-client model update status message", () => {
       });
 
       expect(result.message).toBe(
-        `Model updated to ${modelLabel} (Extra-High).`,
+        `Model updated to ${modelLabel} (Extra High).`,
       );
     }
+  });
+
+  test("shows Extra High for reasoning_effort xhigh on GPT-5.6 Sol ChatGPT", () => {
+    const result = __listenClientTestUtils.buildModelUpdateStatusMessage({
+      modelLabel: "GPT-5.6 Sol (ChatGPT)",
+      toolsetError: null,
+      updateArgs: { reasoning_effort: "xhigh" },
+      modelHandle: "chatgpt-plus-pro/gpt-5.6-sol",
+    });
+
+    expect(result.message).toBe(
+      "Model updated to GPT-5.6 Sol (ChatGPT) (Extra High).",
+    );
+  });
+
+  test("shows Max for reasoning_effort max on GPT-5.6 Sol ChatGPT", () => {
+    const result = __listenClientTestUtils.buildModelUpdateStatusMessage({
+      modelLabel: "GPT-5.6 Sol (ChatGPT)",
+      toolsetError: null,
+      updateArgs: { reasoning_effort: "max" },
+      modelHandle: "chatgpt-plus-pro/gpt-5.6-sol",
+    });
+
+    expect(result.message).toBe(
+      "Model updated to GPT-5.6 Sol (ChatGPT) (Max).",
+    );
   });
 
   test("omits effort when updateArgs has no reasoning_effort", () => {

--- a/src/websocket/listener/commands/model-toolset.ts
+++ b/src/websocket/listener/commands/model-toolset.ts
@@ -13,6 +13,10 @@ import {
   updateAgentLLMConfig,
   updateConversationLLMConfig,
 } from "@/agent/modify";
+import {
+  catalogHasDistinctMaxTier,
+  formatXhighEffortLabel,
+} from "@/agent/reasoning-effort-label";
 import { refreshModelCatalog } from "@/agent/remote-model-catalog";
 import { getBackend } from "@/backend";
 import {
@@ -351,22 +355,19 @@ export function resolveModelForUpdate(
 function formatEffortSuffix(
   modelLabel: string,
   updateArgs?: Record<string, unknown>,
+  modelHandle?: string,
 ): string {
   if (!updateArgs) return "";
   const effort = updateArgs.reasoning_effort;
   if (typeof effort !== "string" || effort.length === 0) return "";
-  const xhighLabel =
-    modelLabel.includes("Fable 5") ||
-    modelLabel.includes("Opus 4.7") ||
-    modelLabel.includes("Opus 4.8")
-      ? "Extra-High"
-      : "Max";
   const labels: Record<string, string> = {
     none: "No Reasoning",
     low: "Low",
     medium: "Medium",
     high: "High",
-    xhigh: xhighLabel,
+    xhigh: formatXhighEffortLabel(
+      catalogHasDistinctMaxTier({ modelLabel, modelHandle }),
+    ),
     max: "Max",
   };
   return ` (${labels[effort] ?? effort})`;
@@ -376,9 +377,10 @@ export function buildModelUpdateStatusMessage(params: {
   modelLabel: string;
   toolsetError: string | null;
   updateArgs?: Record<string, unknown>;
+  modelHandle?: string;
 }): { message: string; level: "info" | "warning" } {
-  const { modelLabel, toolsetError, updateArgs } = params;
-  let message = `Model updated to ${modelLabel}${formatEffortSuffix(modelLabel, updateArgs)}.`;
+  const { modelLabel, toolsetError, updateArgs, modelHandle } = params;
+  let message = `Model updated to ${modelLabel}${formatEffortSuffix(modelLabel, updateArgs, modelHandle)}.`;
   if (toolsetError) {
     message += ` Warning: toolset switch failed (${toolsetError}).`;
     return { message, level: "warning" };
@@ -515,6 +517,7 @@ export async function applyModelUpdateForRuntime(params: {
       modelLabel: model.label,
       toolsetError,
       updateArgs: model.updateArgs,
+      modelHandle: model.handle,
     });
 
   emitStatusDelta(socket, scopedRuntime, {


### PR DESCRIPTION
## Summary

LCD shows Extra High in the reasoning selector for GPT-5.6 Sol (ChatGPT), but the listener status line said Max after selecting that tier.

The status string is built in letta-code (`formatEffortSuffix`). It labeled `xhigh` as Extra-High only for a hardcoded Fable 5 / Opus 4.7+ name list, and Max for everything else — including models that now have both `xhigh` and `max` in the catalog.

This change:
- Looks up whether the catalog has a distinct `max` tier for the selected model
- Labels `xhigh` as Extra High when `max` exists, and Max when `xhigh` is still the top tier (Opus 4.6)
- Aligns TUI copy with LCD (`Extra High` instead of `Extra-High`)

Fixes [LET-11121](https://linear.app/letta/issue/LET-11121/reasoning-level-system-reminder-does-not-match-setting).

## Verification

- `bun test src/agent/reasoning-effort-label.test.ts` — 5 pass
- `bun test src/websocket/listen-model-update.test.ts` — 29 pass
- `bun run check` — 12/12 PASS (biome, typescript, cycles, boundaries)

## AI Disclosure

- [ ] This pull request was written entirely by a human
- [x] This pull request was written with AI assistance and reviewed and edited by a human
- [x] I have read the [AI Policy](https://github.com/letta-ai/letta-code/blob/main/AI_POLICY.md) and agree to its terms

## AI Tool(s) Used

Cursor Cloud Agent (Grok 4.6)

## Human Verification

I have reviewed and understand every change in this pull request and take responsibility for its correctness.
