### PR TITLE
feat(ci): add Claude upstream watcher

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -16,6 +16,9 @@
 /.github/workflows/codex-agent-watch.yml @kl2806
 /.github/agent-prompts/codex-agent-watch.md @kl2806
 /scripts/codex-watch/ @kl2806
+/.github/workflows/claude-agent-watch.yml @kl2806
+/.github/agent-prompts/claude-agent-watch.md @kl2806
+/scripts/claude-watch/ @kl2806
 /src/agent/prompts/source_codex.md @kl2806
 
 # TUI/CLI runtime and UI

--- a/.github/agent-prompts/claude-agent-watch.md
+++ b/.github/agent-prompts/claude-agent-watch.md
@@ -1,0 +1,115 @@
+You are Amelia running in your managed cloud sandbox for `letta-ai/letta-code`, dispatched by GitHub Actions.
+
+Your job is to review one exact published Claude Code candidate against the local Letta Code harness and either open one focused parity PR, record that no local change is needed, or explicitly request human review.
+
+## Evidence model
+
+Claude Code is closed source. Use these independent public/observable signals:
+
+1. Exact GitHub release and npm package metadata.
+2. Official `code.claude.com` Markdown documentation indexed by `llms.txt`.
+3. Structured observations from the exact isolated package install.
+
+Do not invent or rely on a private prompt dump, schema dump, `--list-tools`, or undocumented introspection API. `system/init.tools` establishes only the names advertised in that exact session. Model-generated tool inputs and black-box probe results are observations, not complete schemas or proof of internal implementation.
+
+The detector has already captured and committed the normalized candidate snapshot on `claude-watch-state`. Use the rebuilt analysis from the exact state commit as your starting point.
+
+## Sandbox setup
+
+The detector ran on a GitHub Actions runner, but your turn does not. Runner files and environment variables are unavailable here. The run inputs and an exact bootstrap block are appended to this prompt.
+
+Run that exact block before reviewing. It clones current `letta-ai/letta-code`, installs dependencies, fetches the state branch, and rebuilds the sanitized analysis from the exact state commit and its parent. Perform all inspection, edits, tests, state checks, and tracker updates from that clone.
+
+## Required review behavior
+
+1. Read the complete analysis JSON, release notes, official source URLs, every focused docs diff, runtime inventory diff, and probe observation.
+2. Inspect the current official docs directly when a preview is truncated or the evidence points at an unwatched page.
+3. Review every relevant signal against the corresponding local Letta Code mirror. Account for each signal in the tracker note.
+4. Compare implementation behavior, parsing, mutation ordering, output formatting, failure semantics, defaults, and model-facing guidance when the two harnesses mirror the same contract. A matching tool name or schema is not enough.
+5. If a concrete local mirror should change, make only that change with focused tests and open one separate draft PR.
+6. If the change is upstream-only, record `no_local_impact` with a specific reason. Claude-only UI, IDE, Desktop, hosted-cloud, subscription, MCP/plugin, and model-routing changes often do not belong locally.
+7. If public evidence is incomplete or a probe is inconclusive, do not guess. Record `needs_human_review` with the exact uncertainty.
+8. Search open and closed PRs for the exact `Claude-watch: <candidate-id>` marker before creating a PR. A retry must never duplicate a PR.
+9. Verify that the state branch's current snapshot has the exact candidate ID before recording a terminal outcome.
+10. Do not merge, disable another workflow, wait for CI, or update the parity PR after creation.
+
+If the exact candidate marker already exists on a parity PR, treat it as a recovered partial run: verify that PR, record `pr_created` with its URL, and do not create or modify another PR.
+
+For a bootstrap candidate, there is intentionally no historical Claude snapshot. Treat the complete current official docs/runtime surface as a current-vs-local audit rather than limiting review to the latest release note. This is the one-time opportunity to catch older accumulated drift without replaying every historical package release.
+
+## Local mirrors to inspect
+
+Narrow based on evidence, but begin with:
+
+- prompt/provenance: `src/agent/prompts/source_claude.md`, `src/agent/prompts/README.md`, `src/agent/prompt-assets.ts`, and tests
+- model-facing tool names/default membership: `src/tools/manager.ts` (`TOOL_NAME_MAPPINGS`, `ANTHROPIC_DEFAULT_TOOLS`), `src/tools/tool-definitions.ts`, `src/tools/toolset.ts`, `src/tools/filter.ts`, `src/tools/toolset-labels.ts`
+- mirrored contracts and behavior: `src/tools/schemas/`, `src/tools/descriptions/`, `src/tools/impl/`, and adjacent tests
+- Claude-derived output behavior: `src/tools/impl/truncation.ts`, `src/tools/impl/read.ts`, `src/tools/impl/bash.ts`
+- permissions: `src/permissions/matcher.ts`, `src/permissions/types.ts`, and tests
+- stream/headless protocol: `src/stream-json-writer.ts`, `src/types/protocol.ts`, `src/integration-tests/headless-stream-json-format.test.ts`
+- tasks/subagents/worktrees: built-in subagent Markdown, Task/TaskCreate/TaskGet/TaskList/TaskUpdate/TaskOutput/TaskStop and EnterWorktree/ExitWorktree schemas, descriptions, implementations, and tests
+
+When the official tool inventory changes, compare both the top-level Letta defaults and every built-in subagent's tool frontmatter/body. Local-only stale names are drift even when the parent toolset is already current.
+
+When task contracts are implicated, review the Task family as one contract: creation, dependencies, metadata value types, null-based metadata deletion, permanent deletion, list/get behavior, and model guidance.
+
+When Read is implicated, inspect raw tool-result bytes around the 9-to-10 line-number boundary. Preserve the exact separator and whitespace because Edit uses exact matching.
+
+## Tracker finalization
+
+Always update the central tracker before returning. Use `scripts/claude-watch/update-tracker.ts`, not a normal issue comment. Pass the exact analysis file and state commit SHA from the run inputs.
+
+No local impact:
+
+```bash
+GH_TOKEN="$GITHUB_TOKEN" bun scripts/claude-watch/update-tracker.ts \
+  --tracker-issue <tracker-issue> \
+  --analysis-file /tmp/claude-watch-analysis.json \
+  --state-commit-sha <state-commit-sha> \
+  --outcome no_local_impact \
+  --notes "<specific reason covering all evidence>"
+```
+
+PR created:
+
+```bash
+GH_TOKEN="$GITHUB_TOKEN" bun scripts/claude-watch/update-tracker.ts \
+  --tracker-issue <tracker-issue> \
+  --analysis-file /tmp/claude-watch-analysis.json \
+  --state-commit-sha <state-commit-sha> \
+  --outcome pr_created \
+  --pr-url "$PR_URL" \
+  --notes "<focused local mirror change>"
+```
+
+Uncertain or blocked:
+
+```bash
+GH_TOKEN="$GITHUB_TOKEN" bun scripts/claude-watch/update-tracker.ts \
+  --tracker-issue <tracker-issue> \
+  --analysis-file /tmp/claude-watch-analysis.json \
+  --state-commit-sha <state-commit-sha> \
+  --outcome needs_human_review \
+  --notes "<exact missing or inconclusive evidence>"
+```
+
+## PR rules
+
+If a local change is required:
+
+- create a fresh branch from current `main`
+- use `GH_TOKEN="$GITHUB_TOKEN"` for every GitHub CLI operation
+- make the minimum mirror change and focused tests only; do not include watcher implementation changes
+- use a Conventional Commit title
+- open the PR as a draft
+- immediately verify `draft: true` and `author.login: carenthomas`; if either is wrong, fix or close it instead of reporting success
+- include `Claude-watch: <candidate-id>`, package version, release URL, docs/runtime evidence, and validation in the body
+- never commit generated snapshots or analysis files to the parity branch
+
+## Final response
+
+After the tracker update succeeds, respond with exactly one line:
+
+- `PR_CREATED <url>`
+- `NO_LOCAL_IMPACT <candidate-id>`
+- `NEEDS_HUMAN_REVIEW <candidate-id>`

--- a/.github/workflows/claude-agent-watch.yml
+++ b/.github/workflows/claude-agent-watch.yml
@@ -1,0 +1,164 @@
+name: Claude Agent Watch
+
+on:
+  # Enable after the manual bootstrap/dedupe/docs-only/failure/no-impact bake:
+  # schedule:
+  #   - cron: "17 * * * *"
+  workflow_dispatch:
+    inputs:
+      previous_version:
+        description: "Previous exact Claude Code npm version"
+        required: false
+        type: string
+      current_version:
+        description: "Current exact Claude Code npm version"
+        required: false
+        type: string
+      force_docs_scan:
+        description: "Fetch and hash every page in the official docs index"
+        required: false
+        default: false
+        type: boolean
+      dry_run:
+        description: "Detect only; do not write shared state or invoke Amelia"
+        required: false
+        default: false
+        type: boolean
+      validation_only:
+        description: "Run exact probes for historical validation without writing shared state"
+        required: false
+        default: false
+        type: boolean
+
+concurrency:
+  group: claude-agent-watch
+  cancel-in-progress: false
+
+jobs:
+  watch:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    permissions:
+      actions: read
+      contents: write
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.10
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Detect Claude Code drift
+        id: detect
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ANTHROPIC_API_KEY: ${{ inputs.dry_run != true && secrets.ANTHROPIC_API_KEY || '' }}
+          PREVIOUS_VERSION: ${{ inputs.previous_version }}
+          CURRENT_VERSION: ${{ inputs.current_version }}
+          FORCE_DOCS_SCAN: ${{ inputs.force_docs_scan }}
+          DRY_RUN: ${{ inputs.dry_run }}
+          VALIDATION_ONLY: ${{ inputs.validation_only }}
+        run: |
+          ARGS=(--analysis-file "$RUNNER_TEMP/claude-watch-analysis.json")
+          if [ -n "$PREVIOUS_VERSION" ]; then
+            ARGS+=(--previous-version "$PREVIOUS_VERSION")
+          fi
+          if [ -n "$CURRENT_VERSION" ]; then
+            ARGS+=(--current-version "$CURRENT_VERSION")
+          fi
+          if [ "$FORCE_DOCS_SCAN" = "true" ]; then
+            ARGS+=(--force-docs-scan)
+          fi
+          if [ "$DRY_RUN" = "true" ]; then
+            ARGS+=(--dry-run)
+          fi
+          if [ "$VALIDATION_ONLY" = "true" ]; then
+            ARGS+=(--validation-only)
+          fi
+          bun scripts/claude-watch/agent-watch.ts "${ARGS[@]}"
+
+      - name: Upload validation analysis
+        if: inputs.validation_only == true
+        uses: actions/upload-artifact@v6
+        with:
+          name: claude-watch-validation-${{ github.run_id }}
+          path: ${{ runner.temp }}/claude-watch-analysis.json
+          retention-days: 3
+
+      - name: Build Amelia prompt
+        id: prompt
+        if: steps.detect.outputs.should_run_agent == 'true'
+        env:
+          TRACKER_ISSUE: ${{ steps.detect.outputs.tracker_issue }}
+          TRACKER_ISSUE_URL: ${{ steps.detect.outputs.tracker_issue_url }}
+          CANDIDATE_ID: ${{ steps.detect.outputs.candidate_id }}
+          CURRENT_VERSION: ${{ steps.detect.outputs.current_version }}
+          PREVIOUS_VERSION: ${{ steps.detect.outputs.previous_version }}
+          VERDICT: ${{ steps.detect.outputs.verdict }}
+          STATE_COMMIT_SHA: ${{ steps.detect.outputs.state_commit_sha }}
+        run: |
+          {
+            echo "prompt<<AMELIA_PROMPT_EOF"
+            cat .github/agent-prompts/claude-agent-watch.md
+            echo
+            echo "## Run inputs"
+            echo
+            echo "- Tracker issue: #$TRACKER_ISSUE ($TRACKER_ISSUE_URL)"
+            echo "- Candidate ID: $CANDIDATE_ID"
+            echo "- Current package: @anthropic-ai/claude-code@$CURRENT_VERSION"
+            echo "- Previous package: @anthropic-ai/claude-code@$PREVIOUS_VERSION"
+            echo "- Detector verdict: $VERDICT"
+            echo "- State commit SHA: $STATE_COMMIT_SHA"
+            echo
+            echo "## Sandbox bootstrap"
+            echo
+            echo "Run this exact block before reviewing the candidate:"
+            echo
+            echo '```bash'
+            echo 'set -euo pipefail'
+            echo 'rm -rf /tmp/letta-code-claude-watch'
+            echo 'GH_TOKEN="$GITHUB_TOKEN" gh repo clone letta-ai/letta-code /tmp/letta-code-claude-watch'
+            echo 'cd /tmp/letta-code-claude-watch'
+            echo 'bun install --frozen-lockfile'
+            echo 'git fetch origin claude-watch-state'
+            echo "GH_TOKEN=\"\$GITHUB_TOKEN\" GITHUB_SERVER_URL=https://github.com GITHUB_REPOSITORY=letta-ai/letta-code GITHUB_RUN_ID=\"$GITHUB_RUN_ID\" bun scripts/claude-watch/agent-watch.ts --dry-run --rebuild-state-commit \"$STATE_COMMIT_SHA\" --analysis-file /tmp/claude-watch-analysis.json > /tmp/claude-watch-analysis.log"
+            echo "jq -e --arg candidate \"$CANDIDATE_ID\" --arg current \"$CURRENT_VERSION\" '.candidate_id == \$candidate and .current_version == \$current and (.docs_diff | type == \"object\")' /tmp/claude-watch-analysis.json > /dev/null"
+            echo '```'
+            echo "AMELIA_PROMPT_EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Ask Amelia to review Claude Code drift
+        if: steps.detect.outputs.should_run_agent == 'true'
+        uses: letta-ai/letta-code-action@4b8e508a523ff576fee09be1432d6f39158c272c
+        with:
+          letta_api_key: ${{ secrets.AMELIA_LETTA_API_KEY }}
+          github_token: ${{ secrets.AMELIA_GITHUB_TOKEN }}
+          agent_id: agent-cd664b86-4d28-49b7-8ad6-60677eaff9be
+          environment: cloud
+          track_progress: ""
+          tracking_comment: "false"
+          model: auto
+          prompt: ${{ steps.prompt.outputs.prompt }}
+
+      - name: Verify terminal outcome
+        if: steps.detect.outputs.should_run_agent == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          bun scripts/claude-watch/update-tracker.ts \
+            --tracker-issue "${{ steps.detect.outputs.tracker_issue }}" \
+            --candidate-id "${{ steps.detect.outputs.candidate_id }}" \
+            --state-commit-sha "${{ steps.detect.outputs.state_commit_sha }}" \
+            --assert-terminal

--- a/scripts/claude-watch/agent-watch.ts
+++ b/scripts/claude-watch/agent-watch.ts
@@ -1,0 +1,604 @@
+#!/usr/bin/env bun
+
+import { mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import {
+  type CapturedDocs,
+  captureDocsSnapshot,
+  sha256,
+} from "./docs-snapshot.ts";
+import {
+  createIssue,
+  editIssueBody,
+  ensureLabel,
+  findIssueByExactTitle,
+  getIssueBody,
+} from "./github.ts";
+import {
+  analyzeClaudeCandidate,
+  buildClaudeStateSnapshot,
+  rebuildClaudeAnalysisFromState,
+} from "./release-analysis.ts";
+import {
+  fetchClaudeGitHubReleases,
+  fetchClaudeNpmMetadata,
+  selectClaudeReleaseCandidate,
+} from "./release-source.ts";
+import {
+  captureClaudeRuntime,
+  createClaudeRuntimeCommandPlan,
+} from "./runtime-probe.ts";
+import {
+  fetchStateBranchTip,
+  finalizeStateBranch,
+  loadStateFilesAtCommit,
+  loadStateSnapshotAtCommit,
+} from "./state-branch.ts";
+import {
+  type ClaudeTrackerState,
+  findTrackerEntry,
+  hasProcessedCandidate,
+  isTerminalOutcome,
+  parseTrackerState,
+  recordAnalysis,
+  renderTrackerBody,
+} from "./tracker.ts";
+import type {
+  ClaudeReleaseCandidate,
+  ClaudeRuntimeSnapshot,
+  ClaudeWatchAnalysis,
+  ClaudeWatchOutcome,
+  ClaudeWatchStateSnapshot,
+} from "./types.ts";
+
+const DEFAULT_REPO = "letta-ai/letta-code";
+const TRACKER_TITLE = "Claude upstream drift tracker";
+const TRACKER_LABEL = "claude-watch";
+
+interface Args {
+  repo: string;
+  analysisFile: string;
+  previousVersion: string | null;
+  currentVersion: string | null;
+  forceDocsScan: boolean;
+  dryRun: boolean;
+  validationOnly: boolean;
+  rebuildStateCommit: string | null;
+}
+
+interface TrackerContext {
+  number: number;
+  url: string;
+  state: ClaudeTrackerState;
+}
+
+export function parseArgs(argv: string[]): Args {
+  const args: Args = {
+    repo: DEFAULT_REPO,
+    analysisFile: join(tmpdir(), "claude-watch-analysis.json"),
+    previousVersion: null,
+    currentVersion: null,
+    forceDocsScan: false,
+    dryRun: false,
+    validationOnly: false,
+    rebuildStateCommit: null,
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    if (argument === "--repo") args.repo = argv[++index] ?? args.repo;
+    else if (argument === "--analysis-file")
+      args.analysisFile = argv[++index] ?? args.analysisFile;
+    else if (argument === "--previous-version")
+      args.previousVersion = argv[++index] ?? null;
+    else if (argument === "--current-version")
+      args.currentVersion = argv[++index] ?? null;
+    else if (argument === "--force-docs-scan") args.forceDocsScan = true;
+    else if (argument === "--dry-run") args.dryRun = true;
+    else if (argument === "--validation-only") args.validationOnly = true;
+    else if (argument === "--rebuild-state-commit")
+      args.rebuildStateCommit = argv[++index] ?? null;
+    else throw new Error(`Unknown argument: ${argument}`);
+  }
+  return args;
+}
+
+function workflowRunUrl(): string {
+  const server = process.env.GITHUB_SERVER_URL ?? "https://github.com";
+  const repo = process.env.GITHUB_REPOSITORY ?? DEFAULT_REPO;
+  const run = process.env.GITHUB_RUN_ID;
+  return run ? `${server}/${repo}/actions/runs/${run}` : "local-dry-run";
+}
+
+function setOutput(name: string, value: string | number | boolean): void {
+  const output = process.env.GITHUB_OUTPUT;
+  if (output)
+    writeFileSync(output, `${name}=${String(value)}\n`, { flag: "a" });
+  else console.log(`${name}=${String(value)}`);
+}
+
+function writeAnalysis(path: string, analysis: ClaudeWatchAnalysis): void {
+  mkdirSync(resolve(path, ".."), { recursive: true });
+  writeFileSync(path, `${JSON.stringify(analysis, null, 2)}\n`);
+}
+
+function ensureTracker(repo: string, dryRun: boolean): TrackerContext {
+  const existing = findIssueByExactTitle(repo, TRACKER_TITLE);
+  if (existing) {
+    return {
+      number: existing.number,
+      url: existing.url,
+      state: parseTrackerState(existing.body),
+    };
+  }
+  if (dryRun)
+    return { number: 0, url: "dry-run", state: parseTrackerState("") };
+  ensureLabel(repo, TRACKER_LABEL);
+  const emptyBody = renderTrackerBody(parseTrackerState(""));
+  const created = createIssue(repo, TRACKER_TITLE, emptyBody, TRACKER_LABEL);
+  return {
+    number: created.number,
+    url: created.url,
+    state: parseTrackerState(created.body),
+  };
+}
+
+function recordTrackerOutcome(
+  repo: string,
+  tracker: TrackerContext,
+  analysis: ClaudeWatchAnalysis,
+  outcome: ClaudeWatchOutcome,
+  notes: string,
+  stateCommitSha: string | null,
+  error: string | null = null,
+): TrackerContext {
+  const current = parseTrackerState(getIssueBody(repo, tracker.number));
+  const next = recordAnalysis(current, {
+    analysis,
+    outcome,
+    notes,
+    stateCommitSha,
+    error,
+  });
+  editIssueBody(repo, tracker.number, renderTrackerBody(next));
+  return { ...tracker, state: next };
+}
+
+function trackerOutputs(tracker: TrackerContext): void {
+  setOutput("tracker_issue", tracker.number);
+  setOutput("tracker_issue_url", tracker.url);
+}
+
+function analysisOutputs(
+  analysis: ClaudeWatchAnalysis,
+  shouldRunAgent: boolean,
+  stateCommitSha: string | null,
+): void {
+  setOutput("should_run_agent", shouldRunAgent);
+  setOutput("candidate_id", analysis.candidate_id);
+  setOutput("previous_version", analysis.previous_version ?? "");
+  setOutput("current_version", analysis.current_version);
+  setOutput("verdict", analysis.verdict);
+  setOutput("state_commit_sha", stateCommitSha ?? "");
+}
+
+function stateSources(repoPath: string, commitSha: string | null) {
+  if (!commitSha) return {};
+  return Object.fromEntries(
+    Object.entries(loadStateFilesAtCommit(repoPath, commitSha)).filter(
+      ([path]) => path.startsWith("sources/"),
+    ),
+  );
+}
+
+function releaseForState(
+  snapshot: ClaudeWatchStateSnapshot,
+): ClaudeReleaseCandidate {
+  return {
+    version: snapshot.package_version,
+    published_at: snapshot.npm_published_at,
+    integrity: snapshot.npm_integrity,
+    tarball_url: "",
+    release_url: snapshot.release_url,
+    release_notes_md: snapshot.release_notes_md,
+    release_published_at: snapshot.release_published_at,
+    dist_tags: snapshot.dist_tags,
+  };
+}
+
+async function selectCandidate(
+  state: ClaudeWatchStateSnapshot | null,
+  args: Args,
+): Promise<ClaudeReleaseCandidate> {
+  const [githubReleases, npmMetadata] = await Promise.all([
+    fetchClaudeGitHubReleases(),
+    fetchClaudeNpmMetadata(),
+  ]);
+  const selected = selectClaudeReleaseCandidate({
+    githubReleases,
+    npmMetadata,
+    previousVersion: args.previousVersion ?? state?.package_version ?? null,
+    currentVersion: args.currentVersion,
+  });
+  if (selected) return selected;
+  const latest = selectClaudeReleaseCandidate({
+    githubReleases,
+    npmMetadata,
+    currentVersion: npmMetadata.dist_tags.latest,
+  });
+  if (!latest) throw new Error("Claude latest release could not be selected");
+  return latest;
+}
+
+async function captureRuntimePair(
+  candidate: ClaudeReleaseCandidate,
+  previous: ClaudeWatchStateSnapshot | null,
+  args: Args,
+  runBehaviorProbes: boolean,
+): Promise<{
+  previousRuntime: ClaudeRuntimeSnapshot | null;
+  currentRuntime: ClaudeRuntimeSnapshot | null;
+}> {
+  const previousVersion =
+    args.previousVersion ?? previous?.package_version ?? null;
+  const packageChanged = previousVersion !== candidate.version;
+  if (args.dryRun) {
+    const root = join(tmpdir(), "claude-watch-dry-run");
+    const plans = [
+      ...(packageChanged && previousVersion
+        ? [
+            createClaudeRuntimeCommandPlan(
+              previousVersion,
+              join(root, "previous"),
+            ),
+          ]
+        : []),
+      ...(packageChanged || !previous?.runtime
+        ? [
+            createClaudeRuntimeCommandPlan(
+              candidate.version,
+              join(root, "current"),
+            ),
+          ]
+        : []),
+    ];
+    console.log(
+      JSON.stringify(
+        {
+          dry_run_runtime_commands: plans.map((plan) => ({
+            package: plan.packageSpec,
+            install: [plan.install.command, ...plan.install.args],
+            public: [
+              [plan.version.command, ...plan.version.args],
+              [plan.help.command, ...plan.help.args],
+              [plan.doctor.command, ...plan.doctor.args],
+              [plan.autoModeDefaults.command, ...plan.autoModeDefaults.args],
+            ],
+            authenticated: [
+              [plan.init.command, ...plan.init.args],
+              ...(runBehaviorProbes
+                ? plan.probes.map(({ command }) => [
+                    command.command,
+                    ...command.args,
+                  ])
+                : []),
+            ],
+          })),
+        },
+        null,
+        2,
+      ),
+    );
+    return {
+      previousRuntime: previous?.runtime ?? null,
+      currentRuntime: previous?.runtime ?? null,
+    };
+  }
+  if (!packageChanged) {
+    const currentRuntime = await captureClaudeRuntime({
+      version: candidate.version,
+      tempDir: tmpdir(),
+      requireAuth: true,
+      reuseProbes: runBehaviorProbes ? undefined : previous?.runtime?.probes,
+    });
+    return { previousRuntime: previous?.runtime ?? null, currentRuntime };
+  }
+  const [previousRuntime, currentRuntime] = await Promise.all([
+    previousVersion
+      ? captureClaudeRuntime({
+          version: previousVersion,
+          tempDir: tmpdir(),
+          requireAuth: true,
+        })
+      : Promise.resolve(null),
+    captureClaudeRuntime({
+      version: candidate.version,
+      tempDir: tmpdir(),
+      requireAuth: true,
+    }),
+  ]);
+  return { previousRuntime, currentRuntime };
+}
+
+function buildErrorAnalysis(
+  error: unknown,
+  state: ClaudeWatchStateSnapshot | null,
+): ClaudeWatchAnalysis {
+  const message = error instanceof Error ? error.message : String(error);
+  const candidate = state
+    ? releaseForState(state)
+    : {
+        version: "unknown",
+        published_at: new Date(0).toISOString(),
+        integrity: "unknown",
+        tarball_url: "",
+        release_url: "https://github.com/anthropics/claude-code/releases",
+        release_notes_md: "",
+        release_published_at: new Date(0).toISOString(),
+        dist_tags: { latest: "unknown", stable: null, next: null },
+      };
+  const docs = state?.docs ?? {
+    index_url: "https://code.claude.com/docs/llms.txt",
+    index_hash: "unknown",
+    digest: "unknown",
+    full_scan: false,
+    scanned_at: new Date(0).toISOString(),
+    pages: {},
+  };
+  const analysis = analyzeClaudeCandidate({
+    candidate,
+    previous: state,
+    currentDocs: docs,
+    currentRuntime: state?.runtime ?? null,
+    workflowRunUrl: workflowRunUrl(),
+    stateBaseSha: state?.state_commit_parent ?? null,
+    errors: [message],
+  });
+  return {
+    ...analysis,
+    candidate_id: `${state?.candidate_id ?? "claude@unknown"}:error:${sha256(message).slice(0, 12)}`,
+  };
+}
+
+export async function main(argv = process.argv.slice(2)): Promise<void> {
+  const args = parseArgs(argv);
+  if (
+    (args.previousVersion || args.currentVersion) &&
+    !args.dryRun &&
+    !args.validationOnly
+  ) {
+    throw new Error(
+      "Manual version overrides require --dry-run or --validation-only so historical replays cannot advance durable watcher state.",
+    );
+  }
+  const repoPath = process.cwd();
+  if (args.rebuildStateCommit) {
+    const rebuilt = rebuildClaudeAnalysisFromState(
+      repoPath,
+      args.rebuildStateCommit,
+    );
+    writeAnalysis(args.analysisFile, rebuilt);
+    console.log(JSON.stringify(rebuilt, null, 2));
+    return;
+  }
+
+  const tracker = ensureTracker(args.repo, args.dryRun || args.validationOnly);
+  trackerOutputs(tracker);
+  const stateTip = args.validationOnly ? null : fetchStateBranchTip(repoPath);
+  const state = stateTip ? loadStateSnapshotAtCommit(repoPath, stateTip) : null;
+  if (stateTip && !state) {
+    throw new Error(`Invalid Claude state snapshot at ${stateTip}`);
+  }
+
+  if (
+    !args.validationOnly &&
+    stateTip &&
+    state &&
+    !hasProcessedCandidate(tracker.state, state.candidate_id)
+  ) {
+    const analysis = rebuildClaudeAnalysisFromState(repoPath, stateTip);
+    writeAnalysis(args.analysisFile, analysis);
+    if (analysis.verdict === "no-op" && !args.dryRun) {
+      const updated = recordTrackerOutcome(
+        args.repo,
+        tracker,
+        analysis,
+        "recorded_noop",
+        "reconciled finalized no-op state after a partial run",
+        stateTip,
+      );
+      trackerOutputs(updated);
+      analysisOutputs(analysis, false, stateTip);
+    } else {
+      analysisOutputs(analysis, !args.dryRun, stateTip);
+    }
+    return;
+  }
+
+  if (!args.validationOnly && state && stateTip) {
+    const entry = findTrackerEntry(tracker.state, state.candidate_id);
+    if (
+      entry &&
+      isTerminalOutcome(entry.outcome) &&
+      entry.state_commit_sha !== stateTip
+    ) {
+      if (!args.dryRun) {
+        recordTrackerOutcome(
+          args.repo,
+          tracker,
+          rebuildClaudeAnalysisFromState(repoPath, stateTip),
+          entry.outcome,
+          entry.notes,
+          stateTip,
+        );
+      }
+    }
+  }
+
+  let analysis: ClaudeWatchAnalysis;
+  let docsCapture: CapturedDocs;
+  let currentRuntime: ClaudeRuntimeSnapshot | null;
+  let previousForAnalysis = state;
+  try {
+    const candidate = await selectCandidate(state, args);
+    const packageChanged = state?.package_version !== candidate.version;
+    docsCapture = await captureDocsSnapshot({
+      previous: state?.docs ?? null,
+      forceFullScan: args.forceDocsScan,
+      packageRelease: packageChanged,
+    });
+    const docsChanged = docsCapture.snapshot.digest !== state?.docs.digest;
+    const runtime = await captureRuntimePair(
+      candidate,
+      state,
+      args,
+      packageChanged || docsChanged || !state?.runtime,
+    );
+    currentRuntime = runtime.currentRuntime;
+    if (args.previousVersion && runtime.previousRuntime) {
+      previousForAnalysis = {
+        schema_version: 1,
+        candidate_id: `manual-replay@${args.previousVersion}`,
+        package_version: args.previousVersion,
+        npm_integrity: "manual-replay",
+        npm_published_at: candidate.published_at,
+        release_url: candidate.release_url,
+        release_notes_md: "manual replay baseline",
+        release_published_at: candidate.release_published_at,
+        dist_tags: candidate.dist_tags,
+        docs: docsCapture.snapshot,
+        runtime: runtime.previousRuntime,
+        fetched_at: new Date().toISOString(),
+        workflow_run_url: workflowRunUrl(),
+        state_commit_parent: null,
+      };
+    } else if (state && runtime.previousRuntime) {
+      previousForAnalysis = { ...state, runtime: runtime.previousRuntime };
+    }
+    analysis = analyzeClaudeCandidate({
+      candidate,
+      previous: previousForAnalysis,
+      currentDocs: docsCapture.snapshot,
+      previousSources: stateSources(repoPath, stateTip),
+      currentSources: docsCapture.sources,
+      currentRuntime,
+      workflowRunUrl: workflowRunUrl(),
+      stateBaseSha: stateTip,
+    });
+  } catch (error) {
+    analysis = buildErrorAnalysis(error, state);
+    writeAnalysis(args.analysisFile, analysis);
+    analysisOutputs(analysis, false, null);
+    if (!args.dryRun && !args.validationOnly) {
+      recordTrackerOutcome(
+        args.repo,
+        tracker,
+        analysis,
+        "error",
+        "retryable detector error; state was not advanced",
+        null,
+        analysis.errors[0] ?? "unknown detector error",
+      );
+    }
+    throw error;
+  }
+
+  writeAnalysis(args.analysisFile, analysis);
+  if (args.validationOnly) {
+    analysisOutputs(analysis, false, null);
+    console.log(JSON.stringify(analysis, null, 2));
+    return;
+  }
+  if (state?.candidate_id === analysis.candidate_id) {
+    analysisOutputs(analysis, false, stateTip);
+    return;
+  }
+  if (hasProcessedCandidate(tracker.state, analysis.candidate_id)) {
+    const entry = findTrackerEntry(tracker.state, analysis.candidate_id);
+    if (args.dryRun || !entry) {
+      analysisOutputs(analysis, false, entry?.state_commit_sha ?? stateTip);
+      return;
+    }
+    const snapshot = buildClaudeStateSnapshot(
+      analysis,
+      docsCapture.snapshot,
+      currentRuntime,
+    );
+    const finalized = finalizeStateBranch({
+      repoPath,
+      snapshot,
+      files: docsCapture.sources,
+      expectedBaseSha: stateTip,
+    });
+    recordTrackerOutcome(
+      args.repo,
+      tracker,
+      analysis,
+      entry.outcome,
+      entry.notes,
+      finalized.commitSha,
+    );
+    analysisOutputs(analysis, false, finalized.commitSha);
+    return;
+  }
+  if (args.dryRun) {
+    analysisOutputs(analysis, false, null);
+    console.log(JSON.stringify(analysis, null, 2));
+    return;
+  }
+
+  const snapshot = buildClaudeStateSnapshot(
+    analysis,
+    docsCapture.snapshot,
+    currentRuntime,
+  );
+  let finalized: ReturnType<typeof finalizeStateBranch>;
+  try {
+    finalized = finalizeStateBranch({
+      repoPath,
+      snapshot,
+      files: docsCapture.sources,
+      expectedBaseSha: stateTip,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    const failedAnalysis: ClaudeWatchAnalysis = {
+      ...analysis,
+      verdict: "manual review required",
+      verdict_reasons: [`state finalization failed: ${message}`],
+      errors: [...analysis.errors, message],
+    };
+    writeAnalysis(args.analysisFile, failedAnalysis);
+    recordTrackerOutcome(
+      args.repo,
+      tracker,
+      failedAnalysis,
+      "error",
+      "retryable state finalization error; durable state was not advanced",
+      null,
+      message,
+    );
+    throw error;
+  }
+  if (analysis.verdict === "no-op") {
+    const updated = recordTrackerOutcome(
+      args.repo,
+      tracker,
+      analysis,
+      "recorded_noop",
+      analysis.verdict_reasons.join("; "),
+      finalized.commitSha,
+    );
+    trackerOutputs(updated);
+    analysisOutputs(analysis, false, finalized.commitSha);
+    return;
+  }
+  analysisOutputs(analysis, true, finalized.commitSha);
+}
+
+if (import.meta.main) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : error);
+    process.exit(1);
+  });
+}

