### PR TITLE
ci: run Codex watcher in cloud sandbox

### DIFF
--- a/.github/agent-prompts/codex-agent-watch.md
+++ b/.github/agent-prompts/codex-agent-watch.md
@@ -1,4 +1,4 @@
-You are Amelia running in GitHub Actions for `letta-ai/letta-code`.
+You are Amelia running in your managed cloud sandbox for `letta-ai/letta-code`, dispatched by GitHub Actions.
 
 Your job is to review one stable `openai/codex` release against the local Letta Code harness and either open a focused PR or record that no local change is needed.
 
@@ -6,7 +6,19 @@ Your job is to review one stable `openai/codex` release against the local Letta 
 
 The legacy `.github/workflows/codex-release-watch.yml` issue workflow is still enabled as the baseline. This new workflow must keep its own state in the central tracker issue and must not rely on per-release `codex-watch` issues for dedupe.
 
-The detector already compared the latest stable Codex release to the previous stable release and wrote a JSON payload. Use the payload below as your starting point.
+The detector already compared the latest stable Codex release to the previous stable release. Use the reconstructed analysis file as your starting point.
+
+## Sandbox setup
+
+The detector ran on a GitHub Actions runner, but your turn does not. The runner checkout, environment variables, and analysis file path are unavailable in the sandbox. The run inputs and an exact bootstrap command are included below in this prompt.
+
+Before reviewing the release, run the exact `Sandbox bootstrap` block below. It:
+
+1. Clones `letta-ai/letta-code` into `/tmp/letta-code-codex-watch`.
+2. Reconstructs the detector payload at `/tmp/codex-watch-analysis.json`.
+3. Installs the repository dependencies.
+
+Perform all repository inspection, edits, tests, and tracker updates from that sandbox clone. Use the tracker issue number and tags from the `Run inputs` block directly rather than relying on environment variables.
 
 ## Required behavior
 
@@ -30,20 +42,20 @@ Many upstream Codex tool changes are upstream-only: MCP/plugin internals, Respon
 
 ## Tracker updates
 
-The detector provides:
+The prompt provides:
 
 - tracker issue number
 - tracker issue URL
-- analysis JSON file path
+- reconstructed analysis at `/tmp/codex-watch-analysis.json`
 
 Always update the tracker before your final response.
 
 For no local impact:
 
 ```bash
-bun scripts/codex-watch/update-tracker.ts \
-  --tracker-issue "$TRACKER_ISSUE" \
-  --analysis-file "$ANALYSIS_FILE" \
+GH_TOKEN="$GITHUB_TOKEN" bun scripts/codex-watch/update-tracker.ts \
+  --tracker-issue <tracker-issue> \
+  --analysis-file /tmp/codex-watch-analysis.json \
   --outcome no_local_impact \
   --notes "<short reason>"
 ```
@@ -51,9 +63,9 @@ bun scripts/codex-watch/update-tracker.ts \
 For a PR:
 
 ```bash
-bun scripts/codex-watch/update-tracker.ts \
-  --tracker-issue "$TRACKER_ISSUE" \
-  --analysis-file "$ANALYSIS_FILE" \
+GH_TOKEN="$GITHUB_TOKEN" bun scripts/codex-watch/update-tracker.ts \
+  --tracker-issue <tracker-issue> \
+  --analysis-file /tmp/codex-watch-analysis.json \
   --outcome pr_created \
   --pr-url "$PR_URL" \
   --notes "<short summary of local mirror update>"
@@ -62,9 +74,9 @@ bun scripts/codex-watch/update-tracker.ts \
 For blocked/uncertain:
 
 ```bash
