### PR TITLE
ci: assign watcher output PR owners

### DIFF
--- a/.github/agent-prompts/claude-agent-watch.md
+++ b/.github/agent-prompts/claude-agent-watch.md
@@ -110,7 +110,7 @@ If a local change is required:
 - use a Conventional Commit title
 - open the PR as a draft
 - immediately verify `draft: true` and that the PR author matches the Expected GitHub login from the run inputs; if either is wrong, fix or close it instead of reporting success
-- before the tracker update, GET `repos/letta-ai/letta-code/pulls/${PR_URL##*/}/requested_reviewers` with the same explicit Amelia credential, then request each configured reviewer that is not already present with `test -n "$AMELIA_GITHUB_TOKEN" && GITHUB_TOKEN= GH_TOKEN="$AMELIA_GITHUB_TOKEN" gh api --method POST "repos/letta-ai/letta-code/pulls/${PR_URL##*/}/requested_reviewers" -f "reviewers[]=<login>"`; skip this only when the configured value is `none`
+- before the tracker update, GET `repos/letta-ai/letta-code/pulls/${PR_URL##*/}/requested_reviewers` with the same explicit Amelia credential, then request each configured reviewer that is not already present with `test -n "$AMELIA_GITHUB_TOKEN" && GITHUB_TOKEN= GH_TOKEN="$AMELIA_GITHUB_TOKEN" gh api --method POST "repos/letta-ai/letta-code/pulls/${PR_URL##*/}/requested_reviewers" -f "reviewers[]=<login>"`
 - include `Claude-watch: <candidate-id>`, package version, release URL, docs/runtime evidence, and validation in the body
 - never commit generated snapshots or analysis files to the parity branch
 
@@ -118,17 +118,13 @@ If a local change is required:
 
 Only for a `pr_created` outcome, after the tracker update succeeds, call the native `MessageChannel` tool with `action="send"`, `channel="slack"`, and `target="C0871ER46KT"` to send exactly one message. Do not use `curl` or another Slack API client.
 
-Use this message shape with the exact URLs from the run inputs and created PR. Convert each comma-separated Slack owner ID from the run inputs to a `<@USER_ID>` mention on the Owners line; omit that line when the configured value is `none`.
+Use the selected Slack owner ID from the run inputs and the created PR URL. Send exactly one line in this form:
 
 ```text
-Claude watcher created a parity PR for <candidate-id>.
-Owners: <owner-mentions>
-PR: <pr-url>
-Tracker: <tracker-issue-url>
-Workflow: <workflow-run-url>
+<@U079W8F9Z7G> https://github.com/letta-ai/letta-code/pull/1234
 ```
 
-The notification creates the Slack thread route back to this watcher conversation. Do not send a Slack notification for `no_local_impact` or `needs_human_review`.
+Replace the example values with the selected owner and created PR. Do not include a watcher prefix, tracker URL, workflow URL, or any other text. The notification creates the Slack thread route back to this watcher conversation. Do not send a Slack notification for `no_local_impact` or `needs_human_review`.
 
 ## Final response
 

--- a/.github/agent-prompts/codex-agent-watch.md
+++ b/.github/agent-prompts/codex-agent-watch.md
@@ -98,7 +98,7 @@ If you create a PR:
 - create a new branch from the checked-out branch
 - use `test -n "$AMELIA_GITHUB_TOKEN" && GITHUB_TOKEN= GH_TOKEN="$AMELIA_GITHUB_TOKEN"` for GitHub CLI commands so the sandbox injects the watcher-specific GitHub credentials
 - verify the created PR author matches the Expected GitHub login from the run inputs; if it does not, close the PR instead of reporting success
-- before the tracker update, GET `repos/letta-ai/letta-code/pulls/${PR_URL##*/}/requested_reviewers` with the same explicit Amelia credential, then request each configured reviewer that is not already present with `test -n "$AMELIA_GITHUB_TOKEN" && GITHUB_TOKEN= GH_TOKEN="$AMELIA_GITHUB_TOKEN" gh api --method POST "repos/letta-ai/letta-code/pulls/${PR_URL##*/}/requested_reviewers" -f "reviewers[]=<login>"`; skip this only when the configured value is `none`
+- before the tracker update, GET `repos/letta-ai/letta-code/pulls/${PR_URL##*/}/requested_reviewers` with the same explicit Amelia credential, then request each configured reviewer that is not already present with `test -n "$AMELIA_GITHUB_TOKEN" && GITHUB_TOKEN= GH_TOKEN="$AMELIA_GITHUB_TOKEN" gh api --method POST "repos/letta-ai/letta-code/pulls/${PR_URL##*/}/requested_reviewers" -f "reviewers[]=<login>"`
 - keep the diff minimal and focused on this Codex release
 - do not include unrelated cleanup
 - use a Conventional Commit PR title, for example `chore(tools): align Codex schema wording`
@@ -110,17 +110,13 @@ If you create a PR:
 
 Only for a `pr_created` outcome, after the tracker update succeeds, call the native `MessageChannel` tool with `action="send"`, `channel="slack"`, and `target="C0871ER46KT"` to send exactly one message. Do not use `curl` or another Slack API client.
 
-Use this message shape with the exact URLs from the run inputs and created PR. Convert each comma-separated Slack owner ID from the run inputs to a `<@USER_ID>` mention on the Owners line; omit that line when the configured value is `none`.
+Use the selected Slack owner ID from the run inputs and the created PR URL. Send exactly one line in this form:
 
 ```text
-Codex watcher created a parity PR for <tag>.
-Owners: <owner-mentions>
-PR: <pr-url>
-Tracker: <tracker-issue-url>
-Workflow: <workflow-run-url>
+<@U079W8F9Z7G> https://github.com/letta-ai/letta-code/pull/1234
 ```
 
