### PR TITLE
fix(ci): harden Claude review handoff

### DIFF
--- a/.github/agent-prompts/claude-agent-watch.md
+++ b/.github/agent-prompts/claude-agent-watch.md
@@ -20,6 +20,8 @@ The detector ran on a GitHub Actions runner, but your turn does not. Runner file
 
 Run that exact block before reviewing. It clones current `letta-ai/letta-code`, installs dependencies, fetches the state branch, and rebuilds the sanitized analysis from the exact state commit and its parent. Perform all inspection, edits, tests, state checks, and tracker updates from that clone.
 
+Immediately after the block succeeds, use `SetWorkingDirectory` to select `/tmp/letta-code-claude-watch`. A shell `cd` applies only to that one command and does not move later tool calls. If `SetWorkingDirectory` is unavailable, pass that absolute directory as `workdir` for every command.
+
 ## Required review behavior
 
 1. Read the complete analysis JSON, release notes, official source URLs, every focused docs diff, runtime inventory diff, and probe observation.

--- a/.github/workflows/claude-agent-watch.yml
+++ b/.github/workflows/claude-agent-watch.yml
@@ -168,6 +168,14 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          if bun scripts/claude-watch/update-tracker.ts \
+            --tracker-issue "${{ steps.detect.outputs.tracker_issue }}" \
+            --candidate-id "${{ steps.detect.outputs.candidate_id }}" \
+            --state-commit-sha "${{ steps.detect.outputs.state_commit_sha }}" \
+            --assert-terminal; then
+            echo "The agent recorded a terminal outcome before its action failed"
+            exit 0
+          fi
           bun scripts/claude-watch/update-tracker.ts \
             --tracker-issue "${{ steps.detect.outputs.tracker_issue }}" \
             --analysis-file "$RUNNER_TEMP/claude-watch-analysis.json" \

--- a/.github/workflows/claude-agent-watch.yml
+++ b/.github/workflows/claude-agent-watch.yml
@@ -162,3 +162,15 @@ jobs:
             --candidate-id "${{ steps.detect.outputs.candidate_id }}" \
             --state-commit-sha "${{ steps.detect.outputs.state_commit_sha }}" \
             --assert-terminal
+
+      - name: Record failed review attempt
+        if: failure() && steps.detect.outputs.should_run_agent == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          bun scripts/claude-watch/update-tracker.ts \
+            --tracker-issue "${{ steps.detect.outputs.tracker_issue }}" \
+            --analysis-file "$RUNNER_TEMP/claude-watch-analysis.json" \
+            --state-commit-sha "${{ steps.detect.outputs.state_commit_sha }}" \
+            --outcome error \
+            --notes "Amelia review failed before recording a terminal outcome; retry this candidate"


### PR DESCRIPTION
## Summary

- explicitly move cloud review tools into the disposable repository clone
- record failed agent reviews in the central tracker as retryable attempts

The first production bootstrap exposed both issues: shell `cd` did not persist across tool calls, and the action timeout left no tracker record.

## Validation

- `bun run check`
- production failure: https://github.com/letta-ai/letta-code/actions/runs/32335167241

[LET-11097](https://linear.app/letta/issue/LET-11097/add-claude-watcher)