### PR TITLE
fix(web): include non-markdown files in memory viewer

### DIFF
--- a/src/web/generate-memory-viewer.test.ts
+++ b/src/web/generate-memory-viewer.test.ts
@@ -1,0 +1,126 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { collectFiles } from "./generate-memory-viewer";
+
+describe("collectFiles", () => {
+  let tempRoot: string;
+
+  beforeEach(() => {
+    tempRoot = mkdtempSync(join(tmpdir(), "letta-memory-viewer-test-"));
+  });
+
+  afterEach(() => {
+    try {
+      rmSync(tempRoot, { recursive: true, force: true });
+    } catch {}
+  });
+
+  test("collects markdown files with frontmatter parsed", () => {
+    const sysDir = join(tempRoot, "system");
+    mkdirSync(sysDir, { recursive: true });
+
+    writeFileSync(
+      join(sysDir, "persona.md"),
+      "---\ndescription: Agent persona\nread_only: true\n---\nI am a helpful agent.",
+    );
+
+    const files = collectFiles(tempRoot);
+    expect(files).toHaveLength(1);
+    const persona = files[0];
+    expect(persona).toBeDefined();
+    if (persona) {
+      expect(persona).toEqual({
+        path: "system/persona.md",
+        isSystem: true,
+        frontmatter: {
+          description: "Agent persona",
+          read_only: "true",
+        },
+        content: "I am a helpful agent.",
+      });
+    }
+  });
+
+  test("collects non-Markdown files without dropping them", () => {
+    const skillsDir = join(tempRoot, "skills", "data-analyzer");
+    const scriptsDir = join(skillsDir, "scripts");
+    mkdirSync(scriptsDir, { recursive: true });
+
+    writeFileSync(
+      join(skillsDir, "SKILL.md"),
+      "---\ndescription: Data analyzer skill\n---\nSkill instructions here.",
+    );
+    writeFileSync(
+      join(scriptsDir, "process.py"),
+      'def run():\n    print("processing data")\n',
+    );
+    writeFileSync(
+      join(skillsDir, "config.json"),
+      '{\n  "version": "1.0.0"\n}\n',
+    );
+    writeFileSync(
+      join(skillsDir, "run.sh"),
+      "#!/bin/bash\npython scripts/process.py\n",
+    );
+
+    const files = collectFiles(tempRoot);
+    const paths = files.map((f) => f.path).sort();
+
+    expect(paths).toEqual([
+      "skills/data-analyzer/SKILL.md",
+      "skills/data-analyzer/config.json",
+      "skills/data-analyzer/run.sh",
+      "skills/data-analyzer/scripts/process.py",
+    ]);
+
+    const pyFile = files.find((f) => f.path.endsWith("process.py"));
+    expect(pyFile).toBeDefined();
+    expect(pyFile?.isSystem).toBe(false);
+    expect(pyFile?.frontmatter).toEqual({});
+    expect(pyFile?.content).toBe('def run():\n    print("processing data")\n');
+
+    const jsonFile = files.find((f) => f.path.endsWith("config.json"));
+    expect(jsonFile).toBeDefined();
+    expect(jsonFile?.isSystem).toBe(false);
+    expect(jsonFile?.frontmatter).toEqual({});
+    expect(jsonFile?.content).toBe('{\n  "version": "1.0.0"\n}\n');
+  });
+
+  test("preserves non-markdown content starting with triple dashes", () => {
+    const extDir = join(tempRoot, "configs");
+    mkdirSync(extDir, { recursive: true });
+
+    const yamlContent = "---\nversion: 2\nname: test\n";
+    writeFileSync(join(extDir, "settings.yaml"), yamlContent);
+
+    const files = collectFiles(tempRoot);
+    expect(files).toHaveLength(1);
+    const yamlFile = files[0];
+    expect(yamlFile).toBeDefined();
+    if (yamlFile) {
+      expect(yamlFile.path).toBe("configs/settings.yaml");
+      expect(yamlFile.frontmatter).toEqual({});
+      expect(yamlFile.content).toBe(yamlContent);
+    }
+  });
+
+  test("ignores hidden files and directories", () => {
+    const gitDir = join(tempRoot, ".git");
+    mkdirSync(gitDir, { recursive: true });
+    writeFileSync(join(gitDir, "HEAD"), "ref: refs/heads/main\n");
+
+    writeFileSync(join(tempRoot, ".hidden.md"), "secret");
+    writeFileSync(join(tempRoot, "visible.txt"), "hello world");
+
+    const files = collectFiles(tempRoot);
+    expect(files).toHaveLength(1);
+    const visibleFile = files[0];
+    expect(visibleFile).toBeDefined();
+    if (visibleFile) {
+      expect(visibleFile.path).toBe("visible.txt");
+      expect(visibleFile.content).toBe("hello world");
+    }
+  });
+});

