### PR TITLE
fix(cli): keep streaming through interleaved reasoning re-entry

### DIFF
--- a/scripts/source-file-size-baseline.json
+++ b/scripts/source-file-size-baseline.json
@@ -16,7 +16,7 @@
   "src/cli/components/ModelSelector.tsx": 1259,
   "src/cli/components/ProviderSelector.tsx": 1692,
   "src/cli/components/ToolCallMessageRich.tsx": 1109,
-  "src/cli/helpers/accumulator.ts": 1600,
+  "src/cli/helpers/accumulator.ts": 1620,
   "src/cli/helpers/reflection-transcript.ts": 1956,
   "src/cli/mods/local-mod-loader.test.ts": 1043,
   "src/cli/reflection-transcript.test.ts": 1084,

--- a/src/cli/helpers/accumulator-reentry.test.ts
+++ b/src/cli/helpers/accumulator-reentry.test.ts
@@ -1,0 +1,263 @@
+import { describe, expect, test } from "bun:test";
+import type { LettaStreamingResponse } from "@letta-ai/letta-client/resources/agents/messages";
+import {
+  createBuffers,
+  type Line,
+  markCurrentLineAsFinished,
+  onChunk,
+  toLines,
+} from "@/cli/helpers/accumulator";
+
+function reasoning(otid: string, delta: string): LettaStreamingResponse {
+  return {
+    message_type: "reasoning_message",
+    otid,
+    reasoning: delta,
+  } as unknown as LettaStreamingResponse;
+}
+
+function assistant(otid: string, delta: string): LettaStreamingResponse {
+  return {
+    message_type: "assistant_message",
+    otid,
+    content: delta,
+  } as unknown as LettaStreamingResponse;
+}
+
+function textOf(line: Line | undefined): string {
+  if (!line) throw new Error("missing line");
+  if (line.kind === "assistant" || line.kind === "reasoning") return line.text;
+  throw new Error(`unexpected line kind: ${line.kind}`);
+}
+
+function nothingContentStreaming(b: ReturnType<typeof createBuffers>): boolean {
+  return toLines(b).every((line) => {
+    if (line.kind !== "assistant" && line.kind !== "reasoning") return true;
+    return line.phase === "finished";
+  });
+}
+
+describe("interleaved reasoning/assistant blocks", () => {
+  test("R -> A -> R -> A merges re-entered deltas into one live line per block", () => {
+    const b = createBuffers("agent-1");
+
+    onChunk(b, reasoning("R1", "first "));
+    onChunk(b, reasoning("R1", "second"));
+    expect(b.byId.get("R1")).toMatchObject({
+      kind: "reasoning",
+      phase: "streaming",
+      text: "first second",
+    });
+
+    // The assistant start does NOT finalize the reasoning block: an OTID
+    // switch proves interleaving, not closure.
+    onChunk(b, assistant("A1", "say"));
+    expect(b.byId.get("R1")).toMatchObject({
+      kind: "reasoning",
+      phase: "streaming",
+      text: "first second",
+    });
+    expect(b.byId.get("A1")).toMatchObject({
+      kind: "assistant",
+      phase: "streaming",
+      text: "say",
+    });
+
+    // The resumed reasoning fragment merges into the still-live reasoning
+    // line: one row, no continuation machinery, no lost bytes.
+    onChunk(b, reasoning("R1", " ignored-tail"));
+    expect(b.byId.get("R1")).toMatchObject({
+      kind: "reasoning",
+      phase: "streaming",
+      text: "first second ignored-tail",
+    });
+    expect(b.byId.has("R1-cont-1")).toBe(false);
+    expect(b.byId.has("A1-cont-1")).toBe(false);
+
+    onChunk(b, assistant("A1", " bye"));
+    onChunk(b, assistant("A1", " world"));
+    expect(b.byId.get("A1")).toMatchObject({
+      kind: "assistant",
+      phase: "streaming",
+      text: "say bye world",
+    });
+
+    markCurrentLineAsFinished(b);
+    expect(b.byId.get("R1")).toMatchObject({
+      kind: "reasoning",
+      phase: "finished",
+      text: "first second ignored-tail",
+    });
+    expect(b.byId.get("A1")).toMatchObject({
+      kind: "assistant",
+      phase: "finished",
+      text: "say bye world",
+    });
+    expect(nothingContentStreaming(b)).toBe(true);
+    // Hooks see the complete merged block.
+    expect(b.lastReasoning).toBe("first second ignored-tail");
+  });
+
+  test("behaves the same with aggressive token streaming enabled", () => {
+    const b = createBuffers("agent-1");
+    b.tokenStreamingEnabled = true;
+
+    onChunk(b, reasoning("R1", "first "));
+    onChunk(b, assistant("A1", "say"));
+    onChunk(b, reasoning("R1", " tail"));
+    onChunk(b, assistant("A1", " bye"));
+    onChunk(b, assistant("A1", " world"));
+
+    markCurrentLineAsFinished(b);
+
+    expect(b.byId.get("A1")).toMatchObject({
+      kind: "assistant",
+      phase: "finished",
+      text: "say bye world",
+    });
+    expect(b.byId.get("R1")).toMatchObject({
+      kind: "reasoning",
+      phase: "finished",
+      text: "first  tail",
+    });
+    expect(nothingContentStreaming(b)).toBe(true);
+  });
+
+  test("immediate stop_reason after the final re-entry finalizes merged blocks", () => {
+    const b = createBuffers("agent-1");
+
+    onChunk(b, reasoning("R1", "r1 "));
+    onChunk(b, reasoning("R1", "r2"));
+    onChunk(b, assistant("A1", "say"));
+    onChunk(b, reasoning("R1", " tail"));
+    onChunk(b, assistant("A1", " bye world"));
+    markCurrentLineAsFinished(b);
+
+    expect(b.byId.get("A1")).toMatchObject({
+      kind: "assistant",
+      phase: "finished",
+      text: "say bye world",
+    });
+    expect(b.byId.get("R1")).toMatchObject({
+      kind: "reasoning",
+      phase: "finished",
+      text: "r1 r2 tail",
+    });
+    expect(b.lastReasoning).toBe("r1 r2 tail");
+    expect(nothingContentStreaming(b)).toBe(true);
+  });
+
+  test("A -> R -> A merges the resumed assistant tail into the live assistant line", () => {
+    const b = createBuffers("agent-1");
+
+    onChunk(b, assistant("A1", "hello"));
+    expect(b.byId.get("A1")).toMatchObject({
+      kind: "assistant",
+      phase: "streaming",
+      text: "hello",
+    });
+
+    // A reasoning block between the assistant chunks does not close A1.
+    onChunk(b, reasoning("R2", "thinking more"));
+    expect(b.byId.get("A1")).toMatchObject({ phase: "streaming" });
+    expect(b.byId.get("R2")).toMatchObject({ phase: "streaming" });
+
+    onChunk(b, assistant("A1", ", and world"));
+    expect(b.byId.get("A1")).toMatchObject({
+      kind: "assistant",
+      phase: "streaming",
+      text: "hello, and world",
+    });
+
+    markCurrentLineAsFinished(b);
+    expect(b.byId.get("A1")).toMatchObject({
+      kind: "assistant",
+      phase: "finished",
+      text: "hello, and world",
+    });
+    expect(b.byId.get("R2")).toMatchObject({
+      kind: "reasoning",
+      phase: "finished",
+      text: "thinking more",
+    });
+    expect(b.lastAssistantMessage).toBe("hello, and world");
+    expect(nothingContentStreaming(b)).toBe(true);
+  });
+
+  test("R -> A -> R -> stop leaves nothing streaming and merges the fragment", () => {
+    const b = createBuffers("agent-1");
+
+    onChunk(b, reasoning("R1", "r1"));
+    onChunk(b, assistant("A1", "say"));
+    onChunk(b, reasoning("R1", " tail"));
+    markCurrentLineAsFinished(b);
+
+    expect(nothingContentStreaming(b)).toBe(true);
+    expect(b.byId.get("R1")).toMatchObject({
+      kind: "reasoning",
+      phase: "finished",
+      text: "r1 tail",
+    });
+    expect(b.byId.get("A1")).toMatchObject({ phase: "finished" });
+  });
+
+  test("A -> R -> A -> stop leaves nothing streaming and merges the tail", () => {
+    const b = createBuffers("agent-1");
+
+    onChunk(b, assistant("A1", "hello"));
+    onChunk(b, reasoning("R2", "thinking"));
+    onChunk(b, assistant("A1", ", world"));
+    markCurrentLineAsFinished(b);
+
+    expect(nothingContentStreaming(b)).toBe(true);
+    expect(b.byId.get("A1")).toMatchObject({
+      kind: "assistant",
+      phase: "finished",
+      text: "hello, world",
+    });
+    expect(b.byId.get("R2")).toMatchObject({ phase: "finished" });
+  });
+
+  test("multiple reasoning re-entries merge into the same line (R -> A -> R -> A -> R)", () => {
+    const b = createBuffers("agent-1");
+
+    onChunk(b, reasoning("R1", "r1"));
+    onChunk(b, assistant("A1", "say"));
+    onChunk(b, reasoning("R1", " tail1"));
+    onChunk(b, assistant("A1", " bye"));
+    onChunk(b, reasoning("R1", " tail2"));
+    markCurrentLineAsFinished(b);
+
+    // Both fragments land on the single reasoning line; nothing is dropped.
+    expect(b.byId.get("R1")).toMatchObject({
+      kind: "reasoning",
+      phase: "finished",
+      text: "r1 tail1 tail2",
+    });
+    expect(b.byId.get("A1")).toMatchObject({
+      kind: "assistant",
+      phase: "finished",
+      text: "say bye",
+    });
+    expect(nothingContentStreaming(b)).toBe(true);
+  });
+
+  test("token streaming promotes a long re-entered tail via paragraph splits", () => {
+    const b = createBuffers("agent-1");
+    b.tokenStreamingEnabled = true;
+
+    onChunk(b, assistant("A1", "intro "));
+    onChunk(b, reasoning("R2", "more"));
+    // The assistant block resumes with a long paragraph-bounded tail:
+    // trySplitContent promotes the completed prefix instead of keeping one
+    // unbounded streaming line.
+    onChunk(b, assistant("A1", `para one\n\n${"x".repeat(1500)}`));
+
+    expect(b.byId.has("A1-split-0")).toBe(true);
+    expect(b.byId.get("A1")).toMatchObject({
+      kind: "assistant",
+      phase: "streaming",
+    });
+    expect(textOf(b.byId.get("A1"))).toBe("x".repeat(1500));
+  });
+});

