### PR TITLE
fix(tools): reject duplicate resolved paths in apply_patch

### DIFF
--- a/src/tools/apply-patch.test.ts
+++ b/src/tools/apply-patch.test.ts
@@ -243,4 +243,60 @@ EOF`,
     const filePath = join(testDir.path, "eof.txt");
     expect(readFileSync(filePath, "utf-8")).toBe("line1\nline2 updated\n");
   });
+
+  test("rejects duplicate resolved paths across operations", async () => {
+    testDir = new TestDirectory();
+    originalUserCwd = process.env.USER_CWD;
+    process.env.USER_CWD = testDir.path;
+
+    testDir.createFile("duplicate.txt", "before\n");
+
+    await expect(
+      apply_patch({
+        input: `*** Begin Patch
+*** Update File: duplicate.txt
+@@
+-before
++first after
+*** Update File: ./duplicate.txt
+@@
+-before
++second after
+*** End Patch`,
+      }),
+    ).rejects.toThrow(/multiple operations target/);
+
+    expect(readFileSync(join(testDir.path, "duplicate.txt"), "utf-8")).toBe(
+      "before\n",
+    );
+  });
+
+  test("allows distinct resolved paths across operations", async () => {
+    testDir = new TestDirectory();
+    originalUserCwd = process.env.USER_CWD;
+    process.env.USER_CWD = testDir.path;
+
+    testDir.createFile("first.txt", "first before\n");
+    testDir.createFile("second.txt", "second before\n");
+
+    await apply_patch({
+      input: `*** Begin Patch
+*** Update File: first.txt
+@@
+-first before
++first after
+*** Update File: second.txt
+@@
+-second before
++second after
+*** End Patch`,
+    });
+
+    expect(readFileSync(join(testDir.path, "first.txt"), "utf-8")).toBe(
+      "first after\n",
+    );
+    expect(readFileSync(join(testDir.path, "second.txt"), "utf-8")).toBe(
+      "second after\n",
+    );
+  });
 });

--- a/src/tools/impl/apply-patch.ts
+++ b/src/tools/impl/apply-patch.ts
@@ -67,6 +67,7 @@ export async function apply_patch(
   }
 
   const cwd = getCurrentWorkingDirectory();
+  verifyNoDuplicatePaths(cwd, operations);
   const affected: AffectedPaths = { added: [], modified: [], deleted: [] };
 
   for (const op of operations) {
@@ -407,6 +408,21 @@ function assertPatchPath(patchPath: string, operation: string): void {
 
 function resolvePatchPath(cwd: string, patchPath: string): string {
   return path.isAbsolute(patchPath) ? patchPath : path.resolve(cwd, patchPath);
+}
+
+function verifyNoDuplicatePaths(
+  cwd: string,
+  operations: FileOperation[],
+): void {
+  const seen = new Set<string>();
+  for (const op of operations) {
+    const patchPath = op.kind === "update" ? op.fromPath : op.path;
+    const resolved = resolvePatchPath(cwd, patchPath);
+    if (seen.has(resolved)) {
+      throw new Error(`multiple operations target ${patchPath}`);
+    }
+    seen.add(resolved);
+  }
 }
 
 async function deriveNewContentsFromChunks(


### PR DESCRIPTION
## Summary
- Adds a pre-pass to `apply_patch` that resolves all operation paths and rejects patches where multiple operations resolve to the same file path (e.g. `duplicate.txt` and `./duplicate.txt`)
- Aligns with upstream Codex commit [a1c88e865d](https://github.com/openai/codex/commit/a1c88e865d) ("Reject duplicate resolved paths in apply_patch")
- The check runs before any file mutations occur, matching upstream verification semantics

Codex-watch: openai/codex `rust-v0.148.0`
Compare: https://github.com/openai/codex/compare/rust-v0.147.0...rust-v0.148.0

## Test plan
- [x] `bun test src/tools/apply-patch.test.ts` — 13/13 pass (including 2 new tests)
- [x] `tsc --noEmit` — clean
- [x] Pre-commit hooks (biome, layer checks) — clean

👾 Generated with [Letta Code](https://letta.com)

Co-Authored-By: Letta Code <noreply@letta.com>

## Automation evidence
- controlled agentic replay created this PR and recorded `pr_created` in tracker #3915: https://github.com/letta-ai/letta-code/actions/runs/32312731329