--- a/src/web/generate-memory-viewer.ts
+++ b/src/web/generate-memory-viewer.ts
@@ -155,29 +155,30 @@ function parseFrontmatter(raw: string): {
       if (key) fm[key] = value;
     }
   }
-  const body = raw.slice(closingIdx + 4).replace(/^\n/, "");
+  const body = raw.slice(closingIdx + 4).replace(/^\r?\n/, "");
   return { frontmatter: fm, body };
 }
 
 /** Collect memory files from the working tree on disk. */
-function collectFiles(memoryRoot: string): MemoryFile[] {
+export function collectFiles(memoryRoot: string): MemoryFile[] {
   const treeNodes = scanMemoryFilesystem(memoryRoot);
   const fileNodes = getFileNodes(treeNodes);
 
-  return fileNodes
-    .filter((n) => n.name.endsWith(".md"))
-    .map((n) => {
-      const raw = readFileContent(n.fullPath);
-      const { frontmatter, body } = parseFrontmatter(raw);
-      return {
-        path: n.relativePath,
-        isSystem:
-          n.relativePath.startsWith("system/") ||
-          n.relativePath.startsWith("system\\"),
-        frontmatter,
-        content: body,
-      };
-    });
+  return fileNodes.map((n) => {
+    const raw = readFileContent(n.fullPath);
+    const isMarkdown = n.name.endsWith(".md") || n.name.endsWith(".markdown");
+    const { frontmatter, body } = isMarkdown
+      ? parseFrontmatter(raw)
+      : { frontmatter: {}, body: raw };
+    return {
+      path: n.relativePath,
+      isSystem:
+        n.relativePath.startsWith("system/") ||
+        n.relativePath.startsWith("system\\"),
+      frontmatter,
+      content: body,
+    };
+  });
 }
 
 /** Collect commit metadata via a single git log call. */

--- a/src/web/memory-viewer-template.txt
+++ b/src/web/memory-viewer-template.txt
@@ -1448,9 +1448,14 @@ html.dark .warning-badge { background: hsl(42, 30%, 18%); color: hsl(42, 80%, 70
     if (pills) metaHtml += '<div class="meta-row">' + pills + '</div>';
     metaHtml += '</div>';
 
+    var isMd = /\.(md|markdown)$/i.test(String(file.path || ''));
+    var renderedContent = isMd
+      ? renderMarkdown(file.content || '')
+      : '<pre><code>' + escHtml(file.content || '') + '</code></pre>';
+
     panel.innerHTML =
       metaHtml +
-      '<article class="file-body" style="' + (rawMode ? 'display:none' : '') + '">' + renderMarkdown(file.content || '') + '</article>' +
+      '<article class="file-body" style="' + (rawMode ? 'display:none' : '') + '">' + renderedContent + '</article>' +
       '<pre class="file-body-raw" style="' + (rawMode ? 'display:block' : '') + '">' + escHtml(file.content || '') + '</pre>';
 
     panel.currentFile = file;


### PR DESCRIPTION
## Summary

Fixes #3894

The memory viewer (`/memory`) was filtering files with `.filter((n) => n.name.endsWith(".md"))` when collecting files from MemFS. This excluded any non-Markdown files (such as `.py`, `.json`, `.sh`, `.ts`, or `.yaml` files in skill packages or memory directory structures) from being displayed in the file tree.

This change:
1. Removes the `.md` filter in `collectFiles()` in `src/web/generate-memory-viewer.ts` so all memory files are included in the viewer.
2. Only parses YAML frontmatter for Markdown files (`.md`, `.markdown`) while preserving complete raw file content for other files.
3. Updates the viewer template in `src/web/memory-viewer-template.txt` to render non-Markdown files cleanly inside code blocks in Rendered mode (and plain text in Raw mode).
4. Adds comprehensive unit tests in `src/web/generate-memory-viewer.test.ts` covering Markdown with frontmatter, non-Markdown files, YAML files with triple-dash headers, and hidden file exclusions.

## Verification

- Ran `bun test src/web/generate-memory-viewer.test.ts src/web/context-usage.test.ts` (7 passed)
- Ran `bunx --bun @biomejs/biome@2.2.5 check src/web` (clean)
- Ran `bun run typecheck` / `tsc --noEmit` (clean)
- Ran all architectural checks (`check:cycles`, `check:boundaries`, `check:exported-functions`, `check:filename-casing`, `check:file-size`, `check:module-ownership`, `check:test-mock-isolation`, `check:test-coverage`, `check:skill-frontmatter`, `check:bundled-skill-scripts`) (all passed)

## AI Disclosure

- [ ] This pull request was written entirely by a human
- [x] This pull request was written with AI assistance and reviewed and edited by a human
- [x] I have read the [AI Policy](https://github.com/letta-ai/letta-code/blob/main/AI_POLICY.md) and agree to its terms

## AI Tool(s) Used

Antigravity

## Human Verification

I have reviewed and understand every change in this pull request and take responsibility for its correctness.