### PR TITLE
fix(listener): resume tasks after teleport [LET-11204]

### DIFF
--- a/src/websocket/listener/message-router.ts
+++ b/src/websocket/listener/message-router.ts
@@ -66,6 +66,7 @@ import { emitLoopErrorNotice } from "./recoverable-notices";
 import { getActiveRuntime, safeEmitWsEvent } from "./runtime";
 import { parseListenerReadyMessage } from "./split-stream-lifecycle";
 import {
+  buildTeleportContinuationMessages,
   clearPriorReadyTeleports,
   handleTeleportProbe,
   handleTeleportRequest,
@@ -489,13 +490,10 @@ export function createListenerMessageHandler(
                 connectionId,
                 agentId: parsed.runtime.agent_id,
                 conversationId: parsed.runtime.conversation_id,
-                messages: [
-                  {
-                    type: "approval",
-                    approvals,
-                    otid: teleportId,
-                  },
-                ],
+                messages: buildTeleportContinuationMessages({
+                  teleportId,
+                  approvals,
+                }),
               },
               socket,
               scopedRuntime,

--- a/src/websocket/listener/protocol-ergonomics.test.ts
+++ b/src/websocket/listener/protocol-ergonomics.test.ts
@@ -158,7 +158,7 @@ describe("listener protocol ergonomics", () => {
     });
   });
 
-  test("teleport continuation resumes with tool results and no user message", async () => {
+  test("teleport continuation resumes with tool results and hidden destination context", async () => {
     const runtime = __listenClientTestUtils.createListenerRuntime();
     const conversationRuntime =
       __listenClientTestUtils.getOrCreateScopedRuntime(
@@ -221,7 +221,7 @@ describe("listener protocol ergonomics", () => {
       disposition: "started",
     });
     const incoming = receivedIncoming[0];
-    expect(incoming?.messages).toHaveLength(1);
+    expect(incoming?.messages).toHaveLength(2);
     expect(incoming?.messages[0]).toMatchObject({
       type: "approval",
       otid: "teleport-1",
@@ -234,7 +234,17 @@ describe("listener protocol ergonomics", () => {
         },
       ],
     });
-    expect(incoming?.messages.some((message) => "role" in message)).toBe(false);
+    expect(incoming?.messages[1]).toEqual({
+      role: "system",
+      content:
+        "<system-reminder>Teleportation to this environment is complete. Continue the existing task from this environment now.</system-reminder>",
+      otid: "teleport-1:continue",
+    });
+    expect(
+      incoming?.messages.some(
+        (message) => "role" in message && message.role === "user",
+      ),
+    ).toBe(false);
   });
 
   test("sync request_id gets a failure response when the listener is inactive", async () => {

--- a/src/websocket/listener/teleport.ts
+++ b/src/websocket/listener/teleport.ts
@@ -16,6 +16,7 @@ import { isListenerTransportOpen } from "./transport";
 import type { TurnFinishTransition, TurnLease } from "./turn-lifecycle";
 import type {
   ConversationRuntime,
+  IncomingMessage,
   ListenerConnectionId,
   ListenerRuntime,
   PendingTeleport,
@@ -29,6 +30,25 @@ type SafeSocketSend = (
 ) => boolean;
 
 const TELEPORT_RECOVERY_TTL_MS = 5 * 60_000;
+
+export function buildTeleportContinuationMessages(params: {
+  teleportId: string;
+  approvals: NonNullable<TeleportContinuation["approvals"]>;
+}): IncomingMessage["messages"] {
+  return [
+    {
+      type: "approval",
+      approvals: params.approvals,
+      otid: params.teleportId,
+    },
+    {
+      role: "system",
+      content:
+        "<system-reminder>Teleportation to this environment is complete. Continue the existing task from this environment now.</system-reminder>",
+      otid: `${params.teleportId}:continue`,
+    },
+  ];
+}
 
 function getPendingTeleports(
   runtime: ListenerRuntime,


### PR DESCRIPTION
## Summary
- append hidden destination-side continuation context after applying the source teleport tool result
- keep the continuation invisible as a user message and use stable OTIDs for retry safety
- cover the protocol payload shape with a focused listener regression

## Production diagnosis
The reported teleport completed successfully, but the destination run received only the approved Bash result (`status: waiting_for_source`) and ended with zero tool calls and zero persisted messages.

## Validation
- `bun test src/websocket/listener/protocol-ergonomics.test.ts src/websocket/listener/message-router.test.ts src/websocket/listener/turn-lifecycle-integration.test.ts`
- `bun run check`

Linear: [LET-11204](https://linear.app/letta/issue/LET-11204/teleport-e2e-tests)

👾 Generated with [Letta Code](https://letta.com)