### PR TITLE
fix(ci): rebuild Codex watcher analysis in cloud

### DIFF
--- a/.github/workflows/codex-agent-watch.yml
+++ b/.github/workflows/codex-agent-watch.yml
@@ -61,14 +61,10 @@ jobs:
         env:
           TRACKER_ISSUE: ${{ steps.detect.outputs.tracker_issue }}
           TRACKER_ISSUE_URL: ${{ steps.detect.outputs.tracker_issue_url }}
-          ANALYSIS_FILE: ${{ steps.detect.outputs.analysis_file }}
           CURRENT_TAG: ${{ steps.detect.outputs.current_tag }}
           PREVIOUS_TAG: ${{ steps.detect.outputs.previous_tag }}
           VERDICT: ${{ steps.detect.outputs.verdict }}
         run: |
-          REVIEW_ANALYSIS="$RUNNER_TEMP/codex-watch-review-analysis.json"
-          jq 'del(.release_notes_md, .changed_files)' "$ANALYSIS_FILE" > "$REVIEW_ANALYSIS"
-          ANALYSIS_ARCHIVE_BASE64=$(gzip -c "$REVIEW_ANALYSIS" | base64 -w 0)
           {
             echo "prompt<<AMELIA_PROMPT_EOF"
             cat .github/agent-prompts/codex-agent-watch.md
@@ -89,9 +85,9 @@ jobs:
             echo 'rm -rf /tmp/letta-code-codex-watch'
             echo 'GH_TOKEN="$GITHUB_TOKEN" gh repo clone letta-ai/letta-code /tmp/letta-code-codex-watch'
             echo 'cd /tmp/letta-code-codex-watch'
-            echo "printf '%s' '$ANALYSIS_ARCHIVE_BASE64' | base64 --decode | gzip --decompress > /tmp/codex-watch-analysis.json"
-            echo "jq -e '.current_tag == \"$CURRENT_TAG\" and .previous_tag == \"$PREVIOUS_TAG\" and (.path_changes | type == \"array\")' /tmp/codex-watch-analysis.json > /dev/null"
             echo 'bun install --frozen-lockfile'
+            echo "GH_TOKEN=\"\$GITHUB_TOKEN\" GITHUB_SERVER_URL=https://github.com GITHUB_REPOSITORY=letta-ai/letta-code GITHUB_RUN_ID=\"$GITHUB_RUN_ID\" bun scripts/codex-watch/agent-watch.ts --dry-run --since \"$PREVIOUS_TAG\" --current \"$CURRENT_TAG\" --analysis-file /tmp/codex-watch-analysis.json > /tmp/codex-watch-analysis.log"
+            echo "jq -e '.current_tag == \"$CURRENT_TAG\" and .previous_tag == \"$PREVIOUS_TAG\" and (.path_changes | type == \"array\")' /tmp/codex-watch-analysis.json > /dev/null"
             echo '```'
             echo "AMELIA_PROMPT_EOF"
           } >> "$GITHUB_OUTPUT"

--- a/.github/workflows/codex-agent-watch.yml
+++ b/.github/workflows/codex-agent-watch.yml
@@ -66,7 +66,9 @@ jobs:
           PREVIOUS_TAG: ${{ steps.detect.outputs.previous_tag }}
           VERDICT: ${{ steps.detect.outputs.verdict }}
         run: |
-          ANALYSIS_ARCHIVE_BASE64=$(gzip -c "$ANALYSIS_FILE" | base64 -w 0)
+          REVIEW_ANALYSIS="$RUNNER_TEMP/codex-watch-review-analysis.json"
+          jq 'del(.release_notes_md, .changed_files)' "$ANALYSIS_FILE" > "$REVIEW_ANALYSIS"
+          ANALYSIS_ARCHIVE_BASE64=$(gzip -c "$REVIEW_ANALYSIS" | base64 -w 0)
           {
             echo "prompt<<AMELIA_PROMPT_EOF"
             cat .github/agent-prompts/codex-agent-watch.md
@@ -83,10 +85,12 @@ jobs:
             echo "Run this exact block before reviewing the release:"
             echo
             echo '```bash'
+            echo 'set -euo pipefail'
             echo 'rm -rf /tmp/letta-code-codex-watch'
             echo 'GH_TOKEN="$GITHUB_TOKEN" gh repo clone letta-ai/letta-code /tmp/letta-code-codex-watch'
             echo 'cd /tmp/letta-code-codex-watch'
             echo "printf '%s' '$ANALYSIS_ARCHIVE_BASE64' | base64 --decode | gzip --decompress > /tmp/codex-watch-analysis.json"
+            echo "jq -e '.current_tag == \"$CURRENT_TAG\" and .previous_tag == \"$PREVIOUS_TAG\" and (.path_changes | type == \"array\")' /tmp/codex-watch-analysis.json > /dev/null"
             echo 'bun install --frozen-lockfile'
             echo '```'
             echo "AMELIA_PROMPT_EOF"


### PR DESCRIPTION
## Summary
- stop embedding opaque base64 analysis data in the cloud review prompt
- deterministically rebuild the analysis inside the sandbox from the exact previous/current stable tags
- carry the originating workflow run ID into the rebuilt analysis for tracker provenance
- validate the rebuilt JSON and tag pair before review begins

The first controlled replay crossed the action prompt-size boundary and truncated a 26.9 KB payload. A compact 1.4 KB payload avoided that boundary but was still corrupted when the model copied the opaque string into its bootstrap tool call. Rebuilding from the exact tags removes both failure modes.

## Test plan
- [x] generate and execute the exact sandbox rebuild command for `rust-v0.147.0...rust-v0.148.0`
- [x] validate reconstructed JSON, exact tag pair, path changes, and workflow run URL with `jq -e`
- [x] validate workflow YAML
- [x] `bun run check`
- [x] controlled cloud replay without opaque payload transport: https://github.com/letta-ai/letta-code/actions/runs/32315333639

Linear: [LET-11184](https://linear.app/letta/issue/LET-11184/prevent-codex-watcher-analysis-prompt-truncation)
Parent: [LET-11098](https://linear.app/letta/issue/LET-11098/cut-over-codex-watcher)

👾 Generated with [Letta Code](https://letta.com)