### PR TITLE
ci: configure agent watcher PR notifications

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,13 +12,7 @@
 # Headless mode runtime
 /src/headless.ts @cpacker @4shub @kl2806 @devanshrj @sarahwooders @jnjpng @carenthomas
 
-# Codex agent watcher and source prompt provenance
-/.github/workflows/codex-agent-watch.yml @kl2806
-/.github/agent-prompts/codex-agent-watch.md @kl2806
-/scripts/codex-watch/ @kl2806
-/.github/workflows/claude-agent-watch.yml @kl2806
-/.github/agent-prompts/claude-agent-watch.md @kl2806
-/scripts/claude-watch/ @kl2806
+# Codex source prompt provenance
 /src/agent/prompts/source_codex.md @kl2806
 
 # TUI/CLI runtime and UI

--- a/.github/agent-prompts/claude-agent-watch.md
+++ b/.github/agent-prompts/claude-agent-watch.md
@@ -110,7 +110,7 @@ If a local change is required:
 - use a Conventional Commit title
 - open the PR as a draft
 - immediately verify `draft: true` and that the PR author matches the Expected GitHub login from the run inputs; if either is wrong, fix or close it instead of reporting success
-- before the tracker update, request every comma-separated GitHub reviewer from the run inputs with `GITHUB_TOKEN= GH_TOKEN="${AMELIA_GITHUB_TOKEN:?}" gh pr edit "$PR_URL" --add-reviewer <login>`; skip this only when the configured value is `none`
+- before the tracker update, request every comma-separated GitHub reviewer from the run inputs with `GITHUB_TOKEN= GH_TOKEN="${AMELIA_GITHUB_TOKEN:?}" gh api --method POST "repos/letta-ai/letta-code/pulls/${PR_URL##*/}/requested_reviewers" -f "reviewers[]=<login>"`; skip this only when the configured value is `none`
 - include `Claude-watch: <candidate-id>`, package version, release URL, docs/runtime evidence, and validation in the body
 - never commit generated snapshots or analysis files to the parity branch
 

--- a/.github/agent-prompts/claude-agent-watch.md
+++ b/.github/agent-prompts/claude-agent-watch.md
@@ -110,7 +110,7 @@ If a local change is required:
 - use a Conventional Commit title
 - open the PR as a draft
 - immediately verify `draft: true` and that the PR author matches the Expected GitHub login from the run inputs; if either is wrong, fix or close it instead of reporting success
-- before the tracker update, request every comma-separated GitHub reviewer from the run inputs with `test -n "$AMELIA_GITHUB_TOKEN" && GITHUB_TOKEN= GH_TOKEN="$AMELIA_GITHUB_TOKEN" gh api --method POST "repos/letta-ai/letta-code/pulls/${PR_URL##*/}/requested_reviewers" -f "reviewers[]=<login>"`; skip this only when the configured value is `none`
+- before the tracker update, GET `repos/letta-ai/letta-code/pulls/${PR_URL##*/}/requested_reviewers` with the same explicit Amelia credential, then request each configured reviewer that is not already present with `test -n "$AMELIA_GITHUB_TOKEN" && GITHUB_TOKEN= GH_TOKEN="$AMELIA_GITHUB_TOKEN" gh api --method POST "repos/letta-ai/letta-code/pulls/${PR_URL##*/}/requested_reviewers" -f "reviewers[]=<login>"`; skip this only when the configured value is `none`
 - include `Claude-watch: <candidate-id>`, package version, release URL, docs/runtime evidence, and validation in the body
 - never commit generated snapshots or analysis files to the parity branch
 

--- a/.github/agent-prompts/claude-agent-watch.md
+++ b/.github/agent-prompts/claude-agent-watch.md
@@ -14,6 +14,10 @@ Do not invent or rely on a private prompt dump, schema dump, `--list-tools`, or 
 
 The detector has already captured and committed the normalized candidate snapshot on `claude-watch-state`. Use the rebuilt analysis from the exact state commit as your starting point.
 
+## GitHub authentication
+
+Before running the sandbox bootstrap, resolve the watcher credential identity with `GITHUB_TOKEN= GH_TOKEN="${AMELIA_GITHUB_TOKEN:?}" gh api user --jq .login`. It must exactly match the Expected GitHub login from the run inputs. If the secret is missing or the identities differ, stop without modifying GitHub or the tracker.
+
 ## Sandbox setup
 
 The detector ran on a GitHub Actions runner, but your turn does not. Runner files and environment variables are unavailable here. The run inputs and an exact bootstrap block are appended to this prompt.
@@ -33,7 +37,8 @@ Immediately after the block succeeds, use `SetWorkingDirectory` to select `/tmp/
 7. If public evidence is incomplete or a probe is inconclusive, do not guess. Record `needs_human_review` with the exact uncertainty.
 8. Search open and closed PRs for the exact `Claude-watch: <candidate-id>` marker before creating a PR. A retry must never duplicate a PR.
 9. Verify that the state branch's current snapshot has the exact candidate ID before recording a terminal outcome.
-10. Do not merge, disable another workflow, wait for CI, or update the parity PR after creation.
+10. Use only `GITHUB_TOKEN= GH_TOKEN="${AMELIA_GITHUB_TOKEN:?}"` for GitHub operations. Never use the agent's general `$GITHUB_TOKEN` secret.
+11. Do not merge, disable another workflow, wait for CI, or update the parity PR after creation.
 
 If the exact candidate marker already exists on a parity PR, treat it as a recovered partial run: verify that PR, record `pr_created` with its URL, and do not create or modify another PR.
 
@@ -64,7 +69,7 @@ Always update the central tracker before returning. Use `scripts/claude-watch/up
 No local impact:
 
 ```bash
-GH_TOKEN="$GITHUB_TOKEN" bun scripts/claude-watch/update-tracker.ts \
+GITHUB_TOKEN= GH_TOKEN="${AMELIA_GITHUB_TOKEN:?}" bun scripts/claude-watch/update-tracker.ts \
   --tracker-issue <tracker-issue> \
   --analysis-file /tmp/claude-watch-analysis.json \
   --state-commit-sha <state-commit-sha> \
@@ -75,7 +80,7 @@ GH_TOKEN="$GITHUB_TOKEN" bun scripts/claude-watch/update-tracker.ts \
 PR created:
 
 ```bash
