### PR TITLE
ci: harden code review authentication

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -50,7 +50,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.AMELIA_GITHUB_TOKEN }}
 
-      - uses: letta-ai/letta-code-action@bd5cc55fcbad7be71134ce93406ca477e9fc6ec3
+      - uses: letta-ai/letta-code-action@244cc9e80c77cfebdb3ec8e146e018a5fe0af027
         id: letta_review
         with:
           letta_api_key: ${{ secrets.AMELIA_LETTA_API_KEY }}

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -6,23 +6,25 @@ on:
   workflow_dispatch:
     inputs:
       pr_number:
-        description: "PR number to review"
+        description: "PR number to review, including an approved external PR"
         required: true
         type: number
 
 jobs:
   review:
-    # Only run on non-draft PRs or manual dispatch. Dependabot PRs do not get
-    # access to the Amelia secrets used by this workflow.
+    # Fork pull_request runs do not receive the Amelia secrets even after a
+    # maintainer approves the Actions run. Use workflow_dispatch to explicitly
+    # review an external PR after approval.
     if: >
       (github.event_name == 'workflow_dispatch') ||
-      (github.event.pull_request.draft == false && github.actor != 'dependabot[bot]')
+      (github.event.pull_request.draft == false &&
+       github.actor != 'dependabot[bot]' &&
+       github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: write
       issues: write
-      checks: read
     env:
       PR_NUMBER: ${{ github.event.inputs.pr_number || github.event.pull_request.number }}
     steps:
@@ -30,39 +32,12 @@ jobs:
         with:
           fetch-depth: 0
 
-      # Wait for CI lint to pass before running review
-      - name: Wait for CI lint
-        id: lint_wait
-        if: github.event_name == 'pull_request'
-        run: |
-          # Poll until the lint check completes
-          for i in $(seq 1 30); do
-            STATUS=$(gh api "repos/$GITHUB_REPOSITORY/commits/${{ github.event.pull_request.head.sha }}/check-runs" \
-              --jq '.check_runs[] | select(.name == "Lint & Type Check") | .status')
-            if [ "$STATUS" = "completed" ]; then
-              CONCLUSION=$(gh api "repos/$GITHUB_REPOSITORY/commits/${{ github.event.pull_request.head.sha }}/check-runs" \
-                --jq '.check_runs[] | select(.name == "Lint & Type Check") | .conclusion')
-              echo "Lint check completed: $CONCLUSION"
-              if [ "$CONCLUSION" != "success" ]; then
-                echo "Lint check failed or was cancelled ($CONCLUSION), skipping review"
-                echo "skipped=true" >> $GITHUB_OUTPUT
-                exit 0
-              fi
-              break
-            fi
-            echo "Waiting for lint check... (attempt $i/30)"
-            sleep 10
-          done
-        env:
-          GITHUB_TOKEN: ${{ secrets.AMELIA_GITHUB_TOKEN }}
-
       - name: React with eyes (review starting)
         id: eyes_reaction
-        if: steps.lint_wait.outputs.skipped != 'true'
         run: |
           # Clear any existing rocket from a previous LGTM run on this PR
           EXISTING_ROCKET=$(gh api repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/reactions \
-            --jq '.[] | select(.content == "rocket" and .user.login == "github-actions[bot]") | .id' | head -1)
+            --jq '.[] | select(.content == "rocket" and .user.login == "amelia-letta") | .id' | head -1)
           if [ -n "$EXISTING_ROCKET" ]; then
             echo "Clearing previous rocket reaction: $EXISTING_ROCKET"
             gh api repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/reactions/$EXISTING_ROCKET -X DELETE || true
@@ -73,11 +48,10 @@ jobs:
           echo "Eyes reaction ID: $REACTION_ID"
           echo "reaction_id=$REACTION_ID" >> $GITHUB_OUTPUT
         env:
-          GITHUB_TOKEN: ${{ secrets.AMELIA_GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.AMELIA_GITHUB_TOKEN }}
 
       - uses: letta-ai/letta-code-action@bd5cc55fcbad7be71134ce93406ca477e9fc6ec3
         id: letta_review
-        if: steps.lint_wait.outputs.skipped != 'true'
         with:
           letta_api_key: ${{ secrets.AMELIA_LETTA_API_KEY }}
           github_token: ${{ secrets.AMELIA_GITHUB_TOKEN }}
@@ -89,12 +63,24 @@ jobs:
           prompt: |
             You are reviewing PR #${{ env.PR_NUMBER }} in ${{ github.repository }}.
 