-The notification creates the Slack thread route back to this watcher conversation. Do not send a Slack notification for `no_local_impact` or `needs_human_review`.
+Replace the example values with the selected owner and created PR. Do not include a watcher prefix, tracker URL, workflow URL, or any other text. The notification creates the Slack thread route back to this watcher conversation. Do not send a Slack notification for `no_local_impact` or `needs_human_review`.
 
 ## Final response
 

--- a/.github/workflows/claude-agent-watch.yml
+++ b/.github/workflows/claude-agent-watch.yml
@@ -117,9 +117,18 @@ jobs:
           VERDICT: ${{ steps.detect.outputs.verdict }}
           STATE_COMMIT_SHA: ${{ steps.detect.outputs.state_commit_sha }}
           EXPECTED_GITHUB_LOGIN: ${{ steps.github-identity.outputs.login }}
-          GITHUB_REVIEWERS: ${{ vars.CLAUDE_WATCH_GITHUB_REVIEWERS }}
-          SLACK_OWNER_IDS: ${{ vars.CLAUDE_WATCH_SLACK_OWNER_IDS }}
+          OWNERS: ${{ vars.CLAUDE_WATCH_OWNERS }}
         run: |
+          jq -e '
+            type == "array" and length > 0 and
+            all(.[];
+              ((.github | type) == "string" and (.github | length) > 0) and
+              ((.slack | type) == "string" and (.slack | test("^U[A-Z0-9]+$")))
+            )
+          ' <<< "$OWNERS" > /dev/null
+          github_reviewers=$(jq -r 'map(.github) | join(",")' <<< "$OWNERS")
+          owner_count=$(jq 'length' <<< "$OWNERS")
+          slack_owner_id=$(jq -r --argjson index "$((RANDOM % owner_count))" '.[$index].slack' <<< "$OWNERS")
           {
             echo "prompt<<AMELIA_PROMPT_EOF"
             cat .github/agent-prompts/claude-agent-watch.md
@@ -129,8 +138,8 @@ jobs:
             echo "- Tracker issue: #$TRACKER_ISSUE ($TRACKER_ISSUE_URL)"
             echo "- Workflow run: $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
             echo "- Expected GitHub login: $EXPECTED_GITHUB_LOGIN"
-            echo "- GitHub reviewers: ${GITHUB_REVIEWERS:-none}"
-            echo "- Slack owner IDs: ${SLACK_OWNER_IDS:-none}"
+            echo "- GitHub reviewers: $github_reviewers"
+            echo "- Slack owner ID: $slack_owner_id"
             echo "- Candidate ID: $CANDIDATE_ID"
             echo "- Current package: @anthropic-ai/claude-code@$CURRENT_VERSION"
             echo "- Previous package: @anthropic-ai/claude-code@$PREVIOUS_VERSION"

--- a/.github/workflows/codex-agent-watch.yml
+++ b/.github/workflows/codex-agent-watch.yml
@@ -74,9 +74,18 @@ jobs:
           PREVIOUS_TAG: ${{ steps.detect.outputs.previous_tag }}
           VERDICT: ${{ steps.detect.outputs.verdict }}
           EXPECTED_GITHUB_LOGIN: ${{ steps.github-identity.outputs.login }}
-          GITHUB_REVIEWERS: ${{ vars.CODEX_WATCH_GITHUB_REVIEWERS }}
-          SLACK_OWNER_IDS: ${{ vars.CODEX_WATCH_SLACK_OWNER_IDS }}
+          OWNERS: ${{ vars.CODEX_WATCH_OWNERS }}
         run: |
+          jq -e '
+            type == "array" and length > 0 and
+            all(.[];
+              ((.github | type) == "string" and (.github | length) > 0) and
+              ((.slack | type) == "string" and (.slack | test("^U[A-Z0-9]+$")))
+            )
+          ' <<< "$OWNERS" > /dev/null
+          github_reviewers=$(jq -r 'map(.github) | join(",")' <<< "$OWNERS")
+          owner_count=$(jq 'length' <<< "$OWNERS")
+          slack_owner_id=$(jq -r --argjson index "$((RANDOM % owner_count))" '.[$index].slack' <<< "$OWNERS")
           {
             echo "prompt<<AMELIA_PROMPT_EOF"
             cat .github/agent-prompts/codex-agent-watch.md
@@ -86,8 +95,8 @@ jobs:
             echo "- Tracker issue: #$TRACKER_ISSUE ($TRACKER_ISSUE_URL)"
             echo "- Workflow run: $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
             echo "- Expected GitHub login: $EXPECTED_GITHUB_LOGIN"
-            echo "- GitHub reviewers: ${GITHUB_REVIEWERS:-none}"
-            echo "- Slack owner IDs: ${SLACK_OWNER_IDS:-none}"
+            echo "- GitHub reviewers: $github_reviewers"
+            echo "- Slack owner ID: $slack_owner_id"
             echo "- Current tag: $CURRENT_TAG"
             echo "- Previous tag: $PREVIOUS_TAG"
             echo "- Detector verdict: $VERDICT"


### PR DESCRIPTION
## Summary
- request Charles, Kevin, and Devansh as reviewers on every watcher-created parity PR
- select one configured owner at random for the routed Slack notification
- reduce the Slack message to the selected mention and PR link only

## Test plan
- [x] `bun run check`
- [x] owner mapping validation
- [x] random Slack selection validation
- [x] watcher notification contract assertions
- [x] `git diff --check`

👾 Generated with [Letta Code](https://letta.com)