-GH_TOKEN="$GITHUB_TOKEN" bun scripts/claude-watch/update-tracker.ts \
+GITHUB_TOKEN= GH_TOKEN="${AMELIA_GITHUB_TOKEN:?}" bun scripts/claude-watch/update-tracker.ts \
   --tracker-issue <tracker-issue> \
   --analysis-file /tmp/claude-watch-analysis.json \
   --state-commit-sha <state-commit-sha> \
@@ -87,7 +92,7 @@ GH_TOKEN="$GITHUB_TOKEN" bun scripts/claude-watch/update-tracker.ts \
 Uncertain or blocked:
 
 ```bash
-GH_TOKEN="$GITHUB_TOKEN" bun scripts/claude-watch/update-tracker.ts \
+GITHUB_TOKEN= GH_TOKEN="${AMELIA_GITHUB_TOKEN:?}" bun scripts/claude-watch/update-tracker.ts \
   --tracker-issue <tracker-issue> \
   --analysis-file /tmp/claude-watch-analysis.json \
   --state-commit-sha <state-commit-sha> \
@@ -100,17 +105,34 @@ GH_TOKEN="$GITHUB_TOKEN" bun scripts/claude-watch/update-tracker.ts \
 If a local change is required:
 
 - create a fresh branch from current `main`
-- use `GH_TOKEN="$GITHUB_TOKEN"` for every GitHub CLI operation
+- use `GITHUB_TOKEN= GH_TOKEN="${AMELIA_GITHUB_TOKEN:?}"` for every GitHub CLI operation
 - make the minimum mirror change and focused tests only; do not include watcher implementation changes
 - use a Conventional Commit title
 - open the PR as a draft
-- immediately verify `draft: true` and `author.login: carenthomas`; if either is wrong, fix or close it instead of reporting success
+- immediately verify `draft: true` and that the PR author matches the Expected GitHub login from the run inputs; if either is wrong, fix or close it instead of reporting success
+- before the tracker update, request every comma-separated GitHub reviewer from the run inputs with `GITHUB_TOKEN= GH_TOKEN="${AMELIA_GITHUB_TOKEN:?}" gh pr edit "$PR_URL" --add-reviewer <login>`; skip this only when the configured value is `none`
 - include `Claude-watch: <candidate-id>`, package version, release URL, docs/runtime evidence, and validation in the body
 - never commit generated snapshots or analysis files to the parity branch
 
+## Slack notification
+
+Only for a `pr_created` outcome, after the tracker update succeeds, call the native `MessageChannel` tool with `action="send"`, `channel="slack"`, and `target="C0871ER46KT"` to send exactly one message. Do not use `curl` or another Slack API client.
+
+Use this message shape with the exact URLs from the run inputs and created PR. Convert each comma-separated Slack owner ID from the run inputs to a `<@USER_ID>` mention on the Owners line; omit that line when the configured value is `none`.
+
+```text
+Claude watcher created a parity PR for <candidate-id>.
+Owners: <owner-mentions>
+PR: <pr-url>
+Tracker: <tracker-issue-url>
+Workflow: <workflow-run-url>
+```
+
+The notification creates the Slack thread route back to this watcher conversation. Do not send a Slack notification for `no_local_impact` or `needs_human_review`.
+
 ## Final response
 
-After the tracker update succeeds, respond with exactly one line:
+After the tracker update and any required Slack notification succeed, respond with exactly one line:
 
 - `PR_CREATED <url>`
 - `NO_LOCAL_IMPACT <candidate-id>`

--- a/.github/agent-prompts/claude-agent-watch.md
+++ b/.github/agent-prompts/claude-agent-watch.md
@@ -16,7 +16,7 @@ The detector has already captured and committed the normalized candidate snapsho
 
 ## GitHub authentication
 
-Before running the sandbox bootstrap, resolve the watcher credential identity with `GITHUB_TOKEN= GH_TOKEN="${AMELIA_GITHUB_TOKEN:?}" gh api user --jq .login`. It must exactly match the Expected GitHub login from the run inputs. If the secret is missing or the identities differ, stop without modifying GitHub or the tracker.
+Before running the sandbox bootstrap, resolve the watcher credential identity with `test -n "$AMELIA_GITHUB_TOKEN" && GITHUB_TOKEN= GH_TOKEN="$AMELIA_GITHUB_TOKEN" gh api user --jq .login`. It must exactly match the Expected GitHub login from the run inputs. If the secret is missing or the identities differ, stop without modifying GitHub or the tracker.
 
 ## Sandbox setup
 
@@ -37,7 +37,7 @@ Immediately after the block succeeds, use `SetWorkingDirectory` to select `/tmp/
 7. If public evidence is incomplete or a probe is inconclusive, do not guess. Record `needs_human_review` with the exact uncertainty.
 8. Search open and closed PRs for the exact `Claude-watch: <candidate-id>` marker before creating a PR. A retry must never duplicate a PR.
 9. Verify that the state branch's current snapshot has the exact candidate ID before recording a terminal outcome.
-10. Use only `GITHUB_TOKEN= GH_TOKEN="${AMELIA_GITHUB_TOKEN:?}"` for GitHub operations. Never use the agent's general `$GITHUB_TOKEN` secret.
+10. Use only `test -n "$AMELIA_GITHUB_TOKEN" && GITHUB_TOKEN= GH_TOKEN="$AMELIA_GITHUB_TOKEN"` for GitHub operations. Never use the agent's general `$GITHUB_TOKEN` secret.
 11. Do not merge, disable another workflow, wait for CI, or update the parity PR after creation.
 
 If the exact candidate marker already exists on a parity PR, treat it as a recovered partial run: verify that PR, record `pr_created` with its URL, and do not create or modify another PR.
@@ -69,7 +69,7 @@ Always update the central tracker before returning. Use `scripts/claude-watch/up
 No local impact:
 
 ```bash
