### PR TITLE
fix(ci): report observable Claude Task behavior

### DIFF
--- a/scripts/claude-watch/runtime-observations.ts
+++ b/scripts/claude-watch/runtime-observations.ts
@@ -45,28 +45,36 @@ export function evaluateProbe(
     const list = calls.find(
       (call, index) => call.name === "TaskList" && index > deletedIndex,
     );
+    const metadataUpdate = calls.find(
+      (call) =>
+        call.name === "TaskUpdate" &&
+        record(call.input)?.metadata !== undefined,
+    );
     const resultFor = (id: string | null | undefined) =>
       parsed.toolResults.find((candidate) => candidate.toolUseId === id);
     const beforeResult = resultFor(beforeGet?.id);
     const afterResult = resultFor(afterGet?.id);
     const listResult = resultFor(list?.id);
-    const metadata = findMetadata(parseJsonResult(beforeResult?.content ?? ""));
+    const metadataResult = resultFor(metadataUpdate?.id);
+    const metadata = record(record(metadataUpdate?.input)?.metadata);
     return {
       complete:
         calls.some((call) => call.name === "TaskCreate") &&
         calls.some((call) => call.name === "TaskUpdate") &&
         deletedIndex >= 0 &&
+        metadataResult !== undefined &&
         beforeResult !== undefined &&
         afterResult !== undefined &&
         listResult !== undefined,
       assertions: {
-        metadata_arbitrary_values:
+        metadata_arbitrary_values_accepted:
           metadata?.count === 3 &&
           Array.isArray(metadata.flags) &&
           metadata.flags[0] === "ready" &&
-          record(metadata.details)?.source === "claude-watch",
-        metadata_null_deleted:
-          metadata?.keep === "yes" && !("probe" in (metadata ?? {})),
+          record(metadata.details)?.source === "claude-watch" &&
+          metadataResult?.isError === false,
+        metadata_null_update_accepted:
+          metadata?.probe === null && metadataResult?.isError === false,
         deleted_task_get_errors:
           afterResult?.isError === true ||
           /not[ -]?found|does not exist|deleted/iu.test(
@@ -81,35 +89,6 @@ export function evaluateProbe(
     complete: parsed.toolCalls.length > 0 && parsed.toolResults.length > 0,
     assertions: {},
   };
-}
-
-function parseJsonResult(content: string): unknown {
-  try {
-    return JSON.parse(content);
-  } catch {
-    const start = content.indexOf("{");
-    const end = content.lastIndexOf("}");
-    if (start >= 0 && end > start) {
-      try {
-        return JSON.parse(content.slice(start, end + 1));
-      } catch {
-        return null;
-      }
-    }
-    return null;
-  }
-}
-
-function findMetadata(value: unknown): Record<string, unknown> | null {
-  const object = record(value);
-  if (!object) return null;
-  const metadata = record(object.metadata);
-  if (metadata) return metadata;
-  for (const child of Object.values(object)) {
-    const found = findMetadata(child);
-    if (found) return found;
-  }
-  return null;
 }
 
 function record(value: unknown): Record<string, unknown> | null {

--- a/scripts/claude-watch/runtime-probe.test.ts
+++ b/scripts/claude-watch/runtime-probe.test.ts
@@ -280,7 +280,15 @@ describe("stream parsing and normalization", () => {
         {
           id: "metadata",
           name: "TaskUpdate",
-          input: { taskId: "1", metadata: { probe: null } },
+          input: {
+            taskId: "1",
+            metadata: {
+              probe: null,
+              count: 3,
+              flags: ["ready"],
+              details: { source: "claude-watch" },
+            },
+          },
         },
         { id: "before", name: "TaskGet", input: { taskId: "1" } },
         {
@@ -322,8 +330,8 @@ describe("stream parsing and normalization", () => {
     expect(evaluation).toEqual({
       complete: true,
       assertions: {
-        metadata_arbitrary_values: true,
-        metadata_null_deleted: true,
+        metadata_arbitrary_values_accepted: true,
+        metadata_null_update_accepted: true,
         deleted_task_get_errors: true,
         deleted_task_absent: true,
       },

--- a/scripts/claude-watch/runtime-probe.ts
+++ b/scripts/claude-watch/runtime-probe.ts
@@ -119,7 +119,7 @@ const PROBES: ProbeDefinition[] = [
     name: "task-metadata-delete-contract",
     allowedTools: ["TaskCreate", "TaskGet", "TaskUpdate", "TaskList"],
     prompt:
-      'Exercise only the task tools and continue through every step even if one call reports an error. Create one task named "probe-task" with metadata {"probe":"remove","keep":"yes"}; update metadata with {"probe":null,"count":3,"flags":["ready"],"details":{"source":"claude-watch"}}; get it to observe metadata; permanently delete it with TaskUpdate status "deleted"; get the deleted ID again expecting a not-found error; then list tasks to confirm it is absent. Do not perform other work or use other tools.',
+      'Exercise only the task tools and continue through every step even if one call reports an error. Create one task named "probe-task" with metadata {"probe":"remove","keep":"yes"}; update metadata with {"probe":null,"count":3,"flags":["ready"],"details":{"source":"claude-watch"}}; get the resulting task record; permanently delete it with TaskUpdate status "deleted"; get the deleted ID again expecting a not-found error; then list tasks to confirm it is absent. Do not perform other work or use other tools.',
   },
 ];
 


### PR DESCRIPTION
## Summary

- treat accepted arbitrary Task metadata values as the observable runtime contract
- stop assuming TaskGet exposes structured metadata when Claude returns only a text summary
- preserve concrete permanent-delete assertions

Found during the first production bootstrap of #3925.

## Validation

- `bun test scripts/claude-watch/runtime-probe.test.ts`
- `bun run check`

[LET-11097](https://linear.app/letta/issue/LET-11097/add-claude-watcher)