### PR TITLE
fix(channels): contain adapter failures instead of crashing the gateway

### DIFF
--- a/src/cli/subcommands/channel-gateway.test.ts
+++ b/src/cli/subcommands/channel-gateway.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test } from "bun:test";
+import {
+  type ChannelFailureContainmentTarget,
+  installChannelFailureContainment,
+} from "@/cli/subcommands/channel-gateway";
+
+function createTarget() {
+  const handlers = new Map<string, (value: never) => void>();
+  const target: ChannelFailureContainmentTarget = {
+    on(event: string, listener: (value: never) => void) {
+      handlers.set(event, listener);
+      return target;
+    },
+  } as ChannelFailureContainmentTarget;
+  return { target, handlers };
+}
+
+describe("installChannelFailureContainment", () => {
+  test("registers handlers for both escape routes", () => {
+    const { target, handlers } = createTarget();
+
+    installChannelFailureContainment(target, () => {});
+
+    expect([...handlers.keys()].sort()).toEqual([
+      "uncaughtException",
+      "unhandledRejection",
+    ]);
+  });
+
+  test("reports an uncaught adapter failure instead of rethrowing", () => {
+    const { target, handlers } = createTarget();
+    const logged: string[] = [];
+
+    installChannelFailureContainment(target, (message) => {
+      logged.push(message);
+    });
+    const error = new Error("An API error occurred: invalid_auth");
+    // The gateway must survive this — an unkillable restart loop is what a
+    // revoked channel credential used to cause.
+    expect(() => {
+      handlers.get("uncaughtException")?.(error as never);
+    }).not.toThrow();
+
+    expect(logged[0]).toBe(
+      "[ChannelGateway] contained uncaughtException: An API error occurred: invalid_auth",
+    );
+  });
+
+  test("reports a rejection whose reason is not an Error", () => {
+    const { target, handlers } = createTarget();
+    const logged: string[] = [];
+
+    installChannelFailureContainment(target, (message) => {
+      logged.push(message);
+    });
+    handlers.get("unhandledRejection")?.("socket closed" as never);
+
+    expect(logged).toEqual([
+      "[ChannelGateway] contained unhandledRejection: socket closed",
+    ]);
+  });
+});

--- a/src/cli/subcommands/channel-gateway.ts
+++ b/src/cli/subcommands/channel-gateway.ts
@@ -32,6 +32,53 @@ function isGatewayCommandEnvelope(
   );
 }
 
+/**
+ * Minimal surface of `process` this module registers failure handlers on, so
+ * tests can observe registration without installing global handlers.
+ */
+export interface ChannelFailureContainmentTarget {
+  on(event: "uncaughtException", listener: (error: Error) => void): unknown;
+  on(event: "unhandledRejection", listener: (reason: unknown) => void): unknown;
+}
+
+/**
+ * Keep a channel adapter's background failure from killing the gateway.
+ *
+ * Adapter startup is already guarded — `startChannelAccounts` catches per
+ * account and reports a failure. But an adapter's own background work escapes
+ * that guard: Slack's socket-mode client keeps retrying `apps.connections.open`
+ * on its own timer, and once a token is revoked that rejection surfaces on the
+ * gateway's event loop with nothing awaiting it.
+ *
+ * Left uncaught it exits the process, the supervisor restarts it, the same
+ * revoked token fails again — an unkillable loop that also takes down every
+ * other channel and, because the listener restarts alongside it, leaves the
+ * Desktop environment permanently "Connecting...". A permanently-bad
+ * credential is not something a restart can fix, so contain it here: report it
+ * and keep serving the channels that do work.
+ */
+export function installChannelFailureContainment(
+  target: ChannelFailureContainmentTarget = process,
+  log: (message: string) => void = (message) => {
+    console.error(message);
+  },
+): void {
+  const report = (scope: string, error: unknown): void => {
+    const message = error instanceof Error ? error.message : String(error);
+    log(`[ChannelGateway] contained ${scope}: ${message}`);
+    if (error instanceof Error && error.stack) {
+      log(error.stack);
+    }
+  };
+
+  target.on("uncaughtException", (error) => {
+    report("uncaughtException", error);
+  });
+  target.on("unhandledRejection", (reason) => {
+    report("unhandledRejection", reason);
+  });
+}
+
 export async function runChannelGatewaySubcommand(
   argv: string[],
 ): Promise<number> {
@@ -96,6 +143,8 @@ export async function runChannelGatewaySubcommand(
       await ensureChannelRuntimeInstalled(channelName);
     }
   }
+
+  installChannelFailureContainment();
 
   return await new Promise<number>((resolve) => {
     let closing = false;


### PR DESCRIPTION
## Summary

A revoked Slack token puts the Desktop app into an unkillable restart loop.

Adapter startup is already guarded — `startChannelAccounts` catches per account and reports a failure, and Desktop already passes `--allow-startup-errors`, so one bad account is meant not to block the rest. But an adapter's own background work escapes that guard: Slack's socket-mode client keeps retrying `apps.connections.open` on its own timer, and once the token is revoked that rejection lands on the gateway's event loop with nothing awaiting it.

Node exits the process, the supervisor restarts it, the same revoked token fails again.

Observed on 0.30.25 with an expired Slack account: **18 gateway crashes and 10 listener respawns in four minutes** — roughly one crash every two seconds. The log ends in Node's uncaught-exception banner, after the clean `[Channels] Failed to start slack/…` line that shows the startup guard did its job:

```
[Channels] Failed to start slack/66dc64ab-…: An API error occurred: invalid_auth
[ChannelGateway] Error: An API error occurred: invalid_auth
[ChannelGateway]     at platformErrorFromResult (@slack/web-api/dist/errors.js:67:33)
[ChannelGateway] Node.js v22.22.0
[ChannelGateway] ChannelGateway exited unexpectedly (1)
[ChannelGateway] started pid=25764        <- immediately restarts
```

Because the listener restarts alongside the gateway, its device WebSocket flaps continuously, the cloud never sees a fresh heartbeat, and the Desktop environment selector sits on `Connecting...` forever while startup crawls.

A permanently-bad credential is not something a restart can fix, so this reports it and keeps serving the channels that work.

## Verification

Reproduced against the packaged 0.30.25 app, then confirmed the trigger by removing the expired account from the same install:

| | before | after |
| --- | --- | --- |
| ChannelGateway crashes | 18 | 0 |
| Listener respawns | 10 in 4 min | 3 (initial only) |
| Device disconnects | continuous | 0 |

Environment selector then read `Local` instead of `Connecting...`, checked over CDP against the running renderer rather than by eye.

- `bun test src/cli/subcommands/channel-gateway.test.ts` — 3 pass (new)
- `bun test src/cli/subcommands/` — 255 pass
- `bun test src/channels/` — 1207 pass, 5 fail; all 5 fail identically on the base commit (4 WhatsApp symlink tests that don't work on Windows, 1 pre-existing supervisor test)
- `bun run typecheck` — clean
- biome + all pre-commit hooks — clean

## Follow-up

Containment is silent by design, so the channel is simply dead with no signal. letta-cloud PR #14684 surfaces `enabled && !running` as a toast in Desktop.

## AI Tool(s) Used

Claude Code (Opus 5) — diagnosis, patch, and tests.

## Human Verification

Not yet signed off — needs a maintainer to review and take responsibility per AI_POLICY.md before this leaves draft.