-GITHUB_TOKEN= GH_TOKEN="${AMELIA_GITHUB_TOKEN:?}" bun scripts/claude-watch/update-tracker.ts \
+test -n "$AMELIA_GITHUB_TOKEN" && GITHUB_TOKEN= GH_TOKEN="$AMELIA_GITHUB_TOKEN" bun scripts/claude-watch/update-tracker.ts \
   --tracker-issue <tracker-issue> \
   --analysis-file /tmp/claude-watch-analysis.json \
   --state-commit-sha <state-commit-sha> \
@@ -80,7 +80,7 @@ GITHUB_TOKEN= GH_TOKEN="${AMELIA_GITHUB_TOKEN:?}" bun scripts/claude-watch/updat
 PR created:
 
 ```bash
-GITHUB_TOKEN= GH_TOKEN="${AMELIA_GITHUB_TOKEN:?}" bun scripts/claude-watch/update-tracker.ts \
+test -n "$AMELIA_GITHUB_TOKEN" && GITHUB_TOKEN= GH_TOKEN="$AMELIA_GITHUB_TOKEN" bun scripts/claude-watch/update-tracker.ts \
   --tracker-issue <tracker-issue> \
   --analysis-file /tmp/claude-watch-analysis.json \
   --state-commit-sha <state-commit-sha> \
@@ -92,7 +92,7 @@ GITHUB_TOKEN= GH_TOKEN="${AMELIA_GITHUB_TOKEN:?}" bun scripts/claude-watch/updat
 Uncertain or blocked:
 
 ```bash
-GITHUB_TOKEN= GH_TOKEN="${AMELIA_GITHUB_TOKEN:?}" bun scripts/claude-watch/update-tracker.ts \
+test -n "$AMELIA_GITHUB_TOKEN" && GITHUB_TOKEN= GH_TOKEN="$AMELIA_GITHUB_TOKEN" bun scripts/claude-watch/update-tracker.ts \
   --tracker-issue <tracker-issue> \
   --analysis-file /tmp/claude-watch-analysis.json \
   --state-commit-sha <state-commit-sha> \
@@ -105,12 +105,12 @@ GITHUB_TOKEN= GH_TOKEN="${AMELIA_GITHUB_TOKEN:?}" bun scripts/claude-watch/updat
 If a local change is required:
 
 - create a fresh branch from current `main`
-- use `GITHUB_TOKEN= GH_TOKEN="${AMELIA_GITHUB_TOKEN:?}"` for every GitHub CLI operation
+- use `test -n "$AMELIA_GITHUB_TOKEN" && GITHUB_TOKEN= GH_TOKEN="$AMELIA_GITHUB_TOKEN"` for every GitHub CLI operation
 - make the minimum mirror change and focused tests only; do not include watcher implementation changes
 - use a Conventional Commit title
 - open the PR as a draft
 - immediately verify `draft: true` and that the PR author matches the Expected GitHub login from the run inputs; if either is wrong, fix or close it instead of reporting success
-- before the tracker update, request every comma-separated GitHub reviewer from the run inputs with `GITHUB_TOKEN= GH_TOKEN="${AMELIA_GITHUB_TOKEN:?}" gh api --method POST "repos/letta-ai/letta-code/pulls/${PR_URL##*/}/requested_reviewers" -f "reviewers[]=<login>"`; skip this only when the configured value is `none`
+- before the tracker update, request every comma-separated GitHub reviewer from the run inputs with `test -n "$AMELIA_GITHUB_TOKEN" && GITHUB_TOKEN= GH_TOKEN="$AMELIA_GITHUB_TOKEN" gh api --method POST "repos/letta-ai/letta-code/pulls/${PR_URL##*/}/requested_reviewers" -f "reviewers[]=<login>"`; skip this only when the configured value is `none`
 - include `Claude-watch: <candidate-id>`, package version, release URL, docs/runtime evidence, and validation in the body
 - never commit generated snapshots or analysis files to the parity branch
 

--- a/.github/agent-prompts/codex-agent-watch.md
+++ b/.github/agent-prompts/codex-agent-watch.md
@@ -98,7 +98,7 @@ If you create a PR:
 - create a new branch from the checked-out branch
 - use `GITHUB_TOKEN= GH_TOKEN="${AMELIA_GITHUB_TOKEN:?}"` for GitHub CLI commands so the sandbox injects the watcher-specific GitHub credentials
 - verify the created PR author matches the Expected GitHub login from the run inputs; if it does not, close the PR instead of reporting success
-- before the tracker update, request every comma-separated GitHub reviewer from the run inputs with `GITHUB_TOKEN= GH_TOKEN="${AMELIA_GITHUB_TOKEN:?}" gh pr edit "$PR_URL" --add-reviewer <login>`; skip this only when the configured value is `none`
+- before the tracker update, request every comma-separated GitHub reviewer from the run inputs with `GITHUB_TOKEN= GH_TOKEN="${AMELIA_GITHUB_TOKEN:?}" gh api --method POST "repos/letta-ai/letta-code/pulls/${PR_URL##*/}/requested_reviewers" -f "reviewers[]=<login>"`; skip this only when the configured value is `none`
 - keep the diff minimal and focused on this Codex release
 - do not include unrelated cleanup
 - use a Conventional Commit PR title, for example `chore(tools): align Codex schema wording`

--- a/.github/agent-prompts/codex-agent-watch.md
+++ b/.github/agent-prompts/codex-agent-watch.md
@@ -10,7 +10,7 @@ The detector already compared the latest stable Codex release to the previous st
 
 ## GitHub authentication
 
-Before running the sandbox bootstrap, resolve the watcher credential identity with `GITHUB_TOKEN= GH_TOKEN="${AMELIA_GITHUB_TOKEN:?}" gh api user --jq .login`. It must exactly match the Expected GitHub login from the run inputs. If the secret is missing or the identities differ, stop without modifying GitHub or the tracker.
+Before running the sandbox bootstrap, resolve the watcher credential identity with `test -n "$AMELIA_GITHUB_TOKEN" && GITHUB_TOKEN= GH_TOKEN="$AMELIA_GITHUB_TOKEN" gh api user --jq .login`. It must exactly match the Expected GitHub login from the run inputs. If the secret is missing or the identities differ, stop without modifying GitHub or the tracker.
 
 ## Sandbox setup
 
