### PR TITLE
feat(cli): teleport to Desktop Local [LET-11100]

### DIFF
--- a/src/backend/api/environments.test.ts
+++ b/src/backend/api/environments.test.ts
@@ -1,9 +1,33 @@
 import { describe, expect, test } from "bun:test";
+import type {
+  EnvironmentConnection,
+  listEnvironments,
+} from "@/backend/api/environments";
 import {
   createAgentSandbox,
+  resolveDesktopEnvironmentConnectionId,
   teleportToEnvironment,
 } from "@/backend/api/environments";
 import type { apiRequest } from "@/backend/api/request";
+
+function environment(
+  overrides: Partial<EnvironmentConnection> = {},
+): EnvironmentConnection {
+  const now = Date.now();
+  return {
+    id: "env-1",
+    connectionId: "conn-1",
+    deviceId: "device-1",
+    connectionName: "Environment",
+    organizationId: "org-1",
+    podId: "pod-1",
+    connectedAt: now,
+    lastHeartbeat: now,
+    lastSeenAt: now,
+    firstSeenAt: now,
+    ...overrides,
+  };
+}
 
 describe("Cloud sandbox environment resolution", () => {
   test("sends conversationId in the create request body", async () => {
@@ -54,6 +78,74 @@ describe("Cloud sandbox environment resolution", () => {
     await createAgentSandbox("agent-1", { conversationId: "default" }, request);
 
     expect(bodies).toEqual([{}]);
+  });
+});
+
+describe("Desktop environment resolution", () => {
+  test("resolves the one online Desktop listener to its Cloud lease", async () => {
+    const list = (async (options) => {
+      expect(options).toEqual({ limit: 100, onlineOnly: true });
+      return {
+        connections: [
+          environment({
+            connectionId: "conn-desktop",
+            listenerInstanceId: "desktop-direct-cloud:install-1",
+            connectionName: "Caren's Mac",
+          }),
+          environment({
+            id: "env-server",
+            connectionId: "conn-server",
+            listenerInstanceId: "desktop-primary:install-1",
+          }),
+        ],
+        hasNextPage: false,
+      };
+    }) as typeof listEnvironments;
+
+    const result = await resolveDesktopEnvironmentConnectionId(list);
+
+    expect(result.connectionId).toBe("conn-desktop");
+    expect(result.environment.connectionName).toBe("Caren's Mac");
+  });
+
+  test("requires Desktop Remote Access to be online", async () => {
+    const list = (async () => ({
+      connections: [
+        environment({
+          connectionId: null,
+          listenerInstanceId: "desktop-direct-cloud:install-1",
+          lastHeartbeat: null,
+        }),
+      ],
+      hasNextPage: false,
+    })) as typeof listEnvironments;
+
+    await expect(resolveDesktopEnvironmentConnectionId(list)).rejects.toThrow(
+      "enable Remote Access",
+    );
+  });
+
+  test("requires an explicit target when several Desktops are online", async () => {
+    const list = (async () => ({
+      connections: [
+        environment({
+          connectionId: "conn-desktop-1",
+          listenerInstanceId: "desktop-direct-cloud:install-1",
+          connectionName: "MacBook",
+        }),
+        environment({
+          id: "env-2",
+          connectionId: "conn-desktop-2",
+          listenerInstanceId: "desktop-direct-cloud:install-2",
+          connectionName: "Mac Mini",
+        }),
+      ],
+      hasNextPage: false,
+    })) as typeof listEnvironments;
+
+    await expect(resolveDesktopEnvironmentConnectionId(list)).rejects.toThrow(
+      "Multiple Desktop environments are online",
+    );
   });
 });
 

--- a/src/backend/api/environments.ts
+++ b/src/backend/api/environments.ts
@@ -121,6 +121,34 @@ export function describeEnvironment(
   return `${environment.connectionName} (${environment.deviceId}, ${status})`;
 }
 
+export async function resolveDesktopEnvironmentConnectionId(
+  list: typeof listEnvironments = listEnvironments,
+): Promise<{ connectionId: string; environment: EnvironmentConnection }> {
+  const response = await list({ limit: 100, onlineOnly: true });
+  const matches = response.connections.filter(
+    (environment) =>
+      environment.listenerInstanceId?.startsWith("desktop-direct-cloud:") ===
+        true && isEnvironmentOnline(environment),
+  );
+
+  if (matches.length === 0) {
+    throw new Error(
+      "Desktop Local is unavailable. Open Letta Desktop, enable Remote Access, and wait for its environment to come online.",
+    );
+  }
+  if (matches.length > 1) {
+    throw new Error(
+      `Multiple Desktop environments are online. Run \`letta teleport list\` and choose one by name, device ID, or connection ID. Matched: ${matches.map(describeEnvironment).join(", ")}`,
+    );
+  }
+
+  const environment = matches[0];
+  if (!environment?.connectionId) {
+    throw new Error("Desktop Local has no active connection id");
+  }
+  return { connectionId: environment.connectionId, environment };
+}
+
 export async function resolveEnvironmentConnectionId(
   selector: string,
 ): Promise<{ connectionId: string; environment: EnvironmentConnection }> {

--- a/src/cli/subcommands/router.test.ts
+++ b/src/cli/subcommands/router.test.ts
@@ -159,6 +159,7 @@ describe("subcommand router", () => {
       expect(exitCode).toBe(0);
       expect(messages.join("\n")).toContain("letta teleport list");
       expect(messages.join("\n")).toContain("letta teleport cloud");
+      expect(messages.join("\n")).toContain("letta teleport local");
       expect(messages.join("\n")).not.toContain("letta teleport back");
     } finally {
       console.log = originalLog;

--- a/src/cli/subcommands/teleport.test.ts
+++ b/src/cli/subcommands/teleport.test.ts
@@ -65,10 +65,8 @@ describe("teleport subcommand", () => {
       expect(exitCode).toBe(0);
       expect(out.messages.join("\n")).toContain("letta teleport list");
       expect(out.messages.join("\n")).toContain("letta teleport cloud");
+      expect(out.messages.join("\n")).toContain("letta teleport local");
       expect(out.messages.join("\n")).not.toContain("letta teleport back");
-      expect(out.messages.join("\n")).toContain(
-        "Desktop Local is not a teleport target yet",
-      );
     } finally {
       out.restore();
     }
@@ -261,7 +259,7 @@ describe("teleport subcommand", () => {
     }
   });
 
-  test("back explains that return teleport is not supported yet", async () => {
+  test("back directs callers to the explicit local target", async () => {
     const out = captureOutput();
     try {
       const exitCode = await withEnvironment(CLOUD_ENV, () =>
@@ -272,7 +270,52 @@ describe("teleport subcommand", () => {
       );
 
       expect(exitCode).toBe(1);
-      expect(out.errors[0]).toContain("Teleport back is not supported yet");
+      expect(out.errors[0]).toContain("Use `letta teleport local`");
+    } finally {
+      out.restore();
+    }
+  });
+
+  test("local resolves the online Desktop lease and submits teleport", async () => {
+    const out = captureOutput();
+    const teleportCalls: Array<{ targetConnectionId: string }> = [];
+    try {
+      const exitCode = await withEnvironment(CLOUD_ENV, () =>
+        runTeleportSubcommand(["local"], {
+          initializeSettings: async () => {},
+          getLastSession: () => null,
+          resolveDesktopEnvironmentConnectionId: async () => ({
+            connectionId: "conn-desktop",
+            environment: {} as never,
+          }),
+          teleportToEnvironment: async (
+            _agentId,
+            _conversationId,
+            targetConnectionId,
+          ) => {
+            teleportCalls.push({ targetConnectionId });
+            return {
+              id: "teleport-local",
+              agentId: "agent-1",
+              conversationId: "conv-1",
+              sourceConnectionId: "conn-cloud",
+              targetConnectionId,
+              targetDeviceId: "device-desktop",
+              targetConnectionName: "Caren's Mac",
+              status: "waiting_for_source",
+              error: null,
+              createdAt: 1,
+              updatedAt: 1,
+            };
+          },
+        }),
+      );
+
+      expect(exitCode).toBe(0);
+      expect(teleportCalls).toEqual([{ targetConnectionId: "conn-desktop" }]);
+      expect(JSON.parse(out.messages[0] ?? "{}").targetConnectionId).toBe(
+        "conn-desktop",
+      );
     } finally {
       out.restore();
     }
@@ -305,7 +348,7 @@ describe("teleport subcommand", () => {
 
       expect(exitCode).toBe(1);
       expect(out.errors[0]).toContain(
-        "Desktop Local is not a teleport target yet",
+        "Desktop-local connection is not Cloud-routable",
       );
     } finally {
       out.restore();

--- a/src/cli/subcommands/teleport.ts
+++ b/src/cli/subcommands/teleport.ts
@@ -5,6 +5,7 @@ import {
   isEnvironmentOnline,
   listEnvironments,
   resolveAgentSandboxConnectionId,
+  resolveDesktopEnvironmentConnectionId,
   resolveEnvironmentConnectionId,
   teleportToEnvironment,
 } from "@/backend/api/environments";
@@ -17,6 +18,7 @@ interface TeleportSubcommandDeps {
   listEnvironments?: typeof listEnvironments;
   resolveEnvironmentConnectionId?: typeof resolveEnvironmentConnectionId;
   resolveAgentSandboxConnectionId?: typeof resolveAgentSandboxConnectionId;
+  resolveDesktopEnvironmentConnectionId?: typeof resolveDesktopEnvironmentConnectionId;
   teleportToEnvironment?: typeof teleportToEnvironment;
 }
 
@@ -30,6 +32,7 @@ function printUsage(): void {
 Usage:
   letta teleport list
   letta teleport cloud
+  letta teleport local
   letta teleport <environment>
 
 Notes:
@@ -39,10 +42,10 @@ Notes:
   - Requires a Letta Cloud agent and a non-virtual conversation.
   - list: prints accessible online remote environments as JSON.
   - cloud: teleports to the agent's Cloud sandbox.
+  - local: teleports to the one online Desktop environment. Desktop Remote
+    Access must be enabled; if several are online, choose one explicitly.
   - <environment>: teleports to a specific remote environment by name,
     device-id, connection-id, or environment id.
-  - Desktop Local is not a teleport target yet. Use the Desktop environment
-    picker to switch back to Local.
   - Output is JSON only.
 `.trim(),
   );
@@ -147,7 +150,7 @@ function assertTeleportableRemoteEnvironment(
 ): void {
   if (!isTeleportableRemoteEnvironment(environment)) {
     throw new Error(
-      "Desktop Local is not a teleport target yet. Use the Desktop environment picker to switch back to Local.",
+      "The Desktop-local connection is not Cloud-routable. Use `letta teleport local` to resolve its Remote Access environment.",
     );
   }
 }
@@ -210,9 +213,15 @@ export async function runTeleportSubcommand(
         conversationId: session.conversationId,
       });
       targetConnectionId = result.connectionId;
+    } else if (action === "local") {
+      const resolve =
+        deps.resolveDesktopEnvironmentConnectionId ??
+        resolveDesktopEnvironmentConnectionId;
+      const result = await resolve();
+      targetConnectionId = result.connectionId;
     } else if (action === "back") {
       throw new Error(
-        "Teleport back is not supported yet. Use the Desktop environment picker to switch back to Local.",
+        "Teleport back is not supported. Use `letta teleport local` or choose an explicit environment.",
       );
     } else {
       const resolve =

--- a/src/index.ts
+++ b/src/index.ts
@@ -208,7 +208,7 @@ SUBCOMMANDS
   letta agents list [--query <text> | --name <name> | --tags <tags>]
   letta environments list [--online-only]
   letta environments current
-  letta teleport list|cloud|<environment>
+  letta teleport list|cloud|local|<environment>
   letta messages search --query <text> [--all-agents]
   letta messages list [--agent <id>]
   letta messages transcript --conversation <id> [--out <path>]

--- a/src/skills/builtin/teleporting-between-environments/SKILL.md
+++ b/src/skills/builtin/teleporting-between-environments/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: teleporting-between-environments
-description: Moves the current agent conversation to Cloud or a Cloud-registered remote environment while coordinating machine-local files and setup. Use when the user says "let's continue this task on cloud", asks to continue or move work on another connected computer, wants to teleport between environments, or needs to upload or download artifacts before a handoff.
+description: Moves the current agent conversation to Cloud, Desktop Local, or another Cloud-registered environment while coordinating machine-local files and setup. Use when the user says "let's continue this task on cloud", asks to continue or move work on another connected computer, wants to teleport between environments, or needs to upload or download artifacts before a handoff.
 ---
 
 # Teleporting Between Environments
@@ -19,17 +19,16 @@ Teleport the current agent and conversation without losing conversational memory
 ```bash
 letta teleport list
 letta teleport cloud
+letta teleport local
 letta teleport <environment>
 ```
 
-- `list`: show accessible online remote targets. Desktop Local is excluded.
+- `list`: show accessible online Cloud-registered targets.
 - `cloud`: create or resume this conversation’s managed Cloud sandbox.
+- `local`: target the one online Letta Desktop environment. Desktop Remote Access must be enabled. If several Desktop environments are online, use `list` and target one explicitly.
 - `<environment>`: target a listed remote environment by its friendly selector.
 
-Teleport cannot target Desktop Local yet. Once the conversation runs in Cloud,
-the agent cannot programmatically return to Desktop Local. The user can still
-switch manually with Desktop's environment picker. Do not run or recommend
-`letta teleport back`.
+Do not run or recommend `letta teleport back`; return to Desktop with `local`.
 
 Transfer files with the existing sandbox commands:
 
@@ -80,9 +79,24 @@ If the command reports an offline, stale, unsupported, same-source, or startup e
 
 ### Return to Desktop Local
 
-The agent cannot initiate this transition. Retain the next local action and ask
-the user to select Local from Desktop's environment picker. After continuation
-locally, resume the task from the retained context.
+1. Retain the next local action and any setup the Desktop environment needs.
+2. Confirm Desktop is open with Remote Access enabled. If more than one Desktop environment is online, use `letta teleport list` and choose one explicitly.
+3. As the final action, run:
+
+   ```bash
+   letta teleport local
+   ```
+
+### Run a separate headless turn on an environment
+
+Use `--environment` when a separate headless invocation, rather than the current conversation handoff, should execute on Cloud or another online environment:
+
+```bash
+letta -p --conversation <id> --environment cloud "<prompt>"
+letta -p --conversation <id> --environment <name|device-id|connection-id> "<prompt>"
+```
+
+This routes that headless message only. Use `letta teleport ...` to move the currently executing conversation.
 
 ### Continue on another connected computer
 


### PR DESCRIPTION
## Summary
- add `letta teleport local` and resolve it to the one online Desktop Remote Access `conn-*` lease
- fail safely when Desktop is offline or multiple Desktop installations are ambiguous
- update the bundled teleport skill with Local return and headless `--environment` workflows

## Validation
- `bun test src/backend/api/environments.test.ts src/cli/subcommands/teleport.test.ts src/cli/subcommands/router.test.ts`
- `bun run check`

Linear: [LET-11100](https://linear.app/letta/issue/LET-11100/teleport-feature-for-environments)

👾 Generated with [Letta Code](https://letta.com)