--- a/scripts/claude-watch/docs-snapshot.test.ts
+++ b/scripts/claude-watch/docs-snapshot.test.ts
@@ -1,0 +1,259 @@
+import { describe, expect, test } from "bun:test";
+import {
+  captureDocsSnapshot,
+  deterministicSourcePath,
+  diffDocsSnapshots,
+  extractNamedChanges,
+  hashDocsMarkdown,
+  isWatchedDocsUrl,
+  normalizeDocsMarkdown,
+  parseLlmsTxt,
+  sha256,
+  unifiedDiff,
+} from "./docs-snapshot.ts";
+import type { ClaudeDocsSnapshot } from "./types.ts";
+
+const INDEX = "https://docs.example/llms.txt";
+const TOOLS = "https://docs.example/en/tools.md";
+const GUIDE = "https://docs.example/en/guide.md";
+
+function fixtureFetch(
+  fixtures: Record<string, string>,
+  calls: string[] = [],
+): typeof fetch {
+  return (async (input: string | URL | Request) => {
+    const url = String(input);
+    calls.push(url);
+    const body = fixtures[url];
+    return body === undefined
+      ? new Response("missing", { status: 404 })
+      : new Response(body, { status: 200 });
+  }) as typeof fetch;
+}
+
+describe("official docs capture", () => {
+  test("parses every unique absolute .md URL from llms.txt", () => {
+    expect(
+      parseLlmsTxt(
+        `- [Tools](${TOOLS})\n${GUIDE}?raw=1#part\nrelative.md\nhttps://docs.example/nope.html\n${TOOLS}`,
+      ),
+    ).toEqual([`${GUIDE}?raw=1`, TOOLS]);
+  });
+
+  test("treats the official changelog as watched contract evidence", () => {
+    expect(
+      isWatchedDocsUrl(
+        "https://raw.githubusercontent.com/anthropics/claude-code/main/CHANGELOG.md",
+      ),
+    ).toBe(true);
+  });
+
+  test("semantic normalization preserves markdown while removing transport noise", () => {
+    const source =
+      "# Claude Code Docs  \r\n\r\n# Heading\t\r\n| parameter_name | Value |  \r\n| --- | --- |\r\n| `exactName` |  x  |\r\n```sh\r\nclaude --flag  \r\n```\r\n# Claude Code Docs\r\n";
+    expect(normalizeDocsMarkdown(source)).toBe(
+      "# Claude Code Docs\n\n# Heading\n| parameter_name | Value |\n| --- | --- |\n| `exactName` |  x  |\n```sh\nclaude --flag\n```\n",
+    );
+  });
+
+  test("hashes exact normalized UTF-8 content", () => {
+    expect(hashDocsMarkdown("hello  \r\n")).toBe(sha256("hello\n"));
+    expect(hashDocsMarkdown("Hello\n")).not.toBe(hashDocsMarkdown("hello\n"));
+  });
+
+  test("full capture persists only watched normalized sources deterministically", async () => {
+    const captured = await captureDocsSnapshot({
+      indexUrl: INDEX,
+      now: "2026-01-01T00:00:00Z",
+      fetch: fixtureFetch({
+        [INDEX]: `${GUIDE}\n${TOOLS}\n`,
+        [TOOLS]: "# Tools  \r\n",
+        [GUIDE]: "# Guide\n",
+      }),
+    });
+    expect(captured.snapshot.full_scan).toBe(true);
+    expect(Object.keys(captured.snapshot.pages)).toEqual([GUIDE, TOOLS]);
+    const path = deterministicSourcePath(TOOLS);
+    expect(captured.snapshot.pages[TOOLS]?.source_path).toBe(path);
+    expect(captured.snapshot.pages[GUIDE]?.source_path).toBeNull();
+    expect(captured.sources).toEqual({
+      "sources/llms.txt": `${GUIDE}\n${TOOLS}\n`,
+      [path]: "# Tools\n",
+    });
+  });
+
+  test("refuses indexed and redirected pages outside the authoritative docs origin", async () => {
+    await expect(
+      captureDocsSnapshot({
+        indexUrl: INDEX,
+        retries: 0,
+        fetch: fixtureFetch({
+          [INDEX]: "https://127.0.0.1/internal.md",
+        }),
+      }),
+    ).rejects.toThrow("outside https://docs.example");
+
+    const redirectingFetch = (async (input: string | URL | Request) => {
+      const url = String(input);
+      if (url === INDEX) return new Response(TOOLS);
+      return new Response(null, {
+        status: 302,
+        headers: { location: "https://169.254.169.254/metadata.md" },
+      });
+    }) as typeof fetch;
+    await expect(
+      captureDocsSnapshot({
+        indexUrl: INDEX,
+        retries: 0,
+        fetch: redirectingFetch,
+      }),
+    ).rejects.toThrow("outside https://docs.example");
+  });
+
+  test("detects added, removed, and changed pages with watched source previews", async () => {
+    const oldCapture = await captureDocsSnapshot({
+      indexUrl: INDEX,
+      now: "2026-01-01T00:00:00Z",
+      fetch: fixtureFetch({
+        [INDEX]: `${TOOLS}\n${GUIDE}`,
+        [TOOLS]: "# Tools\nold\n",
+        [GUIDE]: "old",
+      }),
+    });
+    const added = "https://docs.example/en/hooks.md";
+    const current = await captureDocsSnapshot({
+      indexUrl: INDEX,
+      now: "2026-01-02T01:00:00Z",
+      fetch: fixtureFetch({
+        [INDEX]: `${TOOLS}\n${added}`,
+        [TOOLS]: "# Tools\nnew\n",
+        [added]: "# Hooks\n",
+      }),
+      previous: oldCapture.snapshot,
+      forceFullScan: true,
+    });
+    const diff = diffDocsSnapshots(oldCapture.snapshot, current.snapshot, {
+      previousSources: oldCapture.sources,
+      currentSources: current.sources,
+    });
+    expect(diff.added_pages).toEqual([added]);
+    expect(diff.removed_pages).toEqual([GUIDE]);
+    expect(diff.changed_pages).toEqual([TOOLS]);
+    expect(diff.watched_page_diffs[0]?.preview).toContain(
+      `--- a/${deterministicSourcePath(added)}`,
+    );
+  });
+
+  test("digest is stable when only scan metadata changes", async () => {
+    const fixtures = { [INDEX]: TOOLS, [TOOLS]: "# Tools\n" };
+    const first = await captureDocsSnapshot({
+      indexUrl: INDEX,
+      now: 0,
+      fetch: fixtureFetch(fixtures),
+    });
+    const second = await captureDocsSnapshot({
+      indexUrl: INDEX,
+      now: 1000,
+      fetch: fixtureFetch(fixtures),
+      forceFullScan: true,
+    });
+    expect(second.snapshot.digest).toBe(first.snapshot.digest);
+  });
+
+  test("extracts named surfaces only from strongly labelled contexts", () => {
+    const named = extractNamedChanges(
+      `# Tools\n| Tool | Description |\n| --- | --- |\n| Read | reads |\n\n# CLI flags and commands\nUse \`--verbose\` and \`claude doctor\`.\n\n# Settings\n\`sandbox.enabled\`\n\n# Environment variables\n\`CLAUDE_CODE_TOKEN\`\n\n# Permissions\n\`allow(Bash)\`\n\n# Narrative\n\`NOT_AN_ENV\``,
+    );
+    expect([...named.tools]).toEqual(["Read"]);
+    expect([...named.cli].sort()).toEqual(["--verbose", "claude doctor"]);
+    expect([...named.settings]).toEqual(["sandbox.enabled"]);
+    expect([...named.env_vars]).toEqual(["CLAUDE_CODE_TOKEN"]);
+    expect([...named.permission_rules]).toEqual(["allow(Bash)"]);
+  });
+
+  test("reports conservative named additions and removals", () => {
+    const path = deterministicSourcePath(TOOLS);
+    const previous = snapshot({
+      [TOOLS]: { url: TOOLS, watched: true, source_path: path, hash: "old" },
+    });
+    const current = snapshot({
+      [TOOLS]: { url: TOOLS, watched: true, source_path: path, hash: "new" },
+    });
+    const diff = diffDocsSnapshots(previous, current, {
+      previousSources: {
+        [path]:
+          "# Tools\n| Tool | Description |\n| --- | --- |\n| Read | old |\n",
+      },
+      currentSources: {
+        [path]:
+          "# Tools\n| Tool | Description |\n| --- | --- |\n| Write | new |\n",
+      },
+    });
+    expect(diff.tools).toEqual({
+      added: ["Write"],
+      removed: ["Read"],
+      changed: [],
+    });
+  });
+
+  test("bounds diff previews with explicit truncation marker and source path", () => {
+    const result = unifiedDiff(
+      "a\nb\nc\nd\n",
+      "a\nx\ny\nz\n",
+      "docs/source.md",
+      6,
+      10_000,
+    );
+    expect(result.truncated).toBe(true);
+    expect(result.preview).toContain("--- a/docs/source.md");
+    expect(result.preview).toContain("[diff truncated:");
+  });
+
+  test("incremental capture fetches index and watched pages and reuses unwatched hashes", async () => {
+    const previous = snapshot(
+      {
+        [TOOLS]: {
+          url: TOOLS,
+          watched: true,
+          source_path: deterministicSourcePath(TOOLS),
+          hash: "old-tool",
+        },
+        [GUIDE]: {
+          url: GUIDE,
+          watched: false,
+          source_path: null,
+          hash: "reused-guide",
+        },
+      },
+      "2026-01-01T12:00:00Z",
+    );
+    const calls: string[] = [];
+    const result = await captureDocsSnapshot({
+      indexUrl: INDEX,
+      previous,
+      now: "2026-01-01T13:00:00Z",
+      fetch: fixtureFetch(
+        { [INDEX]: `${TOOLS}\n${GUIDE}`, [TOOLS]: "# Tools\nchanged\n" },
+        calls,
+      ),
+      retries: 0,
+    });
+    expect(result.snapshot.full_scan).toBe(false);
+    expect(calls).toEqual([INDEX, TOOLS]);
+    expect(result.snapshot.pages[GUIDE]?.hash).toBe("reused-guide");
+  });
+});
+
+function snapshot(
+  pages: ClaudeDocsSnapshot["pages"],
+  scannedAt = "2026-01-01T00:00:00Z",
+): ClaudeDocsSnapshot {
+  return {
+    index_url: INDEX,
+    index_hash: "index",
+    digest: "digest",
+    full_scan: true,
+    scanned_at: scannedAt,
+    pages,
+  };
+}