@@ -32,7 +32,7 @@ Perform all repository inspection, edits, tests, and tracker updates from that s
 4. If a local mirror should change, make the minimal local fix, run targeted validation, push a branch, and open a PR.
 5. If no local mirror should change, do not open a PR. Record `no_local_impact` in the tracker.
 6. If you are blocked or not confident, do not guess. Record `needs_human_review` in the tracker with a concise reason.
-7. Use only `GITHUB_TOKEN= GH_TOKEN="${AMELIA_GITHUB_TOKEN:?}"` for GitHub operations. Never use the agent's general `$GITHUB_TOKEN` secret.
+7. Use only `test -n "$AMELIA_GITHUB_TOKEN" && GITHUB_TOKEN= GH_TOKEN="$AMELIA_GITHUB_TOKEN"` for GitHub operations. Never use the agent's general `$GITHUB_TOKEN` secret.
 8. Do not update PRs after creation, wait for CI, or merge PRs. Those follow-ups are handled outside release review.
 
 ## Local mirrors to check
@@ -63,7 +63,7 @@ Use `scripts/codex-watch/update-tracker.ts` for the terminal outcome. Do not sub
 For no local impact:
 
 ```bash
-GITHUB_TOKEN= GH_TOKEN="${AMELIA_GITHUB_TOKEN:?}" bun scripts/codex-watch/update-tracker.ts \
+test -n "$AMELIA_GITHUB_TOKEN" && GITHUB_TOKEN= GH_TOKEN="$AMELIA_GITHUB_TOKEN" bun scripts/codex-watch/update-tracker.ts \
   --tracker-issue <tracker-issue> \
   --analysis-file /tmp/codex-watch-analysis.json \
   --outcome no_local_impact \
@@ -73,7 +73,7 @@ GITHUB_TOKEN= GH_TOKEN="${AMELIA_GITHUB_TOKEN:?}" bun scripts/codex-watch/update
 For a PR:
 
 ```bash
-GITHUB_TOKEN= GH_TOKEN="${AMELIA_GITHUB_TOKEN:?}" bun scripts/codex-watch/update-tracker.ts \
+test -n "$AMELIA_GITHUB_TOKEN" && GITHUB_TOKEN= GH_TOKEN="$AMELIA_GITHUB_TOKEN" bun scripts/codex-watch/update-tracker.ts \
   --tracker-issue <tracker-issue> \
   --analysis-file /tmp/codex-watch-analysis.json \
   --outcome pr_created \
@@ -84,7 +84,7 @@ GITHUB_TOKEN= GH_TOKEN="${AMELIA_GITHUB_TOKEN:?}" bun scripts/codex-watch/update
 For blocked/uncertain:
 
 ```bash
-GITHUB_TOKEN= GH_TOKEN="${AMELIA_GITHUB_TOKEN:?}" bun scripts/codex-watch/update-tracker.ts \
+test -n "$AMELIA_GITHUB_TOKEN" && GITHUB_TOKEN= GH_TOKEN="$AMELIA_GITHUB_TOKEN" bun scripts/codex-watch/update-tracker.ts \
   --tracker-issue <tracker-issue> \
   --analysis-file /tmp/codex-watch-analysis.json \
   --outcome needs_human_review \
@@ -96,9 +96,9 @@ GITHUB_TOKEN= GH_TOKEN="${AMELIA_GITHUB_TOKEN:?}" bun scripts/codex-watch/update
 If you create a PR:
 
 - create a new branch from the checked-out branch
-- use `GITHUB_TOKEN= GH_TOKEN="${AMELIA_GITHUB_TOKEN:?}"` for GitHub CLI commands so the sandbox injects the watcher-specific GitHub credentials
+- use `test -n "$AMELIA_GITHUB_TOKEN" && GITHUB_TOKEN= GH_TOKEN="$AMELIA_GITHUB_TOKEN"` for GitHub CLI commands so the sandbox injects the watcher-specific GitHub credentials
 - verify the created PR author matches the Expected GitHub login from the run inputs; if it does not, close the PR instead of reporting success
-- before the tracker update, request every comma-separated GitHub reviewer from the run inputs with `GITHUB_TOKEN= GH_TOKEN="${AMELIA_GITHUB_TOKEN:?}" gh api --method POST "repos/letta-ai/letta-code/pulls/${PR_URL##*/}/requested_reviewers" -f "reviewers[]=<login>"`; skip this only when the configured value is `none`
+- before the tracker update, request every comma-separated GitHub reviewer from the run inputs with `test -n "$AMELIA_GITHUB_TOKEN" && GITHUB_TOKEN= GH_TOKEN="$AMELIA_GITHUB_TOKEN" gh api --method POST "repos/letta-ai/letta-code/pulls/${PR_URL##*/}/requested_reviewers" -f "reviewers[]=<login>"`; skip this only when the configured value is `none`
 - keep the diff minimal and focused on this Codex release
 - do not include unrelated cleanup
 - use a Conventional Commit PR title, for example `chore(tools): align Codex schema wording`

--- a/.github/agent-prompts/codex-agent-watch.md
+++ b/.github/agent-prompts/codex-agent-watch.md
@@ -8,6 +8,10 @@ The central tracker issue is the source of truth for release dedupe and terminal
 
 The detector already compared the latest stable Codex release to the previous stable release. Use the rebuilt analysis file as your starting point.
 
+## GitHub authentication
+
+Before running the sandbox bootstrap, resolve the watcher credential identity with `GITHUB_TOKEN= GH_TOKEN="${AMELIA_GITHUB_TOKEN:?}" gh api user --jq .login`. It must exactly match the Expected GitHub login from the run inputs. If the secret is missing or the identities differ, stop without modifying GitHub or the tracker.
+
 ## Sandbox setup
 
 The detector ran on a GitHub Actions runner, but your turn does not. The runner checkout, environment variables, and analysis file path are unavailable in the sandbox. The run inputs and an exact bootstrap command are included below in this prompt.
@@ -28,7 +32,8 @@ Perform all repository inspection, edits, tests, and tracker updates from that s
 4. If a local mirror should change, make the minimal local fix, run targeted validation, push a branch, and open a PR.
 5. If no local mirror should change, do not open a PR. Record `no_local_impact` in the tracker.
 6. If you are blocked or not confident, do not guess. Record `needs_human_review` in the tracker with a concise reason.
-7. Do not update PRs after creation, wait for CI, or merge PRs. Those follow-ups are handled outside release review.
+7. Use only `GITHUB_TOKEN= GH_TOKEN="${AMELIA_GITHUB_TOKEN:?}"` for GitHub operations. Never use the agent's general `$GITHUB_TOKEN` secret.
+8. Do not update PRs after creation, wait for CI, or merge PRs. Those follow-ups are handled outside release review.
 
 ## Local mirrors to check
 
@@ -58,7 +63,7 @@ Use `scripts/codex-watch/update-tracker.ts` for the terminal outcome. Do not sub
 For no local impact:
 
 ```bash
