### PR TITLE
feat(local): expose Grok subscription OAuth

### DIFF
--- a/src/cli/commands/connect-local-oauth.test.ts
+++ b/src/cli/commands/connect-local-oauth.test.ts
@@ -4,6 +4,13 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { OAuthSelectPrompt } from "@earendil-works/pi-ai/oauth";
 import {
+  clearAvailableModelsCache,
+  getAvailableModelHandles,
+  getAvailableModelsCacheInfo,
+} from "@/agent/available-models";
+import { __testSetBackend } from "@/backend";
+import { FakeHeadlessBackend } from "@/backend/dev/fake-headless-backend";
+import {
   clearRegisteredPiProviders,
   type PiProviderOAuthLoginCallbacks,
   registerPiProvider,
@@ -78,6 +85,8 @@ describe("runLocalOAuthConnectFlow select prompts", () => {
   });
 
   afterEach(async () => {
+    clearAvailableModelsCache();
+    __testSetBackend(null);
     clearRegisteredPiProviders();
     if (previousStorageDir === undefined) {
       delete process.env.LETTA_LOCAL_BACKEND_DIR;
@@ -126,5 +135,18 @@ describe("runLocalOAuthConnectFlow select prompts", () => {
       timeout: 30_000,
       auth: { type: "oauth" },
     });
+  });
+
+  test("invalidates the available model cache after OAuth login", async () => {
+    __testSetBackend(new FakeHeadlessBackend());
+    await getAvailableModelHandles();
+    expect(getAvailableModelsCacheInfo().hasCache).toBe(true);
+
+    await runLocalOAuthConnectFlow(FAKE_BYOK_PROVIDER, {
+      onStatus: () => {},
+      openBrowser: async () => {},
+    });
+
+    expect(getAvailableModelsCacheInfo().hasCache).toBe(false);
   });
 });

--- a/src/cli/commands/connect-local-oauth.ts
+++ b/src/cli/commands/connect-local-oauth.ts
@@ -3,6 +3,7 @@ import type {
   OAuthPrompt,
   OAuthSelectPrompt,
 } from "@earendil-works/pi-ai/oauth";
+import { clearAvailableModelsCache } from "@/agent/available-models";
 import { getProviderOAuthAuth } from "@/backend/dev/pi-oauth";
 import {
   localOAuthAuthFromCredentials,
@@ -131,6 +132,7 @@ export async function runLocalOAuthConnectFlow(
     baseURL: callbacks.baseURL,
     timeout: callbacks.timeout,
   });
+  clearAvailableModelsCache();
 
   return { providerName: provider.providerName };
 }

--- a/src/cli/commands/connect-normalize.ts
+++ b/src/cli/commands/connect-normalize.ts
@@ -24,6 +24,7 @@ const ALIAS_TO_CANONICAL: Record<string, ConnectProviderCanonical> = {
 
 const LOCAL_ALIAS_TO_CANONICAL: Record<string, ConnectProviderCanonical> = {
   gemini: "google",
+  grok: "xai",
   "kimi-code": "kimi-coding",
   moonshot: "moonshotai",
   bedrock: "amazon-bedrock",
@@ -109,7 +110,11 @@ export function listConnectProvidersForHelp(
 export function listConnectProviderTokens(
   target: ProviderStorageTarget = defaultProviderStorageTarget(),
 ): string[] {
-  return [...listConnectProvidersForHelp(target), "codex"];
+  return [
+    ...listConnectProvidersForHelp(target),
+    "codex",
+    ...(target === "local" ? ["grok"] : []),
+  ];
 }
 
 export function isConnectOAuthProvider(

--- a/src/cli/connect-normalize.test.ts
+++ b/src/cli/connect-normalize.test.ts
@@ -5,6 +5,7 @@ import {
   isConnectBedrockProvider,
   isConnectOAuthProvider,
   listConnectProvidersForHelp,
+  listConnectProviderTokens,
   resolveConnectProvider,
 } from "@/cli/commands/connect-normalize";
 
@@ -147,8 +148,9 @@ describe("connect provider normalization", () => {
   test("resolves local subscription providers from the pi OAuth catalog", () => {
     const anthropicOAuth = resolveConnectProvider("anthropic-oauth", "local");
     const githubCopilot = resolveConnectProvider("github-copilot", "local");
+    const grok = resolveConnectProvider("grok", "local");
 
-    if (!anthropicOAuth || !githubCopilot) {
+    if (!anthropicOAuth || !githubCopilot || !grok) {
       throw new Error("Expected local OAuth providers to resolve");
     }
 
@@ -156,6 +158,16 @@ describe("connect provider normalization", () => {
     expect(anthropicOAuth.byokProvider.oauthProviderId).toBe("anthropic");
     expect(isConnectOAuthProvider(githubCopilot)).toBe(true);
     expect(githubCopilot.byokProvider.oauthProviderId).toBe("github-copilot");
+    expect(grok.canonical).toBe("xai");
+    expect(grok.byokProvider).toMatchObject({
+      displayName: "xAI (Grok/X subscription)",
+      providerType: "xai",
+      providerName: "xai",
+      isOAuth: true,
+      oauthProviderId: "xai",
+    });
+    expect(listConnectProviderTokens("local")).toContain("grok");
+    expect(listConnectProviderTokens("api")).not.toContain("grok");
   });
 
   test("uses environment keys before API-key optional defaults", () => {


### PR DESCRIPTION
## Summary

Local Letta Code inherits xAI device-code OAuth and Grok models from Pi, but the connection surface only exposed the provider as `xai`. This adds `grok` as a local-only alias and includes it in provider completion.

It also invalidates the model availability cache after any successful local Pi OAuth login. Previously, `/model` could retain the catalog fetched before login for five minutes, hiding the newly connected Grok models even though the credentials were saved correctly.

Validated with focused OAuth/provider tests and the full `bun run check` suite.

👾 Generated with [Letta Code](https://letta.com)