--- a/scripts/claude-watch/docs-snapshot.ts
+++ b/scripts/claude-watch/docs-snapshot.ts
@@ -1,0 +1,672 @@
+import { createHash } from "node:crypto";
+import { createTwoFilesPatch } from "diff";
+import type {
+  ClaudeDocsDiff,
+  ClaudeDocsPageDiff,
+  ClaudeDocsPageSnapshot,
+  ClaudeDocsSnapshot,
+  ClaudeNamedChange,
+} from "./types.ts";
+
+export const DEFAULT_LLMS_URL = "https://code.claude.com/docs/llms.txt";
+export const OFFICIAL_CHANGELOG_URL =
+  "https://raw.githubusercontent.com/anthropics/claude-code/main/CHANGELOG.md";
+export const FULL_SCAN_INTERVAL_MS = 24 * 60 * 60 * 1_000;
+
+const WATCHED_PATH_PARTS = [
+  "/tools",
+  "/cli",
+  "/commands",
+  "/changelog",
+  "/settings",
+  "/environment",
+  "/env",
+  "/permissions",
+  "/headless",
+  "/how-it-works",
+  "/sub-agents",
+  "/subagents",
+  "/worktrees",
+  "/interactive",
+  "/hooks",
+  "/agent-sdk",
+  "/claude-agent-sdk",
+] as const;
+
+export type DocsFetch = (
+  input: string | URL | Request,
+  init?: RequestInit,
+) => Promise<Response>;
+
+export interface CaptureDocsOptions {
+  fetch?: DocsFetch;
+  indexUrl?: string;
+  previous?: ClaudeDocsSnapshot | null;
+  forceFullScan?: boolean;
+  packageRelease?: boolean;
+  now?: Date | string | number;
+  timeoutMs?: number;
+  retries?: number;
+  retryBackoffMs?: number;
+}
+
+export interface CapturedDocs {
+  snapshot: ClaudeDocsSnapshot;
+  /** Normalized markdown, keyed by the snapshot's deterministic source_path. */
+  sources: Record<string, string>;
+}
+
+export interface DiffDocsOptions {
+  previousSources?: Record<string, string>;
+  currentSources?: Record<string, string>;
+  maxPreviewLines?: number;
+  maxPreviewChars?: number;
+}
+
+/** llms.txt is an index, not prose: every absolute HTTP(S) URL ending in .md is authoritative. */
+export function parseLlmsTxt(text: string): string[] {
+  const urls = new Set<string>();
+  const pattern = /https?:\/\/[^\s<>"'`]+/gu;
+  for (const match of text.matchAll(pattern)) {
+    const candidate = match[0].replace(/[),.;:\]}]+$/u, "");
+    try {
+      const url = new URL(candidate);
+      if (url.pathname.toLowerCase().endsWith(".md")) {
+        url.hash = "";
+        urls.add(url.toString());
+      }
+    } catch {
+      // A malformed absolute URL cannot be fetched and is intentionally ignored.
+    }
+  }
+  return [...urls].sort();
+}
+
+/**
+ * Normalize only transport/presentation noise. In particular, leading whitespace,
+ * blank lines, headings, tables, code and identifier spelling remain untouched.
+ */
+export function normalizeDocsMarkdown(input: string): string {
+  const lines = input
+    .replace(/^\uFEFF/u, "")
+    .replace(/\r\n?/gu, "\n")
+    .split("\n");
+  const seenBanners = new Set<string>();
+  const normalized: string[] = [];
+
+  for (const rawLine of lines) {
+    const line = rawLine.replace(/[\t ]+$/u, "");
+    if (isDocsBanner(line)) {
+      const key = line.trim().toLowerCase();
+      if (seenBanners.has(key)) continue;
+      seenBanners.add(key);
+    }
+    normalized.push(line);
+  }
+
+  while (normalized.length > 0 && normalized[normalized.length - 1] === "") {
+    normalized.pop();
+  }
+  return `${normalized.join("\n")}\n`;
+}
+
+function isDocsBanner(line: string): boolean {
+  const value = line
+    .trim()
+    .replace(/^#+\s*/u, "")
+    .replace(/^>\s*/u, "");
+  return /^(?:anthropic\s+)?claude(?:\s+code)?\s+docs(?:umentation)?$/iu.test(
+    value,
+  );
+}
+
+export function sha256(content: string): string {
+  return createHash("sha256").update(content, "utf8").digest("hex");
+}
+
+export function hashDocsMarkdown(content: string): string {
+  return sha256(normalizeDocsMarkdown(content));
+}
+
+export function isWatchedDocsUrl(value: string): boolean {
+  try {
+    const url = new URL(value);
+    const path = url.pathname.toLowerCase().replace(/\.md$/u, "");
+    const slugParts = path.split("/").filter(Boolean);
+    return (
+      WATCHED_PATH_PARTS.some((part) => {
+        const watched = part.slice(1);
+        return (
+          path.includes(`${part}/`) ||
+          slugParts.some(
+            (slug) =>
+              slug === watched ||
+              slug.startsWith(`${watched}-`) ||
+              slug.endsWith(`-${watched}`),
+          )
+        );
+      }) || slugParts.some((slug) => /^(?:how-.*-works|env-vars)$/u.test(slug))
+    );
+  } catch {
+    return false;
+  }
+}
+
+export function deterministicSourcePath(value: string): string {
+  const url = new URL(value);
+  const host = url.hostname.toLowerCase().replace(/[^a-z0-9.-]+/gu, "-");
+  const path = decodeURIComponent(url.pathname)
+    .replace(/^\/+|\/+$/gu, "")
+    .replace(/\.md$/iu, "")
+    .split("/")
+    .map((part) =>
+      part.replace(/[^a-zA-Z0-9._-]+/gu, "-").replace(/^-+|-+$/gu, ""),
+    )
+    .filter(Boolean)
+    .join("/");
+  const query = url.search ? `-${sha256(url.search).slice(0, 10)}` : "";
+  return `sources/${host}/${path || "index"}${query}.md`;
+}
+
+export function shouldFullScan(options: CaptureDocsOptions): boolean {
+  if (options.forceFullScan || options.packageRelease || !options.previous)
+    return true;
+  const now = toDate(options.now ?? new Date()).getTime();
+  const lastFullScanAt = Date.parse(options.previous.scanned_at);
+  return (
+    !Number.isFinite(lastFullScanAt) ||
+    now - lastFullScanAt >= FULL_SCAN_INTERVAL_MS
+  );
+}
+
+export async function captureDocsSnapshot(
+  options: CaptureDocsOptions = {},
+): Promise<CapturedDocs> {
+  const fetcher = options.fetch ?? globalThis.fetch;
+  const indexUrl = options.indexUrl ?? DEFAULT_LLMS_URL;
+  const allowedOrigin = new URL(indexUrl).origin;
+  const fixedAllowedUrls = new Set(
+    indexUrl === DEFAULT_LLMS_URL ? [OFFICIAL_CHANGELOG_URL] : [],
+  );
+  const now = toDate(options.now ?? new Date());
+  const indexText = await fetchText(
+    indexUrl,
+    fetcher,
+    options,
+    allowedOrigin,
+    fixedAllowedUrls,
+  );
+  const normalizedIndex = normalizeDocsMarkdown(indexText);
+  const urls = [
+    ...new Set([...parseLlmsTxt(indexText), ...fixedAllowedUrls]),
+  ].sort();
+  const fullScan = shouldFullScan(options);
+  const pages: Record<string, ClaudeDocsPageSnapshot> = {};
+  const sources: Record<string, string> = {
+    "sources/llms.txt": normalizedIndex,
+  };
+
+  const capturedPages = await mapConcurrent(urls, 8, async (url) => {
+    const watched = isWatchedDocsUrl(url);
+    const oldPage = options.previous?.pages[url];
+    if (!fullScan && !watched && oldPage) {
+      return {
+        page: { ...oldPage, watched: false, source_path: null },
+        source: null,
+      };
+    }
+    // A newly indexed unwatched page has no truthful hash to reuse, so fetch it
+    // once. Established unwatched pages above remain network-free incrementally.
+    const normalized = normalizeDocsMarkdown(
+      await fetchText(url, fetcher, options, allowedOrigin, fixedAllowedUrls),
+    );
+    const sourcePath = watched ? deterministicSourcePath(url) : null;
+    return {
+      page: {
+        url,
+        hash: sha256(normalized),
+        watched,
+        source_path: sourcePath,
+      },
+      source: sourcePath ? ([sourcePath, normalized] as const) : null,
+    };
+  });
+  for (const { page, source } of capturedPages) {
+    pages[page.url] = page;
+    if (source) sources[source[0]] = source[1];
+  }
+
+  const snapshotWithoutDigest = {
+    index_url: indexUrl,
+    index_hash: sha256(normalizedIndex),
+    full_scan: fullScan,
+    // Preserve the last full-scan clock across incremental captures so the
+    // 24-hour policy remains enforceable with the persisted snapshot schema.
+    scanned_at: fullScan
+      ? now.toISOString()
+      : (options.previous?.scanned_at ?? now.toISOString()),
+    pages: sortRecord(pages),
+  };
+  const digest = docsDigest(
+    snapshotWithoutDigest.index_hash,
+    snapshotWithoutDigest.pages,
+  );
+  return {
+    snapshot: { ...snapshotWithoutDigest, digest },
+    sources: sortRecord(sources),
+  };
+}
+
+async function mapConcurrent<T, R>(
+  values: readonly T[],
+  concurrency: number,
+  mapper: (value: T) => Promise<R>,
+): Promise<R[]> {
+  const results = new Array<R>(values.length);
+  let next = 0;
+  const workers = Array.from(
+    { length: Math.min(concurrency, values.length) },
+    async () => {
+      while (next < values.length) {
+        const index = next;
+        next += 1;
+        results[index] = await mapper(values[index] as T);
+      }
+    },
+  );
+  await Promise.all(workers);
+  return results;
+}
+
+function docsDigest(
+  indexHash: string,
+  pages: Record<string, ClaudeDocsPageSnapshot>,
+): string {
+  // scanned_at and full_scan are operational metadata, not documentation content.
+  return sha256(
+    JSON.stringify({
+      index_hash: indexHash,
+      pages: Object.keys(pages)
+        .sort()
+        .map((url) => [url, pages[url]?.hash]),
+    }),
+  );
+}
+
+async function fetchText(
+  url: string,
+  fetcher: DocsFetch,
+  options: CaptureDocsOptions,
+  allowedOrigin: string,
+  fixedAllowedUrls: ReadonlySet<string>,
+): Promise<string> {
+  const retries = options.retries ?? 2;
+  const timeoutMs = options.timeoutMs ?? 15_000;
+  const backoff = options.retryBackoffMs ?? 250;
+  let lastError: unknown;
+  let currentUrl = url;
+  let redirects = 0;
+
+  for (let attempt = 0; attempt <= retries; attempt += 1) {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+    try {
+      assertAllowedDocsUrl(currentUrl, allowedOrigin, fixedAllowedUrls);
+      const response = await fetcher(currentUrl, {
+        signal: controller.signal,
+        redirect: "manual",
+      });
+      if (response.status >= 300 && response.status < 400) {
+        redirects += 1;
+        if (redirects > 3)
+          throw new Error(`Too many redirects fetching ${url}`);
+        const location = response.headers.get("location");
+        if (!location)
+          throw new Error(`Redirect without Location from ${currentUrl}`);
+        const redirected = new URL(location, currentUrl).toString();
+        assertAllowedDocsUrl(redirected, allowedOrigin, fixedAllowedUrls);
+        currentUrl = redirected;
+        attempt -= 1;
+        continue;
+      }
+      if (!response.ok)
+        throw new Error(`HTTP ${response.status} fetching ${currentUrl}`);
+      return await response.text();
+    } catch (error) {
+      lastError = error;
+      if (attempt < retries && backoff > 0) await sleep(backoff * 2 ** attempt);
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+  throw lastError instanceof Error
+    ? lastError
+    : new Error(`Failed to fetch ${url}`);
+}
+
+function assertAllowedDocsUrl(
+  value: string,
+  allowedOrigin: string,
+  fixedAllowedUrls: ReadonlySet<string>,
+): void {
+  const url = new URL(value);
+  url.hash = "";
+  if (
+    url.protocol !== "https:" ||
+    (url.origin !== allowedOrigin && !fixedAllowedUrls.has(url.toString())) ||
+    url.username ||
+    url.password
+  ) {
+    throw new Error(
+      `Refusing documentation URL outside ${allowedOrigin}: ${value}`,
+    );
+  }
+}
+
+export function diffDocsSnapshots(
+  previous: ClaudeDocsSnapshot | null,
+  current: ClaudeDocsSnapshot,
+  options: DiffDocsOptions = {},
+): ClaudeDocsDiff {
+  const previousPages = previous?.pages ?? {};
+  const oldUrls = new Set(Object.keys(previousPages));
+  const newUrls = new Set(Object.keys(current.pages));
+  const addedPages = [...newUrls].filter((url) => !oldUrls.has(url)).sort();
+  const removedPages = [...oldUrls].filter((url) => !newUrls.has(url)).sort();
+  const changedPages = [...newUrls]
+    .filter(
+      (url) =>
+        oldUrls.has(url) &&
+        previousPages[url]?.hash !== current.pages[url]?.hash,
+    )
+    .sort();
+
+  const watchedPageDiffs: ClaudeDocsPageDiff[] = [];
+  const oldNamed = emptyNamedMaps();
+  const newNamed = emptyNamedMaps();
+  const relevant = [
+    ...new Set([...addedPages, ...removedPages, ...changedPages]),
+  ].sort();
+  for (const url of relevant) {
+    const oldPage = previousPages[url];
+    const newPage = current.pages[url];
+    const sourcePath = newPage?.source_path ?? oldPage?.source_path ?? null;
+    if (!sourcePath) continue;
+    const oldText = oldPage?.source_path
+      ? options.previousSources?.[oldPage.source_path]
+      : undefined;
+    const newText = newPage?.source_path
+      ? options.currentSources?.[newPage.source_path]
+      : undefined;
+    if (oldText === undefined && newText === undefined) continue;
+    const preview = unifiedDiff(
+      oldText ?? "",
+      newText ?? "",
+      sourcePath,
+      options.maxPreviewLines ?? 160,
+      options.maxPreviewChars ?? 20_000,
+    );
+    watchedPageDiffs.push({ url, source_path: sourcePath, ...preview });
+    mergeNamedMaps(oldNamed, extractNamedEntries(oldText ?? ""));
+    mergeNamedMaps(newNamed, extractNamedEntries(newText ?? ""));
+  }
+
+  return {
+    added_pages: addedPages,
+    removed_pages: removedPages,
+    changed_pages: changedPages,
+    watched_page_diffs: watchedPageDiffs,
+    tools: compareNames(oldNamed.tools, newNamed.tools),
+    cli: compareNames(oldNamed.cli, newNamed.cli),
+    settings: compareNames(oldNamed.settings, newNamed.settings),
+    env_vars: compareNames(oldNamed.env_vars, newNamed.env_vars),
+    permission_rules: compareNames(
+      oldNamed.permission_rules,
+      newNamed.permission_rules,
+    ),
+  };
+}
+
+type NamedSets = Record<
+  "tools" | "cli" | "settings" | "env_vars" | "permission_rules",
+  Set<string>
+>;
+
+function emptyNamedCollections(): NamedSets {
+  return {
+    tools: new Set(),
+    cli: new Set(),
+    settings: new Set(),
+    env_vars: new Set(),
+    permission_rules: new Set(),
+  };
+}
+
+type NamedMaps = Record<keyof NamedSets, Map<string, string>>;
+
+function emptyNamedMaps(): NamedMaps {
+  return {
+    tools: new Map(),
+    cli: new Map(),
+    settings: new Map(),
+    env_vars: new Map(),
+    permission_rules: new Map(),
+  };
+}
+
+function mergeNamedMaps(target: NamedMaps, source: NamedMaps): void {
+  for (const key of Object.keys(target) as Array<keyof NamedMaps>) {
+    for (const [name, signature] of source[key]) {
+      const existing = target[key].get(name);
+      target[key].set(
+        name,
+        existing ? sha256(`${existing}\n${signature}`) : signature,
+      );
+    }
+  }
+}
+
+/** Extract only names presented in strongly-labelled documentation contexts. */
+export function extractNamedChanges(markdown: string): NamedSets {
+  const result = emptyNamedCollections();
+  const lines = normalizeDocsMarkdown(markdown).split("\n");
+  let heading = "";
+  let tableKind: keyof NamedSets | null = null;
+  let tableNameColumn = -1;
+
+  for (const line of lines) {
+    const headingMatch = /^#{1,6}\s+(.+)$/u.exec(line);
+    if (headingMatch?.[1]) {
+      heading = headingMatch[1].toLowerCase();
+      tableKind = null;
+      tableNameColumn = -1;
+    }
+
+    if (line.includes("|") && /^\s*\|/u.test(line)) {
+      const cells = tableCells(line);
+      const lower = cells.map((cell) => cell.toLowerCase());
+      if (lower.some((cell) => /^(tool|tool name)$/u.test(cell))) {
+        tableKind = "tools";
+        tableNameColumn = lower.findIndex((cell) =>
+          /^(tool|tool name)$/u.test(cell),
+        );
+        continue;
+      }
+      const contextualKind = headingKind(heading);
+      const nameColumn = lower.findIndex((cell) =>
+        /^(name|setting|variable|rule|command|flag)$/u.test(cell),
+      );
+      if (contextualKind && nameColumn >= 0) {
+        tableKind = contextualKind;
+        tableNameColumn = nameColumn;
+        continue;
+      }
+      if (tableKind && !cells.every((cell) => /^:?-{3,}:?$/u.test(cell))) {
+        const value = cleanName(cells[tableNameColumn] ?? "");
+        if (
+          value &&
+          (tableKind !== "tools" ||
+            /^(?:[A-Z][A-Za-z0-9_]*|mcp__[A-Za-z0-9_]+)$/u.test(value))
+        ) {
+          result[tableKind].add(value);
+        }
+      }
+    }
+
+    if (/\b(?:cli|command|flags?|options?)\b/iu.test(heading)) {
+      for (const match of line.matchAll(
+        /(?:^|[\s`,(])(--[a-z0-9][a-z0-9-]*)(?=$|[\s`,)=])/giu,
+      )) {
+        if (match[1]) result.cli.add(match[1]);
+      }
+      for (const match of line.matchAll(
+        /`(claude(?:\s+[a-z][a-z0-9-]*)+)`/giu,
+      )) {
+        if (match[1]) result.cli.add(match[1]);
+      }
+    }
+    if (/\b(?:settings?|configuration)\b/iu.test(heading)) {
+      for (const match of line.matchAll(
+        /`([a-z][a-zA-Z0-9]*(?:\.[a-zA-Z0-9_-]+)+)`/gu,
+      )) {
+        if (match[1]) result.settings.add(match[1]);
+      }
+    }
+    if (/\b(?:environment|env(?:ironment)? variables?)\b/iu.test(heading)) {
+      for (const match of line.matchAll(/`([A-Z][A-Z0-9_]{2,})`/gu)) {
+        if (match[1]) result.env_vars.add(match[1]);
+      }
+    }
+    if (/\bpermissions?\b/iu.test(heading)) {
+      for (const match of line.matchAll(
+        /`((?:allow|deny|ask)(?:\([^`\n]+\)|\.[a-zA-Z0-9_.-]+))`/gu,
+      )) {
+        if (match[1]) result.permission_rules.add(match[1]);
+      }
+    }
+  }
+  return result;
+}
+
+function extractNamedEntries(markdown: string): NamedMaps {
+  const names = extractNamedChanges(markdown);
+  const result = emptyNamedMaps();
+  const lines = normalizeDocsMarkdown(markdown).split("\n");
+  for (const key of Object.keys(names) as Array<keyof NamedSets>) {
+    for (const name of names[key]) {
+      // Tie a name to only the strongly-labelled line that exposed it. This
+      // reports table-row/flag-description edits without interpreting prose.
+      const evidence = lines.filter((line) => line.includes(name)).join("\n");
+      result[key].set(name, sha256(evidence));
+    }
+  }
+  return result;
+}
+
+function headingKind(heading: string): keyof NamedSets | null {
+  if (/\btools?\b/u.test(heading)) return "tools";
+  if (/\b(?:cli|commands?|flags?|options?)\b/u.test(heading)) return "cli";
+  if (/\b(?:settings?|configuration)\b/u.test(heading)) return "settings";
+  if (/\b(?:environment|env variables?)\b/u.test(heading)) return "env_vars";
+  if (/\bpermissions?\b/u.test(heading)) return "permission_rules";
+  return null;
+}
+
+function tableCells(line: string): string[] {
+  return line
+    .trim()
+    .replace(/^\||\|$/gu, "")
+    .split("|")
+    .map((cell) => cell.trim());
+}
+
+function cleanName(value: string): string | null {
+  const cleaned = value.replace(/[*_]/gu, "").replace(/^`|`$/gu, "").trim();
+  if (
+    !cleaned ||
+    /^:?-{3,}:?$/u.test(cleaned) ||
+    cleaned.length > 120 ||
+    /\n/u.test(cleaned)
+  )
+    return null;
+  return cleaned;
+}
+
+function compareNames(
+  oldNames: Map<string, string>,
+  newNames: Map<string, string>,
+): ClaudeNamedChange {
+  return {
+    added: [...newNames.keys()].filter((name) => !oldNames.has(name)).sort(),
+    removed: [...oldNames.keys()].filter((name) => !newNames.has(name)).sort(),
+    changed: [...newNames.keys()]
+      .filter(
+        (name) =>
+          oldNames.has(name) && oldNames.get(name) !== newNames.get(name),
+      )
+      .sort(),
+  };
+}
+
+export function unifiedDiff(
+  oldText: string,
+  newText: string,
+  sourcePath: string,
+  maxLines = 160,
+  maxChars = 20_000,
+): { preview: string; truncated: boolean } {
+  const oldLines = splitDiffLines(oldText);
+  const newLines = splitDiffLines(newText);
+  const patch = createTwoFilesPatch(
+    `a/${sourcePath}`,
+    `b/${sourcePath}`,
+    oldLines.join("\n"),
+    newLines.join("\n"),
+    "",
+    "",
+    { context: 3 },
+  );
+  const output = patch.split("\n").filter((line, index) => {
+    return !(index === 0 && /^=+$/u.test(line));
+  });
+  let preview = output.join("\n");
+  let truncated = false;
+  if (output.length > maxLines) {
+    preview = [
+      ...output.slice(0, Math.max(0, maxLines - 1)),
+      `... [diff truncated: ${output.length - maxLines + 1} lines omitted] ...`,
+    ].join("\n");
+    truncated = true;
+  }
+  if (preview.length > maxChars) {
+    const marker = `\n... [diff truncated: character limit ${maxChars}] ...`;
+    preview = `${preview.slice(0, Math.max(0, maxChars - marker.length))}${marker}`;
+    truncated = true;
+  }
+  return { preview, truncated };
+}
+
+function splitDiffLines(text: string): string[] {
+  if (!text) return [];
+  const lines = text.replace(/\r\n?/gu, "\n").split("\n");
+  if (lines[lines.length - 1] === "") lines.pop();
+  return lines;
+}
+
+function sortRecord<T>(record: Record<string, T>): Record<string, T> {
+  return Object.fromEntries(
+    Object.entries(record).sort(([a], [b]) => a.localeCompare(b)),
+  );
+}
+
+function toDate(value: Date | string | number): Date {
+  const date =
+    value instanceof Date ? new Date(value.getTime()) : new Date(value);
+  if (!Number.isFinite(date.getTime()))
+    throw new Error(`Invalid snapshot time: ${String(value)}`);
+  return date;
+}
+
+function sleep(milliseconds: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}

--- a/scripts/claude-watch/fixtures/historical-replays.json
+++ b/scripts/claude-watch/fixtures/historical-replays.json
@@ -1,0 +1,52 @@
+[
+  {
+    "id": "read-tab-prefix",
+    "previous_version": "2.1.227",
+    "current_version": "2.1.228",
+    "previous_tools": ["Read"],
+    "current_tools": ["Read"],
+    "probe_name": "read-lines-9-10-tab-prefix",
+    "previous_result": " 9→line9\n10→line10",
+    "current_result": "9\tline9\n10\tline10",
+    "expected_verdict": "tool contract review needed",
+    "local_surfaces": ["src/tools/impl/read.ts", "src/tools/read.test.ts"]
+  },
+  {
+    "id": "task-metadata-delete-contract",
+    "previous_version": "2.1.19",
+    "current_version": "2.1.20",
+    "previous_tools": ["TaskCreate", "TaskGet", "TaskList", "TaskUpdate"],
+    "current_tools": ["TaskCreate", "TaskGet", "TaskList", "TaskUpdate"],
+    "probe_name": "task-metadata-delete-contract",
+    "previous_result": "metadata values must be strings; deleted task remains retrievable",
+    "current_result": "metadata accepts arbitrary values; null deletes a key; deleted task is absent",
+    "expected_verdict": "tool contract review needed",
+    "local_surfaces": [
+      "src/tools/schemas/TaskUpdate.json",
+      "src/tools/impl/task-update.ts",
+      "src/tools/impl/tasks/store.ts"
+    ]
+  },
+  {
+    "id": "task-tool-transition",
+    "previous_version": "2.1.82",
+    "current_version": "2.1.83",
+    "previous_tools": ["LS", "MultiEdit", "Read", "TaskOutput", "TodoWrite"],
+    "current_tools": [
+      "Read",
+      "TaskCreate",
+      "TaskGet",
+      "TaskList",
+      "TaskUpdate"
+    ],
+    "probe_name": "task-metadata-delete-contract",
+    "previous_result": "legacy task surface",
+    "current_result": "task family advertised; TaskOutput deprecated in favor of Read output path",
+    "expected_verdict": "tool surface review needed",
+    "local_surfaces": [
+      "src/agent/subagents/builtin/fork.md",
+      "src/agent/subagents/builtin/general-purpose.md",
+      "src/tools/descriptions/TaskOutput.md"
+    ]
+  }
+]

--- a/scripts/claude-watch/github.ts
+++ b/scripts/claude-watch/github.ts
@@ -1,0 +1,137 @@
+import { spawnSync } from "node:child_process";
+import { rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+export function runGh(args: string[], input?: string): string {
+  const result = spawnSync("gh", args, {
+    encoding: "utf8",
+    input,
+    maxBuffer: 50 * 1024 * 1024,
+    stdio: input ? ["pipe", "pipe", "pipe"] : ["ignore", "pipe", "pipe"],
+  });
+  if (result.status !== 0) {
+    throw new Error(`gh ${args.join(" ")} failed:\n${result.stderr}`);
+  }
+  return result.stdout;
+}
+
+export function ghJson<T>(args: string[]): T {
+  return JSON.parse(runGh(args)) as T;
+}
+
+export function ensureLabel(repo: string, label: string): void {
+  const result = spawnSync(
+    "gh",
+    [
+      "label",
+      "create",
+      label,
+      "--repo",
+      repo,
+      "--description",
+      "Automated Claude Code upstream monitoring",
+      "--color",
+      "7E57C2",
+    ],
+    { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] },
+  );
+  if (result.status !== 0 && !result.stderr.includes("already exists")) {
+    throw new Error(`gh label create ${label} failed:\n${result.stderr}`);
+  }
+}
+
+export function findIssueByExactTitle(
+  repo: string,
+  title: string,
+): { number: number; url: string; body: string } | null {
+  const issues = ghJson<Array<{ number: number; title: string; url: string }>>([
+    "issue",
+    "list",
+    "--repo",
+    repo,
+    "--state",
+    "all",
+    "--search",
+    `${title} in:title`,
+    "--limit",
+    "20",
+    "--json",
+    "number,title,url",
+  ]);
+  const issue = issues.find((candidate) => candidate.title === title);
+  if (!issue) return null;
+  return { ...issue, body: getIssueBody(repo, issue.number) };
+}
+
+export function createIssue(
+  repo: string,
+  title: string,
+  body: string,
+  label: string,
+): { number: number; url: string; body: string } {
+  const bodyFile = writeTemp(body, "claude-watch-issue");
+  try {
+    const url = runGh([
+      "issue",
+      "create",
+      "--repo",
+      repo,
+      "--title",
+      title,
+      "--body-file",
+      bodyFile,
+      "--label",
+      label,
+    ]).trim();
+    const issue = ghJson<{ number: number; url: string; body: string | null }>([
+      "issue",
+      "view",
+      url,
+      "--repo",
+      repo,
+      "--json",
+      "number,url,body",
+    ]);
+    return { ...issue, body: issue.body ?? "" };
+  } finally {
+    rmSync(bodyFile, { force: true });
+  }
+}
+
+export function getIssueBody(repo: string, issue: number): string {
+  return (
+    ghJson<{ body: string | null }>([
+      "issue",
+      "view",
+      String(issue),
+      "--repo",
+      repo,
+      "--json",
+      "body",
+    ]).body ?? ""
+  );
+}
+
+export function editIssueBody(repo: string, issue: number, body: string): void {
+  const bodyFile = writeTemp(body, "claude-watch-tracker");
+  try {
+    runGh([
+      "issue",
+      "edit",
+      String(issue),
+      "--repo",
+      repo,
+      "--body-file",
+      bodyFile,
+    ]);
+  } finally {
+    rmSync(bodyFile, { force: true });
+  }
+}
+
+function writeTemp(body: string, prefix: string): string {
+  const path = join(tmpdir(), `${prefix}-${process.pid}-${Date.now()}.md`);
+  writeFileSync(path, body);
+  return path;
+}

--- a/scripts/claude-watch/release-analysis.test.ts
+++ b/scripts/claude-watch/release-analysis.test.ts
@@ -1,0 +1,235 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+  analyzeClaudeCandidate,
+  buildClaudeCandidateId,
+} from "./release-analysis.ts";
+import type {
+  ClaudeDocsSnapshot,
+  ClaudeProbeObservation,
+  ClaudeReleaseCandidate,
+  ClaudeRuntimeSnapshot,
+  ClaudeWatchStateSnapshot,
+  ClaudeWatchVerdict,
+} from "./types.ts";
+
+interface ReplayFixture {
+  id: string;
+  previous_version: string;
+  current_version: string;
+  previous_tools: string[];
+  current_tools: string[];
+  probe_name: string;
+  previous_result: string;
+  current_result: string;
+  expected_verdict: ClaudeWatchVerdict;
+  local_surfaces: string[];
+}
+
+const fixtures = JSON.parse(
+  readFileSync(
+    join(import.meta.dir, "fixtures", "historical-replays.json"),
+    "utf8",
+  ),
+) as ReplayFixture[];
+
+function docs(digest = "docs-stable"): ClaudeDocsSnapshot {
+  return {
+    index_url: "https://code.claude.com/docs/llms.txt",
+    index_hash: "index",
+    digest,
+    full_scan: true,
+    scanned_at: "2026-08-01T00:00:00Z",
+    pages: {},
+  };
+}
+
+function probe(name: string, result: string): ClaudeProbeObservation {
+  return {
+    name,
+    status: "passed",
+    attempts: 1,
+    assertions: { observed_result: result },
+    tool_calls: [],
+    tool_results: [result],
+    filesystem_changes: [],
+    error: null,
+  };
+}
+
+function runtime(
+  version: string,
+  tools: string[],
+  observation: ClaudeProbeObservation,
+): ClaudeRuntimeSnapshot {
+  return {
+    version,
+    version_output: `${version} (Claude Code)`,
+    help_text: "--permission-mode <mode>",
+    help_hash: "help",
+    doctor: { exit_code: 0, summary: "No installation issues found." },
+    auto_mode_defaults: {},
+    init: {
+      tools,
+      model: "claude-test",
+      capabilities: null,
+      stable_fields: {},
+    },
+    event_inventory: ["assistant", "system/init", "user"],
+    probes: [observation],
+    digest: `${version}-runtime`,
+  };
+}
+
+function candidate(version: string): ClaudeReleaseCandidate {
+  return {
+    version,
+    published_at: "2026-08-01T00:00:00Z",
+    integrity: `sha512-${version}`,
+    tarball_url: `https://registry.npmjs.org/${version}.tgz`,
+    release_url: `https://github.com/anthropics/claude-code/releases/tag/v${version}`,
+    release_notes_md: "Observable Claude Code harness behavior changed.",
+    release_published_at: "2026-08-01T00:01:00Z",
+    dist_tags: { latest: version, stable: version, next: null },
+  };
+}
+
+function previousState(
+  version: string,
+  previousRuntime: ClaudeRuntimeSnapshot,
+): ClaudeWatchStateSnapshot {
+  return {
+    schema_version: 1,
+    candidate_id: buildClaudeCandidateId(
+      version,
+      docs().digest,
+      previousRuntime.digest,
+    ),
+    package_version: version,
+    npm_integrity: `sha512-${version}`,
+    npm_published_at: "2026-08-01T00:00:00Z",
+    release_url: `https://github.com/anthropics/claude-code/releases/tag/v${version}`,
+    release_notes_md: "previous",
+    release_published_at: "2026-08-01T00:00:00Z",
+    dist_tags: { latest: version, stable: version, next: null },
+    docs: docs(),
+    runtime: previousRuntime,
+    fetched_at: "2026-08-01T00:00:00Z",
+    workflow_run_url: "https://example.test/actions/1",
+    state_commit_parent: null,
+  };
+}
+
+describe("historical Claude parity routing fixtures", () => {
+  for (const fixture of fixtures) {
+    test(`${fixture.id} routes captured evidence to semantic review`, () => {
+      const oldRuntime = runtime(
+        fixture.previous_version,
+        fixture.previous_tools,
+        probe(fixture.probe_name, fixture.previous_result),
+      );
+      const currentRuntime = runtime(
+        fixture.current_version,
+        fixture.current_tools,
+        probe(fixture.probe_name, fixture.current_result),
+      );
+      const analysis = analyzeClaudeCandidate({
+        candidate: candidate(fixture.current_version),
+        previous: previousState(fixture.previous_version, oldRuntime),
+        currentDocs: docs(),
+        currentRuntime,
+        workflowRunUrl: "https://example.test/actions/2",
+        stateBaseSha: "state-parent",
+      });
+
+      expect(analysis.verdict).toBe(fixture.expected_verdict);
+      expect(fixture.local_surfaces.length).toBeGreaterThan(0);
+    });
+  }
+});
+
+describe("Claude verdict routing", () => {
+  test("bootstrap requires a current-vs-local audit", () => {
+    const currentRuntime = runtime(
+      "2.1.237",
+      ["Read"],
+      probe("read-lines-9-10-tab-prefix", "9\tline9\n10\tline10"),
+    );
+    const analysis = analyzeClaudeCandidate({
+      candidate: candidate("2.1.237"),
+      previous: null,
+      currentDocs: docs(),
+      currentRuntime,
+      workflowRunUrl: "https://example.test/actions/bootstrap",
+      stateBaseSha: null,
+    });
+
+    expect(analysis.verdict).toBe("manual review required");
+    expect(analysis.runtime_snapshot?.init?.tools).toEqual(["Read"]);
+  });
+
+  test("inconclusive behavioral probes require manual review", () => {
+    const old = runtime(
+      "2.1.236",
+      ["Read"],
+      probe("read-lines-9-10-tab-prefix", "old"),
+    );
+    const inconclusive = runtime("2.1.237", ["Read"], {
+      ...probe("read-lines-9-10-tab-prefix", ""),
+      status: "inconclusive",
+      error: "model did not call Read",
+    });
+    const analysis = analyzeClaudeCandidate({
+      candidate: candidate("2.1.237"),
+      previous: previousState("2.1.236", old),
+      currentDocs: docs(),
+      currentRuntime: inconclusive,
+      workflowRunUrl: "https://example.test/actions/3",
+      stateBaseSha: "parent",
+    });
+    expect(analysis.verdict).toBe("manual review required");
+    expect(analysis.verdict_reasons[0]).toContain("inconclusive");
+  });
+
+  test("an unwatched docs-only digest change still receives semantic review", () => {
+    const stableRuntime = runtime(
+      "2.1.237",
+      ["Read"],
+      probe("read-lines-9-10-tab-prefix", "stable"),
+    );
+    const previous = previousState("2.1.237", stableRuntime);
+    previous.docs = {
+      ...docs("old-docs"),
+      pages: {
+        "https://code.claude.com/docs/en/billing.md": {
+          url: "https://code.claude.com/docs/en/billing.md",
+          hash: "old",
+          watched: false,
+          source_path: null,
+        },
+      },
+    };
+    const currentDocs = {
+      ...docs("new-docs"),
+      pages: {
+        "https://code.claude.com/docs/en/billing.md": {
+          url: "https://code.claude.com/docs/en/billing.md",
+          hash: "new",
+          watched: false,
+          source_path: null,
+        },
+      },
+    };
+    const analysis = analyzeClaudeCandidate({
+      candidate: candidate("2.1.237"),
+      previous,
+      currentDocs,
+      currentRuntime: stableRuntime,
+      workflowRunUrl: "https://example.test/actions/4",
+      stateBaseSha: "parent",
+    });
+    expect(analysis.verdict).toBe("harness behavior review needed");
+    expect(analysis.verdict_reasons[0]).toContain("unwatched");
+  });
+});

--- a/scripts/claude-watch/release-analysis.ts
+++ b/scripts/claude-watch/release-analysis.ts
@@ -1,0 +1,291 @@
+import { diffDocsSnapshots } from "./docs-snapshot.ts";
+import { diffClaudeRuntime } from "./runtime-probe.ts";
+import {
+  loadStateFilesAtCommit,
+  loadStateSnapshotAtCommit,
+} from "./state-branch.ts";
+import type {
+  ClaudeDocsSnapshot,
+  ClaudeReleaseCandidate,
+  ClaudeRuntimeSnapshot,
+  ClaudeWatchAnalysis,
+  ClaudeWatchStateSnapshot,
+  ClaudeWatchVerdict,
+} from "./types.ts";
+
+export interface AnalyzeClaudeCandidateOptions {
+  candidate: ClaudeReleaseCandidate;
+  previous: ClaudeWatchStateSnapshot | null;
+  currentDocs: ClaudeDocsSnapshot;
+  previousSources?: Record<string, string>;
+  currentSources?: Record<string, string>;
+  currentRuntime: ClaudeRuntimeSnapshot | null;
+  workflowRunUrl: string;
+  stateBaseSha: string | null;
+  errors?: string[];
+}
+
+export interface ClaudeVerdictInput {
+  analysis: Omit<ClaudeWatchAnalysis, "verdict" | "verdict_reasons">;
+}
+
+export function buildClaudeCandidateId(
+  version: string,
+  docsDigest: string,
+  runtimeDigest: string | null = null,
+): string {
+  return `claude@${version}:docs:${docsDigest}:runtime:${runtimeDigest ?? "none"}`;
+}
+
+export function buildClaudeStateSnapshot(
+  analysis: ClaudeWatchAnalysis,
+  docs: ClaudeDocsSnapshot,
+  runtime: ClaudeRuntimeSnapshot | null,
+): ClaudeWatchStateSnapshot {
+  return {
+    schema_version: 1,
+    candidate_id: analysis.candidate_id,
+    package_version: analysis.current_version,
+    npm_integrity: analysis.npm_integrity,
+    npm_published_at: analysis.npm_published_at,
+    release_url: analysis.release_url,
+    release_notes_md: analysis.release_notes_md,
+    release_published_at: analysis.release_published_at,
+    dist_tags: analysis.dist_tags,
+    docs,
+    runtime,
+    fetched_at: new Date().toISOString(),
+    workflow_run_url: analysis.workflow_run_url,
+    state_commit_parent: analysis.state_base_sha,
+  };
+}
+
+export function analyzeClaudeCandidate(
+  options: AnalyzeClaudeCandidateOptions,
+): ClaudeWatchAnalysis {
+  const docsDiff = diffDocsSnapshots(
+    options.previous?.docs ?? null,
+    options.currentDocs,
+    {
+      previousSources: options.previousSources,
+      currentSources: options.currentSources,
+    },
+  );
+  const runtimeDiff =
+    options.previous?.runtime && options.currentRuntime
+      ? diffClaudeRuntime(options.previous.runtime, options.currentRuntime)
+      : null;
+  const candidateId = buildClaudeCandidateId(
+    options.candidate.version,
+    options.currentDocs.digest,
+    options.currentRuntime?.digest ?? null,
+  );
+  const base = {
+    schema_version: 1,
+    candidate_id: candidateId,
+    previous_candidate_id: options.previous?.candidate_id ?? null,
+    previous_version: options.previous?.package_version ?? null,
+    current_version: options.candidate.version,
+    is_bootstrap: options.previous === null,
+    release_url: options.candidate.release_url,
+    release_notes_md: options.candidate.release_notes_md,
+    npm_integrity: options.candidate.integrity,
+    npm_published_at: options.candidate.published_at,
+    release_published_at: options.candidate.release_published_at,
+    dist_tags: options.candidate.dist_tags,
+    docs_digest: options.currentDocs.digest,
+    runtime_digest: options.currentRuntime?.digest ?? null,
+    docs_diff: docsDiff,
+    previous_runtime_snapshot: options.previous?.runtime ?? null,
+    runtime_snapshot: options.currentRuntime,
+    runtime_diff: runtimeDiff,
+    errors: options.errors ?? [],
+    workflow_run_url: options.workflowRunUrl,
+    state_base_sha: options.stateBaseSha,
+    state_snapshot_candidate_id: options.previous?.candidate_id ?? null,
+  } satisfies Omit<ClaudeWatchAnalysis, "verdict" | "verdict_reasons">;
+  const { verdict, reasons } = classifyClaudeVerdict({ analysis: base });
+  return {
+    ...base,
+    verdict,
+    verdict_reasons: reasons,
+  };
+}
+
+export function rebuildClaudeAnalysisFromState(
+  repoPath: string,
+  stateCommitSha: string,
+): ClaudeWatchAnalysis {
+  const current = loadStateSnapshotAtCommit(repoPath, stateCommitSha);
+  if (!current) {
+    throw new Error(`No valid Claude state snapshot at ${stateCommitSha}`);
+  }
+  const previous = current.state_commit_parent
+    ? loadStateSnapshotAtCommit(repoPath, current.state_commit_parent)
+    : null;
+  const currentFiles = loadStateFilesAtCommit(repoPath, stateCommitSha);
+  const previousFiles = current.state_commit_parent
+    ? loadStateFilesAtCommit(repoPath, current.state_commit_parent)
+    : {};
+  const candidate: ClaudeReleaseCandidate = {
+    version: current.package_version,
+    published_at: current.npm_published_at,
+    integrity: current.npm_integrity,
+    tarball_url: "",
+    release_url: current.release_url,
+    release_notes_md: current.release_notes_md,
+    release_published_at: current.release_published_at,
+    dist_tags: current.dist_tags,
+  };
+  const analysis = analyzeClaudeCandidate({
+    candidate,
+    previous,
+    currentDocs: current.docs,
+    previousSources: sourceFiles(previousFiles),
+    currentSources: sourceFiles(currentFiles),
+    currentRuntime: current.runtime,
+    workflowRunUrl: current.workflow_run_url,
+    stateBaseSha: current.state_commit_parent,
+  });
+  if (analysis.candidate_id !== current.candidate_id) {
+    throw new Error(
+      `Rebuilt candidate ${analysis.candidate_id} does not match state ${current.candidate_id}`,
+    );
+  }
+  return analysis;
+}
+
+function sourceFiles(files: Record<string, string>): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(files).filter(([path]) => path.startsWith("sources/")),
+  );
+}
+
+export function classifyClaudeVerdict(input: ClaudeVerdictInput): {
+  verdict: ClaudeWatchVerdict;
+  reasons: string[];
+} {
+  const { analysis } = input;
+  const reasons: string[] = [];
+  if (analysis.errors.length > 0) {
+    return {
+      verdict: "manual review required",
+      reasons: analysis.errors.map((error) => `capture error: ${error}`),
+    };
+  }
+  if (analysis.is_bootstrap) {
+    return {
+      verdict: "manual review required",
+      reasons: [
+        "bootstrap requires a complete current Claude-vs-local parity audit",
+      ],
+    };
+  }
+
+  const runtime = analysis.runtime_diff;
+  if (
+    runtime &&
+    (runtime.tools_added.length > 0 || runtime.tools_removed.length > 0)
+  ) {
+    reasons.push(
+      `runtime tool inventory changed (${[
+        ...runtime.tools_added.map((name) => `+${name}`),
+        ...runtime.tools_removed.map((name) => `-${name}`),
+      ].join(", ")})`,
+    );
+    return { verdict: "tool surface review needed", reasons };
+  }
+
+  const namedToolChanges = analysis.docs_diff.tools;
+  const probeProblems = [
+    ...(analysis.previous_runtime_snapshot?.probes.map((probe) => ({
+      side: "previous",
+      probe,
+    })) ?? []),
+    ...(analysis.runtime_snapshot?.probes.map((probe) => ({
+      side: "current",
+      probe,
+    })) ?? []),
+  ].filter(({ probe }) => probe.status !== "passed");
+  if (probeProblems.length > 0) {
+    return {
+      verdict: "manual review required",
+      reasons: probeProblems.map(
+        ({ side, probe }) =>
+          `${side} ${probe.name} probe was ${probe.status}: ${probe.error ?? "unknown"}`,
+      ),
+    };
+  }
+  if (
+    namedToolChanges.added.length > 0 ||
+    namedToolChanges.removed.length > 0 ||
+    namedToolChanges.changed.length > 0 ||
+    (runtime?.changed_probes.length ?? 0) > 0
+  ) {
+    reasons.push("official tool contracts or fixed probe observations changed");
+    return { verdict: "tool contract review needed", reasons };
+  }
+
+  const releaseText = analysis.release_notes_md.toLowerCase();
+  if (
+    /\b(system prompt|prompt instruction|claude\.md|memory|output style|model guidance)\b/u.test(
+      releaseText,
+    )
+  ) {
+    return {
+      verdict: "prompt review needed",
+      reasons: [
+        "release notes describe model-facing prompt or guidance behavior",
+      ],
+    };
+  }
+
+  const docs = analysis.docs_diff;
+  const watchedDocsChanged = docs.watched_page_diffs.length > 0;
+  const anyDocsPageChanged =
+    docs.added_pages.length > 0 ||
+    docs.removed_pages.length > 0 ||
+    docs.changed_pages.length > 0;
+  const namedHarnessChanged = [
+    docs.cli,
+    docs.settings,
+    docs.env_vars,
+    docs.permission_rules,
+  ].some(
+    (change) =>
+      change.added.length > 0 ||
+      change.removed.length > 0 ||
+      change.changed.length > 0,
+  );
+  const runtimeChanged = Boolean(
+    runtime &&
+      (runtime.help_changed ||
+        runtime.doctor_changed ||
+        runtime.init_changed ||
+        runtime.auto_mode_defaults_changed ||
+        runtime.event_types_added.length > 0 ||
+        runtime.event_types_removed.length > 0),
+  );
+  const packageChanged = analysis.previous_version !== analysis.current_version;
+  if (
+    watchedDocsChanged ||
+    anyDocsPageChanged ||
+    namedHarnessChanged ||
+    runtimeChanged ||
+    packageChanged
+  ) {
+    if (watchedDocsChanged) reasons.push("watched official docs changed");
+    else if (anyDocsPageChanged)
+      reasons.push("an unwatched official docs page changed and needs review");
+    if (namedHarnessChanged) reasons.push("named harness surfaces changed");
+    if (runtimeChanged) reasons.push("observable runtime behavior changed");
+    if (packageChanged)
+      reasons.push("a new exact Claude package was published");
+    return { verdict: "harness behavior review needed", reasons };
+  }
+
+  return {
+    verdict: "no-op",
+    reasons: ["only unwatched documentation content or metadata changed"],
+  };
+}