-GH_TOKEN="$GITHUB_TOKEN" bun scripts/codex-watch/update-tracker.ts \
+GITHUB_TOKEN= GH_TOKEN="${AMELIA_GITHUB_TOKEN:?}" bun scripts/codex-watch/update-tracker.ts \
   --tracker-issue <tracker-issue> \
   --analysis-file /tmp/codex-watch-analysis.json \
   --outcome no_local_impact \
@@ -68,7 +73,7 @@ GH_TOKEN="$GITHUB_TOKEN" bun scripts/codex-watch/update-tracker.ts \
 For a PR:
 
 ```bash
-GH_TOKEN="$GITHUB_TOKEN" bun scripts/codex-watch/update-tracker.ts \
+GITHUB_TOKEN= GH_TOKEN="${AMELIA_GITHUB_TOKEN:?}" bun scripts/codex-watch/update-tracker.ts \
   --tracker-issue <tracker-issue> \
   --analysis-file /tmp/codex-watch-analysis.json \
   --outcome pr_created \
@@ -79,7 +84,7 @@ GH_TOKEN="$GITHUB_TOKEN" bun scripts/codex-watch/update-tracker.ts \
 For blocked/uncertain:
 
 ```bash
-GH_TOKEN="$GITHUB_TOKEN" bun scripts/codex-watch/update-tracker.ts \
+GITHUB_TOKEN= GH_TOKEN="${AMELIA_GITHUB_TOKEN:?}" bun scripts/codex-watch/update-tracker.ts \
   --tracker-issue <tracker-issue> \
   --analysis-file /tmp/codex-watch-analysis.json \
   --outcome needs_human_review \
@@ -91,7 +96,9 @@ GH_TOKEN="$GITHUB_TOKEN" bun scripts/codex-watch/update-tracker.ts \
 If you create a PR:
 
 - create a new branch from the checked-out branch
-- use `GH_TOKEN="$GITHUB_TOKEN"` for GitHub CLI commands so the sandbox injects GitHub credentials
+- use `GITHUB_TOKEN= GH_TOKEN="${AMELIA_GITHUB_TOKEN:?}"` for GitHub CLI commands so the sandbox injects the watcher-specific GitHub credentials
+- verify the created PR author matches the Expected GitHub login from the run inputs; if it does not, close the PR instead of reporting success
+- before the tracker update, request every comma-separated GitHub reviewer from the run inputs with `GITHUB_TOKEN= GH_TOKEN="${AMELIA_GITHUB_TOKEN:?}" gh pr edit "$PR_URL" --add-reviewer <login>`; skip this only when the configured value is `none`
 - keep the diff minimal and focused on this Codex release
 - do not include unrelated cleanup
 - use a Conventional Commit PR title, for example `chore(tools): align Codex schema wording`
@@ -99,9 +106,25 @@ If you create a PR:
 - run targeted tests/typecheck appropriate to the files changed
 - if validation cannot run or fails for unrelated reasons, mention that in the PR body and tracker note
 
+## Slack notification
+
+Only for a `pr_created` outcome, after the tracker update succeeds, call the native `MessageChannel` tool with `action="send"`, `channel="slack"`, and `target="C0871ER46KT"` to send exactly one message. Do not use `curl` or another Slack API client.
+
+Use this message shape with the exact URLs from the run inputs and created PR. Convert each comma-separated Slack owner ID from the run inputs to a `<@USER_ID>` mention on the Owners line; omit that line when the configured value is `none`.
+
+```text
+Codex watcher created a parity PR for <tag>.
+Owners: <owner-mentions>
+PR: <pr-url>
+Tracker: <tracker-issue-url>
+Workflow: <workflow-run-url>
+```
+
+The notification creates the Slack thread route back to this watcher conversation. Do not send a Slack notification for `no_local_impact` or `needs_human_review`.
+
 ## Final response
 
-Respond with exactly one of:
+After the tracker update and any required Slack notification succeed, respond with exactly one of:
 
 - `PR_CREATED <url>`
 - `NO_LOCAL_IMPACT <tag>`

--- a/.github/agent-prompts/codex-agent-watch.md
+++ b/.github/agent-prompts/codex-agent-watch.md
@@ -98,7 +98,7 @@ If you create a PR:
 - create a new branch from the checked-out branch
 - use `test -n "$AMELIA_GITHUB_TOKEN" && GITHUB_TOKEN= GH_TOKEN="$AMELIA_GITHUB_TOKEN"` for GitHub CLI commands so the sandbox injects the watcher-specific GitHub credentials
 - verify the created PR author matches the Expected GitHub login from the run inputs; if it does not, close the PR instead of reporting success
