### PR TITLE
fix(headless): follow turns across task notifications

### DIFF
--- a/src/headless-environment-response.test.ts
+++ b/src/headless-environment-response.test.ts
@@ -22,12 +22,13 @@ function userMessage(
   otid: string,
   runId: string,
   sequenceId: number,
+  content = "Run the requested command",
 ) {
   return {
     id,
     message_type: "user_message",
     date: "2026-07-07T12:00:00.000Z",
-    content: "Run the requested command",
+    content,
     otid,
     run_id: runId,
     seq_id: sequenceId,
@@ -127,5 +128,62 @@ describe("headless environment-routed responses", () => {
     });
     expect(messageCalls).toBe(3);
     expect(retrievedRunIds).toEqual(["run-requested", "run-continuation"]);
+  });
+
+  test("ignores task notifications while following the submitted turn", async () => {
+    const retrievedRunIds: string[] = [];
+    const backend = {
+      async retrieveRun(runId: string) {
+        retrievedRunIds.push(runId);
+        return {
+          id: runId,
+          status: "completed",
+          stop_reason:
+            runId === "run-requested" ? "requires_approval" : "end_turn",
+        };
+      },
+      async listConversationMessages() {
+        return [
+          assistantMessage(
+            "msg-final",
+            "The background task completed successfully.",
+            "run-final",
+            15,
+          ),
+          userMessage(
+            "msg-task-notification",
+            "otid-task-notification",
+            "run-task-notification",
+            13,
+            "<task-notification>background command completed</task-notification>",
+          ),
+          assistantMessage(
+            "msg-initial",
+            "Waiting for the background task.",
+            "run-requested",
+            12,
+          ),
+          userMessage("msg-user", "otid-requested", "run-requested", 11),
+        ];
+      },
+      async listAgentMessages() {
+        throw new Error("default conversation path should not be used");
+      },
+    };
+
+    const result = await waitForEnvironmentAssistantMessage({
+      backend: backend as never,
+      agentId: "agent-env",
+      conversationId: "conv-env",
+      otid: "otid-requested",
+      pollIntervalMs: 0,
+      timeoutMs: 1_000,
+    });
+
+    expect(result).toEqual({
+      text: "The background task completed successfully.",
+      stopReason: "end_turn",
+    });
+    expect(retrievedRunIds).toEqual(["run-final"]);
   });
 });

--- a/src/headless-environment-response.ts
+++ b/src/headless-environment-response.ts
@@ -53,6 +53,12 @@ function isUserMessage(message: LettaMessage): boolean {
   return (message as { message_type?: string }).message_type === "user_message";
 }
 
+function isTaskNotificationMessage(message: LettaMessage): boolean {
+  return extractMessageText(message)
+    .trimStart()
+    .startsWith("<task-notification>");
+}
+
 function messageRunId(message: LettaMessage | undefined): string | null {
   if (!message) return null;
   const runId = (message as { run_id?: unknown }).run_id;
@@ -110,7 +116,9 @@ export async function waitForEnvironmentAssistantMessage(params: {
       });
       const nextUserSequenceId = newerMessages.reduce<number | null>(
         (closest, message) => {
-          if (!isUserMessage(message)) return closest;
+          if (!isUserMessage(message) || isTaskNotificationMessage(message)) {
+            return closest;
+          }
           const sequenceId = messageSequenceId(message);
           if (sequenceId === null) return closest;
           return closest === null || sequenceId < closest


### PR DESCRIPTION
## Summary
- ignore harness-generated `<task-notification>` user messages when locating the next true user-turn boundary for environment-routed headless responses
- keep polling through background command completion turns until the final assistant response is terminal
- add regression coverage matching the cloud watcher failure

The controlled Codex watcher replay created its PR, updated its tracker, and returned its exact final response after four minutes, but the caller excluded that response after seeing a background-task notification and timed out at ten minutes.

## Test plan
- [x] `bun test src/headless-environment-response.test.ts`
- [x] `bun run check`

Linear: [LET-11187](https://linear.app/letta/issue/LET-11187/complete-environment-routed-headless-turns-after-task-notifications)
Parent: [LET-11098](https://linear.app/letta/issue/LET-11098/cut-over-codex-watcher)

👾 Generated with [Letta Code](https://letta.com)
- [x] controlled cloud replay crossed a persisted task-notification boundary and completed successfully: https://github.com/letta-ai/letta-code/actions/runs/32315333639