--- a/scripts/claude-watch/release-source.test.ts
+++ b/scripts/claude-watch/release-source.test.ts
@@ -1,0 +1,154 @@
+import {
+  ClaudeReleaseSourceDisagreementError,
+  parseClaudeGitHubReleases,
+  parseClaudeNpmMetadata,
+  selectClaudeReleaseCandidate,
+} from "./release-source.ts";
+import type { ClaudeGitHubRelease, ClaudeNpmMetadata } from "./types.ts";
+
+function github(version: string, hour: number): ClaudeGitHubRelease {
+  return {
+    tag_name: version,
+    draft: false,
+    prerelease: false,
+    html_url: `https://github.com/anthropics/claude-code/releases/tag/v${version}`,
+    body: `notes ${version}`,
+    published_at: `2026-08-01T${String(hour).padStart(2, "0")}:00:00Z`,
+  };
+}
+
+function npm(latest = "1.2.0"): ClaudeNpmMetadata {
+  return {
+    dist_tags: { latest, stable: "1.1.0", next: "2.0.0-beta.1" },
+    versions: ["1.0.0", "1.1.0", "1.2.0"].map((version, index) => ({
+      version,
+      published_at: `2026-08-01T0${index}:30:00Z`,
+      integrity: `sha512-${version}`,
+      tarball_url: `https://registry.npmjs.org/pkg/-/${version}.tgz`,
+    })),
+  };
+}
+
+const releases = [github("1.0.0", 0), github("1.1.0", 1), github("1.2.0", 2)];
+
+describe("parseClaudeGitHubReleases", () => {
+  test("filters drafts and prereleases, normalizes tags, and orders oldest first", () => {
+    const parsed = parseClaudeGitHubReleases([
+      { ...github("v1.2.0", 2), tag_name: "v1.2.0" },
+      { ...github("1.3.0-beta.1", 3), prerelease: true },
+      { ...github("1.1.0", 1), draft: true },
+      { ...github("v1.0.0", 0), tag_name: "v1.0.0" },
+    ]);
+
+    expect(parsed.map(({ tag_name }) => tag_name)).toEqual(["1.0.0", "1.2.0"]);
+  });
+});
+
+describe("parseClaudeNpmMetadata", () => {
+  test("includes channels, all publish times, integrity, and tarballs", () => {
+    const parsed = parseClaudeNpmMetadata({
+      "dist-tags": { latest: "1.1.0", stable: "1.0.0", next: "1.2.0-beta.1" },
+      versions: {
+        "1.1.0": {
+          dist: { integrity: "sha512-b", tarball: "https://npm/b.tgz" },
+        },
+        "1.0.0": {
+          dist: { integrity: "sha512-a", tarball: "https://npm/a.tgz" },
+        },
+      },
+      time: {
+        "1.0.0": "2026-08-01T00:00:00Z",
+        "1.1.0": "2026-08-02T00:00:00Z",
+      },
+    });
+
+    expect(parsed.dist_tags).toEqual({
+      latest: "1.1.0",
+      stable: "1.0.0",
+      next: "1.2.0-beta.1",
+    });
+    expect(parsed.versions).toEqual([
+      {
+        version: "1.0.0",
+        published_at: "2026-08-01T00:00:00Z",
+        integrity: "sha512-a",
+        tarball_url: "https://npm/a.tgz",
+      },
+      {
+        version: "1.1.0",
+        published_at: "2026-08-02T00:00:00Z",
+        integrity: "sha512-b",
+        tarball_url: "https://npm/b.tgz",
+      },
+    ]);
+  });
+});
+
+describe("selectClaudeReleaseCandidate", () => {
+  test("throws an actionable typed error when latest sources mismatch", () => {
+    expect(() =>
+      selectClaudeReleaseCandidate({
+        githubReleases: releases,
+        npmMetadata: npm("1.1.0"),
+        processedPackageVersions: ["1.0.0"],
+      }),
+    ).toThrow(ClaudeReleaseSourceDisagreementError);
+
+    try {
+      selectClaudeReleaseCandidate({
+        githubReleases: releases,
+        npmMetadata: npm("1.1.0"),
+      });
+    } catch (error) {
+      expect(error).toMatchObject({
+        code: "CLAUDE_RELEASE_SOURCE_DISAGREEMENT",
+        githubVersion: "1.2.0",
+        npmVersion: "1.1.0",
+      });
+      expect((error as Error).message).toContain("rerun the watcher");
+    }
+  });
+
+  test("takes the oldest release after the terminal processed version", () => {
+    const candidate = selectClaudeReleaseCandidate({
+      githubReleases: releases,
+      npmMetadata: npm(),
+      processedPackageVersions: ["1.0.0"],
+    });
+
+    expect(candidate?.version).toBe("1.1.0");
+    expect(candidate?.integrity).toBe("sha512-1.1.0");
+  });
+
+  test("bootstrap selects only the current npm latest release", () => {
+    const candidate = selectClaudeReleaseCandidate({
+      githubReleases: releases,
+      npmMetadata: npm(),
+    });
+
+    expect(candidate?.version).toBe("1.2.0");
+  });
+
+  test("explicit previous and current overrides select the exact release", () => {
+    const candidate = selectClaudeReleaseCandidate({
+      githubReleases: releases,
+      npmMetadata: npm(),
+      processedPackageVersions: ["1.0.0"],
+      previousVersion: "1.0.0",
+      currentVersion: "1.2.0",
+    });
+
+    expect(candidate?.version).toBe("1.2.0");
+    expect(candidate?.release_notes_md).toBe("notes 1.2.0");
+  });
+
+  test("returns null after the latest terminal version", () => {
+    expect(
+      selectClaudeReleaseCandidate({
+        githubReleases: releases,
+        npmMetadata: npm(),
+        processedPackageVersions: ["1.0.0", "1.1.0", "1.2.0"],
+      }),
+    ).toBeNull();
+  });
+});