-- before the tracker update, request every comma-separated GitHub reviewer from the run inputs with `test -n "$AMELIA_GITHUB_TOKEN" && GITHUB_TOKEN= GH_TOKEN="$AMELIA_GITHUB_TOKEN" gh api --method POST "repos/letta-ai/letta-code/pulls/${PR_URL##*/}/requested_reviewers" -f "reviewers[]=<login>"`; skip this only when the configured value is `none`
+- before the tracker update, GET `repos/letta-ai/letta-code/pulls/${PR_URL##*/}/requested_reviewers` with the same explicit Amelia credential, then request each configured reviewer that is not already present with `test -n "$AMELIA_GITHUB_TOKEN" && GITHUB_TOKEN= GH_TOKEN="$AMELIA_GITHUB_TOKEN" gh api --method POST "repos/letta-ai/letta-code/pulls/${PR_URL##*/}/requested_reviewers" -f "reviewers[]=<login>"`; skip this only when the configured value is `none`
 - keep the diff minimal and focused on this Codex release
 - do not include unrelated cleanup
 - use a Conventional Commit PR title, for example `chore(tools): align Codex schema wording`

--- a/.github/workflows/claude-agent-watch.yml
+++ b/.github/workflows/claude-agent-watch.yml
@@ -153,6 +153,7 @@ jobs:
             echo '```'
             echo "AMELIA_PROMPT_EOF"
           } >> "$GITHUB_OUTPUT"
+          echo "conversation_name=$GITHUB_WORKFLOW $(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> "$GITHUB_OUTPUT"
 
       - name: Ask Amelia to review Claude Code drift
         if: steps.detect.outputs.should_run_agent == 'true'
@@ -162,7 +163,8 @@ jobs:
           github_token: ${{ secrets.AMELIA_GITHUB_TOKEN }}
           agent_id: agent-cd664b86-4d28-49b7-8ad6-60677eaff9be
           environment: cloud
-          letta_args: "--new"
+          letta_args: >-
+            --new --name "${{ steps.prompt.outputs.conversation_name }}"
           track_progress: ""
           tracking_comment: "false"
           model: auto

--- a/.github/workflows/claude-agent-watch.yml
+++ b/.github/workflows/claude-agent-watch.yml
@@ -2,7 +2,7 @@ name: Claude Agent Watch
 
 on:
   schedule:
-    - cron: "17 * * * *"
+    - cron: "17 */2 * * *"
   workflow_dispatch:
     inputs:
       previous_version:
@@ -96,6 +96,15 @@ jobs:
           path: ${{ runner.temp }}/claude-watch-analysis.json
           retention-days: 3
 
+      - name: Resolve Amelia GitHub identity
+        id: github-identity
+        env:
+          GH_TOKEN: ${{ secrets.AMELIA_GITHUB_TOKEN }}
+        run: |
+          login=$(gh api user --jq .login)
+          echo "login=$login" >> "$GITHUB_OUTPUT"
+          echo "Authenticated GitHub login: $login"
+
       - name: Build Amelia prompt
         id: prompt
         if: steps.detect.outputs.should_run_agent == 'true'
@@ -107,6 +116,9 @@ jobs:
           PREVIOUS_VERSION: ${{ steps.detect.outputs.previous_version }}
           VERDICT: ${{ steps.detect.outputs.verdict }}
           STATE_COMMIT_SHA: ${{ steps.detect.outputs.state_commit_sha }}