+            ## GitHub authentication
+
+            Before any `gh` command, run:
+
+            ```bash
+            export GH_TOKEN="$AMELIA_GITHUB_TOKEN"
+            export GITHUB_REPOSITORY="${{ github.repository }}"
+            export PR_NUMBER="${{ env.PR_NUMBER }}"
+            ```
+
+            Use `AMELIA_GITHUB_TOKEN` for every GitHub operation. Never use `CAREN_GITHUB_TOKEN`. The action's `github_token` authenticates action-side steps but is not forwarded into the cloud sandbox.
+
             ## Your job
 
             1. Read your review-knowledge.md memory file — it has the detailed codebase footguns, bug patterns, and provider-specific traps
-            2. Run `gh pr view $PR_NUMBER --json title,body,comments` to get the PR title, description, and comments
+            2. Run `gh pr view $PR_NUMBER --repo "$GITHUB_REPOSITORY" --json title,body,comments` to get the PR title, description, and comments
             3. Resolve any previously addressed comments — see "Resolving addressed comments" below
-            4. Run `gh pr diff $PR_NUMBER` to read the full diff
+            4. Run `gh pr diff $PR_NUMBER --repo "$GITHUB_REPOSITORY"` to read the full diff
             5. Assess whether the PR introduces real risk
             6. If nothing to flag, respond with exactly: `LGTM`
             7. If something to flag, leave inline review comments, then respond with exactly: `Left comments`
@@ -198,7 +184,7 @@ jobs:
                ```bash
                OWNER=$(echo $GITHUB_REPOSITORY | cut -d/ -f1)
                REPO=$(echo $GITHUB_REPOSITORY | cut -d/ -f2)
-               gh api graphql -f query="{ repository(owner: \"$OWNER\", name: \"$REPO\") { pullRequest(number: $PR_NUMBER) { reviewThreads(first: 50) { nodes { id isResolved comments(first: 1) { nodes { author { login } databaseId body path line } } } } } } }" --jq '.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false) | select(.comments.nodes[0].author.login == "amelia-letta-code") | {threadId: .id, commentId: .comments.nodes[0].databaseId, body: .comments.nodes[0].body[0:120], path: .comments.nodes[0].path, line: .comments.nodes[0].line}'
+               gh api graphql -f query="{ repository(owner: \"$OWNER\", name: \"$REPO\") { pullRequest(number: $PR_NUMBER) { reviewThreads(first: 50) { nodes { id isResolved comments(first: 1) { nodes { author { login } databaseId body path line } } } } } } }" --jq '.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false) | select(.comments.nodes[0].author.login == "amelia-letta") | {threadId: .id, commentId: .comments.nodes[0].databaseId, body: .comments.nodes[0].body[0:120], path: .comments.nodes[0].path, line: .comments.nodes[0].line}'
                ```
             2. For each unresolved thread, check the current code at that path/line. If the issue has been clearly addressed, resolve it:
                ```bash
@@ -208,6 +194,8 @@ jobs:
 
           followup_prompt: |
             Re-review PR #${{ env.PR_NUMBER }} in ${{ github.repository }} after its latest update.
+
+            Before any `gh` command, export `GH_TOKEN="$AMELIA_GITHUB_TOKEN"`, `GITHUB_REPOSITORY="${{ github.repository }}"`, and `PR_NUMBER="${{ env.PR_NUMBER }}"`. Never use `CAREN_GITHUB_TOKEN`.
 
             Use the review process, risk criteria, voice, and inline-comment instructions established earlier in this conversation.
 
@@ -219,7 +207,7 @@ jobs:
             6. If you leave inline review comments, respond with exactly: `Left comments`
 
       - name: React based on review outcome
-        if: steps.lint_wait.outputs.skipped != 'true' && steps.letta_review.outputs.execution_file != ''
+        if: steps.letta_review.outputs.execution_file != ''
         run: |
           # Parse the agent's final response from the execution file
           RESULT=$(cat "${{ steps.letta_review.outputs.execution_file }}" \
@@ -239,4 +227,4 @@ jobs:
             echo "Comments left — keeping eyes reaction"
           fi
         env:
-          GITHUB_TOKEN: ${{ secrets.AMELIA_GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.AMELIA_GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- require review agents to authenticate GitHub operations with `AMELIA_GITHUB_TOKEN` and correct stale Amelia account-name checks
- automatically run secret-backed reviews only for same-repository PRs, with manual dispatch as the explicit path for approved fork PRs
- remove the lint polling step and its unused checks permission

## Test plan
- [x] `bun run check`
- [x] `actionlint -ignore 'SC2086' .github/workflows/review.yml`
- [x] verify recent fork failures came from missing secrets after Actions approval

Cost summary reporting is fixed separately in https://github.com/letta-ai/letta-code-action/pull/32.

Linear: [LET-11216](https://linear.app/letta/issue/LET-11216/fix-code-review-workflow-authentication-and-gating)

👾 Generated with [Letta Code](https://letta.com)