### PR TITLE
fix(ci): version Claude probe observations

### DIFF
--- a/scripts/claude-watch/agent-watch.ts
+++ b/scripts/claude-watch/agent-watch.ts
@@ -28,6 +28,7 @@ import {
 import {
   captureClaudeRuntime,
   createClaudeRuntimeCommandPlan,
+  isClaudeProbeContractCurrent,
 } from "./runtime-probe.ts";
 import {
   fetchStateBranchTip,
@@ -389,11 +390,15 @@ export async function main(argv = process.argv.slice(2)): Promise<void> {
   if (stateTip && !state) {
     throw new Error(`Invalid Claude state snapshot at ${stateTip}`);
   }
+  const probeContractStale = state?.runtime
+    ? !isClaudeProbeContractCurrent(state.runtime)
+    : false;
 
   if (
     !args.validationOnly &&
     stateTip &&
     state &&
+    !probeContractStale &&
     !hasProcessedCandidate(tracker.state, state.candidate_id)
   ) {
     const analysis = rebuildClaudeAnalysisFromState(repoPath, stateTip);
@@ -452,10 +457,12 @@ export async function main(argv = process.argv.slice(2)): Promise<void> {
       candidate,
       state,
       args,
-      packageChanged || docsChanged || !state?.runtime,
+      packageChanged || docsChanged || !state?.runtime || probeContractStale,
     );
     currentRuntime = runtime.currentRuntime;
-    if (args.previousVersion && runtime.previousRuntime) {
+    if (probeContractStale) {
+      previousForAnalysis = null;
+    } else if (args.previousVersion && runtime.previousRuntime) {
       previousForAnalysis = {
         schema_version: 1,
         candidate_id: `manual-replay@${args.previousVersion}`,
@@ -479,11 +486,13 @@ export async function main(argv = process.argv.slice(2)): Promise<void> {
       candidate,
       previous: previousForAnalysis,
       currentDocs: docsCapture.snapshot,
-      previousSources: stateSources(repoPath, stateTip),
+      previousSources: probeContractStale
+        ? {}
+        : stateSources(repoPath, stateTip),
       currentSources: docsCapture.sources,
       currentRuntime,
       workflowRunUrl: workflowRunUrl(),
-      stateBaseSha: stateTip,
+      stateBaseSha: probeContractStale ? null : stateTip,
     });
   } catch (error) {
     analysis = buildErrorAnalysis(error, state);

--- a/scripts/claude-watch/runtime-probe.test.ts
+++ b/scripts/claude-watch/runtime-probe.test.ts
@@ -4,9 +4,11 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { evaluateProbe } from "./runtime-observations.ts";
 import {
+  CLAUDE_PROBE_CONTRACT_VERSION,
   captureClaudeRuntime,
   createClaudeRuntimeCommandPlan,
   diffClaudeRuntime,
+  isClaudeProbeContractCurrent,
   normalizeVolatile,
   parseClaudeStream,
 } from "./runtime-probe.ts";
@@ -54,6 +56,7 @@ function snapshot(
   overrides: Partial<ClaudeRuntimeSnapshot> = {},
 ): ClaudeRuntimeSnapshot {
   return {
+    probe_contract_version: CLAUDE_PROBE_CONTRACT_VERSION,
     version: "1.2.3",
     version_output: "1.2.3 (Claude Code)",
     help_text: "--permission-mode auto",
@@ -74,6 +77,16 @@ function snapshot(
 }
 
 describe("command planning", () => {
+  test("invalidates cached probes when their observation contract changes", () => {
+    expect(isClaudeProbeContractCurrent(snapshot())).toBe(true);
+    expect(
+      isClaudeProbeContractCurrent(
+        snapshot({ probe_contract_version: CLAUDE_PROBE_CONTRACT_VERSION - 1 }),
+      ),
+    ).toBe(false);
+    expect(isClaudeProbeContractCurrent(undefined)).toBe(false);
+  });
+
   test("uses an exact local package install and a constrained inert command", () => {
     const plan = createClaudeRuntimeCommandPlan("1.2.3", "/tmp/supplied/root", {
       env: { PATH: "/bin", ANTHROPIC_API_KEY: "secret" },

--- a/scripts/claude-watch/runtime-probe.ts
+++ b/scripts/claude-watch/runtime-probe.ts
@@ -23,6 +23,7 @@ import type {
 } from "./types.ts";
 
 const PACKAGE_NAME = "@anthropic-ai/claude-code";
+export const CLAUDE_PROBE_CONTRACT_VERSION = 1;
 const DEFAULT_TIMEOUT_MS = 30_000;
 const DEFAULT_OUTPUT_CAP = 2 * 1024 * 1024;
 const AUTH_ENV_KEYS = ["ANTHROPIC_API_KEY", "CLAUDE_CODE_OAUTH_TOKEN"] as const;
@@ -100,6 +101,12 @@ export interface ParsedClaudeStream {
     content: string;
     isError: boolean;
   }>;
+}
+
+export function isClaudeProbeContractCurrent(
+  runtime: ClaudeRuntimeSnapshot | null | undefined,
+): boolean {
+  return runtime?.probe_contract_version === CLAUDE_PROBE_CONTRACT_VERSION;
 }
 
 interface ProbeDefinition {
@@ -869,6 +876,7 @@ export async function captureClaudeRuntime(
     }
 
     const snapshotWithoutDigest = {
+      probe_contract_version: CLAUDE_PROBE_CONTRACT_VERSION,
       version: options.version,
       version_output: normalizeText(versionResult.stdout),
       help_text: normalizedHelp,

--- a/scripts/claude-watch/types.ts
+++ b/scripts/claude-watch/types.ts
@@ -101,6 +101,7 @@ export interface ClaudeProbeObservation {
 }
 
 export interface ClaudeRuntimeSnapshot {
+  probe_contract_version: number;
   version: string;
   version_output: string;
   help_text: string;


### PR DESCRIPTION
## Summary

- version the Claude runtime probe observation contract inside durable snapshots
- invalidate and recapture cached probes after watcher-side semantic changes
- create a clean semantic audit baseline while preserving linear state-branch history

The production retry after #3927 correctly exposed that retry reconciliation was still replaying the pre-fix snapshot instead of recapturing it.

## Validation

- `bun test scripts/claude-watch` (49 pass)
- `bun run check`
- stale production snapshot at `7e5b75416247cb3a5851dec0797f640eb39075ab`

[LET-11097](https://linear.app/letta/issue/LET-11097/add-claude-watcher)