### PR TITLE
fix(ci): support archived Claude replays

### DIFF
--- a/scripts/claude-watch/agent-watch.ts
+++ b/scripts/claude-watch/agent-watch.ts
@@ -219,6 +219,7 @@ async function selectCandidate(
     npmMetadata,
     previousVersion: args.previousVersion ?? state?.package_version ?? null,
     currentVersion: args.currentVersion,
+    allowNpmOnlyExactVersions: args.validationOnly,
   });
   if (selected) return selected;
   const latest = selectClaudeReleaseCandidate({

--- a/scripts/claude-watch/release-source.test.ts
+++ b/scripts/claude-watch/release-source.test.ts
@@ -142,6 +142,31 @@ describe("selectClaudeReleaseCandidate", () => {
     expect(candidate?.release_notes_md).toBe("notes 1.2.0");
   });
 
+  test("validation can replay exact npm versions omitted from the GitHub feed", () => {
+    expect(() =>
+      selectClaudeReleaseCandidate({
+        githubReleases: [github("1.2.0", 2)],
+        npmMetadata: npm(),
+        previousVersion: "1.0.0",
+        currentVersion: "1.1.0",
+      }),
+    ).toThrow(ClaudeReleaseSourceDisagreementError);
+
+    const candidate = selectClaudeReleaseCandidate({
+      githubReleases: [github("1.2.0", 2)],
+      npmMetadata: npm(),
+      previousVersion: "1.0.0",
+      currentVersion: "1.1.0",
+      allowNpmOnlyExactVersions: true,
+    });
+
+    expect(candidate?.version).toBe("1.1.0");
+    expect(candidate?.release_url).toBe(
+      "https://github.com/anthropics/claude-code/releases",
+    );
+    expect(candidate?.release_notes_md).toContain("validation-only npm replay");
+  });
+
   test("returns null after the latest terminal version", () => {
     expect(
       selectClaudeReleaseCandidate({

--- a/scripts/claude-watch/release-source.ts
+++ b/scripts/claude-watch/release-source.ts
@@ -26,6 +26,7 @@ export interface ReleaseSelectionOptions {
   processedPackageVersions?: string[];
   previousVersion?: string | null;
   currentVersion?: string | null;
+  allowNpmOnlyExactVersions?: boolean;
 }
 
 export class ClaudeReleaseSourceDisagreementError extends Error {
@@ -217,13 +218,16 @@ export function selectClaudeReleaseCandidate(
   const currentVersion = options.currentVersion ?? null;
   const terminalVersion =
     options.previousVersion ?? options.processedPackageVersions?.at(-1) ?? null;
+  const allowNpmOnlyExactVersions =
+    options.allowNpmOnlyExactVersions === true && currentVersion !== null;
 
   if (
     options.previousVersion &&
-    (!githubReleases.some(
-      ({ tag_name }) => tag_name === options.previousVersion,
-    ) ||
-      !npmByVersion.has(options.previousVersion))
+    (!npmByVersion.has(options.previousVersion) ||
+      (!allowNpmOnlyExactVersions &&
+        !githubReleases.some(
+          ({ tag_name }) => tag_name === options.previousVersion,
+        )))
   ) {
     throw new ClaudeReleaseSourceDisagreementError(
       githubReleases.at(-1)?.tag_name ?? null,
@@ -237,12 +241,24 @@ export function selectClaudeReleaseCandidate(
     release = githubReleases.find(
       ({ tag_name }) => tag_name === currentVersion,
     );
-    if (!release || !npmByVersion.has(currentVersion)) {
+    const npmVersion = npmByVersion.get(currentVersion);
+    if (!npmVersion || (!release && !allowNpmOnlyExactVersions)) {
       throw new ClaudeReleaseSourceDisagreementError(
         githubReleases.at(-1)?.tag_name ?? null,
         options.npmMetadata.dist_tags.latest,
         `Explicit current version ${currentVersion} is not present in both sources.`,
       );
+    }
+    if (!release) {
+      return {
+        ...npmVersion,
+        release_url: "https://github.com/anthropics/claude-code/releases",
+        release_notes_md:
+          `Historical validation-only npm replay for ${currentVersion}; ` +
+          "this exact version is not retained in the GitHub release feed.",
+        release_published_at: npmVersion.published_at,
+        dist_tags: options.npmMetadata.dist_tags,
+      };
     }
   } else if (!terminalVersion) {
     release = githubReleases.find(

--- a/scripts/claude-watch/runtime-probe.test.ts
+++ b/scripts/claude-watch/runtime-probe.test.ts
@@ -488,6 +488,25 @@ describe("capture orchestration", () => {
     ).toBe(false);
   });
 
+  test("captures optional diagnostic timeouts without losing runtime evidence", async () => {
+    const root = await temporaryRoot();
+    const base = successfulRunner();
+    const runner: CommandRunner = async (spec) =>
+      spec.label === "doctor" || spec.label === "auto-mode-defaults"
+        ? result("", { exitCode: null, timedOut: true, signal: "SIGTERM" })
+        : base(spec);
+    const captured = await captureClaudeRuntime({
+      version: "1.2.3",
+      tempDir: root,
+      env: { PATH: process.env.PATH },
+      runner,
+      requireAuth: false,
+    });
+
+    expect(captured?.doctor).toEqual({ exit_code: -1, summary: "timed_out" });
+    expect(captured?.auto_mode_defaults).toBeNull();
+  });
+
   test("nonzero authenticated stream fails safely", async () => {
     const root = await temporaryRoot();
     const base = successfulRunner();

--- a/scripts/claude-watch/runtime-probe.ts
+++ b/scripts/claude-watch/runtime-probe.ts
@@ -806,10 +806,9 @@ export async function captureClaudeRuntime(
       }
     }
     const doctorResult = await runner(sandboxed(plan.doctor));
-    if (doctorResult.timedOut || doctorResult.truncated)
-      checkResult(doctorResult, plan.doctor.label);
+    if (doctorResult.truncated) checkResult(doctorResult, plan.doctor.label);
     const autoResult = await runner(sandboxed(plan.autoModeDefaults));
-    if (autoResult.timedOut || autoResult.truncated)
+    if (autoResult.truncated)
       checkResult(autoResult, plan.autoModeDefaults.label);
 
     let init: ClaudeRuntimeSnapshot["init"] = null;
@@ -875,13 +874,15 @@ export async function captureClaudeRuntime(
       help_hash: hash(normalizedHelp),
       doctor: {
         exit_code: doctorResult.exitCode ?? -1,
-        summary: normalizeDoctorVersion(
-          doctorSummary(doctorResult, plan.doctor.env),
-          options.version,
-        ),
+        summary: doctorResult.timedOut
+          ? "timed_out"
+          : normalizeDoctorVersion(
+              doctorSummary(doctorResult, plan.doctor.env),
+              options.version,
+            ),
       },
       auto_mode_defaults:
-        autoResult.exitCode === 0
+        !autoResult.timedOut && autoResult.exitCode === 0
           ? extractAutoModeDefaults(autoResult.stdout)
           : null,
       init,


### PR DESCRIPTION
## Summary

- allow validation-only exact npm replays when old versions have aged out of the GitHub release feed
- preserve strict GitHub/npm agreement for every production candidate
- label fallback evidence explicitly instead of inventing a GitHub release

The 2.1.82 to 2.1.83 historical replay exposed that those exact versions are still on npm but no longer retained by the GitHub Releases API.

## Validation

- `bun test scripts/claude-watch/release-source.test.ts`
- `bun run check`
- production selection still rejects the same missing-source fixture unless the validation-only opt-in is present

[LET-11097](https://linear.app/letta/issue/LET-11097/add-claude-watcher)