+          EXPECTED_GITHUB_LOGIN: ${{ steps.github-identity.outputs.login }}
+          GITHUB_REVIEWERS: ${{ vars.CLAUDE_WATCH_GITHUB_REVIEWERS }}
+          SLACK_OWNER_IDS: ${{ vars.CLAUDE_WATCH_SLACK_OWNER_IDS }}
         run: |
           {
             echo "prompt<<AMELIA_PROMPT_EOF"
@@ -115,6 +127,10 @@ jobs:
             echo "## Run inputs"
             echo
             echo "- Tracker issue: #$TRACKER_ISSUE ($TRACKER_ISSUE_URL)"
+            echo "- Workflow run: $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+            echo "- Expected GitHub login: $EXPECTED_GITHUB_LOGIN"
+            echo "- GitHub reviewers: ${GITHUB_REVIEWERS:-none}"
+            echo "- Slack owner IDs: ${SLACK_OWNER_IDS:-none}"
             echo "- Candidate ID: $CANDIDATE_ID"
             echo "- Current package: @anthropic-ai/claude-code@$CURRENT_VERSION"
             echo "- Previous package: @anthropic-ai/claude-code@$PREVIOUS_VERSION"
@@ -128,11 +144,11 @@ jobs:
             echo '```bash'
             echo 'set -euo pipefail'
             echo 'rm -rf /tmp/letta-code-claude-watch'
-            echo 'GH_TOKEN="$GITHUB_TOKEN" gh repo clone letta-ai/letta-code /tmp/letta-code-claude-watch'
+            echo 'GITHUB_TOKEN= GH_TOKEN="${AMELIA_GITHUB_TOKEN:?}" gh repo clone letta-ai/letta-code /tmp/letta-code-claude-watch'
             echo 'cd /tmp/letta-code-claude-watch'
             echo 'bun install --frozen-lockfile'
             echo 'git fetch origin claude-watch-state'
-            echo "GH_TOKEN=\"\$GITHUB_TOKEN\" GITHUB_SERVER_URL=https://github.com GITHUB_REPOSITORY=letta-ai/letta-code GITHUB_RUN_ID=\"$GITHUB_RUN_ID\" bun scripts/claude-watch/agent-watch.ts --dry-run --rebuild-state-commit \"$STATE_COMMIT_SHA\" --analysis-file /tmp/claude-watch-analysis.json > /tmp/claude-watch-analysis.log"
+            echo "GITHUB_TOKEN= GH_TOKEN=\"\${AMELIA_GITHUB_TOKEN:?}\" GITHUB_SERVER_URL=https://github.com GITHUB_REPOSITORY=letta-ai/letta-code GITHUB_RUN_ID=\"$GITHUB_RUN_ID\" bun scripts/claude-watch/agent-watch.ts --dry-run --rebuild-state-commit \"$STATE_COMMIT_SHA\" --analysis-file /tmp/claude-watch-analysis.json > /tmp/claude-watch-analysis.log"
             echo "jq -e --arg candidate \"$CANDIDATE_ID\" --arg current \"$CURRENT_VERSION\" '.candidate_id == \$candidate and .current_version == \$current and (.docs_diff | type == \"object\")' /tmp/claude-watch-analysis.json > /dev/null"
             echo '```'
             echo "AMELIA_PROMPT_EOF"
@@ -146,6 +162,7 @@ jobs:
           github_token: ${{ secrets.AMELIA_GITHUB_TOKEN }}
           agent_id: agent-cd664b86-4d28-49b7-8ad6-60677eaff9be
           environment: cloud
+          letta_args: "--new"
           track_progress: ""
           tracking_comment: "false"
           model: auto

--- a/.github/workflows/claude-agent-watch.yml
+++ b/.github/workflows/claude-agent-watch.yml
@@ -144,11 +144,11 @@ jobs:
             echo '```bash'
             echo 'set -euo pipefail'
             echo 'rm -rf /tmp/letta-code-claude-watch'
-            echo 'GITHUB_TOKEN= GH_TOKEN="${AMELIA_GITHUB_TOKEN:?}" gh repo clone letta-ai/letta-code /tmp/letta-code-claude-watch'
+            echo 'test -n "$AMELIA_GITHUB_TOKEN" && GITHUB_TOKEN= GH_TOKEN="$AMELIA_GITHUB_TOKEN" gh repo clone letta-ai/letta-code /tmp/letta-code-claude-watch'
             echo 'cd /tmp/letta-code-claude-watch'
             echo 'bun install --frozen-lockfile'
             echo 'git fetch origin claude-watch-state'
-            echo "GITHUB_TOKEN= GH_TOKEN=\"\${AMELIA_GITHUB_TOKEN:?}\" GITHUB_SERVER_URL=https://github.com GITHUB_REPOSITORY=letta-ai/letta-code GITHUB_RUN_ID=\"$GITHUB_RUN_ID\" bun scripts/claude-watch/agent-watch.ts --dry-run --rebuild-state-commit \"$STATE_COMMIT_SHA\" --analysis-file /tmp/claude-watch-analysis.json > /tmp/claude-watch-analysis.log"
+            echo "test -n \"\$AMELIA_GITHUB_TOKEN\" && GITHUB_TOKEN= GH_TOKEN=\"\$AMELIA_GITHUB_TOKEN\" GITHUB_SERVER_URL=https://github.com GITHUB_REPOSITORY=letta-ai/letta-code GITHUB_RUN_ID=\"$GITHUB_RUN_ID\" bun scripts/claude-watch/agent-watch.ts --dry-run --rebuild-state-commit \"$STATE_COMMIT_SHA\" --analysis-file /tmp/claude-watch-analysis.json > /tmp/claude-watch-analysis.log"
             echo "jq -e --arg candidate \"$CANDIDATE_ID\" --arg current \"$CURRENT_VERSION\" '.candidate_id == \$candidate and .current_version == \$current and (.docs_diff | type == \"object\")' /tmp/claude-watch-analysis.json > /dev/null"
             echo '```'
             echo "AMELIA_PROMPT_EOF"

--- a/.github/workflows/codex-agent-watch.yml
+++ b/.github/workflows/codex-agent-watch.yml
@@ -107,6 +107,7 @@ jobs:
             echo '```'
             echo "AMELIA_PROMPT_EOF"
           } >> "$GITHUB_OUTPUT"
+          echo "conversation_name=$GITHUB_WORKFLOW $(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> "$GITHUB_OUTPUT"
 
       - name: Ask Amelia to review actionable Codex drift
         if: steps.detect.outputs.should_run_agent == 'true'
@@ -116,7 +117,8 @@ jobs:
           github_token: ${{ secrets.AMELIA_GITHUB_TOKEN }}
           agent_id: agent-cd664b86-4d28-49b7-8ad6-60677eaff9be
           environment: cloud
-          letta_args: "--new"
+          letta_args: >-
+            --new --name "${{ steps.prompt.outputs.conversation_name }}"
           track_progress: ""
           tracking_comment: "false"
           model: auto

--- a/.github/workflows/codex-agent-watch.yml
+++ b/.github/workflows/codex-agent-watch.yml
@@ -99,10 +99,10 @@ jobs:
             echo '```bash'
             echo 'set -euo pipefail'
             echo 'rm -rf /tmp/letta-code-codex-watch'
-            echo 'GITHUB_TOKEN= GH_TOKEN="${AMELIA_GITHUB_TOKEN:?}" gh repo clone letta-ai/letta-code /tmp/letta-code-codex-watch'
+            echo 'test -n "$AMELIA_GITHUB_TOKEN" && GITHUB_TOKEN= GH_TOKEN="$AMELIA_GITHUB_TOKEN" gh repo clone letta-ai/letta-code /tmp/letta-code-codex-watch'
             echo 'cd /tmp/letta-code-codex-watch'
             echo 'bun install --frozen-lockfile'
-            echo "GITHUB_TOKEN= GH_TOKEN=\"\${AMELIA_GITHUB_TOKEN:?}\" GITHUB_SERVER_URL=https://github.com GITHUB_REPOSITORY=letta-ai/letta-code GITHUB_RUN_ID=\"$GITHUB_RUN_ID\" bun scripts/codex-watch/agent-watch.ts --dry-run --since \"$PREVIOUS_TAG\" --current \"$CURRENT_TAG\" --analysis-file /tmp/codex-watch-analysis.json > /tmp/codex-watch-analysis.log"
+            echo "test -n \"\$AMELIA_GITHUB_TOKEN\" && GITHUB_TOKEN= GH_TOKEN=\"\$AMELIA_GITHUB_TOKEN\" GITHUB_SERVER_URL=https://github.com GITHUB_REPOSITORY=letta-ai/letta-code GITHUB_RUN_ID=\"$GITHUB_RUN_ID\" bun scripts/codex-watch/agent-watch.ts --dry-run --since \"$PREVIOUS_TAG\" --current \"$CURRENT_TAG\" --analysis-file /tmp/codex-watch-analysis.json > /tmp/codex-watch-analysis.log"
             echo "jq -e '.current_tag == \"$CURRENT_TAG\" and .previous_tag == \"$PREVIOUS_TAG\" and (.path_changes | type == \"array\")' /tmp/codex-watch-analysis.json > /dev/null"
             echo '```'
             echo "AMELIA_PROMPT_EOF"

