### PR TITLE
fix(ci): separate Claude state and analysis parents

### DIFF
--- a/scripts/claude-watch/agent-watch.ts
+++ b/scripts/claude-watch/agent-watch.ts
@@ -45,12 +45,13 @@ import {
   recordAnalysis,
   renderTrackerBody,
 } from "./tracker.ts";
-import type {
-  ClaudeReleaseCandidate,
-  ClaudeRuntimeSnapshot,
-  ClaudeWatchAnalysis,
-  ClaudeWatchOutcome,
-  ClaudeWatchStateSnapshot,
+import {
+  CLAUDE_WATCH_STATE_SCHEMA_VERSION,
+  type ClaudeReleaseCandidate,
+  type ClaudeRuntimeSnapshot,
+  type ClaudeWatchAnalysis,
+  type ClaudeWatchOutcome,
+  type ClaudeWatchStateSnapshot,
 } from "./types.ts";
 
 const DEFAULT_REPO = "letta-ai/letta-code";
@@ -393,12 +394,16 @@ export async function main(argv = process.argv.slice(2)): Promise<void> {
   const probeContractStale = state?.runtime
     ? !isClaudeProbeContractCurrent(state.runtime)
     : false;
+  const stateContractStale =
+    state !== null &&
+    state.schema_version !== CLAUDE_WATCH_STATE_SCHEMA_VERSION;
+  const comparisonBaselineStale = probeContractStale || stateContractStale;
 
   if (
     !args.validationOnly &&
     stateTip &&
     state &&
-    !probeContractStale &&
+    !comparisonBaselineStale &&
     !hasProcessedCandidate(tracker.state, state.candidate_id)
   ) {
     const analysis = rebuildClaudeAnalysisFromState(repoPath, stateTip);
@@ -457,10 +462,13 @@ export async function main(argv = process.argv.slice(2)): Promise<void> {
       candidate,
       state,
       args,
-      packageChanged || docsChanged || !state?.runtime || probeContractStale,
+      packageChanged ||
+        docsChanged ||
+        !state?.runtime ||
+        comparisonBaselineStale,
     );
     currentRuntime = runtime.currentRuntime;
-    if (probeContractStale) {
+    if (comparisonBaselineStale) {
       previousForAnalysis = null;
     } else if (args.previousVersion && runtime.previousRuntime) {
       previousForAnalysis = {
@@ -486,13 +494,13 @@ export async function main(argv = process.argv.slice(2)): Promise<void> {
       candidate,
       previous: previousForAnalysis,
       currentDocs: docsCapture.snapshot,
-      previousSources: probeContractStale
+      previousSources: comparisonBaselineStale
         ? {}
         : stateSources(repoPath, stateTip),
       currentSources: docsCapture.sources,
       currentRuntime,
       workflowRunUrl: workflowRunUrl(),
-      stateBaseSha: probeContractStale ? null : stateTip,
+      stateBaseSha: comparisonBaselineStale ? null : stateTip,
     });
   } catch (error) {
     analysis = buildErrorAnalysis(error, state);

--- a/scripts/claude-watch/release-analysis.ts
+++ b/scripts/claude-watch/release-analysis.ts
@@ -4,13 +4,14 @@ import {
   loadStateFilesAtCommit,
   loadStateSnapshotAtCommit,
 } from "./state-branch.ts";
-import type {
-  ClaudeDocsSnapshot,
-  ClaudeReleaseCandidate,
-  ClaudeRuntimeSnapshot,
-  ClaudeWatchAnalysis,
-  ClaudeWatchStateSnapshot,
-  ClaudeWatchVerdict,
+import {
+  CLAUDE_WATCH_STATE_SCHEMA_VERSION,
+  type ClaudeDocsSnapshot,
+  type ClaudeReleaseCandidate,
+  type ClaudeRuntimeSnapshot,
+  type ClaudeWatchAnalysis,
+  type ClaudeWatchStateSnapshot,
+  type ClaudeWatchVerdict,
 } from "./types.ts";
 
 export interface AnalyzeClaudeCandidateOptions {
@@ -43,7 +44,7 @@ export function buildClaudeStateSnapshot(
   runtime: ClaudeRuntimeSnapshot | null,
 ): ClaudeWatchStateSnapshot {
   return {
-    schema_version: 1,
+    schema_version: CLAUDE_WATCH_STATE_SCHEMA_VERSION,
     candidate_id: analysis.candidate_id,
     package_version: analysis.current_version,
     npm_integrity: analysis.npm_integrity,
@@ -57,6 +58,7 @@ export function buildClaudeStateSnapshot(
     fetched_at: new Date().toISOString(),
     workflow_run_url: analysis.workflow_run_url,
     state_commit_parent: analysis.state_base_sha,
+    analysis_parent_sha: analysis.state_base_sha,
   };
 }
 
@@ -120,12 +122,16 @@ export function rebuildClaudeAnalysisFromState(
   if (!current) {
     throw new Error(`No valid Claude state snapshot at ${stateCommitSha}`);
   }
-  const previous = current.state_commit_parent
-    ? loadStateSnapshotAtCommit(repoPath, current.state_commit_parent)
+  const analysisParentSha =
+    current.analysis_parent_sha === undefined
+      ? current.state_commit_parent
+      : current.analysis_parent_sha;
+  const previous = analysisParentSha
+    ? loadStateSnapshotAtCommit(repoPath, analysisParentSha)
     : null;
   const currentFiles = loadStateFilesAtCommit(repoPath, stateCommitSha);
-  const previousFiles = current.state_commit_parent
-    ? loadStateFilesAtCommit(repoPath, current.state_commit_parent)
+  const previousFiles = analysisParentSha
+    ? loadStateFilesAtCommit(repoPath, analysisParentSha)
     : {};
   const candidate: ClaudeReleaseCandidate = {
     version: current.package_version,
@@ -145,7 +151,7 @@ export function rebuildClaudeAnalysisFromState(
     currentSources: sourceFiles(currentFiles),
     currentRuntime: current.runtime,
     workflowRunUrl: current.workflow_run_url,
-    stateBaseSha: current.state_commit_parent,
+    stateBaseSha: analysisParentSha,
   });
   if (analysis.candidate_id !== current.candidate_id) {
     throw new Error(

--- a/scripts/claude-watch/runtime-probe.ts
+++ b/scripts/claude-watch/runtime-probe.ts
@@ -23,7 +23,7 @@ import type {
 } from "./types.ts";
 
 const PACKAGE_NAME = "@anthropic-ai/claude-code";
-export const CLAUDE_PROBE_CONTRACT_VERSION = 1;
+export const CLAUDE_PROBE_CONTRACT_VERSION = 2;
 const DEFAULT_TIMEOUT_MS = 30_000;
 const DEFAULT_OUTPUT_CAP = 2 * 1024 * 1024;
 const AUTH_ENV_KEYS = ["ANTHROPIC_API_KEY", "CLAUDE_CODE_OAUTH_TOKEN"] as const;

--- a/scripts/claude-watch/state-branch.test.ts
+++ b/scripts/claude-watch/state-branch.test.ts
@@ -12,7 +12,10 @@ import {
   materializeStateFiles,
   resolveStateBranchTip,
 } from "./state-branch.ts";
-import type { ClaudeWatchStateSnapshot } from "./types.ts";
+import {
+  CLAUDE_WATCH_STATE_SCHEMA_VERSION,
+  type ClaudeWatchStateSnapshot,
+} from "./types.ts";
 
 function git(cwd: string, ...args: string[]): string {
   const result = spawnSync("git", ["-C", cwd, ...args], {
@@ -33,7 +36,7 @@ function git(cwd: string, ...args: string[]): string {
 
 function snapshot(candidateId: string): ClaudeWatchStateSnapshot {
   return {
-    schema_version: 1,
+    schema_version: CLAUDE_WATCH_STATE_SCHEMA_VERSION,
     candidate_id: candidateId,
     package_version: candidateId,
     npm_integrity: `sha512-${candidateId}`,
@@ -54,6 +57,7 @@ function snapshot(candidateId: string): ClaudeWatchStateSnapshot {
     fetched_at: "2026-08-01T00:00:00Z",
     workflow_run_url: "https://example.test/actions/1",
     state_commit_parent: null,
+    analysis_parent_sha: null,
   };
 }
 
@@ -137,6 +141,7 @@ describe("Claude state branch", () => {
       ).toMatchObject({
         candidate_id: "2.2.0",
         state_commit_parent: first.commitSha,
+        analysis_parent_sha: null,
       });
       expect(git(repo.clone, "rev-parse", "main")).toBe(mainBefore);
       expect(git(repo.clone, "branch", "--show-current")).toBe("main");

--- a/scripts/claude-watch/state-branch.ts
+++ b/scripts/claude-watch/state-branch.ts
@@ -295,7 +295,10 @@ function isStateSnapshot(value: unknown): value is ClaudeWatchStateSnapshot {
     typeof value.fetched_at === "string" &&
     typeof value.workflow_run_url === "string" &&
     (typeof value.state_commit_parent === "string" ||
-      value.state_commit_parent === null)
+      value.state_commit_parent === null) &&
+    (value.analysis_parent_sha === undefined ||
+      typeof value.analysis_parent_sha === "string" ||
+      value.analysis_parent_sha === null)
   );
 }
 

--- a/scripts/claude-watch/types.ts
+++ b/scripts/claude-watch/types.ts
@@ -1,3 +1,5 @@
+export const CLAUDE_WATCH_STATE_SCHEMA_VERSION = 2;
+
 export type ClaudeWatchVerdict =
   | "no-op"
   | "prompt review needed"
@@ -150,7 +152,10 @@ export interface ClaudeWatchStateSnapshot {
   runtime: ClaudeRuntimeSnapshot | null;
   fetched_at: string;
   workflow_run_url: string;
+  /** Physical parent on the durable state branch. */
   state_commit_parent: string | null;
+  /** Snapshot used for semantic diffing; undefined legacy snapshots use the physical parent. */
+  analysis_parent_sha?: string | null;
 }
 
 export interface ClaudeWatchAnalysis {


### PR DESCRIPTION
## Summary

- keep the physical `claude-watch-state` history linear while storing an independent semantic comparison parent
- rebuild cloud analysis from that semantic parent instead of always diffing against the physical commit parent
- version the state/observation contract and force a clean bootstrap audit when it changes
- preserve backwards compatibility for existing state snapshots

Production bake-in exposed that state finalization overwrote the detector’s baseline reset, so the cloud action rebuilt a delta instead of the intended full bootstrap audit.

## Validation

- `bun test scripts/claude-watch` (49 pass)
- `bun run check`
- production state commits `7e5b7541` and `2a3f8bb1` preserve the failure that exposed this path

[LET-11097](https://linear.app/letta/issue/LET-11097/add-claude-watcher)