### PR TITLE
fix(channels): isolate restored startup failures

### DIFF
--- a/src/channels/slack/adapter-test-harness.ts
+++ b/src/channels/slack/adapter-test-harness.ts
@@ -111,8 +111,10 @@ export class FakeSlackApp {
   readonly init = mock(async () => {});
   readonly start = mock(async () => {});
   readonly stop = mock(async () => {});
+  readonly options: Record<string, unknown>;
 
-  constructor(_options: Record<string, unknown>) {
+  constructor(options: Record<string, unknown>) {
+    this.options = options;
     FakeSlackApp.instances.push(this);
   }
 
@@ -139,6 +141,7 @@ export class FakeSlackApp {
 
 export class FakeSlackWriteClient {
   static instances: FakeSlackWriteClient[] = [];
+  static authorizationError: Error | null = null;
   static setStatusHandler:
     | ((args: Record<string, unknown>) => Promise<{ ok: boolean }>)
     | null = null;
@@ -149,6 +152,18 @@ export class FakeSlackWriteClient {
   readonly options: Record<string, unknown> | undefined;
   readonly streamModesByTs = new Map<string, "chunks" | "markdown_text">();
   startStreamCount = 0;
+  readonly auth = {
+    test: mock(async () => {
+      if (FakeSlackWriteClient.authorizationError) {
+        throw FakeSlackWriteClient.authorizationError;
+      }
+      return {
+        team: "Test Workspace",
+        user_id: "U0AS42PTEAX",
+        bot_id: "B0AS42PTEAX",
+      };
+    }),
+  };
   readonly chat = {
     postMessage: mock(async () => ({ ts: "1712800000.000100" })),
     update: mock(async () => ({ ts: "1712800000.000100" })),
@@ -346,6 +361,7 @@ export function installSlackAdapterTestHooks(): void {
   beforeEach(() => {
     FakeSlackApp.instances.length = 0;
     FakeSlackWriteClient.instances.length = 0;
+    FakeSlackWriteClient.authorizationError = null;
     FakeSlackWriteClient.disableStartStream = false;
     FakeSlackWriteClient.distinctStreamTs = false;
     FakeSlackWriteClient.setStatusHandler = null;
@@ -390,6 +406,7 @@ export function installSlackAdapterTestHooks(): void {
       instance.stop.mockClear();
     }
     for (const instance of FakeSlackWriteClient.instances) {
+      instance.auth.test.mockClear();
       instance.chat.postMessage.mockClear();
       instance.chat.update.mockClear();
       instance.chat.startStream?.mockClear();

--- a/src/channels/slack/adapter.test.ts
+++ b/src/channels/slack/adapter.test.ts
@@ -63,8 +63,34 @@ test("slack adapter start does not re-run bolt init", async () => {
 
   const app = FakeSlackApp.instances[0];
   expect(app).toBeDefined();
+  expect(app?.options).toEqual(
+    expect.objectContaining({
+      botUserId: "U0AS42PTEAX",
+      botId: "B0AS42PTEAX",
+    }),
+  );
   expect(app?.init).not.toHaveBeenCalled();
   expect(app?.start).toHaveBeenCalledTimes(1);
+});
+
+test("slack adapter consumes authorization failures before constructing Bolt", async () => {
+  const authorizationError = new Error("account_inactive");
+  FakeSlackWriteClient.authorizationError = authorizationError;
+  const adapter = createSlackAdapter({
+    ...slackAccountDefaults,
+    channel: "slack",
+    enabled: true,
+    mode: "socket",
+    botToken: "xoxb-test-token-1234567890",
+    appToken: "xapp-test-token-1234567890",
+    dmPolicy: "pairing",
+    allowedUsers: [],
+  });
+
+  await expect(adapter.start()).rejects.toBe(authorizationError);
+
+  expect(FakeSlackWriteClient.instances[0]?.auth.test).toHaveBeenCalledTimes(1);
+  expect(FakeSlackApp.instances).toHaveLength(0);
 });
 
 test("slack adapter forwards native channel slash commands as channel slash input", async () => {

--- a/src/channels/slack/adapter.ts
+++ b/src/channels/slack/adapter.ts
@@ -62,6 +62,12 @@ export interface SlackChannelAdapter extends ChannelAdapter {
   }): Promise<ChannelMessageAttachment>;
 }
 
+type SlackAuthClient = {
+  auth: {
+    test(): Promise<{ team?: string; user_id?: string; bot_id?: string }>;
+  };
+};
+
 export function createSlackAdapter(
   config: SlackChannelAccount,
 ): SlackChannelAdapter {
@@ -71,6 +77,7 @@ export function createSlackAdapter(
   let running = false;
   let botUserId: string | null = null;
   let botId: string | null = null;
+  let workspaceName: string | null = null;
   let adapter: SlackChannelAdapter;
 
   const agentThreadTracker: AgentThreadTracker = createAgentThreadTracker();
@@ -100,12 +107,24 @@ export function createSlackAdapter(
 
   async function ensureApp(): Promise<SlackApp> {
     if (app) return app;
+    const auth = await (
+      (await ensureWriteClient()) as SlackWriteClient & SlackAuthClient
+    ).auth.test();
+    if (!isNonEmptyString(auth.user_id) || !isNonEmptyString(auth.bot_id)) {
+      throw new Error("Slack auth.test did not return bot identity fields");
+    }
+    botUserId = auth.user_id;
+    botId = auth.bot_id;
+    workspaceName = isNonEmptyString(auth.team) ? auth.team : null;
+
     const bolt = await loadSlackBoltModule();
     const App = resolveSlackAppConstructor(bolt);
     const instance = new App({
       token: config.botToken,
       appToken: config.appToken,
       socketMode: true,
+      botUserId,
+      botId,
     });
     instance.error(async (error) => {
       console.error("[Slack] Unhandled app error:", error);
@@ -388,16 +407,10 @@ export function createSlackAdapter(
     async start(): Promise<void> {
       if (running) return;
       const slackApp = await ensureApp();
-      const auth = await slackApp.client.auth.test();
-      const authRecord = auth as unknown as Record<string, unknown>;
-      botUserId = isNonEmptyString(authRecord.user_id)
-        ? authRecord.user_id
-        : null;
-      botId = isNonEmptyString(authRecord.bot_id) ? authRecord.bot_id : null;
       await slackApp.start();
       running = true;
       console.log(
-        `[Slack] App started for workspace ${auth.team ?? "unknown"} (dm_policy: ${config.dmPolicy})`,
+        `[Slack] App started for workspace ${workspaceName ?? "unknown"} (dm_policy: ${config.dmPolicy})`,
       );
     },
     async stop(): Promise<void> {
@@ -412,6 +425,7 @@ export function createSlackAdapter(
       writeClientPromise = null;
       botUserId = null;
       botId = null;
+      workspaceName = null;
       status.clear();
       approvals.clear();
       debounce.clear();

--- a/src/cli/subcommands/listen.tsx
+++ b/src/cli/subcommands/listen.tsx
@@ -562,7 +562,9 @@ export async function runListenSubcommand(argv: string[]): Promise<number> {
           },
           onUnexpectedExit: (error) => {
             console.error(`[${formatTimestamp()}] ${error.message}`);
-            void exitWithTelemetry(1, "listener_channel_gateway_exited");
+            if (values.channels) {
+              void exitWithTelemetry(1, "listener_channel_gateway_exited");
+            }
           },
           onServiceEvent: (event) => {
             if (event.kind === "protocol") {


### PR DESCRIPTION
## Summary
- authenticate Slack before constructing Bolt and seed the verified bot identity, preventing Bolt’s eager duplicate `auth.test` promise from rejecting unobserved on `account_inactive`
- keep automatic Desktop channel restore failures isolated to the channel gateway instead of terminating the parent listener and disabling unrelated message/model APIs
- preserve fatal exit behavior for explicit `--channels` sessions

Closes [LET-11154](https://linear.app/letta/issue/LET-11154/prevent-channel-startup-failures-from-crashing-code-desktop-runtime).

## Test plan
- [x] `bun test src/channels/slack/adapter.test.ts src/channels/registry-lifecycle.test.ts src/channels/gateway-supervisor.test.ts`
- [x] `bun run check`
- [x] pre-commit hook stack
- [x] reproduced with the inactive local Slack account: startup returned `account_inactive` while the process remained alive