### PR TITLE
chore: remove watcher implementation code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,13 +12,7 @@
 # Headless mode runtime
 /src/headless.ts @cpacker @4shub @kl2806 @devanshrj @sarahwooders @jnjpng @carenthomas
 
-# Codex agent watcher and source prompt provenance
-/.github/workflows/codex-agent-watch.yml @kl2806
-/.github/agent-prompts/codex-agent-watch.md @kl2806
-/scripts/codex-watch/ @kl2806
-/.github/workflows/claude-agent-watch.yml @kl2806
-/.github/agent-prompts/claude-agent-watch.md @kl2806
-/scripts/claude-watch/ @kl2806
+# Codex source prompt provenance
 /src/agent/prompts/source_codex.md @kl2806
 
 # TUI/CLI runtime and UI


### PR DESCRIPTION
## Summary
- remove CODEOWNERS rules for the Claude and Codex watcher workflows, prompts, and implementation scripts
- retain ownership of the generated Codex source provenance file
- leave output PR reviewer assignment to each watcher’s configurable reviewer list

## Test plan
- [x] `bun run check`
- [x] `git diff --check`

👾 Generated with [Letta Code](https://letta.com)