--- a/src/cli/helpers/accumulator.ts
+++ b/src/cli/helpers/accumulator.ts
@@ -482,24 +482,56 @@ function markAsFinished(b: Buffers, id: string) {
   }
 }
 
-// Helper to mark previous otid's line as finished when transitioning to new otid
-function handleOtidTransition(b: Buffers, newOtid: string | undefined) {
-  // console.log(`[OTID_TRANSITION] Called with newOtid=${newOtid}, lastOtid=${b.lastOtid}`);
+// Finalize every still-streaming assistant/reasoning line. Content blocks stay
+// open across OTID switches (pi keys blocks by content index and permits
+// interleaving), so strong boundaries and stream end must sweep rather than
+// trust lastOtid.
+function finalizeOpenContentLines(b: Buffers): void {
+  for (const id of b.order) {
+    const line = b.byId.get(id);
+    if (
+      line &&
+      (line.kind === "assistant" || line.kind === "reasoning") &&
+      line.phase === "streaming"
+    ) {
+      markAsFinished(b, id);
+    }
+  }
+}
 
-  // If transitioning to a different otid (including null/undefined), finish only assistant/reasoning lines.
-  // Tool calls should finish exclusively when a tool_return arrives (merged by toolCallId).
+// A content block stays open until a strong boundary: a new block of the same
+// kind, a tool call, a user message, an event, or stream end. An OTID switch
+// to the other content kind is an interleave, not a closure.
+function handleOtidTransition(
+  b: Buffers,
+  newOtid: string | undefined,
+  incomingKind?: "assistant" | "reasoning" | "tool" | "user" | "event",
+) {
   if (b.lastOtid && b.lastOtid !== newOtid) {
     const prev = b.byId.get(b.lastOtid);
-    // console.log(`[OTID_TRANSITION] Found prev line: kind=${prev?.kind}, phase=${(prev as any)?.phase}`);
     if (prev && (prev.kind === "assistant" || prev.kind === "reasoning")) {
-      // console.log(`[OTID_TRANSITION] Marking ${b.lastOtid} as finished (was ${(prev as any).phase})`);
-      markAsFinished(b, b.lastOtid);
+      const isContent =
+        incomingKind === "assistant" || incomingKind === "reasoning";
+      if (isContent) {
+        const incoming = newOtid ? b.byId.get(newOtid) : undefined;
+        const reentersFinished =
+          incoming !== undefined &&
+          "phase" in incoming &&
+          incoming.phase === "finished";
+        if (incomingKind === prev.kind && !reentersFinished) {
+          markAsFinished(b, b.lastOtid);
+        }
+      } else if (incomingKind === "event") {
+        markAsFinished(b, b.lastOtid);
+      } else if (incomingKind === undefined) {
+        markAsFinished(b, b.lastOtid);
+      } else {
+        finalizeOpenContentLines(b);
+      }
     }
   }
 
-  // Update last otid (can be null)
   b.lastOtid = newOtid ?? null;
-  // console.log(`[OTID_TRANSITION] Updated lastOtid to ${b.lastOtid}`);
 }
 
 /**
@@ -507,19 +539,7 @@ function handleOtidTransition(b: Buffers, newOtid: string | undefined) {
  * Call this after stream completion to ensure the final line isn't stuck in "streaming" state.
  */
 export function markCurrentLineAsFinished(b: Buffers) {
-  // console.log(`[MARK_CURRENT_FINISHED] Called with lastOtid=${b.lastOtid}`);
-  if (!b.lastOtid) {
-    // console.log(`[MARK_CURRENT_FINISHED] No lastOtid, returning`);
-    return;
-  }
-  const prev = b.byId.get(b.lastOtid);
-  // console.log(`[MARK_CURRENT_FINISHED] Found line: kind=${prev?.kind}, phase=${(prev as any)?.phase}`);
-  if (prev && (prev.kind === "assistant" || prev.kind === "reasoning")) {
-    // console.log(`[MARK_CURRENT_FINISHED] Marking ${b.lastOtid} as finished`);
-    markAsFinished(b, b.lastOtid);
-  } else {
-    // console.log(`[MARK_CURRENT_FINISHED] Not marking (not assistant/reasoning or doesn't exist)`);
-  }
+  finalizeOpenContentLines(b);
 }
 
 /**
@@ -951,7 +971,7 @@ export function onChunk(
       }
 
       // Handle otid transition (mark previous line as finished)
-      handleOtidTransition(b, id);
+      handleOtidTransition(b, id, "reasoning");
 
       const delta = chunk.reasoning;
       const messageId =
@@ -994,7 +1014,7 @@ export function onChunk(
       if (!id) break;
 
       // Handle otid transition (mark previous line as finished)
-      handleOtidTransition(b, id);
+      handleOtidTransition(b, id, "assistant");
 
       const delta = extractTextPart(chunk.content); // NOTE: may be list of parts
       const messageId =
@@ -1042,7 +1062,7 @@ export function onChunk(
       if (!lineId) break;
 
       // Handle otid transition (mark previous line as finished)
-      handleOtidTransition(b, lineId);
+      handleOtidTransition(b, lineId, "user");
 
       // Extract text content from the user message
       const rawText = extractTextPart(chunk.content);
@@ -1090,7 +1110,7 @@ export function onChunk(
     case "tool_call_message":
     case "approval_request_message": {
       // Handle otid transition (mark previous line as finished)
-      handleOtidTransition(b, chunk.otid ?? undefined);
+      handleOtidTransition(b, chunk.otid ?? undefined, "tool");
 
       // Use deprecated tool_call or new tool_calls array
       const toolCall =
@@ -1463,7 +1483,7 @@ export function onChunk(
         if (!id) break;
 
         // Handle otid transition (mark previous line as finished)
-        handleOtidTransition(b, id);
+        handleOtidTransition(b, id, "event");
 
         if (eventType === "retry") {
           upsertStatusLine(b, id, formatRetryEventStatusLines(eventData));


### PR DESCRIPTION
## Summary

Properly handled interleaved reasoning after the agent response has started. Fixes an issue where the TUI would stop rendering the agent response. This was due to Letta freezing the block when it receives a new OTID. The code now checks if the OTID is being reused, and if so, does not freeze the current line. 

## Verification

Tested against opencode-go/deepseek-v4-flash with max reasoning (which currently requires #3793). Prior to this patch, the agent's response would be cut off very early. When Letta was restarted, it would be loaded properly. 

## AI Disclosure

<!-- Select exactly one authorship option, then acknowledge the policy. -->

- [ ] This pull request was written entirely by a human
- [x] This pull request was written with AI assistance and reviewed and edited by a human
- [x] I have read the [AI Policy](https://github.com/letta-ai/letta-code/blob/main/AI_POLICY.md) and agree to its terms

## AI Tool(s) Used

Letta Code. Analysis was assisted by Ezra in the discord: https://discord.com/channels/1161736243340640419/1539361997861294150

## Human Verification

I have reviewed and understand every change in this pull request and take responsibility for its correctness.