-bun scripts/codex-watch/update-tracker.ts \
-  --tracker-issue "$TRACKER_ISSUE" \
-  --analysis-file "$ANALYSIS_FILE" \
+GH_TOKEN="$GITHUB_TOKEN" bun scripts/codex-watch/update-tracker.ts \
+  --tracker-issue <tracker-issue> \
+  --analysis-file /tmp/codex-watch-analysis.json \
   --outcome needs_human_review \
   --notes "<short reason>"
 ```
@@ -74,6 +86,7 @@ bun scripts/codex-watch/update-tracker.ts \
 If you create a PR:
 
 - create a new branch from the checked-out branch
+- use `GH_TOKEN="$GITHUB_TOKEN"` for GitHub CLI commands so the sandbox injects GitHub credentials
 - keep the diff minimal and focused on this Codex release
 - do not include unrelated cleanup
 - use a Conventional Commit PR title, for example `chore(tools): align Codex schema wording`

--- a/.github/workflows/codex-agent-watch.yml
+++ b/.github/workflows/codex-agent-watch.yml
@@ -66,6 +66,7 @@ jobs:
           PREVIOUS_TAG: ${{ steps.detect.outputs.previous_tag }}
           VERDICT: ${{ steps.detect.outputs.verdict }}
         run: |
+          ANALYSIS_ARCHIVE_BASE64=$(gzip -c "$ANALYSIS_FILE" | base64 -w 0)
           {
             echo "prompt<<AMELIA_PROMPT_EOF"
             cat .github/agent-prompts/codex-agent-watch.md
@@ -73,36 +74,32 @@ jobs:
             echo "## Run inputs"
             echo
             echo "- Tracker issue: #$TRACKER_ISSUE ($TRACKER_ISSUE_URL)"
-            echo "- Analysis file: $ANALYSIS_FILE"
             echo "- Current tag: $CURRENT_TAG"
             echo "- Previous tag: $PREVIOUS_TAG"
             echo "- Detector verdict: $VERDICT"
             echo
-            echo "The same values are available in the environment as TRACKER_ISSUE, TRACKER_ISSUE_URL, ANALYSIS_FILE, CURRENT_TAG, PREVIOUS_TAG, and VERDICT."
+            echo "## Sandbox bootstrap"
             echo
-            echo "## Analysis JSON"
+            echo "Run this exact block before reviewing the release:"
             echo
-            echo '```json'
-            cat "$ANALYSIS_FILE"
+            echo '```bash'
+            echo 'rm -rf /tmp/letta-code-codex-watch'
+            echo 'GH_TOKEN="$GITHUB_TOKEN" gh repo clone letta-ai/letta-code /tmp/letta-code-codex-watch'
+            echo 'cd /tmp/letta-code-codex-watch'
+            echo "printf '%s' '$ANALYSIS_ARCHIVE_BASE64' | base64 --decode | gzip --decompress > /tmp/codex-watch-analysis.json"
+            echo 'bun install --frozen-lockfile'
             echo '```'
             echo "AMELIA_PROMPT_EOF"
           } >> "$GITHUB_OUTPUT"
 
       - name: Ask Amelia to review actionable Codex drift
         if: steps.detect.outputs.should_run_agent == 'true'
-        uses: letta-ai/letta-code-action@daa80f29e345315623ff759f5ecf5018946bbc15
-        env:
-          GH_TOKEN: ${{ secrets.AMELIA_GITHUB_TOKEN }}
-          TRACKER_ISSUE: ${{ steps.detect.outputs.tracker_issue }}
-          TRACKER_ISSUE_URL: ${{ steps.detect.outputs.tracker_issue_url }}
-          ANALYSIS_FILE: ${{ steps.detect.outputs.analysis_file }}
-          CURRENT_TAG: ${{ steps.detect.outputs.current_tag }}
-          PREVIOUS_TAG: ${{ steps.detect.outputs.previous_tag }}
-          VERDICT: ${{ steps.detect.outputs.verdict }}
+        uses: letta-ai/letta-code-action@4b8e508a523ff576fee09be1432d6f39158c272c
         with:
           letta_api_key: ${{ secrets.AMELIA_LETTA_API_KEY }}
           github_token: ${{ secrets.AMELIA_GITHUB_TOKEN }}
           agent_id: agent-cd664b86-4d28-49b7-8ad6-60677eaff9be
+          environment: cloud
           track_progress: ""
           tracking_comment: "false"
           model: auto


### PR DESCRIPTION
## Summary
- update Codex Agent Watch to the sandbox-enabled Letta Code Action revision and set `environment: cloud`
- remove runner-only environment forwarding from the headless step
- bootstrap a fresh letta-code clone and reconstruct the compressed analysis payload inside the sandbox
- update Amelia’s watcher instructions to use sandbox-local paths and credentials

## Test plan
- [x] `bun run check`
- [x] `bun test scripts/codex-watch/tracker.test.ts`
- [x] validate workflow YAML
- [x] round-trip a real 112 KB Codex analysis through the compressed sandbox bootstrap

Linear: [LET-11149](https://linear.app/letta/issue/LET-11149/run-codex-agent-watch-in-cloud-sandbox)

👾 Generated with [Letta Code](https://letta.com)