### PR TITLE
ci: schedule hourly Claude drift reviews

### DIFF
--- a/.github/workflows/claude-agent-watch.yml
+++ b/.github/workflows/claude-agent-watch.yml
@@ -1,9 +1,8 @@
 name: Claude Agent Watch
 
 on:
-  # Enable after the manual bootstrap/dedupe/docs-only/failure/no-impact bake:
-  # schedule:
-  #   - cron: "17 * * * *"
+  schedule:
+    - cron: "17 * * * *"
   workflow_dispatch:
     inputs:
       previous_version:


### PR DESCRIPTION
## Summary

Enable the Claude Agent Watch hourly at minute 17 after its dispatch-only bake completed.

## Bake evidence

- bootstrap + state/tracker: https://github.com/letta-ai/letta-code/actions/runs/32335167241
- corrected no-impact review: https://github.com/letta-ai/letta-code/actions/runs/32340339920
- dedupe: https://github.com/letta-ai/letta-code/actions/runs/32340997249
- forced full docs scan: https://github.com/letta-ai/letta-code/actions/runs/32341144095
- Read replay: https://github.com/letta-ai/letta-code/actions/runs/32339115817
- Task contract replay: https://github.com/letta-ai/letta-code/actions/runs/32339888102
- current tool-surface replay: https://github.com/letta-ai/letta-code/actions/runs/32340080447
- failure/retry path is preserved in tracker #3926

## Validation

- `bun run check`

[LET-11097](https://linear.app/letta/issue/LET-11097/add-claude-watcher)