### PR TITLE
ci: run Amelia reviews in cloud sandbox

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -75,13 +75,14 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.AMELIA_GITHUB_TOKEN }}
 
-      - uses: letta-ai/letta-code-action@daa80f29e345315623ff759f5ecf5018946bbc15
+      - uses: letta-ai/letta-code-action@4b8e508a523ff576fee09be1432d6f39158c272c
         id: letta_review
         if: steps.lint_wait.outputs.skipped != 'true'
         with:
           letta_api_key: ${{ secrets.AMELIA_LETTA_API_KEY }}
           github_token: ${{ secrets.AMELIA_GITHUB_TOKEN }}
           agent_id: agent-cd664b86-4d28-49b7-8ad6-60677eaff9be
+          environment: cloud
           track_progress: ""
           tracking_comment: "false"
           model: auto


### PR DESCRIPTION
## Summary
- update the Amelia review workflow to the sandbox-enabled Letta Code Action revision
- route headless review execution through `environment: cloud` instead of the GitHub Actions runner

## Test plan
- [x] `bun run check`

Linear: [LET-11148](https://linear.app/letta/issue/LET-11148/run-amelia-code-reviews-in-cloud-sandbox)

👾 Generated with [Letta Code](https://letta.com)