--- a/scripts/claude-watch/release-source.ts
+++ b/scripts/claude-watch/release-source.ts
@@ -1,0 +1,353 @@
+import type {
+  ClaudeGitHubRelease,
+  ClaudeNpmMetadata,
+  ClaudeNpmVersion,
+  ClaudeReleaseCandidate,
+} from "./types.ts";
+
+const GITHUB_RELEASES_URL =
+  "https://api.github.com/repos/anthropics/claude-code/releases";
+const NPM_METADATA_URL =
+  "https://registry.npmjs.org/%40anthropic-ai%2Fclaude-code";
+const EXACT_SEMVER =
+  /^[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/u;
+
+export interface ReleaseSourceFetchOptions {
+  fetch?: typeof globalThis.fetch;
+  timeoutMs?: number;
+  retries?: number;
+  backoffMs?: number;
+  sleep?: (milliseconds: number) => Promise<void>;
+}
+
+export interface ReleaseSelectionOptions {
+  githubReleases: ClaudeGitHubRelease[];
+  npmMetadata: ClaudeNpmMetadata;
+  processedPackageVersions?: string[];
+  previousVersion?: string | null;
+  currentVersion?: string | null;
+}
+
+export class ClaudeReleaseSourceDisagreementError extends Error {
+  readonly code = "CLAUDE_RELEASE_SOURCE_DISAGREEMENT";
+  readonly githubVersion: string | null;
+  readonly npmVersion: string;
+
+  constructor(
+    githubVersion: string | null,
+    npmVersion: string,
+    detail?: string,
+  ) {
+    const action =
+      "Wait for the GitHub release and npm latest channel to agree, then rerun the watcher.";
+    super(
+      `Claude Code release sources disagree: GitHub latest is ${githubVersion ?? "missing"}, ` +
+        `npm latest is ${npmVersion}.${detail ? ` ${detail}` : ""} ${action}`,
+    );
+    this.name = "ClaudeReleaseSourceDisagreementError";
+    this.githubVersion = githubVersion;
+    this.npmVersion = npmVersion;
+  }
+}
+
+export function normalizeGitHubReleaseTag(tag: string): string {
+  return tag.startsWith("v") ? tag.slice(1) : tag;
+}
+
+function object(value: unknown, context: string): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new TypeError(`${context} must be an object`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function string(value: unknown, context: string): string {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new TypeError(`${context} must be a non-empty string`);
+  }
+  return value;
+}
+
+function nullableString(value: unknown, context: string): string | null {
+  if (value === null || value === undefined) return null;
+  return string(value, context);
+}
+
+function compareTimestampsThenVersions(
+  left: { published_at: string; version: string },
+  right: { published_at: string; version: string },
+): number {
+  return (
+    Date.parse(left.published_at) - Date.parse(right.published_at) ||
+    left.version.localeCompare(right.version, undefined, { numeric: true })
+  );
+}
+
+/** Parse, normalize, filter, de-duplicate, and chronologically order GitHub releases. */
+export function parseClaudeGitHubReleases(
+  input: unknown,
+): ClaudeGitHubRelease[] {
+  if (!Array.isArray(input))
+    throw new TypeError("GitHub releases response must be an array");
+
+  const byVersion = new Map<string, ClaudeGitHubRelease>();
+  for (const [index, item] of input.entries()) {
+    const raw = object(item, `GitHub release ${index}`);
+    if (raw.draft === true || raw.prerelease === true) continue;
+    if (typeof raw.draft !== "boolean" || typeof raw.prerelease !== "boolean") {
+      throw new TypeError(`GitHub release ${index} has invalid release flags`);
+    }
+    const version = normalizeGitHubReleaseTag(
+      string(raw.tag_name, `GitHub release ${index}.tag_name`),
+    );
+    if (!EXACT_SEMVER.test(version)) continue;
+    const publishedAt = nullableString(
+      raw.published_at,
+      `GitHub release ${index}.published_at`,
+    );
+    if (!publishedAt || Number.isNaN(Date.parse(publishedAt))) continue;
+    const release: ClaudeGitHubRelease = {
+      tag_name: version,
+      draft: false,
+      prerelease: false,
+      html_url: string(raw.html_url, `GitHub release ${index}.html_url`),
+      body: nullableString(raw.body, `GitHub release ${index}.body`),
+      published_at: publishedAt,
+    };
+    const existing = byVersion.get(version);
+    if (
+      !existing ||
+      Date.parse(publishedAt) < Date.parse(existing.published_at ?? publishedAt)
+    ) {
+      byVersion.set(version, release);
+    }
+  }
+
+  return [...byVersion.values()].sort((left, right) =>
+    compareTimestampsThenVersions(
+      { published_at: left.published_at ?? "", version: left.tag_name },
+      { published_at: right.published_at ?? "", version: right.tag_name },
+    ),
+  );
+}
+
+/** Parse the npm registry document into the small, stable shape used by the watcher. */
+export function parseClaudeNpmMetadata(input: unknown): ClaudeNpmMetadata {
+  const raw = object(input, "npm metadata response");
+  const rawTags = object(raw["dist-tags"], "npm dist-tags");
+  const latest = string(rawTags.latest, "npm dist-tags.latest");
+  if (!EXACT_SEMVER.test(latest)) {
+    throw new TypeError(
+      `npm dist-tags.latest is not an exact semver: ${latest}`,
+    );
+  }
+  const rawVersions = object(raw.versions, "npm versions");
+  const rawTimes = object(raw.time, "npm publish times");
+  const versions: ClaudeNpmVersion[] = [];
+
+  for (const [version, versionValue] of Object.entries(rawVersions)) {
+    const versionDocument = object(versionValue, `npm version ${version}`);
+    const dist = object(versionDocument.dist, `npm version ${version}.dist`);
+    const publishedAt = string(
+      rawTimes[version],
+      `npm publish time ${version}`,
+    );
+    if (Number.isNaN(Date.parse(publishedAt))) {
+      throw new TypeError(
+        `npm publish time ${version} is not a valid timestamp`,
+      );
+    }
+    versions.push({
+      version,
+      published_at: publishedAt,
+      integrity: string(
+        dist.integrity,
+        `npm version ${version}.dist.integrity`,
+      ),
+      tarball_url: string(dist.tarball, `npm version ${version}.dist.tarball`),
+    });
+  }
+  versions.sort(compareTimestampsThenVersions);
+
+  if (!versions.some((version) => version.version === latest)) {
+    throw new TypeError(
+      `npm latest version ${latest} is absent from npm versions`,
+    );
+  }
+
+  return {
+    dist_tags: {
+      latest,
+      stable: nullableString(rawTags.stable, "npm dist-tags.stable"),
+      next: nullableString(rawTags.next, "npm dist-tags.next"),
+    },
+    versions,
+  };
+}
+
+function assertSourcesAgree(
+  githubReleases: ClaudeGitHubRelease[],
+  npmMetadata: ClaudeNpmMetadata,
+): void {
+  const npmLatest = npmMetadata.dist_tags.latest;
+  const githubLatest = githubReleases.at(-1)?.tag_name ?? null;
+  if (githubLatest !== npmLatest) {
+    throw new ClaudeReleaseSourceDisagreementError(githubLatest, npmLatest);
+  }
+}
+
+/**
+ * Select one release without side effects. Sources are checked before any selection,
+ * so a disagreement cannot accidentally advance persisted watcher state.
+ */
+export function selectClaudeReleaseCandidate(
+  options: ReleaseSelectionOptions,
+): ClaudeReleaseCandidate | null {
+  const githubReleases = [...options.githubReleases].sort((left, right) =>
+    compareTimestampsThenVersions(
+      { published_at: left.published_at ?? "", version: left.tag_name },
+      { published_at: right.published_at ?? "", version: right.tag_name },
+    ),
+  );
+  assertSourcesAgree(githubReleases, options.npmMetadata);
+
+  const npmByVersion = new Map(
+    options.npmMetadata.versions.map((version) => [version.version, version]),
+  );
+  const currentVersion = options.currentVersion ?? null;
+  const terminalVersion =
+    options.previousVersion ?? options.processedPackageVersions?.at(-1) ?? null;
+
+  if (
+    options.previousVersion &&
+    (!githubReleases.some(
+      ({ tag_name }) => tag_name === options.previousVersion,
+    ) ||
+      !npmByVersion.has(options.previousVersion))
+  ) {
+    throw new ClaudeReleaseSourceDisagreementError(
+      githubReleases.at(-1)?.tag_name ?? null,
+      options.npmMetadata.dist_tags.latest,
+      `Explicit previous version ${options.previousVersion} is not present in both sources.`,
+    );
+  }
+
+  let release: ClaudeGitHubRelease | undefined;
+  if (currentVersion) {
+    release = githubReleases.find(
+      ({ tag_name }) => tag_name === currentVersion,
+    );
+    if (!release || !npmByVersion.has(currentVersion)) {
+      throw new ClaudeReleaseSourceDisagreementError(
+        githubReleases.at(-1)?.tag_name ?? null,
+        options.npmMetadata.dist_tags.latest,
+        `Explicit current version ${currentVersion} is not present in both sources.`,
+      );
+    }
+  } else if (!terminalVersion) {
+    release = githubReleases.find(
+      ({ tag_name }) => tag_name === options.npmMetadata.dist_tags.latest,
+    );
+  } else {
+    const terminalIndex = githubReleases.findIndex(
+      ({ tag_name }) => tag_name === terminalVersion,
+    );
+    if (terminalIndex < 0) {
+      throw new ClaudeReleaseSourceDisagreementError(
+        githubReleases.at(-1)?.tag_name ?? null,
+        options.npmMetadata.dist_tags.latest,
+        `Terminal version ${terminalVersion} is not present in GitHub releases.`,
+      );
+    }
+    release = githubReleases[terminalIndex + 1];
+  }
+
+  if (!release) return null;
+  const npmVersion = npmByVersion.get(release.tag_name);
+  if (!npmVersion || !release.published_at) {
+    throw new ClaudeReleaseSourceDisagreementError(
+      githubReleases.at(-1)?.tag_name ?? null,
+      options.npmMetadata.dist_tags.latest,
+      `Selected version ${release.tag_name} is incomplete in a release source.`,
+    );
+  }
+  return {
+    ...npmVersion,
+    release_url: release.html_url,
+    release_notes_md: release.body ?? "",
+    release_published_at: release.published_at,
+    dist_tags: options.npmMetadata.dist_tags,
+  };
+}
+
+async function fetchJson(
+  url: string,
+  options: ReleaseSourceFetchOptions,
+  headers: HeadersInit,
+): Promise<unknown> {
+  const fetchImplementation = options.fetch ?? globalThis.fetch;
+  const retries = options.retries ?? 2;
+  const timeoutMs = options.timeoutMs ?? 10_000;
+  const backoffMs = options.backoffMs ?? 250;
+  const sleep =
+    options.sleep ??
+    ((ms) => new Promise((resolve) => setTimeout(resolve, ms)));
+  let lastError: unknown;
+
+  for (let attempt = 0; attempt <= retries; attempt += 1) {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+    try {
+      const response = await fetchImplementation(url, {
+        headers,
+        signal: controller.signal,
+      });
+      if (!response.ok)
+        throw new Error(`${response.status} ${response.statusText}`);
+      return await response.json();
+    } catch (error) {
+      lastError = error;
+      if (attempt === retries) break;
+      await sleep(backoffMs * 2 ** attempt);
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+  throw new Error(`Failed to fetch ${url} after ${retries + 1} attempts`, {
+    cause: lastError,
+  });
+}
+
+export async function fetchClaudeGitHubReleases(
+  options: ReleaseSourceFetchOptions = {},
+): Promise<ClaudeGitHubRelease[]> {
+  const rawReleases: unknown[] = [];
+  for (let page = 1; ; page += 1) {
+    const payload = await fetchJson(
+      `${GITHUB_RELEASES_URL}?per_page=100&page=${page}`,
+      options,
+      {
+        Accept: "application/vnd.github+json",
+        "User-Agent": "letta-claude-watch",
+        ...(process.env.GH_TOKEN
+          ? { Authorization: `Bearer ${process.env.GH_TOKEN}` }
+          : {}),
+      },
+    );
+    if (!Array.isArray(payload)) {
+      throw new TypeError("GitHub releases response must be an array");
+    }
+    rawReleases.push(...payload);
+    if (payload.length < 100) break;
+  }
+  return parseClaudeGitHubReleases(rawReleases);
+}
+
+export async function fetchClaudeNpmMetadata(
+  options: ReleaseSourceFetchOptions = {},
+): Promise<ClaudeNpmMetadata> {
+  const payload = await fetchJson(NPM_METADATA_URL, options, {
+    Accept: "application/json",
+  });
+  return parseClaudeNpmMetadata(payload);
+}

--- a/scripts/claude-watch/runtime-observations.ts
+++ b/scripts/claude-watch/runtime-observations.ts
@@ -1,0 +1,119 @@
+export interface ProbeTranscript {
+  toolCalls: Array<{ id: string | null; name: string; input: unknown }>;
+  toolResults: Array<{
+    toolUseId: string | null;
+    content: string;
+    isError: boolean;
+  }>;
+}
+
+export function evaluateProbe(
+  name: string,
+  parsed: ProbeTranscript,
+): { complete: boolean; assertions: Record<string, boolean> } {
+  if (name === "read-lines-9-10-tab-prefix") {
+    const read = parsed.toolCalls.find((call) => call.name === "Read");
+    const input = record(read?.input);
+    const result = parsed.toolResults.find(
+      (candidate) => candidate.toolUseId === read?.id,
+    );
+    const content = result?.content ?? "";
+    return {
+      complete:
+        input?.offset === 9 && input.limit === 2 && result !== undefined,
+      assertions: {
+        exact_line_9: /(?:^|\n)9\tline9(?:\n|$)/u.test(content),
+        exact_line_10: /(?:^|\n)10\tline10(?:\n|$)/u.test(content),
+        no_line_9_padding: !/(?:^|\n)[ \t]+9\tline9(?:\n|$)/u.test(content),
+        no_arrow_separator: !content.includes("→"),
+        result_not_error: result?.isError === false,
+      },
+    };
+  }
+  if (name === "task-metadata-delete-contract") {
+    const calls = parsed.toolCalls;
+    const deletedIndex = calls.findIndex(
+      (call) =>
+        call.name === "TaskUpdate" && record(call.input)?.status === "deleted",
+    );
+    const beforeGet = calls.find(
+      (call, index) => call.name === "TaskGet" && index < deletedIndex,
+    );
+    const afterGet = calls.find(
+      (call, index) => call.name === "TaskGet" && index > deletedIndex,
+    );
+    const list = calls.find(
+      (call, index) => call.name === "TaskList" && index > deletedIndex,
+    );
+    const resultFor = (id: string | null | undefined) =>
+      parsed.toolResults.find((candidate) => candidate.toolUseId === id);
+    const beforeResult = resultFor(beforeGet?.id);
+    const afterResult = resultFor(afterGet?.id);
+    const listResult = resultFor(list?.id);
+    const metadata = findMetadata(parseJsonResult(beforeResult?.content ?? ""));
+    return {
+      complete:
+        calls.some((call) => call.name === "TaskCreate") &&
+        calls.some((call) => call.name === "TaskUpdate") &&
+        deletedIndex >= 0 &&
+        beforeResult !== undefined &&
+        afterResult !== undefined &&
+        listResult !== undefined,
+      assertions: {
+        metadata_arbitrary_values:
+          metadata?.count === 3 &&
+          Array.isArray(metadata.flags) &&
+          metadata.flags[0] === "ready" &&
+          record(metadata.details)?.source === "claude-watch",
+        metadata_null_deleted:
+          metadata?.keep === "yes" && !("probe" in (metadata ?? {})),
+        deleted_task_get_errors:
+          afterResult?.isError === true ||
+          /not[ -]?found|does not exist|deleted/iu.test(
+            afterResult?.content ?? "",
+          ),
+        deleted_task_absent:
+          listResult !== undefined && !/probe-task/iu.test(listResult.content),
+      },
+    };
+  }
+  return {
+    complete: parsed.toolCalls.length > 0 && parsed.toolResults.length > 0,
+    assertions: {},
+  };
+}
+
+function parseJsonResult(content: string): unknown {
+  try {
+    return JSON.parse(content);
+  } catch {
+    const start = content.indexOf("{");
+    const end = content.lastIndexOf("}");
+    if (start >= 0 && end > start) {
+      try {
+        return JSON.parse(content.slice(start, end + 1));
+      } catch {
+        return null;
+      }
+    }
+    return null;
+  }
+}
+
+function findMetadata(value: unknown): Record<string, unknown> | null {
+  const object = record(value);
+  if (!object) return null;
+  const metadata = record(object.metadata);
+  if (metadata) return metadata;
+  for (const child of Object.values(object)) {
+    const found = findMetadata(child);
+    if (found) return found;
+  }
+  return null;
+}
+
+function record(value: unknown): Record<string, unknown> | null {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}

--- a/scripts/claude-watch/runtime-probe.test.ts
+++ b/scripts/claude-watch/runtime-probe.test.ts
@@ -1,0 +1,536 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtemp, readdir, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { evaluateProbe } from "./runtime-observations.ts";
+import {
+  captureClaudeRuntime,
+  createClaudeRuntimeCommandPlan,
+  diffClaudeRuntime,
+  normalizeVolatile,
+  parseClaudeStream,
+} from "./runtime-probe.ts";
+import {
+  type CommandResult,
+  type CommandRunner,
+  type CommandSpec,
+  runBoundedCommand,
+  sandboxClaudeCommand,
+} from "./runtime-sandbox.ts";
+import type { ClaudeRuntimeSnapshot } from "./types.ts";
+
+const tempRoots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    tempRoots
+      .splice(0)
+      .map((root) => rm(root, { recursive: true, force: true })),
+  );
+});
+
+async function temporaryRoot(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "runtime-probe-test-"));
+  tempRoots.push(root);
+  return root;
+}
+
+function result(
+  stdout = "",
+  overrides: Partial<CommandResult> = {},
+): CommandResult {
+  return {
+    exitCode: 0,
+    stdout,
+    stderr: "",
+    timedOut: false,
+    truncated: false,
+    signal: null,
+    ...overrides,
+  };
+}
+
+function snapshot(
+  overrides: Partial<ClaudeRuntimeSnapshot> = {},
+): ClaudeRuntimeSnapshot {
+  return {
+    version: "1.2.3",
+    version_output: "1.2.3 (Claude Code)",
+    help_text: "--permission-mode auto",
+    help_hash: "help-a",
+    doctor: { exit_code: 0, summary: "ok" },
+    auto_mode_defaults: ["auto default"],
+    init: {
+      tools: ["Read"],
+      model: "claude-test",
+      capabilities: null,
+      stable_fields: {},
+    },
+    event_inventory: ["assistant", "system/init"],
+    probes: [],
+    digest: "digest",
+    ...overrides,
+  };
+}
+
+describe("command planning", () => {
+  test("uses an exact local package install and a constrained inert command", () => {
+    const plan = createClaudeRuntimeCommandPlan("1.2.3", "/tmp/supplied/root", {
+      env: { PATH: "/bin", ANTHROPIC_API_KEY: "secret" },
+    });
+
+    expect(plan.packageSpec).toBe("@anthropic-ai/claude-code@1.2.3");
+    expect(plan.install.command).toBe("npm");
+    expect(plan.install.args.join(" ")).toContain(plan.packageSpec);
+    expect(plan.install.args).not.toContain("--ignore-scripts");
+    expect(plan.install.args.join(" ")).not.toMatch(
+      /@latest|\bnpx\b|--global|-g\b/,
+    );
+    expect(plan.binary).toStartWith(plan.installRoot);
+    expect(plan.init.env.HOME).toBe(plan.home);
+    expect(plan.init.env.CLAUDE_CONFIG_DIR).toBe(plan.config);
+    expect(plan.init.env.DISABLE_UPDATES).toBe("1");
+    expect(plan.install.env.ANTHROPIC_API_KEY).toBeUndefined();
+    expect(plan.init.env.ANTHROPIC_API_KEY).toBe("secret");
+    expect(plan.autoModeDefaults.args).toEqual(["auto-mode", "defaults"]);
+    expect(plan.init.args).toContain("stream-json");
+    expect(plan.init.args).toContain("dontAsk");
+    expect(plan.init.args).toContain("--safe-mode");
+    expect(plan.init.args).not.toContain("--tools");
+    expect(plan.probes).toHaveLength(2);
+    for (const probe of plan.probes) {
+      expect(probe.command.args).toContain("--allowedTools");
+      expect(probe.command.args).toContain("--safe-mode");
+      expect(probe.command.args).not.toContain("--max-turns");
+      expect(probe.command.args).toContain("--max-budget-usd");
+    }
+  });
+
+  test("rejects ranges and dist tags", () => {
+    expect(() => createClaudeRuntimeCommandPlan("latest", "/tmp/x")).toThrow(
+      "exact",
+    );
+    expect(() => createClaudeRuntimeCommandPlan("^1.2.3", "/tmp/x")).toThrow(
+      "exact",
+    );
+  });
+
+  test("container sandbox mounts only the disposable root and hides secret values from argv", () => {
+    const plan = createClaudeRuntimeCommandPlan("1.2.3", "/tmp/probe-root", {
+      env: {
+        PATH: "/usr/bin",
+        ANTHROPIC_API_KEY: "sk-ant-never-in-argv",
+        GH_TOKEN: "must-not-be-in-plan",
+      },
+    });
+    const sandboxed = sandboxClaudeCommand(plan.init, plan.root);
+    const serialized = sandboxed.args.join(" ");
+    expect(sandboxed.command).toBe("/usr/bin/docker");
+    expect(serialized).toContain("/tmp/probe-root:/watch:rw");
+    expect(serialized).toContain("node:22.18.0-bookworm@sha256:");
+    expect(serialized).toContain("--cap-drop ALL");
+    expect(serialized).toContain("--read-only");
+    expect(serialized).toContain("--env ANTHROPIC_API_KEY");
+    expect(serialized).not.toContain("sk-ant-never-in-argv");
+    expect(serialized).not.toContain("GH_TOKEN");
+    expect(serialized).not.toContain(process.cwd());
+  });
+});
+
+describe("stream parsing and normalization", () => {
+  test("extracts first init, event inventory, calls, and results", () => {
+    const stream = [
+      JSON.stringify({
+        type: "system",
+        subtype: "init",
+        session_id: "volatile",
+        tools: ["Write", "Read", "Read"],
+        model: "claude-test",
+        permissionMode: "dontAsk",
+        capabilities: { beta: true, timestamp: "gone" },
+      }),
+      JSON.stringify({
+        type: "assistant",
+        message: {
+          content: [
+            {
+              type: "tool_use",
+              id: "tool-123",
+              name: "Read",
+              input: { file_path: "/tmp/random/file" },
+            },
+          ],
+        },
+      }),
+      JSON.stringify({
+        type: "user",
+        message: {
+          content: [
+            {
+              type: "tool_result",
+              tool_use_id: "tool-123",
+              content: "     9→\tnine",
+              is_error: false,
+            },
+          ],
+        },
+      }),
+    ].join("\n");
+
+    const parsed = parseClaudeStream(stream);
+    expect(parsed.init?.tools).toEqual(["Read", "Write"]);
+    expect(parsed.init?.stableFields).toEqual({ permissionMode: "dontAsk" });
+    expect(parsed.init?.capabilities).toEqual({ beta: true });
+    expect(parsed.eventTypes).toEqual(["assistant", "system/init", "user"]);
+    expect(parsed.toolCalls).toEqual([
+      { id: "tool-123", name: "Read", input: { file_path: "<tmp>" } },
+    ]);
+    expect(parsed.toolResults[0]?.content).toBe("     9→\tnine");
+  });
+
+  test("evaluates exact Read bytes rather than mere tool completion", () => {
+    const definition = {
+      name: "read-lines-9-10-tab-prefix",
+      allowedTools: ["Read"],
+      prompt: "",
+    };
+    const exact = parseClaudeStream(
+      [
+        JSON.stringify({ type: "system", subtype: "init", tools: ["Read"] }),
+        JSON.stringify({
+          type: "assistant",
+          message: {
+            content: [
+              {
+                type: "tool_use",
+                id: "read-1",
+                name: "Read",
+                input: { file_path: "./read-fixture.txt", offset: 9, limit: 2 },
+              },
+            ],
+          },
+        }),
+        JSON.stringify({
+          type: "user",
+          message: {
+            content: [
+              {
+                type: "tool_result",
+                tool_use_id: "read-1",
+                content: "9\tline9\n10\tline10",
+              },
+            ],
+          },
+        }),
+      ].join("\n"),
+    );
+    expect(evaluateProbe(definition.name, exact)).toEqual({
+      complete: true,
+      assertions: {
+        exact_line_9: true,
+        exact_line_10: true,
+        no_line_9_padding: true,
+        no_arrow_separator: true,
+        result_not_error: true,
+      },
+    });
+
+    const arrow = parseClaudeStream(
+      [
+        JSON.stringify({ type: "system", subtype: "init", tools: ["Read"] }),
+        JSON.stringify({
+          type: "assistant",
+          message: {
+            content: [
+              {
+                type: "tool_use",
+                id: "read-2",
+                name: "Read",
+                input: { offset: 9, limit: 2 },
+              },
+            ],
+          },
+        }),
+        JSON.stringify({
+          type: "user",
+          message: {
+            content: [
+              {
+                type: "tool_result",
+                tool_use_id: "read-2",
+                content: " 9→line9\n10→line10",
+              },
+            ],
+          },
+        }),
+      ].join("\n"),
+    );
+    expect(evaluateProbe(definition.name, arrow).complete).toBe(true);
+    expect(evaluateProbe(definition.name, arrow).assertions).toMatchObject({
+      exact_line_9: false,
+      exact_line_10: false,
+      no_arrow_separator: false,
+    });
+  });
+
+  test("evaluates arbitrary task metadata, null deletion, and permanent deletion", () => {
+    const evaluation = evaluateProbe("task-metadata-delete-contract", {
+      toolCalls: [
+        { id: "create", name: "TaskCreate", input: {} },
+        {
+          id: "metadata",
+          name: "TaskUpdate",
+          input: { taskId: "1", metadata: { probe: null } },
+        },
+        { id: "before", name: "TaskGet", input: { taskId: "1" } },
+        {
+          id: "delete",
+          name: "TaskUpdate",
+          input: { taskId: "1", status: "deleted" },
+        },
+        { id: "after", name: "TaskGet", input: { taskId: "1" } },
+        { id: "list", name: "TaskList", input: {} },
+      ],
+      toolResults: [
+        { toolUseId: "create", content: "{}", isError: false },
+        { toolUseId: "metadata", content: "{}", isError: false },
+        {
+          toolUseId: "before",
+          content: JSON.stringify({
+            metadata: {
+              keep: "yes",
+              count: 3,
+              flags: ["ready"],
+              details: { source: "claude-watch" },
+            },
+          }),
+          isError: false,
+        },
+        {
+          toolUseId: "delete",
+          content: '{"status":"deleted"}',
+          isError: false,
+        },
+        {
+          toolUseId: "after",
+          content: "Task not found",
+          isError: true,
+        },
+        { toolUseId: "list", content: '{"tasks":[]}', isError: false },
+      ],
+    });
+    expect(evaluation).toEqual({
+      complete: true,
+      assertions: {
+        metadata_arbitrary_values: true,
+        metadata_null_deleted: true,
+        deleted_task_get_errors: true,
+        deleted_task_absent: true,
+      },
+    });
+  });
+
+  test("rejects malformed and empty streams without including raw data", () => {
+    expect(() => parseClaudeStream('{"type":"system"}\n{secret')).toThrow(
+      "line 2",
+    );
+    expect(() => parseClaudeStream(" \n")).toThrow("no events");
+    try {
+      parseClaudeStream("not-json-containing-sk-ant-supersecret");
+    } catch (error) {
+      expect(String(error)).not.toContain("supersecret");
+    }
+  });
+
+  test("removes volatile fields, paths, identifiers, timestamps, and secrets", () => {
+    expect(
+      normalizeVolatile({
+        session_id: "drop",
+        timestamp: "drop",
+        stable: "at /tmp/random-123/file",
+        nested: { request_id: "drop", token: "sk-ant-abcdefghijk" },
+      }),
+    ).toEqual({ nested: {}, stable: "at <tmp>" });
+  });
+});
+
+describe("runtime diff", () => {
+  test("reports tool/event changes and normalized probe differences", () => {
+    const before = snapshot({
+      probes: [
+        {
+          name: "read-lines-9-10-tab-prefix",
+          status: "passed",
+          attempts: 1,
+          assertions: { exact: false },
+          tool_calls: [{ name: "Read", input: { offset: 9, limit: 2 } }],
+          tool_results: ["old"],
+          filesystem_changes: [],
+          error: null,
+        },
+      ],
+    });
+    const after = snapshot({
+      init: {
+        tools: ["Read", "TaskCreate"],
+        model: "claude-test",
+        capabilities: null,
+        stable_fields: {},
+      },
+      event_inventory: ["assistant", "result", "system/init"],
+      probes: [
+        {
+          name: "read-lines-9-10-tab-prefix",
+          status: "passed",
+          attempts: 1,
+          assertions: { exact: true },
+          tool_calls: [{ name: "Read", input: { offset: 9, limit: 2 } }],
+          tool_results: ["new"],
+          filesystem_changes: [],
+          error: null,
+        },
+      ],
+    });
+
+    expect(diffClaudeRuntime(before, after)).toEqual({
+      tools_added: ["TaskCreate"],
+      tools_removed: [],
+      help_changed: false,
+      help_lines_added: [],
+      help_lines_removed: [],
+      doctor_changed: false,
+      init_changed: true,
+      auto_mode_defaults_changed: false,
+      event_types_added: ["result"],
+      event_types_removed: [],
+      changed_probes: ["read-lines-9-10-tab-prefix"],
+    });
+  });
+});
+
+describe("capture orchestration", () => {
+  function successfulRunner(
+    version = "1.2.3",
+    calls: CommandSpec[] = [],
+  ): CommandRunner {
+    return async (spec) => {
+      calls.push(spec);
+      switch (spec.label) {
+        case "verify-package":
+          return result(version);
+        case "version":
+          return result(`${version} (Claude Code)`);
+        case "help":
+          return result("--permission-mode auto (default: auto)");
+        case "auto-mode-defaults":
+          return result('{"allow":["Read"],"soft_deny":[]}');
+        case "doctor":
+          return result("Doctor OK");
+        default:
+          return result();
+      }
+    };
+  }
+
+  test("fails package version mismatch before invoking the binary", async () => {
+    const root = await temporaryRoot();
+    const calls: CommandSpec[] = [];
+    await expect(
+      captureClaudeRuntime({
+        version: "1.2.3",
+        tempDir: root,
+        runner: successfulRunner("1.2.4", calls),
+      }),
+    ).rejects.toThrow("package version mismatch");
+    expect(calls.some((call) => call.label === "version")).toBe(false);
+  });
+
+  test("fails claude --version mismatch", async () => {
+    const root = await temporaryRoot();
+    const runner: CommandRunner = async (spec) => {
+      if (spec.label === "verify-package") return result("1.2.3");
+      if (spec.label === "version") return result("1.2.4 (Claude Code)");
+      return result();
+    };
+    await expect(
+      captureClaudeRuntime({ version: "1.2.3", tempDir: root, runner }),
+    ).rejects.toThrow("--version mismatch");
+  });
+
+  test("missing auth captures public surfaces and skips authenticated probes", async () => {
+    const root = await temporaryRoot();
+    const calls: CommandSpec[] = [];
+    const captured = await captureClaudeRuntime({
+      version: "1.2.3",
+      tempDir: root,
+      env: { PATH: process.env.PATH },
+      runner: successfulRunner("1.2.3", calls),
+      requireAuth: false,
+    });
+    expect(captured?.init).toBeNull();
+    expect(captured?.probes.map((probe) => probe.status)).toEqual([
+      "skipped",
+      "skipped",
+    ]);
+    expect(
+      calls.some(
+        (call) =>
+          call.label === "init-stream" || call.label.startsWith("probe:"),
+      ),
+    ).toBe(false);
+  });
+
+  test("nonzero authenticated stream fails safely", async () => {
+    const root = await temporaryRoot();
+    const base = successfulRunner();
+    const runner: CommandRunner = async (spec) =>
+      spec.label === "init-stream"
+        ? result("", {
+            exitCode: 2,
+            stderr: "internal failure: sk-ant-do-not-print",
+          })
+        : base(spec);
+    await expect(
+      captureClaudeRuntime({
+        version: "1.2.3",
+        tempDir: root,
+        env: { PATH: process.env.PATH, ANTHROPIC_API_KEY: "secret" },
+        runner,
+      }),
+    ).rejects.toThrow("exited nonzero");
+  });
+
+  test("dry-run creates nothing and runs no commands", async () => {
+    const root = await temporaryRoot();
+    let called = false;
+    const captured = await captureClaudeRuntime({
+      version: "1.2.3",
+      tempDir: root,
+      dryRun: true,
+      runner: async () => {
+        called = true;
+        return result();
+      },
+    });
+    expect(captured).toBeNull();
+    expect(called).toBe(false);
+    expect(await readdir(root)).toEqual([]);
+  });
+});
+
+describe("bounded process runner", () => {
+  test("marks a command timed out and terminates it", async () => {
+    const root = await temporaryRoot();
+    const commandResult = await runBoundedCommand({
+      command: process.execPath,
+      args: ["-e", "setInterval(() => {}, 1000)"],
+      cwd: root,
+      env: process.env,
+      timeoutMs: 30,
+      outputCapBytes: 1024,
+      label: "timeout-test",
+    });
+    expect(commandResult.timedOut).toBe(true);
+    expect(commandResult.exitCode).not.toBe(0);
+  });
+});

