### PR TITLE
fix(cli): document required --name and --description in cron add help

### DIFF
--- a/src/cli/subcommands/cron.test.ts
+++ b/src/cli/subcommands/cron.test.ts
@@ -160,6 +160,21 @@ afterEach(() => {
   }
 });
 
+describe("cron add help text", () => {
+  test("help documents the required --name and --description options", async () => {
+    const logs: string[] = [];
+    console.log = mock((line: string) => {
+      logs.push(String(line));
+    });
+
+    expect(await runCronSubcommand(["add", "--help"])).toBe(0);
+
+    const help = logs.join("");
+    expect(help).toContain("--name <name>");
+    expect(help).toContain("--description <desc>");
+  });
+});
+
 describe("cron add execution targeting", () => {
   test("Cloud schedules default to a new conversation per fire and ignore ambient conversation state", async () => {
     process.env.LETTA_CONVERSATION_ID = "ambient-conversation";

--- a/src/cli/subcommands/cron.ts
+++ b/src/cli/subcommands/cron.ts
@@ -86,6 +86,8 @@ Usage:
   letta cron delete --all [--agent <id>] [--runner local|cloud]
 
 Add options:
+  --name <name>          Schedule name (required)
+  --description <desc>   Schedule description (required)
   --prompt <text>        Prompt to send to the agent (required)
   --every <interval>     Recurring interval (e.g. 5m, 2h, 1d)
   --at <time>            Scheduled time (e.g. "3:00pm", "in 45m")


### PR DESCRIPTION
## Summary

`letta cron add --help` omits `--name` and `--description` from the documented Add options even though `handleAdd` requires both and rejects invocations that omit them:

```
$ letta cron add --prompt 'test' --at '2099-01-01T00:00:00Z'
Error: --name is required.
$ letta cron add --name 'test' --prompt 'test' --at '2099-01-01T00:00:00Z'
Error: --description is required.
```

This PR adds both options to the `Add options` section of the usage text, marked `(required)`, so the displayed help matches the actual CLI contract.

## Verification

Added a regression test asserting `letta cron add --help` documents `--name <name>` and `--description <desc>`.

Ran:

```
bun test src/cli/subcommands/cron.test.ts        # 13 pass, 0 fail
bunx --bun @biomejs/biome@2.2.5 check src/cli/subcommands/cron.ts src/cli/subcommands/cron.test.ts   # clean
bunx tsc --noEmit                                # clean
```

Closes #3895

## AI Disclosure

- [ ] This pull request was written entirely by a human
- [x] This pull request was written with AI assistance and reviewed and edited by a human
- [ ] I have read the [AI Policy](https://github.com/letta-ai/letta-code/blob/main/AI_POLICY.md) and agree to its terms

## AI Tool(s) Used

Command Code (Claude) drafted the change and test; I reviewed, verified, and edited the complete submission and take responsibility for it.

## Human Verification

I have reviewed and understand every change in this pull request and take responsibility for its correctness.