--- a/.github/workflows/codex-agent-watch.yml
+++ b/.github/workflows/codex-agent-watch.yml
@@ -2,7 +2,7 @@ name: Codex Agent Watch
 
 on:
   schedule:
-    - cron: "0 * * * *"
+    - cron: "0 */2 * * *"
   workflow_dispatch:
     inputs:
       since_tag:
@@ -55,6 +55,15 @@ jobs:
           fi
           bun scripts/codex-watch/agent-watch.ts "${ARGS[@]}"
 
+      - name: Resolve Amelia GitHub identity
+        id: github-identity
+        env:
+          GH_TOKEN: ${{ secrets.AMELIA_GITHUB_TOKEN }}
+        run: |
+          login=$(gh api user --jq .login)
+          echo "login=$login" >> "$GITHUB_OUTPUT"
+          echo "Authenticated GitHub login: $login"
+
       - name: Build Amelia prompt
         id: prompt
         if: steps.detect.outputs.should_run_agent == 'true'
@@ -64,6 +73,9 @@ jobs:
           CURRENT_TAG: ${{ steps.detect.outputs.current_tag }}
           PREVIOUS_TAG: ${{ steps.detect.outputs.previous_tag }}
           VERDICT: ${{ steps.detect.outputs.verdict }}
+          EXPECTED_GITHUB_LOGIN: ${{ steps.github-identity.outputs.login }}
+          GITHUB_REVIEWERS: ${{ vars.CODEX_WATCH_GITHUB_REVIEWERS }}
+          SLACK_OWNER_IDS: ${{ vars.CODEX_WATCH_SLACK_OWNER_IDS }}
         run: |
           {
             echo "prompt<<AMELIA_PROMPT_EOF"
@@ -72,6 +84,10 @@ jobs:
             echo "## Run inputs"
             echo
             echo "- Tracker issue: #$TRACKER_ISSUE ($TRACKER_ISSUE_URL)"
+            echo "- Workflow run: $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+            echo "- Expected GitHub login: $EXPECTED_GITHUB_LOGIN"
+            echo "- GitHub reviewers: ${GITHUB_REVIEWERS:-none}"
+            echo "- Slack owner IDs: ${SLACK_OWNER_IDS:-none}"
             echo "- Current tag: $CURRENT_TAG"
             echo "- Previous tag: $PREVIOUS_TAG"
             echo "- Detector verdict: $VERDICT"
@@ -83,10 +99,10 @@ jobs:
             echo '```bash'
             echo 'set -euo pipefail'
             echo 'rm -rf /tmp/letta-code-codex-watch'
-            echo 'GH_TOKEN="$GITHUB_TOKEN" gh repo clone letta-ai/letta-code /tmp/letta-code-codex-watch'
+            echo 'GITHUB_TOKEN= GH_TOKEN="${AMELIA_GITHUB_TOKEN:?}" gh repo clone letta-ai/letta-code /tmp/letta-code-codex-watch'
             echo 'cd /tmp/letta-code-codex-watch'
             echo 'bun install --frozen-lockfile'
-            echo "GH_TOKEN=\"\$GITHUB_TOKEN\" GITHUB_SERVER_URL=https://github.com GITHUB_REPOSITORY=letta-ai/letta-code GITHUB_RUN_ID=\"$GITHUB_RUN_ID\" bun scripts/codex-watch/agent-watch.ts --dry-run --since \"$PREVIOUS_TAG\" --current \"$CURRENT_TAG\" --analysis-file /tmp/codex-watch-analysis.json > /tmp/codex-watch-analysis.log"
+            echo "GITHUB_TOKEN= GH_TOKEN=\"\${AMELIA_GITHUB_TOKEN:?}\" GITHUB_SERVER_URL=https://github.com GITHUB_REPOSITORY=letta-ai/letta-code GITHUB_RUN_ID=\"$GITHUB_RUN_ID\" bun scripts/codex-watch/agent-watch.ts --dry-run --since \"$PREVIOUS_TAG\" --current \"$CURRENT_TAG\" --analysis-file /tmp/codex-watch-analysis.json > /tmp/codex-watch-analysis.log"
             echo "jq -e '.current_tag == \"$CURRENT_TAG\" and .previous_tag == \"$PREVIOUS_TAG\" and (.path_changes | type == \"array\")' /tmp/codex-watch-analysis.json > /dev/null"
             echo '```'
             echo "AMELIA_PROMPT_EOF"
@@ -100,6 +116,7 @@ jobs:
           github_token: ${{ secrets.AMELIA_GITHUB_TOKEN }}
           agent_id: agent-cd664b86-4d28-49b7-8ad6-60677eaff9be
           environment: cloud
+          letta_args: "--new"
           track_progress: ""
           tracking_comment: "false"
           model: auto


### PR DESCRIPTION
## Summary
- run Claude and Codex release watchers every two hours in fresh workflow-and-timestamp-named Amelia conversations
- require watcher-specific GitHub credentials and request configured owners only on watcher-created output PRs
- send one routed Slack notification with the owner, PR, tracker, and workflow only when a watcher creates a PR
- remove CODEOWNERS rules for the watcher implementation itself

## Test plan
- [x] `bun run check`
- [x] watcher contract and secret-injection assertions
- [x] conversation-name argument parsing
- [x] `git diff --check`
- [x] independent auth and routing reviews
- [x] validated repository token identity as `amelia-letta`
- [x] validated agent `AMELIA_GITHUB_TOKEN` as `amelia-letta` inside a fresh cloud sandbox
- [ ] run controlled Claude and Codex production notification tests

👾 Generated with [Letta Code](https://letta.com)