--- a/scripts/claude-watch/runtime-probe.ts
+++ b/scripts/claude-watch/runtime-probe.ts
@@ -1,0 +1,902 @@
+import { createHash } from "node:crypto";
+import {
+  mkdir,
+  mkdtemp,
+  readdir,
+  readFile,
+  rm,
+  stat,
+  writeFile,
+} from "node:fs/promises";
+import { join, relative, resolve } from "node:path";
+import { evaluateProbe } from "./runtime-observations.ts";
+import {
+  type CommandRunner,
+  type CommandSpec,
+  runBoundedCommand,
+  sandboxClaudeCommand,
+} from "./runtime-sandbox.ts";
+import type {
+  ClaudeProbeObservation,
+  ClaudeRuntimeDiff,
+  ClaudeRuntimeSnapshot,
+} from "./types.ts";
+
+const PACKAGE_NAME = "@anthropic-ai/claude-code";
+const DEFAULT_TIMEOUT_MS = 30_000;
+const DEFAULT_OUTPUT_CAP = 2 * 1024 * 1024;
+const AUTH_ENV_KEYS = ["ANTHROPIC_API_KEY", "CLAUDE_CODE_OAUTH_TOKEN"] as const;
+// biome-ignore lint/suspicious/noControlCharactersInRegex: this intentionally strips ANSI escape sequences.
+const ANSI_PATTERN = /\x1B\[[0-?]*[ -/]*[@-~]/g;
+const VOLATILE_KEYS = new Set([
+  "id",
+  "message_id",
+  "session_id",
+  "request_id",
+  "uuid",
+  "timestamp",
+  "created_at",
+  "duration_ms",
+  "duration_api_ms",
+  "total_cost_usd",
+  "cost_usd",
+  "usage",
+]);
+const SAFE_INIT_FIELDS = new Set([
+  "permissionMode",
+  "claude_code_version",
+  "output_style",
+  "fast_mode_state",
+]);
+const SENSITIVE_KEY_PATTERN =
+  /(?:token|secret|credential|password|api.?key|email|account|organization|user.?name)/iu;
+
+export interface ClaudeRuntimeCommandPlan {
+  root: string;
+  installRoot: string;
+  home: string;
+  config: string;
+  repo: string;
+  packageSpec: string;
+  binary: string;
+  install: CommandSpec;
+  initializeRepo: CommandSpec;
+  verifyPackage: CommandSpec;
+  version: CommandSpec;
+  help: CommandSpec;
+  doctor: CommandSpec;
+  autoModeDefaults: CommandSpec;
+  init: CommandSpec;
+  probes: Array<{ name: string; command: CommandSpec }>;
+}
+
+export interface CaptureClaudeRuntimeOptions {
+  version: string;
+  tempDir: string;
+  dryRun?: boolean;
+  keepRoot?: boolean;
+  env?: NodeJS.ProcessEnv;
+  runner?: CommandRunner;
+  timeoutMs?: number;
+  outputCapBytes?: number;
+  maxProbeAttempts?: number;
+  requireAuth?: boolean;
+  reuseProbes?: ClaudeProbeObservation[];
+  sandbox?: "docker" | "direct";
+}
+
+export interface ParsedClaudeStream {
+  events: unknown[];
+  eventTypes: string[];
+  init: {
+    tools: string[];
+    model: string | null;
+    capabilities: unknown | null;
+    stableFields: Record<string, unknown>;
+  } | null;
+  toolCalls: Array<{ id: string | null; name: string; input: unknown }>;
+  toolResults: Array<{
+    toolUseId: string | null;
+    content: string;
+    isError: boolean;
+  }>;
+}
+
+interface ProbeDefinition {
+  name: string;
+  allowedTools: string[];
+  prompt: string;
+}
+
+const PROBES: ProbeDefinition[] = [
+  {
+    name: "read-lines-9-10-tab-prefix",
+    allowedTools: ["Read"],
+    prompt:
+      "Use the Read tool exactly once on ./read-fixture.txt with offset 9 and limit 2. Then stop. Do not modify files or use any other tool.",
+  },
+  {
+    name: "task-metadata-delete-contract",
+    allowedTools: ["TaskCreate", "TaskGet", "TaskUpdate", "TaskList"],
+    prompt:
+      'Exercise only the task tools and continue through every step even if one call reports an error. Create one task named "probe-task" with metadata {"probe":"remove","keep":"yes"}; update metadata with {"probe":null,"count":3,"flags":["ready"],"details":{"source":"claude-watch"}}; get it to observe metadata; permanently delete it with TaskUpdate status "deleted"; get the deleted ID again expecting a not-found error; then list tasks to confirm it is absent. Do not perform other work or use other tools.',
+  },
+];
+
+function safeVersion(version: string): string {
+  if (
+    !/^[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/.test(
+      version,
+    )
+  ) {
+    throw new Error(`Invalid exact Claude version: ${version}`);
+  }
+  return version;
+}
+
+function command(
+  label: string,
+  executable: string,
+  args: string[],
+  cwd: string,
+  env: NodeJS.ProcessEnv,
+  timeoutMs: number,
+  outputCapBytes: number,
+  stdin?: string,
+): CommandSpec {
+  return {
+    command: executable,
+    args,
+    cwd,
+    env,
+    timeoutMs,
+    outputCapBytes,
+    stdin,
+    label,
+  };
+}
+
+export function createClaudeRuntimeCommandPlan(
+  version: string,
+  root: string,
+  options: Pick<
+    CaptureClaudeRuntimeOptions,
+    "env" | "timeoutMs" | "outputCapBytes"
+  > = {},
+): ClaudeRuntimeCommandPlan {
+  safeVersion(version);
+  const installRoot = join(root, "install");
+  const home = join(root, "home");
+  const config = join(root, "config");
+  const repo = join(root, "repo");
+  const binary = join(
+    installRoot,
+    "node_modules",
+    ".bin",
+    process.platform === "win32" ? "claude.cmd" : "claude",
+  );
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const outputCapBytes = options.outputCapBytes ?? DEFAULT_OUTPUT_CAP;
+  const suppliedEnv = options.env ?? process.env;
+  const commonEnv: NodeJS.ProcessEnv = {
+    HOME: home,
+    USERPROFILE: home,
+    XDG_CONFIG_HOME: config,
+    CLAUDE_CONFIG_DIR: config,
+    DISABLE_UPDATES: "1",
+    DISABLE_AUTOUPDATER: "1",
+    CI: "1",
+    NO_COLOR: "1",
+    COLUMNS: "120",
+    LINES: "40",
+    TERM: "dumb",
+    LANG: "C.UTF-8",
+    LC_ALL: "C.UTF-8",
+    TZ: "UTC",
+    PATH: suppliedEnv.PATH ?? "/usr/bin:/bin",
+  };
+  const runtimeEnv: NodeJS.ProcessEnv = { ...commonEnv };
+  for (const key of AUTH_ENV_KEYS) {
+    if (suppliedEnv[key]) runtimeEnv[key] = suppliedEnv[key];
+  }
+  const packageSpec = `${PACKAGE_NAME}@${version}`;
+  const streamArgs = [
+    "-p",
+    "Reply with exactly OK and do not use tools.",
+    "--safe-mode",
+    "--output-format",
+    "stream-json",
+    "--verbose",
+    "--permission-mode",
+    "dontAsk",
+    "--no-session-persistence",
+    "--max-budget-usd",
+    "0.05",
+  ];
+  const autoModeDefaults = command(
+    "auto-mode-defaults",
+    binary,
+    ["auto-mode", "defaults"],
+    repo,
+    runtimeEnv,
+    timeoutMs,
+    outputCapBytes,
+  );
+  const probeCommands = PROBES.map((probe) => ({
+    name: probe.name,
+    command: command(
+      `probe:${probe.name}`,
+      binary,
+      [
+        "-p",
+        probe.prompt,
+        "--safe-mode",
+        "--output-format",
+        "stream-json",
+        "--verbose",
+        "--permission-mode",
+        "dontAsk",
+        "--no-session-persistence",
+        "--tools",
+        probe.allowedTools.join(","),
+        "--allowedTools",
+        probe.allowedTools.join(","),
+        "--max-budget-usd",
+        "0.25",
+      ],
+      repo,
+      runtimeEnv,
+      Math.min(timeoutMs, 60_000),
+      outputCapBytes,
+    ),
+  }));
+  return {
+    root,
+    installRoot,
+    home,
+    config,
+    repo,
+    packageSpec,
+    binary,
+    install: command(
+      "install",
+      "npm",
+      [
+        "install",
+        "--prefix",
+        installRoot,
+        "--no-package-lock",
+        "--no-audit",
+        "--no-fund",
+        packageSpec,
+      ],
+      root,
+      commonEnv,
+      Math.max(timeoutMs, 300_000),
+      outputCapBytes,
+    ),
+    initializeRepo: command(
+      "git-init",
+      "/usr/bin/git",
+      ["init", "--quiet"],
+      repo,
+      commonEnv,
+      timeoutMs,
+      outputCapBytes,
+    ),
+    verifyPackage: command(
+      "verify-package",
+      "node",
+      [
+        "-e",
+        "const p=require(process.argv[1]); process.stdout.write(String(p.version))",
+        join(installRoot, "node_modules", PACKAGE_NAME, "package.json"),
+      ],
+      root,
+      commonEnv,
+      timeoutMs,
+      outputCapBytes,
+    ),
+    version: command(
+      "version",
+      binary,
+      ["--version"],
+      repo,
+      commonEnv,
+      timeoutMs,
+      outputCapBytes,
+    ),
+    help: command(
+      "help",
+      binary,
+      ["--help"],
+      repo,
+      commonEnv,
+      timeoutMs,
+      outputCapBytes,
+    ),
+    doctor: command(
+      "doctor",
+      binary,
+      ["doctor"],
+      repo,
+      commonEnv,
+      timeoutMs,
+      outputCapBytes,
+    ),
+    autoModeDefaults,
+    init: command(
+      "init-stream",
+      binary,
+      streamArgs,
+      repo,
+      runtimeEnv,
+      Math.min(timeoutMs, 60_000),
+      outputCapBytes,
+    ),
+    probes: probeCommands,
+  };
+}
+
+function record(value: unknown): Record<string, unknown> | null {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function textContent(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (Array.isArray(value))
+    return value.map(textContent).filter(Boolean).join("\n");
+  const object = record(value);
+  if (!object) return "";
+  return textContent(object.text ?? object.content ?? object.output ?? "");
+}
+
+function contentBlocks(event: Record<string, unknown>): unknown[] {
+  const message = record(event.message);
+  const content = message?.content ?? event.content;
+  return Array.isArray(content)
+    ? content
+    : content === undefined
+      ? []
+      : [content];
+}
+
+export function parseClaudeStream(output: string): ParsedClaudeStream {
+  const events: unknown[] = [];
+  for (const [index, rawLine] of output.split(/\r?\n/).entries()) {
+    const line = rawLine.trim();
+    if (!line) continue;
+    try {
+      events.push(JSON.parse(line));
+    } catch {
+      throw new Error(`Malformed Claude stream-json at line ${index + 1}`);
+    }
+  }
+  if (events.length === 0)
+    throw new Error("Claude stream-json contained no events");
+
+  let init: ParsedClaudeStream["init"] = null;
+  const eventTypes = new Set<string>();
+  const toolCalls: ParsedClaudeStream["toolCalls"] = [];
+  const toolResults: ParsedClaudeStream["toolResults"] = [];
+  for (const eventValue of events) {
+    const event = record(eventValue);
+    if (!event) continue;
+    const type = typeof event.type === "string" ? event.type : "unknown";
+    const subtype = typeof event.subtype === "string" ? event.subtype : null;
+    eventTypes.add(subtype ? `${type}/${subtype}` : type);
+    if (!init && type === "system" && subtype === "init") {
+      const tools = Array.isArray(event.tools)
+        ? event.tools.filter((tool): tool is string => typeof tool === "string")
+        : [];
+      const stableFields: Record<string, unknown> = {};
+      const structuralFields = new Set([
+        "type",
+        "subtype",
+        "tools",
+        "model",
+        "capabilities",
+        "cwd",
+        "session_id",
+      ]);
+      for (const key of Object.keys(event).sort()) {
+        if (!structuralFields.has(key) && SAFE_INIT_FIELDS.has(key))
+          stableFields[key] = normalizeVolatile(event[key]);
+      }
+      init = {
+        tools: [...new Set(tools)].sort(),
+        model: typeof event.model === "string" ? event.model : null,
+        capabilities: normalizeVolatile(event.capabilities ?? null),
+        stableFields,
+      };
+    }
+    for (const blockValue of contentBlocks(event)) {
+      const block = record(blockValue);
+      if (!block) continue;
+      if (block.type === "tool_use" && typeof block.name === "string") {
+        toolCalls.push({
+          id: typeof block.id === "string" ? block.id : null,
+          name: block.name,
+          input: normalizeVolatile(block.input ?? null),
+        });
+      } else if (block.type === "tool_result") {
+        toolResults.push({
+          toolUseId:
+            typeof block.tool_use_id === "string" ? block.tool_use_id : null,
+          content: normalizeToolResultText(textContent(block.content)),
+          isError: block.is_error === true,
+        });
+      }
+    }
+  }
+  return {
+    events,
+    eventTypes: [...eventTypes].sort(),
+    init,
+    toolCalls,
+    toolResults,
+  };
+}
+
+function normalizeString(value: string): string {
+  return value
+    .replace(ANSI_PATTERN, "")
+    .replace(/\b(?:sk-ant|sk-|oauth-)[A-Za-z0-9_-]{8,}\b/g, "<redacted>")
+    .replace(/[A-Fa-f0-9]{8}-[A-Fa-f0-9-]{27,}/g, "<id>")
+    .replace(/\b20\d\d-\d\d-\d\dT\d\d:\d\d:\d\d(?:\.\d+)?Z\b/g, "<timestamp>")
+    .replace(
+      /(["']?(?:createdAt|updatedAt|created_at|updated_at)["']?\s*[:=]\s*)\d{10,}/gu,
+      "$1<timestamp>",
+    )
+    .replace(/\/tmp\/[\w./-]+/g, "<tmp>")
+    .replace(/\\tmp\\[-\w.\\]+/g, "<tmp>");
+}
+
+export function normalizeText(value: string): string {
+  return normalizeString(value).trim();
+}
+
+export function normalizeToolResultText(value: string): string {
+  return normalizeString(value);
+}
+
+export function normalizeVolatile(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(normalizeVolatile);
+  if (typeof value === "string") return normalizeText(value);
+  const object = record(value);
+  if (!object) return value;
+  const normalized: Record<string, unknown> = {};
+  for (const key of Object.keys(object).sort()) {
+    if (!VOLATILE_KEYS.has(key) && !SENSITIVE_KEY_PATTERN.test(key))
+      normalized[key] = normalizeVolatile(object[key]);
+  }
+  return normalized;
+}
+
+function stableJson(value: unknown): string {
+  return JSON.stringify(normalizeVolatile(value));
+}
+
+function hash(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function semanticProbe(probe: ClaudeProbeObservation): unknown {
+  return {
+    name: probe.name,
+    status: probe.status,
+    assertions: probe.assertions,
+    error: probe.error,
+  };
+}
+
+function namesDiff(
+  before: string[],
+  after: string[],
+): { added: string[]; removed: string[] } {
+  const oldSet = new Set(before);
+  const newSet = new Set(after);
+  return {
+    added: [...newSet].filter((name) => !oldSet.has(name)).sort(),
+    removed: [...oldSet].filter((name) => !newSet.has(name)).sort(),
+  };
+}
+
+function linesDiff(
+  before: string,
+  after: string,
+): { added: string[]; removed: string[] } {
+  const oldLines = new Set(before.split("\n").filter(Boolean));
+  const newLines = new Set(after.split("\n").filter(Boolean));
+  return {
+    added: [...newLines].filter((line) => !oldLines.has(line)).sort(),
+    removed: [...oldLines].filter((line) => !newLines.has(line)).sort(),
+  };
+}
+
+export function diffClaudeRuntime(
+  previous: ClaudeRuntimeSnapshot,
+  current: ClaudeRuntimeSnapshot,
+): ClaudeRuntimeDiff {
+  const tools = namesDiff(
+    previous.init?.tools ?? [],
+    current.init?.tools ?? [],
+  );
+  const eventTypes = namesDiff(
+    previous.event_inventory,
+    current.event_inventory,
+  );
+  const helpLines = linesDiff(previous.help_text, current.help_text);
+  const oldProbes = new Map(
+    previous.probes.map((probe) => [
+      probe.name,
+      stableJson(semanticProbe(probe)),
+    ]),
+  );
+  const newProbes = new Map(
+    current.probes.map((probe) => [
+      probe.name,
+      stableJson(semanticProbe(probe)),
+    ]),
+  );
+  const changedProbes = [...new Set([...oldProbes.keys(), ...newProbes.keys()])]
+    .filter((name) => oldProbes.get(name) !== newProbes.get(name))
+    .sort();
+  return {
+    tools_added: tools.added,
+    tools_removed: tools.removed,
+    help_changed: previous.help_hash !== current.help_hash,
+    help_lines_added: helpLines.added,
+    help_lines_removed: helpLines.removed,
+    doctor_changed: stableJson(previous.doctor) !== stableJson(current.doctor),
+    init_changed: stableJson(previous.init) !== stableJson(current.init),
+    auto_mode_defaults_changed:
+      stableJson(previous.auto_mode_defaults) !==
+      stableJson(current.auto_mode_defaults),
+    event_types_added: eventTypes.added,
+    event_types_removed: eventTypes.removed,
+    changed_probes: changedProbes,
+  };
+}
+
+export const diffRuntimeSnapshots = diffClaudeRuntime;
+
+function checkResult(result: CommandResult, label: string): void {
+  if (result.timedOut) throw new Error(`Command ${label} timed out`);
+  if (result.truncated)
+    throw new Error(`Command ${label} exceeded its output cap`);
+  if (result.exitCode !== 0) throw new Error(`Command ${label} exited nonzero`);
+}
+
+function authAvailable(env: NodeJS.ProcessEnv): boolean {
+  return AUTH_ENV_KEYS.some(
+    (key) => typeof env[key] === "string" && (env[key]?.length ?? 0) > 0,
+  );
+}
+
+function isAuthFailure(result: CommandResult): boolean {
+  const text = `${result.stdout}\n${result.stderr}`.toLowerCase();
+  return /not logged in|authentication|authenticate|api key|oauth|unauthorized/.test(
+    text,
+  );
+}
+
+function doctorSummary(result: CommandResult, env: NodeJS.ProcessEnv): string {
+  let combined = `${result.stdout}\n${result.stderr}`;
+  for (const key of AUTH_ENV_KEYS) {
+    const secret = env[key];
+    if (secret) combined = combined.split(secret).join("<redacted>");
+  }
+  return normalizeText(combined)
+    .split(/\r?\n/)
+    .filter(Boolean)
+    .slice(0, 40)
+    .join("\n")
+    .slice(0, 8_000);
+}
+
+function normalizeDoctorVersion(summary: string, version: string): string {
+  return summary
+    .replaceAll(version, "<version>")
+    .replace(/^Commit: [0-9a-f]+$/gmu, "Commit: <commit>");
+}
+
+export function extractAutoModeDefaults(output: string): unknown | null {
+  const normalized = normalizeText(output);
+  if (!normalized) return null;
+  try {
+    return normalizeVolatile(JSON.parse(normalized));
+  } catch {
+    // Older releases may print the defaults as text rather than JSON.
+    const lines = normalized
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter(Boolean);
+    return lines.length > 0 ? [...new Set(lines)].sort() : null;
+  }
+}
+
+async function filesystemInventory(root: string): Promise<Map<string, string>> {
+  const inventory = new Map<string, string>();
+  async function walk(directory: string): Promise<void> {
+    for (const entry of await readdir(directory, { withFileTypes: true })) {
+      if (entry.name === ".git") continue;
+      const path = join(directory, entry.name);
+      const name = relative(root, path);
+      if (entry.isDirectory()) await walk(path);
+      else if (entry.isFile()) {
+        const info = await stat(path);
+        inventory.set(
+          name,
+          `${info.size}:${hash(await readFile(path, "utf8"))}`,
+        );
+      }
+    }
+  }
+  await walk(root);
+  return inventory;
+}
+
+function filesystemChanges(
+  before: Map<string, string>,
+  after: Map<string, string>,
+): string[] {
+  const names = [...new Set([...before.keys(), ...after.keys()])].sort();
+  return names.flatMap((name) => {
+    if (!before.has(name)) return [`added:${name}`];
+    if (!after.has(name)) return [`removed:${name}`];
+    return before.get(name) === after.get(name) ? [] : [`changed:${name}`];
+  });
+}
+
+function skippedProbe(name: string, reason: string): ClaudeProbeObservation {
+  return {
+    name,
+    status: "skipped",
+    attempts: 0,
+    assertions: {},
+    tool_calls: [],
+    tool_results: [],
+    filesystem_changes: [],
+    error: reason,
+  };
+}
+
+async function runProbe(
+  definition: ProbeDefinition,
+  spec: CommandSpec,
+  runner: CommandRunner,
+  repo: string,
+  maxAttempts: number,
+): Promise<ClaudeProbeObservation> {
+  let lastError = "Probe produced no conclusive tool transcript";
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    const before = await filesystemInventory(repo);
+    const result = await runner(spec);
+    const after = await filesystemInventory(repo);
+    if (result.timedOut || result.truncated || result.exitCode !== 0) {
+      lastError = result.timedOut
+        ? "Probe timed out"
+        : result.truncated
+          ? "Probe exceeded output cap"
+          : "Probe exited nonzero";
+      continue;
+    }
+    let parsed: ParsedClaudeStream;
+    try {
+      parsed = parseClaudeStream(result.stdout);
+    } catch (error) {
+      lastError =
+        error instanceof Error ? error.message : "Malformed probe stream";
+      continue;
+    }
+    const disallowed = parsed.toolCalls.find(
+      (call) => !definition.allowedTools.includes(call.name),
+    );
+    const evaluation = evaluateProbe(definition.name, parsed);
+    const observation: ClaudeProbeObservation = {
+      name: definition.name,
+      status: disallowed
+        ? "failed"
+        : evaluation.complete
+          ? "passed"
+          : "inconclusive",
+      attempts: attempt,
+      assertions: evaluation.assertions,
+      tool_calls: parsed.toolCalls.map(({ name, input }) => ({ name, input })),
+      tool_results: parsed.toolResults.map(
+        (resultValue) => resultValue.content,
+      ),
+      filesystem_changes: filesystemChanges(before, after),
+      error: disallowed
+        ? `Tool outside allowlist: ${disallowed.name}`
+        : evaluation.complete
+          ? null
+          : "Probe transcript did not complete the fixed contract",
+    };
+    if (observation.status !== "inconclusive" || attempt === maxAttempts)
+      return observation;
+    lastError = "Probe transcript did not complete the fixed contract";
+  }
+  return {
+    name: definition.name,
+    status: "inconclusive",
+    attempts: maxAttempts,
+    assertions: {},
+    tool_calls: [],
+    tool_results: [],
+    filesystem_changes: [],
+    error: lastError,
+  };
+}
+
+/**
+ * Installs and captures one exact Claude release in its own disposable root.
+ * Dry-run returns null before creating directories or invoking install/auth commands.
+ */
+export async function captureClaudeRuntime(
+  options: CaptureClaudeRuntimeOptions,
+): Promise<ClaudeRuntimeSnapshot | null> {
+  safeVersion(options.version);
+  if (options.dryRun) return null;
+  const root = await mkdtemp(
+    join(resolve(options.tempDir), `claude-${options.version}-`),
+  );
+  const plan = createClaudeRuntimeCommandPlan(options.version, root, options);
+  const runner = options.runner ?? runBoundedCommand;
+  const sandboxed = (spec: CommandSpec): CommandSpec =>
+    options.sandbox === "direct" ? spec : sandboxClaudeCommand(spec, root);
+  try {
+    await Promise.all([
+      mkdir(plan.installRoot, { recursive: true }),
+      mkdir(plan.home, { recursive: true }),
+      mkdir(plan.config, { recursive: true }),
+      mkdir(plan.repo, { recursive: true }),
+    ]);
+    await writeFile(
+      join(plan.repo, "read-fixture.txt"),
+      [
+        "one",
+        "two",
+        "three",
+        "four",
+        "five",
+        "six",
+        "seven",
+        "eight",
+        "line9",
+        "line10",
+        "eleven",
+      ].join("\n"),
+      "utf8",
+    );
+
+    checkResult(await runner(sandboxed(plan.install)), plan.install.label);
+    checkResult(await runner(plan.initializeRepo), plan.initializeRepo.label);
+    const packageResult = await runner(sandboxed(plan.verifyPackage));
+    checkResult(packageResult, plan.verifyPackage.label);
+    if (packageResult.stdout.trim() !== options.version) {
+      throw new Error(
+        `Installed Claude package version mismatch: expected ${options.version}`,
+      );
+    }
+    const versionResult = await runner(sandboxed(plan.version));
+    checkResult(versionResult, plan.version.label);
+    const reportedVersion =
+      /^\s*([0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?)/u.exec(
+        versionResult.stdout,
+      )?.[1];
+    if (reportedVersion !== options.version) {
+      throw new Error(`Claude --version mismatch: expected ${options.version}`);
+    }
+    const helpResult = await runner(sandboxed(plan.help));
+    checkResult(helpResult, plan.help.label);
+    const normalizedHelp = normalizeText(helpResult.stdout);
+    const safeModeSupported = normalizedHelp.includes("--safe-mode");
+    if (!safeModeSupported) {
+      plan.init.args = plan.init.args.filter(
+        (argument) => argument !== "--safe-mode",
+      );
+      for (const probe of plan.probes) {
+        probe.command.args = probe.command.args.filter(
+          (argument) => argument !== "--safe-mode",
+        );
+      }
+    }
+    const doctorResult = await runner(sandboxed(plan.doctor));
+    if (doctorResult.timedOut || doctorResult.truncated)
+      checkResult(doctorResult, plan.doctor.label);
+    const autoResult = await runner(sandboxed(plan.autoModeDefaults));
+    if (autoResult.timedOut || autoResult.truncated)
+      checkResult(autoResult, plan.autoModeDefaults.label);
+
+    let init: ClaudeRuntimeSnapshot["init"] = null;
+    let eventInventory: string[] = [];
+    const probes: ClaudeProbeObservation[] = [];
+    if (authAvailable(plan.init.env)) {
+      const initResult = await runner(sandboxed(plan.init));
+      if (initResult.exitCode !== 0 && isAuthFailure(initResult)) {
+        throw new Error(
+          "Claude runtime authentication failed. Check the ANTHROPIC_API_KEY Actions secret and rerun the watcher.",
+        );
+      } else {
+        checkResult(initResult, plan.init.label);
+        const parsed = parseClaudeStream(initResult.stdout);
+        if (!parsed.init) {
+          throw new Error(
+            "Claude stream completed without a system/init event; runtime inventory is incomplete.",
+          );
+        }
+        init = {
+          tools: parsed.init.tools,
+          model: parsed.init.model,
+          capabilities: parsed.init.capabilities,
+          stable_fields: parsed.init.stableFields,
+        };
+        eventInventory = parsed.eventTypes;
+        if (options.reuseProbes) {
+          probes.push(
+            ...options.reuseProbes.map(
+              (probe) => normalizeVolatile(probe) as ClaudeProbeObservation,
+            ),
+          );
+        } else {
+          for (const [index, probe] of PROBES.entries()) {
+            const probePlan = plan.probes[index];
+            if (!probePlan)
+              throw new Error(`Missing command plan for probe ${probe.name}`);
+            probes.push(
+              await runProbe(
+                probe,
+                sandboxed(probePlan.command),
+                runner,
+                plan.repo,
+                Math.max(1, Math.min(options.maxProbeAttempts ?? 2, 3)),
+              ),
+            );
+          }
+        }
+      }
+    } else if (options.requireAuth !== false) {
+      throw new Error(
+        "ANTHROPIC_API_KEY is required for Claude runtime inventory and probes.",
+      );
+    } else {
+      for (const probe of PROBES)
+        probes.push(skippedProbe(probe.name, "Authentication unavailable"));
+    }
+
+    const snapshotWithoutDigest = {
+      version: options.version,
+      version_output: normalizeText(versionResult.stdout),
+      help_text: normalizedHelp,
+      help_hash: hash(normalizedHelp),
+      doctor: {
+        exit_code: doctorResult.exitCode ?? -1,
+        summary: normalizeDoctorVersion(
+          doctorSummary(doctorResult, plan.doctor.env),
+          options.version,
+        ),
+      },
+      auto_mode_defaults:
+        autoResult.exitCode === 0
+          ? extractAutoModeDefaults(autoResult.stdout)
+          : null,
+      init,
+      event_inventory: eventInventory,
+      probes,
+    };
+    const semanticSnapshot = {
+      ...snapshotWithoutDigest,
+      probes: probes.map(semanticProbe),
+    };
+    return {
+      ...snapshotWithoutDigest,
+      digest: hash(stableJson(semanticSnapshot)),
+    };
+  } finally {
+    if (!options.keepRoot) await rm(root, { recursive: true, force: true });
+  }
+}

--- a/scripts/claude-watch/runtime-sandbox.ts
+++ b/scripts/claude-watch/runtime-sandbox.ts
@@ -1,0 +1,170 @@
+import { spawn } from "node:child_process";
+
+const RUNTIME_SANDBOX_IMAGE =
+  "node:22.18.0-bookworm@sha256:3266bc9e8bee1acc8a77386eefaf574987d2729b8c5ec35b0dbd6ddbc40b0ce2";
+const AUTH_ENV_KEYS = ["ANTHROPIC_API_KEY", "CLAUDE_CODE_OAUTH_TOKEN"] as const;
+
+export interface CommandSpec {
+  command: string;
+  args: string[];
+  cwd: string;
+  env: NodeJS.ProcessEnv;
+  timeoutMs: number;
+  outputCapBytes: number;
+  stdin?: string;
+  label: string;
+}
+
+export interface CommandResult {
+  exitCode: number | null;
+  stdout: string;
+  stderr: string;
+  timedOut: boolean;
+  truncated: boolean;
+  signal?: NodeJS.Signals | null;
+}
+
+export type CommandRunner = (spec: CommandSpec) => Promise<CommandResult>;
+
+/**
+ * Runs untrusted package install scripts and the closed-source Claude binary in
+ * a container that can see only its disposable probe root. The Docker client
+ * receives only the already-minimized command environment; secret values are
+ * inherited by name rather than placed in argv.
+ */
+export function sandboxClaudeCommand(
+  spec: CommandSpec,
+  root: string,
+): CommandSpec {
+  const containerRoot = "/watch";
+  const mapPath = (value: string): string =>
+    value === root || value.startsWith(`${root}/`)
+      ? `${containerRoot}${value.slice(root.length)}`
+      : value;
+  const args = [
+    "run",
+    "--rm",
+    "--network",
+    "bridge",
+    "--read-only",
+    "--tmpfs",
+    "/tmp:rw,nosuid,nodev,size=128m",
+    "--cap-drop",
+    "ALL",
+    "--security-opt",
+    "no-new-privileges",
+    "--pids-limit",
+    "256",
+    "--user",
+    `${process.getuid?.() ?? 1000}:${process.getgid?.() ?? 1000}`,
+    "--memory",
+    "2g",
+    "--cpus",
+    "2",
+    "--volume",
+    `${root}:${containerRoot}:rw`,
+    "--workdir",
+    mapPath(spec.cwd),
+  ];
+  for (const [key, value] of Object.entries(spec.env)) {
+    if (value === undefined || key === "PATH") continue;
+    args.push(
+      "--env",
+      AUTH_ENV_KEYS.includes(key as (typeof AUTH_ENV_KEYS)[number])
+        ? key
+        : `${key}=${mapPath(value)}`,
+    );
+  }
+  args.push(
+    RUNTIME_SANDBOX_IMAGE,
+    mapPath(spec.command),
+    ...spec.args.map(mapPath),
+  );
+  return {
+    ...spec,
+    command: "/usr/bin/docker",
+    args,
+    cwd: root,
+  };
+}
+
+/** Spawn with bounded output and terminate the whole process group on timeout/cap. */
+export const runBoundedCommand: CommandRunner = (spec) =>
+  new Promise((resolvePromise, reject) => {
+    const child = spawn(spec.command, spec.args, {
+      cwd: spec.cwd,
+      env: spec.env,
+      stdio: ["pipe", "pipe", "pipe"],
+      detached: process.platform !== "win32",
+      windowsHide: true,
+    });
+    const chunks: { stdout: Buffer[]; stderr: Buffer[] } = {
+      stdout: [],
+      stderr: [],
+    };
+    let bytes = 0;
+    let timedOut = false;
+    let truncated = false;
+    let settled = false;
+    const terminate = () => {
+      if (child.pid === undefined) return;
+      try {
+        if (process.platform === "win32") child.kill("SIGTERM");
+        else process.kill(-child.pid, "SIGTERM");
+      } catch {
+        child.kill("SIGTERM");
+      }
+      const killTimer = setTimeout(() => {
+        try {
+          if (process.platform === "win32") child.kill("SIGKILL");
+          else if (child.pid !== undefined) process.kill(-child.pid, "SIGKILL");
+        } catch {
+          child.kill("SIGKILL");
+        }
+      }, 500);
+      killTimer.unref();
+    };
+    const timer = setTimeout(() => {
+      timedOut = true;
+      terminate();
+    }, spec.timeoutMs);
+    const collect = (which: "stdout" | "stderr", value: Buffer) => {
+      const remaining = spec.outputCapBytes - bytes;
+      if (remaining > 0) {
+        const kept = value.subarray(0, remaining);
+        chunks[which].push(kept);
+        bytes += kept.length;
+      }
+      if (value.length > remaining) {
+        truncated = true;
+        terminate();
+      }
+    };
+    child.stdout.on("data", (value: Buffer) => collect("stdout", value));
+    child.stderr.on("data", (value: Buffer) => collect("stderr", value));
+    child.on("error", (error) => {
+      clearTimeout(timer);
+      if (!settled) {
+        settled = true;
+        reject(
+          new Error(`Command ${spec.label} could not start: ${error.message}`),
+        );
+      }
+    });
+    child.on("close", (exitCode, signal) => {
+      clearTimeout(timer);
+      if (!settled) {
+        settled = true;
+        resolvePromise({
+          exitCode,
+          signal,
+          stdout: Buffer.concat(chunks.stdout).toString("utf8"),
+          stderr: Buffer.concat(chunks.stderr).toString("utf8"),
+          timedOut,
+          truncated,
+        });
+      }
+    });
+    if (spec.stdin !== undefined) child.stdin.end(spec.stdin);
+    else child.stdin.end();
+  });

--- a/scripts/claude-watch/state-branch.test.ts
+++ b/scripts/claude-watch/state-branch.test.ts
@@ -1,0 +1,206 @@
+import { describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  CLAUDE_WATCH_STATE_BRANCH,
+  CLAUDE_WATCH_STATE_FILE,
+  finalizeStateBranch,
+  loadStateSnapshot,
+  loadStateSnapshotAtCommit,
+  materializeStateFiles,
+  resolveStateBranchTip,
+} from "./state-branch.ts";
+import type { ClaudeWatchStateSnapshot } from "./types.ts";
+
+function git(cwd: string, ...args: string[]): string {
+  const result = spawnSync("git", ["-C", cwd, ...args], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      GIT_AUTHOR_NAME: "Test",
+      GIT_AUTHOR_EMAIL: "test@example.test",
+      GIT_COMMITTER_NAME: "Test",
+      GIT_COMMITTER_EMAIL: "test@example.test",
+    },
+  });
+  if (result.status !== 0) {
+    throw new Error(result.stderr || `git ${args.join(" ")} failed`);
+  }
+  return result.stdout.trim();
+}
+
+function snapshot(candidateId: string): ClaudeWatchStateSnapshot {
+  return {
+    schema_version: 1,
+    candidate_id: candidateId,
+    package_version: candidateId,
+    npm_integrity: `sha512-${candidateId}`,
+    npm_published_at: "2026-08-01T00:00:00Z",
+    release_url: `https://example.test/releases/${candidateId}`,
+    release_notes_md: "release notes",
+    release_published_at: "2026-08-01T00:00:00Z",
+    dist_tags: { latest: candidateId, stable: candidateId, next: null },
+    docs: {
+      index_url: "https://example.test/docs",
+      index_hash: "index-hash",
+      digest: `docs-${candidateId}`,
+      full_scan: true,
+      scanned_at: "2026-08-01T00:00:00Z",
+      pages: {},
+    },
+    runtime: null,
+    fetched_at: "2026-08-01T00:00:00Z",
+    workflow_run_url: "https://example.test/actions/1",
+    state_commit_parent: null,
+  };
+}
+
+function repository(): { root: string; remote: string; clone: string } {
+  const root = mkdtempSync(join(tmpdir(), "claude-state-test-"));
+  const remote = join(root, "remote.git");
+  const clone = join(root, "clone");
+  git(root, "init", "--bare", remote);
+  git(root, "clone", remote, clone);
+  git(clone, "checkout", "-b", "main");
+  git(clone, "commit", "--allow-empty", "-m", "initial main");
+  git(clone, "push", "-u", "origin", "main");
+  return { root, remote, clone };
+}
+
+describe("Claude state branch", () => {
+  test("materializes and safely loads a deterministic snapshot", () => {
+    const value = snapshot("2.1.0");
+    const files = materializeStateFiles(value, {
+      "runtime/output.json": "{}\n",
+      "docs/index.json": "[]\n",
+      [CLAUDE_WATCH_STATE_FILE]: "must be replaced",
+    });
+    expect(Object.keys(files)).toEqual([
+      "docs/index.json",
+      "runtime/output.json",
+      CLAUDE_WATCH_STATE_FILE,
+    ]);
+    expect(loadStateSnapshot(files)).toEqual(value);
+    expect(loadStateSnapshot({ [CLAUDE_WATCH_STATE_FILE]: "{" })).toBeNull();
+    expect(() => materializeStateFiles(value, { "../escape": "no" })).toThrow(
+      "Unsafe state file path",
+    );
+  });
+
+  test("creates an orphan state branch, advances by parent, and is idempotent", () => {
+    const repo = repository();
+    try {
+      const mainBefore = git(repo.clone, "rev-parse", "main");
+      const first = finalizeStateBranch({
+        repoPath: repo.clone,
+        snapshot: snapshot("2.1.0"),
+        files: { "docs/page.txt": "first\n" },
+        expectedBaseSha: null,
+      });
+      expect(first.created).toBe(true);
+      expect(first.parentSha).toBeNull();
+      expect(
+        git(repo.clone, "rev-list", "--parents", "-n", "1", first.commitSha),
+      ).toBe(first.commitSha);
+      expect(resolveStateBranchTip(repo.clone)).toBe(first.commitSha);
+      expect(
+        loadStateSnapshotAtCommit(repo.clone, first.commitSha),
+      ).toMatchObject({
+        candidate_id: "2.1.0",
+        state_commit_parent: null,
+      });
+
+      const retry = finalizeStateBranch({
+        repoPath: repo.clone,
+        snapshot: snapshot("2.1.0"),
+        expectedBaseSha: null,
+      });
+      expect(retry).toEqual({
+        commitSha: first.commitSha,
+        created: false,
+        parentSha: first.commitSha,
+      });
+
+      const second = finalizeStateBranch({
+        repoPath: repo.clone,
+        snapshot: snapshot("2.2.0"),
+        expectedBaseSha: first.commitSha,
+      });
+      expect(second.parentSha).toBe(first.commitSha);
+      expect(
+        git(repo.clone, "rev-list", "--parents", "-n", "1", second.commitSha),
+      ).toBe(`${second.commitSha} ${first.commitSha}`);
+      expect(
+        loadStateSnapshotAtCommit(repo.clone, second.commitSha),
+      ).toMatchObject({
+        candidate_id: "2.2.0",
+        state_commit_parent: first.commitSha,
+      });
+      expect(git(repo.clone, "rev-parse", "main")).toBe(mainBefore);
+      expect(git(repo.clone, "branch", "--show-current")).toBe("main");
+      expect(
+        git(repo.clone, "ls-remote", "--heads", "origin", "main"),
+      ).toContain(mainBefore);
+      expect(
+        git(
+          repo.clone,
+          "ls-remote",
+          "--heads",
+          "origin",
+          CLAUDE_WATCH_STATE_BRANCH,
+        ),
+      ).toContain(second.commitSha);
+    } finally {
+      rmSync(repo.root, { recursive: true, force: true });
+    }
+  });
+
+  test("rejects a stale base for a different candidate", () => {
+    const repo = repository();
+    try {
+      const first = finalizeStateBranch({
+        repoPath: repo.clone,
+        snapshot: snapshot("2.1.0"),
+        expectedBaseSha: null,
+      });
+      expect(() =>
+        finalizeStateBranch({
+          repoPath: repo.clone,
+          snapshot: snapshot("2.2.0"),
+          expectedBaseSha: null,
+        }),
+      ).toThrow(`found ${first.commitSha}`);
+    } finally {
+      rmSync(repo.root, { recursive: true, force: true });
+    }
+  });
+
+  test("a rejected push leaves main and the durable state tip unchanged", () => {
+    const repo = repository();
+    try {
+      const first = finalizeStateBranch({
+        repoPath: repo.clone,
+        snapshot: snapshot("2.1.0"),
+        expectedBaseSha: null,
+      });
+      const mainBefore = git(repo.clone, "rev-parse", "main");
+      const hook = join(repo.remote, "hooks", "pre-receive");
+      writeFileSync(hook, "#!/bin/sh\necho rejected >&2\nexit 1\n");
+      chmodSync(hook, 0o755);
+
+      expect(() =>
+        finalizeStateBranch({
+          repoPath: repo.clone,
+          snapshot: snapshot("2.2.0"),
+          expectedBaseSha: first.commitSha,
+        }),
+      ).toThrow("rejected");
+      expect(resolveStateBranchTip(repo.clone)).toBe(first.commitSha);
+      expect(git(repo.clone, "rev-parse", "main")).toBe(mainBefore);
+    } finally {
+      rmSync(repo.root, { recursive: true, force: true });
+    }
+  });
+});

--- a/scripts/claude-watch/state-branch.ts
+++ b/scripts/claude-watch/state-branch.ts
@@ -1,0 +1,313 @@
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, posix } from "node:path";
+import type { ClaudeWatchStateSnapshot } from "./types.ts";
+
+export const CLAUDE_WATCH_STATE_BRANCH = "claude-watch-state";
+export const CLAUDE_WATCH_STATE_FILE = "snapshot.json";
+
+export interface FinalizeStateBranchOptions {
+  repoPath: string;
+  snapshot: ClaudeWatchStateSnapshot;
+  files?: Readonly<Record<string, string>>;
+  /** The SHA observed when analysis started; null means no state branch existed. */
+  expectedBaseSha: string | null;
+  remote?: string;
+  branch?: string;
+  commitMessage?: string;
+}
+
+export interface FinalizeStateBranchResult {
+  commitSha: string;
+  created: boolean;
+  parentSha: string | null;
+}
+
+/**
+ * Produces the complete, deterministic file set for a state commit. This is
+ * intentionally pure so callers can inspect or test a snapshot before git is
+ * involved.
+ */
+export function materializeStateFiles(
+  snapshot: ClaudeWatchStateSnapshot,
+  files: Readonly<Record<string, string>> = {},
+): Record<string, string> {
+  const result: Record<string, string> = {};
+  for (const path of Object.keys(files).sort()) {
+    assertSafeStatePath(path);
+    if (path === CLAUDE_WATCH_STATE_FILE) continue;
+    result[path] = files[path] as string;
+  }
+  result[CLAUDE_WATCH_STATE_FILE] = `${JSON.stringify(snapshot, null, 2)}\n`;
+  return result;
+}
+
+/** Safely loads the canonical snapshot from an already materialized file map. */
+export function loadStateSnapshot(
+  files: Readonly<Record<string, string>>,
+): ClaudeWatchStateSnapshot | null {
+  const source = files[CLAUDE_WATCH_STATE_FILE];
+  if (typeof source !== "string") return null;
+  try {
+    const value: unknown = JSON.parse(source);
+    return isStateSnapshot(value) ? value : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Reads a snapshot at a commit without checking out or changing any branch. */
+export function loadStateSnapshotAtCommit(
+  repoPath: string,
+  commitSha: string,
+): ClaudeWatchStateSnapshot | null {
+  const result = git(
+    repoPath,
+    ["show", `${commitSha}:${CLAUDE_WATCH_STATE_FILE}`],
+    false,
+  );
+  if (!result.ok) return null;
+  return loadStateSnapshot({ [CLAUDE_WATCH_STATE_FILE]: result.stdout });
+}
+
+/** Reads the complete sanitized state tree at a commit without checking it out. */
+export function loadStateFilesAtCommit(
+  repoPath: string,
+  commitSha: string,
+): Record<string, string> {
+  const listed = git(
+    repoPath,
+    ["ls-tree", "-r", "--name-only", commitSha],
+    false,
+  );
+  if (!listed.ok) return {};
+  const files: Record<string, string> = {};
+  for (const path of listed.stdout.split("\n").filter(Boolean).sort()) {
+    assertSafeStatePath(path);
+    const contents = git(repoPath, ["show", `${commitSha}:${path}`], false);
+    if (contents.ok) files[path] = contents.stdout;
+  }
+  return files;
+}
+
+/** Returns the remote state tip, or null when the branch has not been created. */
+export function resolveStateBranchTip(
+  repoPath: string,
+  remote = "origin",
+  branch = CLAUDE_WATCH_STATE_BRANCH,
+): string | null {
+  assertBranchName(branch);
+  const result = git(repoPath, [
+    "ls-remote",
+    "--heads",
+    remote,
+    `refs/heads/${branch}`,
+  ]);
+  const line = result.stdout.trim();
+  if (!line) return null;
+  const sha = line.split(/\s+/, 1)[0];
+  if (!sha || !/^[0-9a-f]{40,64}$/.test(sha)) {
+    throw new Error(`Unexpected state branch response for ${branch}`);
+  }
+  return sha;
+}
+
+/** Fetches the current state tip into a remote-tracking ref without checkout. */
+export function fetchStateBranchTip(
+  repoPath: string,
+  remote = "origin",
+  branch = CLAUDE_WATCH_STATE_BRANCH,
+): string | null {
+  const tip = resolveStateBranchTip(repoPath, remote, branch);
+  if (!tip) return null;
+  git(repoPath, [
+    "fetch",
+    "--no-tags",
+    "--depth=2",
+    remote,
+    `refs/heads/${branch}:refs/remotes/${remote}/${branch}`,
+  ]);
+  return tip;
+}
+
+/**
+ * Commits and pushes a snapshot using git plumbing only. No branch is checked
+ * out, so the caller's current branch (especially main) is never touched.
+ * Pushes have no force refspec and therefore receive normal fast-forward
+ * protection from git.
+ */
+export function finalizeStateBranch(
+  options: FinalizeStateBranchOptions,
+): FinalizeStateBranchResult {
+  const remote = options.remote ?? "origin";
+  const branch = options.branch ?? CLAUDE_WATCH_STATE_BRANCH;
+  assertBranchName(branch);
+
+  const currentTip = resolveStateBranchTip(options.repoPath, remote, branch);
+  if (currentTip) fetchStateBranchTip(options.repoPath, remote, branch);
+  const currentSnapshot = currentTip
+    ? loadStateSnapshotAtCommit(options.repoPath, currentTip)
+    : null;
+
+  // A retry after a successful push is a no-op, even if its remembered base is
+  // now stale. This check is what makes partial workflow reconciliation safe.
+  if (
+    currentTip &&
+    currentSnapshot?.candidate_id === options.snapshot.candidate_id
+  ) {
+    return { commitSha: currentTip, created: false, parentSha: currentTip };
+  }
+
+  if (currentTip !== options.expectedBaseSha) {
+    throw new Error(
+      `Claude state branch advanced: expected ${options.expectedBaseSha ?? "no branch"}, found ${currentTip ?? "no branch"}`,
+    );
+  }
+
+  const snapshot: ClaudeWatchStateSnapshot = {
+    ...options.snapshot,
+    state_commit_parent: currentTip,
+  };
+  const files = materializeStateFiles(snapshot, options.files);
+  const temporaryDirectory = mkdtempSync(join(tmpdir(), "claude-watch-state-"));
+  const indexFile = join(temporaryDirectory, "index");
+  const env = {
+    ...process.env,
+    GIT_INDEX_FILE: indexFile,
+    GIT_AUTHOR_NAME: process.env.GIT_AUTHOR_NAME ?? "Claude Watch",
+    GIT_AUTHOR_EMAIL:
+      process.env.GIT_AUTHOR_EMAIL ?? "claude-watch@users.noreply.github.com",
+    GIT_COMMITTER_NAME: process.env.GIT_COMMITTER_NAME ?? "Claude Watch",
+    GIT_COMMITTER_EMAIL:
+      process.env.GIT_COMMITTER_EMAIL ??
+      "claude-watch@users.noreply.github.com",
+  };
+
+  try {
+    git(options.repoPath, ["read-tree", "--empty"], true, env);
+    for (const [path, contents] of Object.entries(files)) {
+      const blob = git(
+        options.repoPath,
+        ["hash-object", "-w", "--stdin"],
+        true,
+        env,
+        contents,
+      ).stdout.trim();
+      git(
+        options.repoPath,
+        ["update-index", "--add", "--cacheinfo", "100644", blob, path],
+        true,
+        env,
+      );
+    }
+    const tree = git(options.repoPath, ["write-tree"], true, env).stdout.trim();
+    const commitArgs = [
+      "commit-tree",
+      tree,
+      ...(currentTip ? ["-p", currentTip] : []),
+      "-m",
+      options.commitMessage ??
+        `chore(claude-watch): record ${snapshot.candidate_id}`,
+    ];
+    const commitSha = git(
+      options.repoPath,
+      commitArgs,
+      true,
+      env,
+    ).stdout.trim();
+
+    // No leading '+' and no --force: the remote enforces normal FF updates.
+    git(options.repoPath, [
+      "push",
+      remote,
+      `${commitSha}:refs/heads/${branch}`,
+    ]);
+    return { commitSha, created: true, parentSha: currentTip };
+  } finally {
+    rmSync(temporaryDirectory, { recursive: true, force: true });
+  }
+}
+
+interface GitResult {
+  ok: boolean;
+  stdout: string;
+}
+
+function git(
+  repoPath: string,
+  args: string[],
+  required = true,
+  env: NodeJS.ProcessEnv = process.env,
+  input?: string,
+): GitResult {
+  const result = spawnSync("git", ["-C", repoPath, ...args], {
+    encoding: "utf8",
+    env,
+    input,
+  });
+  const stdout = result.stdout ?? "";
+  if (required && result.status !== 0) {
+    const detail = (result.stderr ?? stdout).trim();
+    throw new Error(`git ${args[0]} failed${detail ? `: ${detail}` : ""}`);
+  }
+  return { ok: result.status === 0, stdout };
+}
+
+function assertSafeStatePath(path: string): void {
+  if (
+    !path ||
+    path.includes("\\") ||
+    posix.isAbsolute(path) ||
+    posix.normalize(path) !== path ||
+    path === ".." ||
+    path.startsWith("../")
+  ) {
+    throw new Error(`Unsafe state file path: ${path}`);
+  }
+}
+
+function assertBranchName(branch: string): void {
+  if (
+    !branch ||
+    branch.startsWith("-") ||
+    branch.includes("..") ||
+    !/^[A-Za-z0-9][A-Za-z0-9._/-]*$/.test(branch)
+  ) {
+    throw new Error(`Unsafe state branch name: ${branch}`);
+  }
+}
+
+function isStateSnapshot(value: unknown): value is ClaudeWatchStateSnapshot {
+  if (!isRecord(value)) return false;
+  return (
+    typeof value.schema_version === "number" &&
+    typeof value.candidate_id === "string" &&
+    typeof value.package_version === "string" &&
+    typeof value.npm_integrity === "string" &&
+    typeof value.npm_published_at === "string" &&
+    typeof value.release_url === "string" &&
+    typeof value.release_notes_md === "string" &&
+    typeof value.release_published_at === "string" &&
+    isDistTags(value.dist_tags) &&
+    isRecord(value.docs) &&
+    (isRecord(value.runtime) || value.runtime === null) &&
+    typeof value.fetched_at === "string" &&
+    typeof value.workflow_run_url === "string" &&
+    (typeof value.state_commit_parent === "string" ||
+      value.state_commit_parent === null)
+  );
+}
+
+function isDistTags(value: unknown): boolean {
+  return (
+    isRecord(value) &&
+    typeof value.latest === "string" &&
+    (typeof value.stable === "string" || value.stable === null) &&
+    (typeof value.next === "string" || value.next === null)
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}

--- a/scripts/claude-watch/tracker.test.ts
+++ b/scripts/claude-watch/tracker.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, test } from "bun:test";
+import {
+  emptyTrackerState,
+  hasProcessedCandidate,
+  parseTrackerState,
+  recordAnalysis,
+  renderTrackerBody,
+  serializeTrackerState,
+  TRACKER_ATTEMPT_HISTORY_LIMIT,
+  TRACKER_HISTORY_LIMIT,
+} from "./tracker.ts";
+import type { ClaudeWatchAnalysis } from "./types.ts";
+
+function analysis(candidateId = "2.1.0"): ClaudeWatchAnalysis {
+  return {
+    schema_version: 1,
+    candidate_id: candidateId,
+    previous_candidate_id: "2.0.0",
+    previous_version: "2.0.0",
+    current_version: candidateId,
+    is_bootstrap: false,
+    release_url: `https://example.test/releases/${candidateId}`,
+    release_notes_md: "notes",
+    npm_integrity: `sha512-package-${candidateId}`,
+    npm_published_at: "2026-08-01T00:00:00Z",
+    release_published_at: "2026-08-01T00:00:00Z",
+    dist_tags: { latest: candidateId, stable: candidateId, next: null },
+    docs_digest: `docs-${candidateId}`,
+    runtime_digest: `runtime-${candidateId}`,
+    docs_diff: {
+      added_pages: [],
+      removed_pages: [],
+      changed_pages: [],
+      watched_page_diffs: [],
+      tools: { added: [], removed: [], changed: [] },
+      cli: { added: [], removed: [], changed: [] },
+      settings: { added: [], removed: [], changed: [] },
+      env_vars: { added: [], removed: [], changed: [] },
+      permission_rules: { added: [], removed: [], changed: [] },
+    },
+    previous_runtime_snapshot: null,
+    runtime_snapshot: null,
+    runtime_diff: null,
+    verdict: "no-op",
+    verdict_reasons: [],
+    errors: [],
+    workflow_run_url: "https://example.test/actions/1",
+    state_base_sha: null,
+    state_snapshot_candidate_id: "2.0.0",
+  };
+}
+
+describe("Claude tracker", () => {
+  test("uses a Claude-only hidden marker and parses malformed state safely", () => {
+    expect(parseTrackerState("plain text")).toEqual(emptyTrackerState());
+    expect(
+      parseTrackerState("<!-- claude-watch-tracker-state\n{nope}\n-->"),
+    ).toEqual(emptyTrackerState());
+    expect(
+      parseTrackerState('<!-- codex-agent-watch-state\n{"processed":[]}\n-->'),
+    ).toEqual(emptyTrackerState());
+  });
+
+  test("round trips digests and terminal state", () => {
+    const state = recordAnalysis(emptyTrackerState(), {
+      analysis: analysis(),
+      outcome: "recorded_noop",
+      notes: "nothing watched changed",
+      stateCommitSha: "abc123",
+      processedAt: "2026-08-01T01:00:00Z",
+    });
+    expect(parseTrackerState(serializeTrackerState(state))).toEqual(state);
+    expect(state.processed[0]).toMatchObject({
+      candidate_id: "2.1.0",
+      package_digest: "sha512-package-2.1.0",
+      docs_digest: "docs-2.1.0",
+      runtime_digest: "runtime-2.1.0",
+      state_commit_sha: "abc123",
+    });
+    expect(hasProcessedCandidate(state, "2.1.0")).toBe(true);
+  });
+
+  test("keeps errors nonterminal and accumulates bounded retry history", () => {
+    let state = emptyTrackerState();
+    for (
+      let attempt = 0;
+      attempt < TRACKER_ATTEMPT_HISTORY_LIMIT + 4;
+      attempt++
+    ) {
+      state = recordAnalysis(state, {
+        analysis: analysis(),
+        outcome: "error",
+        notes: "retryable",
+        error: `failure ${attempt}`,
+        processedAt: `2026-08-01T01:${String(attempt).padStart(2, "0")}:00Z`,
+      });
+    }
+    expect(state.processed).toHaveLength(1);
+    expect(state.processed[0]?.attempts).toHaveLength(
+      TRACKER_ATTEMPT_HISTORY_LIMIT,
+    );
+    expect(state.processed[0]?.errors).toHaveLength(
+      TRACKER_ATTEMPT_HISTORY_LIMIT,
+    );
+    expect(hasProcessedCandidate(state, "2.1.0")).toBe(false);
+
+    state = recordAnalysis(state, {
+      analysis: { ...analysis(), verdict: "tool contract review needed" },
+      outcome: "pr_created",
+      notes: "fixed",
+      prUrl: "https://example.test/pull/1",
+      stateCommitSha: "def456",
+    });
+    expect(state.processed).toHaveLength(1);
+    expect(state.processed[0]?.attempts).toHaveLength(
+      TRACKER_ATTEMPT_HISTORY_LIMIT,
+    );
+    expect(hasProcessedCandidate(state, "2.1.0")).toBe(true);
+  });
+
+  test("bounds candidate history and shows only actionable non-noops", () => {
+    let state = emptyTrackerState();
+    for (let index = 0; index < TRACKER_HISTORY_LIMIT + 5; index++) {
+      state = recordAnalysis(state, {
+        analysis: analysis(`2.${index}.0`),
+        outcome: "recorded_noop",
+        notes: `noop ${index}`,
+      });
+    }
+    expect(state.processed).toHaveLength(TRACKER_HISTORY_LIMIT);
+    expect(renderTrackerBody(state)).toContain(
+      "_No actionable Claude changes recorded yet._",
+    );
+    expect(renderTrackerBody(state)).not.toContain("| 2.54.0 | no-op |");
+
+    const actionable = recordAnalysis(state, {
+      analysis: {
+        ...analysis("3.0.0"),
+        verdict: "harness behavior review needed",
+      },
+      outcome: "needs_human_review",
+      notes: "inspect hooks | carefully",
+    });
+    const body = renderTrackerBody(actionable);
+    expect(body).toContain("| 3.0.0 | harness behavior review needed |");
+    expect(body).toContain("inspect hooks \\| carefully");
+  });
+});

--- a/scripts/claude-watch/tracker.ts
+++ b/scripts/claude-watch/tracker.ts
@@ -1,0 +1,325 @@
+import type {
+  ClaudeWatchAnalysis,
+  ClaudeWatchOutcome,
+  ClaudeWatchVerdict,
+} from "./types.ts";
+
+/** Deliberately different from the Codex watcher marker. */
+export const CLAUDE_TRACKER_STATE_START = "<!-- claude-watch-tracker-state";
+export const CLAUDE_TRACKER_STATE_END = "-->";
+export const TRACKER_HISTORY_LIMIT = 50;
+export const TRACKER_ATTEMPT_HISTORY_LIMIT = 10;
+export const TRACKER_ERROR_HISTORY_LIMIT = 10;
+export const VISIBLE_ACTIONABLE_LIMIT = 20;
+
+const TERMINAL_OUTCOMES: ReadonlySet<ClaudeWatchOutcome> = new Set([
+  "recorded_noop",
+  "no_local_impact",
+  "pr_created",
+  "needs_human_review",
+]);
+
+export interface ClaudeTrackerAttempt {
+  attempted_at: string;
+  workflow_run_url: string;
+  outcome: ClaudeWatchOutcome;
+  error: string | null;
+}
+
+export interface ClaudeTrackerError {
+  occurred_at: string;
+  workflow_run_url: string;
+  message: string;
+}
+
+export interface ClaudeTrackerEntry {
+  candidate_id: string;
+  package_digest: string;
+  docs_digest: string;
+  runtime_digest: string | null;
+  verdict: ClaudeWatchVerdict;
+  outcome: ClaudeWatchOutcome;
+  pr_url: string | null;
+  notes: string;
+  processed_at: string;
+  workflow_run_url: string;
+  attempts: ClaudeTrackerAttempt[];
+  errors: ClaudeTrackerError[];
+  state_commit_sha: string | null;
+}
+
+export interface ClaudeTrackerState {
+  last_checked_candidate_id: string | null;
+  last_checked_at: string | null;
+  processed: ClaudeTrackerEntry[];
+}
+
+export interface RecordClaudeAnalysisOptions {
+  analysis: ClaudeWatchAnalysis;
+  outcome: ClaudeWatchOutcome;
+  notes: string;
+  prUrl?: string | null;
+  stateCommitSha?: string | null;
+  error?: string | null;
+  processedAt?: string;
+}
+
+export function emptyTrackerState(): ClaudeTrackerState {
+  return {
+    last_checked_candidate_id: null,
+    last_checked_at: null,
+    processed: [],
+  };
+}
+
+export function isTerminalOutcome(outcome: ClaudeWatchOutcome): boolean {
+  return TERMINAL_OUTCOMES.has(outcome);
+}
+
+export function findTrackerEntry(
+  state: ClaudeTrackerState,
+  candidateId: string,
+): ClaudeTrackerEntry | undefined {
+  return state.processed.find((entry) => entry.candidate_id === candidateId);
+}
+
+/** Errors are retryable and therefore do not count as processed. */
+export function hasProcessedCandidate(
+  state: ClaudeTrackerState,
+  candidateId: string,
+): boolean {
+  const entry = findTrackerEntry(state, candidateId);
+  return entry !== undefined && isTerminalOutcome(entry.outcome);
+}
+
+export function parseTrackerState(body: string): ClaudeTrackerState {
+  const start = body.indexOf(CLAUDE_TRACKER_STATE_START);
+  if (start < 0) return emptyTrackerState();
+  const jsonStart = start + CLAUDE_TRACKER_STATE_START.length;
+  const end = body.indexOf(CLAUDE_TRACKER_STATE_END, jsonStart);
+  if (end < 0) return emptyTrackerState();
+  try {
+    return normalizeState(JSON.parse(body.slice(jsonStart, end).trim()));
+  } catch {
+    return emptyTrackerState();
+  }
+}
+
+export function serializeTrackerState(state: ClaudeTrackerState): string {
+  return `${CLAUDE_TRACKER_STATE_START}\n${JSON.stringify(normalizeState(state), null, 2)}\n${CLAUDE_TRACKER_STATE_END}`;
+}
+
+export function recordAnalysis(
+  state: ClaudeTrackerState,
+  options: RecordClaudeAnalysisOptions,
+): ClaudeTrackerState {
+  const processedAt = options.processedAt ?? new Date().toISOString();
+  const previous = findTrackerEntry(state, options.analysis.candidate_id);
+  const error = options.error ?? options.analysis.errors.at(-1) ?? null;
+  const attempt: ClaudeTrackerAttempt = {
+    attempted_at: processedAt,
+    workflow_run_url: options.analysis.workflow_run_url,
+    outcome: options.outcome,
+    error,
+  };
+  const errors = error
+    ? [
+        {
+          occurred_at: processedAt,
+          workflow_run_url: options.analysis.workflow_run_url,
+          message: error,
+        },
+        ...(previous?.errors ?? []),
+      ].slice(0, TRACKER_ERROR_HISTORY_LIMIT)
+    : (previous?.errors ?? []);
+
+  return upsertTrackerEntry(state, {
+    candidate_id: options.analysis.candidate_id,
+    package_digest: options.analysis.npm_integrity,
+    docs_digest: options.analysis.docs_digest,
+    runtime_digest: options.analysis.runtime_digest,
+    verdict: options.analysis.verdict,
+    outcome: options.outcome,
+    pr_url: options.prUrl ?? previous?.pr_url ?? null,
+    notes: options.notes,
+    processed_at: processedAt,
+    workflow_run_url: options.analysis.workflow_run_url,
+    attempts: [attempt, ...(previous?.attempts ?? [])].slice(
+      0,
+      TRACKER_ATTEMPT_HISTORY_LIMIT,
+    ),
+    errors,
+    state_commit_sha:
+      options.stateCommitSha ?? previous?.state_commit_sha ?? null,
+  });
+}
+
+/** Upserts by candidate id, so retries never create duplicate history rows. */
+export function upsertTrackerEntry(
+  state: ClaudeTrackerState,
+  entry: ClaudeTrackerEntry,
+): ClaudeTrackerState {
+  const normalizedEntry = normalizeEntry(entry);
+  if (!normalizedEntry) return normalizeState(state);
+  return {
+    last_checked_candidate_id: normalizedEntry.candidate_id,
+    last_checked_at: normalizedEntry.processed_at,
+    processed: [
+      normalizedEntry,
+      ...normalizeState(state).processed.filter(
+        (item) => item.candidate_id !== normalizedEntry.candidate_id,
+      ),
+    ].slice(0, TRACKER_HISTORY_LIMIT),
+  };
+}
+
+/** True only for entries useful to a human; no-op and transient errors stay hidden. */
+export function isActionableEntry(entry: ClaudeTrackerEntry): boolean {
+  return (
+    entry.outcome === "pr_created" ||
+    entry.outcome === "needs_human_review" ||
+    (entry.outcome === "no_local_impact" && entry.verdict !== "no-op")
+  );
+}
+
+export function renderTrackerBody(state: ClaudeTrackerState): string {
+  const normalized = normalizeState(state);
+  const rows = normalized.processed
+    .filter(isActionableEntry)
+    .slice(0, VISIBLE_ACTIONABLE_LIMIT);
+  const table =
+    rows.length === 0
+      ? "_No actionable Claude changes recorded yet._"
+      : [
+          "| Candidate | Verdict | Outcome | PR | Notes |",
+          "|---|---|---|---|---|",
+          ...rows.map(
+            (entry) =>
+              `| ${escapeTable(entry.candidate_id)} | ${escapeTable(entry.verdict)} | ${escapeTable(entry.outcome)} | ${entry.pr_url ? `[PR](${entry.pr_url})` : "-"} | ${escapeTable(entry.notes)} |`,
+          ),
+        ].join("\n");
+  const checked =
+    normalized.last_checked_candidate_id && normalized.last_checked_at
+      ? `_Last checked: ${normalized.last_checked_candidate_id} at ${normalized.last_checked_at}._`
+      : "_Last checked: never._";
+  return [
+    "Central tracker for Claude upstream drift monitoring.",
+    "",
+    checked,
+    "",
+    "## Recent actionable candidates",
+    "",
+    table,
+    "",
+    "## Hidden state",
+    "",
+    "The workflow uses the Claude-specific hidden JSON block below for dedupe and retries.",
+    "",
+    serializeTrackerState(normalized),
+    "",
+  ].join("\n");
+}
+
+function normalizeState(value: unknown): ClaudeTrackerState {
+  if (!isRecord(value)) return emptyTrackerState();
+  const processed = Array.isArray(value.processed)
+    ? value.processed
+        .map(normalizeEntry)
+        .filter((entry): entry is ClaudeTrackerEntry => entry !== null)
+        .filter(
+          (entry, index, all) =>
+            all.findIndex(
+              (candidate) => candidate.candidate_id === entry.candidate_id,
+            ) === index,
+        )
+        .slice(0, TRACKER_HISTORY_LIMIT)
+    : [];
+  return {
+    last_checked_candidate_id:
+      typeof value.last_checked_candidate_id === "string"
+        ? value.last_checked_candidate_id
+        : null,
+    last_checked_at:
+      typeof value.last_checked_at === "string" ? value.last_checked_at : null,
+    processed,
+  };
+}
+
+function normalizeEntry(value: unknown): ClaudeTrackerEntry | null {
+  if (
+    !isRecord(value) ||
+    typeof value.candidate_id !== "string" ||
+    typeof value.package_digest !== "string" ||
+    typeof value.docs_digest !== "string" ||
+    !(
+      typeof value.runtime_digest === "string" || value.runtime_digest === null
+    ) ||
+    !isVerdict(value.verdict) ||
+    !isOutcome(value.outcome) ||
+    !(typeof value.pr_url === "string" || value.pr_url === null) ||
+    typeof value.notes !== "string" ||
+    typeof value.processed_at !== "string" ||
+    typeof value.workflow_run_url !== "string" ||
+    !(
+      typeof value.state_commit_sha === "string" ||
+      value.state_commit_sha === null
+    )
+  ) {
+    return null;
+  }
+  const attempts = Array.isArray(value.attempts)
+    ? value.attempts.filter(isAttempt).slice(0, TRACKER_ATTEMPT_HISTORY_LIMIT)
+    : [];
+  const errors = Array.isArray(value.errors)
+    ? value.errors.filter(isError).slice(0, TRACKER_ERROR_HISTORY_LIMIT)
+    : [];
+  return { ...value, attempts, errors } as ClaudeTrackerEntry;
+}
+
+function isAttempt(value: unknown): value is ClaudeTrackerAttempt {
+  return (
+    isRecord(value) &&
+    typeof value.attempted_at === "string" &&
+    typeof value.workflow_run_url === "string" &&
+    isOutcome(value.outcome) &&
+    (typeof value.error === "string" || value.error === null)
+  );
+}
+
+function isError(value: unknown): value is ClaudeTrackerError {
+  return (
+    isRecord(value) &&
+    typeof value.occurred_at === "string" &&
+    typeof value.workflow_run_url === "string" &&
+    typeof value.message === "string"
+  );
+}
+
+function isVerdict(value: unknown): value is ClaudeWatchVerdict {
+  return (
+    value === "no-op" ||
+    value === "prompt review needed" ||
+    value === "tool contract review needed" ||
+    value === "tool surface review needed" ||
+    value === "harness behavior review needed" ||
+    value === "manual review required"
+  );
+}
+
+function isOutcome(value: unknown): value is ClaudeWatchOutcome {
+  return (
+    value === "recorded_noop" ||
+    value === "no_local_impact" ||
+    value === "pr_created" ||
+    value === "needs_human_review" ||
+    value === "error"
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function escapeTable(value: string): string {
+  return value.replaceAll("|", "\\|").replaceAll("\n", " ");
+}

--- a/scripts/claude-watch/types.ts
+++ b/scripts/claude-watch/types.ts
@@ -1,0 +1,180 @@
+export type ClaudeWatchVerdict =
+  | "no-op"
+  | "prompt review needed"
+  | "tool contract review needed"
+  | "tool surface review needed"
+  | "harness behavior review needed"
+  | "manual review required";
+
+export type ClaudeWatchOutcome =
+  | "recorded_noop"
+  | "no_local_impact"
+  | "pr_created"
+  | "needs_human_review"
+  | "error";
+
+export interface ClaudeGitHubRelease {
+  tag_name: string;
+  draft: boolean;
+  prerelease: boolean;
+  html_url: string;
+  body: string | null;
+  published_at: string | null;
+}
+
+export interface ClaudeNpmVersion {
+  version: string;
+  published_at: string;
+  integrity: string;
+  tarball_url: string;
+}
+
+export interface ClaudeNpmMetadata {
+  dist_tags: {
+    latest: string;
+    stable: string | null;
+    next: string | null;
+  };
+  versions: ClaudeNpmVersion[];
+}
+
+export interface ClaudeReleaseCandidate extends ClaudeNpmVersion {
+  release_url: string;
+  release_notes_md: string;
+  release_published_at: string;
+  dist_tags: ClaudeNpmMetadata["dist_tags"];
+}
+
+export interface ClaudeDocsPageSnapshot {
+  url: string;
+  hash: string;
+  watched: boolean;
+  source_path: string | null;
+}
+
+export interface ClaudeDocsSnapshot {
+  index_url: string;
+  index_hash: string;
+  digest: string;
+  full_scan: boolean;
+  scanned_at: string;
+  pages: Record<string, ClaudeDocsPageSnapshot>;
+}
+
+export interface ClaudeNamedChange {
+  added: string[];
+  removed: string[];
+  changed: string[];
+}
+
+export interface ClaudeDocsPageDiff {
+  url: string;
+  source_path: string | null;
+  preview: string;
+  truncated: boolean;
+}
+
+export interface ClaudeDocsDiff {
+  added_pages: string[];
+  removed_pages: string[];
+  changed_pages: string[];
+  watched_page_diffs: ClaudeDocsPageDiff[];
+  tools: ClaudeNamedChange;
+  cli: ClaudeNamedChange;
+  settings: ClaudeNamedChange;
+  env_vars: ClaudeNamedChange;
+  permission_rules: ClaudeNamedChange;
+}
+
+export interface ClaudeProbeObservation {
+  name: string;
+  status: "passed" | "inconclusive" | "failed" | "skipped";
+  attempts: number;
+  assertions: Record<string, boolean | string | null>;
+  tool_calls: Array<{
+    name: string;
+    input: unknown;
+  }>;
+  tool_results: string[];
+  filesystem_changes: string[];
+  error: string | null;
+}
+
+export interface ClaudeRuntimeSnapshot {
+  version: string;
+  version_output: string;
+  help_text: string;
+  help_hash: string;
+  doctor: {
+    exit_code: number;
+    summary: string;
+  };
+  auto_mode_defaults: unknown | null;
+  init: {
+    tools: string[];
+    model: string | null;
+    capabilities: unknown | null;
+    stable_fields: Record<string, unknown>;
+  } | null;
+  event_inventory: string[];
+  probes: ClaudeProbeObservation[];
+  digest: string;
+}
+
+export interface ClaudeRuntimeDiff {
+  tools_added: string[];
+  tools_removed: string[];
+  help_changed: boolean;
+  help_lines_added: string[];
+  help_lines_removed: string[];
+  doctor_changed: boolean;
+  init_changed: boolean;
+  auto_mode_defaults_changed: boolean;
+  event_types_added: string[];
+  event_types_removed: string[];
+  changed_probes: string[];
+}
+
+export interface ClaudeWatchStateSnapshot {
+  schema_version: number;
+  candidate_id: string;
+  package_version: string;
+  npm_integrity: string;
+  npm_published_at: string;
+  release_url: string;
+  release_notes_md: string;
+  release_published_at: string;
+  dist_tags: ClaudeNpmMetadata["dist_tags"];
+  docs: ClaudeDocsSnapshot;
+  runtime: ClaudeRuntimeSnapshot | null;
+  fetched_at: string;
+  workflow_run_url: string;
+  state_commit_parent: string | null;
+}
+
+export interface ClaudeWatchAnalysis {
+  schema_version: number;
+  candidate_id: string;
+  previous_candidate_id: string | null;
+  previous_version: string | null;
+  current_version: string;
+  is_bootstrap: boolean;
+  release_url: string;
+  release_notes_md: string;
+  npm_integrity: string;
+  npm_published_at: string;
+  release_published_at: string;
+  dist_tags: ClaudeNpmMetadata["dist_tags"];
+  docs_digest: string;
+  runtime_digest: string | null;
+  docs_diff: ClaudeDocsDiff;
+  previous_runtime_snapshot: ClaudeRuntimeSnapshot | null;
+  runtime_snapshot: ClaudeRuntimeSnapshot | null;
+  runtime_diff: ClaudeRuntimeDiff | null;
+  verdict: ClaudeWatchVerdict;
+  verdict_reasons: string[];
+  errors: string[];
+  workflow_run_url: string;
+  state_base_sha: string | null;
+  state_snapshot_candidate_id: string | null;
+}

--- a/scripts/claude-watch/update-tracker.ts
+++ b/scripts/claude-watch/update-tracker.ts
@@ -1,0 +1,201 @@
+#!/usr/bin/env bun
+
+import { readFileSync } from "node:fs";
+import { editIssueBody, getIssueBody, ghJson } from "./github.ts";
+import {
+  loadStateSnapshotAtCommit,
+  resolveStateBranchTip,
+} from "./state-branch.ts";
+import {
+  findTrackerEntry,
+  hasProcessedCandidate,
+  isTerminalOutcome,
+  parseTrackerState,
+  recordAnalysis,
+  renderTrackerBody,
+} from "./tracker.ts";
+import type { ClaudeWatchAnalysis, ClaudeWatchOutcome } from "./types.ts";
+
+const DEFAULT_REPO = "letta-ai/letta-code";
+
+interface Args {
+  repo: string;
+  trackerIssue: number | null;
+  analysisFile: string | null;
+  candidateId: string | null;
+  stateCommitSha: string | null;
+  outcome: ClaudeWatchOutcome | null;
+  notes: string;
+  prUrl: string | null;
+  assertTerminal: boolean;
+  dryRun: boolean;
+}
+
+export function parseArgs(argv: string[]): Args {
+  const args: Args = {
+    repo: DEFAULT_REPO,
+    trackerIssue: null,
+    analysisFile: null,
+    candidateId: null,
+    stateCommitSha: null,
+    outcome: null,
+    notes: "",
+    prUrl: null,
+    assertTerminal: false,
+    dryRun: false,
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    if (argument === "--repo") args.repo = argv[++index] ?? args.repo;
+    else if (argument === "--tracker-issue")
+      args.trackerIssue = Number(argv[++index]);
+    else if (argument === "--analysis-file")
+      args.analysisFile = argv[++index] ?? null;
+    else if (argument === "--candidate-id")
+      args.candidateId = argv[++index] ?? null;
+    else if (argument === "--state-commit-sha")
+      args.stateCommitSha = argv[++index] ?? null;
+    else if (argument === "--outcome")
+      args.outcome = parseOutcome(argv[++index]);
+    else if (argument === "--notes") args.notes = argv[++index] ?? "";
+    else if (argument === "--pr-url") args.prUrl = argv[++index] ?? null;
+    else if (argument === "--assert-terminal") args.assertTerminal = true;
+    else if (argument === "--dry-run") args.dryRun = true;
+    else throw new Error(`Unknown argument: ${argument}`);
+  }
+  if (!args.trackerIssue || Number.isNaN(args.trackerIssue))
+    throw new Error("--tracker-issue is required");
+  if (args.assertTerminal) {
+    if (!args.candidateId || !args.stateCommitSha)
+      throw new Error(
+        "--candidate-id and --state-commit-sha are required with --assert-terminal",
+      );
+  } else {
+    if (!args.analysisFile) throw new Error("--analysis-file is required");
+    if (!args.outcome) throw new Error("--outcome is required");
+    if (isTerminalOutcome(args.outcome) && !args.stateCommitSha)
+      throw new Error("terminal outcomes require --state-commit-sha");
+    if (args.outcome === "pr_created" && !args.prUrl)
+      throw new Error("--pr-url is required for pr_created");
+  }
+  return args;
+}
+
+function parseOutcome(value: string | undefined): ClaudeWatchOutcome {
+  if (
+    value === "recorded_noop" ||
+    value === "no_local_impact" ||
+    value === "pr_created" ||
+    value === "needs_human_review" ||
+    value === "error"
+  ) {
+    return value;
+  }
+  throw new Error(`Unknown outcome: ${value}`);
+}
+
+export function verifyStateCandidate(
+  candidateId: string,
+  stateCommitSha: string,
+  repoPath = process.cwd(),
+): void {
+  const tip = resolveStateBranchTip(repoPath);
+  if (tip !== stateCommitSha) {
+    throw new Error(
+      `Claude state tip ${tip ?? "missing"} does not match ${stateCommitSha}`,
+    );
+  }
+  const snapshot = loadStateSnapshotAtCommit(repoPath, stateCommitSha);
+  if (snapshot?.candidate_id !== candidateId) {
+    throw new Error(
+      `Claude state candidate ${snapshot?.candidate_id ?? "missing"} does not match ${candidateId}`,
+    );
+  }
+}
+
+function verifyParityPr(
+  repo: string,
+  prUrl: string,
+  candidateId: string,
+): void {
+  const pr = ghJson<{
+    isDraft: boolean;
+    author: { login: string };
+    body: string | null;
+  }>(["pr", "view", prUrl, "--repo", repo, "--json", "isDraft,author,body"]);
+  if (!pr.isDraft || pr.author.login !== "carenthomas") {
+    throw new Error(
+      `Parity PR must be a draft authored by carenthomas (got draft=${pr.isDraft}, author=${pr.author.login})`,
+    );
+  }
+  if (!pr.body?.includes(`Claude-watch: ${candidateId}`)) {
+    throw new Error("Parity PR body is missing the exact Claude-watch marker");
+  }
+}
+
+export function main(argv = process.argv.slice(2)): void {
+  const args = parseArgs(argv);
+  const issue = args.trackerIssue as number;
+  const state = parseTrackerState(getIssueBody(args.repo, issue));
+
+  if (args.assertTerminal) {
+    verifyStateCandidate(
+      args.candidateId as string,
+      args.stateCommitSha as string,
+    );
+    const entry = findTrackerEntry(state, args.candidateId as string);
+    if (
+      !entry ||
+      !hasProcessedCandidate(state, args.candidateId as string) ||
+      entry.state_commit_sha !== args.stateCommitSha
+    ) {
+      throw new Error(
+        `Candidate ${args.candidateId} does not have a matching terminal tracker outcome`,
+      );
+    }
+    console.log(`Verified terminal Claude outcome for ${args.candidateId}`);
+    return;
+  }
+
+  const analysis = JSON.parse(
+    readFileSync(args.analysisFile as string, "utf8"),
+  ) as ClaudeWatchAnalysis;
+  if (isTerminalOutcome(args.outcome as ClaudeWatchOutcome)) {
+    verifyStateCandidate(analysis.candidate_id, args.stateCommitSha as string);
+  }
+  if (args.outcome === "pr_created") {
+    verifyParityPr(args.repo, args.prUrl as string, analysis.candidate_id);
+  }
+  const next = recordAnalysis(state, {
+    analysis,
+    outcome: args.outcome as ClaudeWatchOutcome,
+    notes: args.notes || defaultNotes(args.outcome as ClaudeWatchOutcome),
+    prUrl: args.prUrl,
+    stateCommitSha: args.stateCommitSha,
+    error:
+      args.outcome === "error" ? (analysis.errors.at(-1) ?? args.notes) : null,
+  });
+  const nextBody = renderTrackerBody(next);
+  if (args.dryRun) console.log(nextBody);
+  else editIssueBody(args.repo, issue, nextBody);
+  console.log(
+    `Recorded ${analysis.candidate_id} as ${args.outcome} in #${issue}`,
+  );
+}
+
+function defaultNotes(outcome: ClaudeWatchOutcome): string {
+  switch (outcome) {
+    case "recorded_noop":
+      return "no watched Claude surface changed";
+    case "no_local_impact":
+      return "reviewed; no local Letta Code mirror impact";
+    case "pr_created":
+      return "opened a focused local mirror PR";
+    case "needs_human_review":
+      return "public evidence needs human review";
+    case "error":
+      return "retryable watcher error";
+  }
+}
+
+if (import.meta.main) main();

--- a/scripts/run-unit-tests.cjs
+++ b/scripts/run-unit-tests.cjs
@@ -75,6 +75,7 @@ const allTestFiles = [
   ...findTestFiles("src/channels"),
   ...findRootTestFiles("src"),
   ...findTestFiles("scripts/codex-watch"),
+  ...findTestFiles("scripts/claude-watch"),
   "scripts/unit-test-impact.test.cjs",
 ].sort();
 const discoveredPaths = new Set(allTestFiles);


### PR DESCRIPTION
## Summary

- detect stable Claude Code releases from GitHub and npm, plus official docs and changelog drift
- capture exact-version runtime evidence in a pinned Docker sandbox with canonical Read and Task contract probes
- persist current normalized evidence on `claude-watch-state` and dedupe outcomes through one bounded tracker issue
- dispatch Amelia for semantic current-vs-local review without relying on private Claude internals or runner artifacts

## Safety and rollout

- dry runs perform no installs, authenticated probes, tracker writes, state pushes, or agent dispatches
- historical validation runs can capture exact adjacent versions without advancing shared state
- the hourly schedule is intentionally commented out until bootstrap, dedupe, docs-only, actionable, failure, and no-impact runs complete

## Validation

- `bun test scripts/claude-watch` (48 pass)
- `bun run check` (12 checks pass)
- live dry run against Claude Code 2.1.237 and 187 official Markdown sources, with no tracker issue or state branch created

[LET-11097](https://linear.app/letta/issue/LET-11097/add-claude-watcher)
