### PR TITLE
ci: add pi-ai upgrade watcher

### DIFF
--- a/.github/agent-prompts/pi-ai-agent-watch.md
+++ b/.github/agent-prompts/pi-ai-agent-watch.md
@@ -1,0 +1,120 @@
+You are Amelia running in your managed cloud sandbox for `letta-ai/letta-code`, dispatched by GitHub Actions.
+
+Your job is to review one stable `@earendil-works/pi-ai` release, decide whether Letta Code should adopt it, and either open one complete dependency/integration PR or record why no upgrade is currently needed.
+
+## GitHub authentication
+
+Before running the sandbox bootstrap, resolve the watcher credential identity with `test -n "$AMELIA_GITHUB_TOKEN" && GITHUB_TOKEN= GH_TOKEN="$AMELIA_GITHUB_TOKEN" gh api user --jq .login`. It must exactly match the Expected GitHub login from the run inputs. If the secret is missing or the identities differ, stop without modifying GitHub or the tracker.
+
+## Sandbox setup
+
+The detector ran on a GitHub Actions runner, but your turn does not. Runner files and environment variables are unavailable in the sandbox. Run the exact `Sandbox bootstrap` block appended to this prompt, then use `SetWorkingDirectory` to select `/tmp/letta-code-pi-ai-watch`. If `SetWorkingDirectory` is unavailable, pass that absolute directory as `workdir` for every command.
+
+The rebuilt `/tmp/pi-ai-watch-analysis.json` is the source of truth for the exact adjacent release pair. It includes the installed Letta Code dependency version, npm artifact metadata, the release changelog section, upstream changed files, and compare URL.
+
+## Required review behavior
+
+1. Read the complete analysis JSON and changelog section.
+2. Clone `earendil-works/pi` separately and inspect the complete `packages/ai/**` diff for the exact adjacent release pair. Do not classify from changelog prose or commit titles alone.
+3. Run `npm diff` for the two exact package versions when generated declarations, exports, catalogs, or shipped JavaScript matter. The npm artifacts, not only the monorepo source, define the dependency Letta Code consumes.
+4. Compare the release against every implicated Letta Code integration surface. Check types, runtime behavior, cancellation, auth, provider catalogs, model defaults, message/stream semantics, error handling, standalone bundling, and tests as applicable.
+5. If the installed version is older than the Previous release in the run inputs, also inspect the cumulative installed-to-current changelog and source/package diff before opening a PR. A skipped release must not create a migration gap later.
+6. Decide whether the release is worth adopting now:
+   - Upgrade when it fixes or improves provider behavior Letta Code uses, changes a consumed contract, adds support we should expose, resolves a security/reliability issue, or is needed to keep the integration current.
+   - Record `no_upgrade` when the release is genuinely irrelevant to Letta Code and staying on the installed version is intentional for now.
+   - Record `needs_human_review` when impact or product policy is unclear. Do not guess.
+7. If upgrading, update the dependency and lockfile to the Current release and make all required application changes in the same PR. Do not leave compile breaks, runtime contract gaps, provider catalog drift, or missing feature wiring for a follow-up.
+8. Keep pi-ai as the owner of provider runtime behavior. Do not duplicate image filtering, provider capability checks, request-format fixups, model catalog data, or retry logic inside Letta Code when the new pi-ai version already owns it.
+9. Search open and closed PRs for the exact marker before creating anything: `Pi-ai-watch: <previous>...<current>`. Recover an existing open matching PR rather than creating a duplicate. Do not adopt a closed unmerged PR.
+10. Use only `test -n "$AMELIA_GITHUB_TOKEN" && GITHUB_TOKEN= GH_TOKEN="$AMELIA_GITHUB_TOKEN"` for GitHub operations. Never use `CAREN_GITHUB_TOKEN` or a general `GITHUB_TOKEN` secret.
+11. Do not merge, wait for CI, or update the upgrade PR after creation.
+
+## Local integration map
+
+Narrow based on the actual diff, but start with:
+
+- dependency/build: `package.json`, `bun.lock`, `bun.nix`, `build.js`, `src/standalone-entry.ts`
+- provider catalogs/defaults: `src/backend/dev/pi-provider-registry.ts`, `src/providers/byok-providers.ts`, `src/providers/local-pi-provider-catalog.test.ts`
+- runtime/model collection: `src/backend/dev/pi-models-runtime.ts`, `src/backend/dev/pi-model-factory.ts`, `src/backend/dev/pi-api-streams.ts`
+- dynamic providers: `src/backend/dev/pi-local-endpoint-provider.ts`, `src/backend/dev/pi-mod-provider.ts`, adjacent `pi-*-provider.ts` implementations
+- auth/OAuth/credentials: `src/backend/dev/pi-oauth.ts`, `src/backend/local/local-pi-credential-store.ts`, `src/backend/local/local-provider-auth-store.ts`, connect command paths
+- streaming/messages/compaction: `src/backend/dev/pi-stream-adapter.ts`, `src/backend/local/local-message.ts`, `src/backend/local/local-message-projection.ts`, `src/backend/local/local-stream-chunks.ts`, `src/backend/local/compaction.ts`
+- test utilities and contract fixtures: `src/test-utils/pi-refresh-context.ts` and adjacent pi-ai tests
+
+When the upstream provider inventory changes, the local catalog coverage tests should prove that each provider/default is either supported or intentionally excluded. When a public contract changes, test both successful behavior and cancellation/failure semantics, not only TypeScript compilation.
+
+## Upgrade workflow
+
+For an upgrade:
+
+1. Create a fresh branch from current `main`.
+2. Update to the exact Current release while preserving the repository's dependency range style, for example `bun add '@earendil-works/pi-ai@^<current>'`.
+3. Follow repository instructions for every generated dependency artifact affected by the lockfile.
+4. Fix required application integration and add focused tests.
+5. Run `bun run check`, the relevant pi-ai/provider/runtime tests, and build validation appropriate to the diff. If a documented platform-specific validation cannot run, say so in the PR body and tracker note.
+6. Open one draft PR with a Conventional Commit title.
+7. Include all of these in the PR body:
+   - `Pi-ai-watch: <previous>...<current>`
+   - installed and target package versions
+   - upstream compare and release URLs
+   - changelog items that matter locally
+   - application changes or explicit reasons none were needed
+   - validation performed
+8. Immediately verify `draft: true` and that the PR author matches the Expected GitHub login. If either is wrong, fix or close the PR instead of reporting success.
+9. Request the single GitHub reviewer from the run inputs unless already requested.
+
+## Tracker updates
+
+Always update the tracker before your final response. Use `scripts/pi-ai-watch/update-tracker.ts`, not a normal issue comment.
+
+No upgrade needed:
+
+```bash
+test -n "$AMELIA_GITHUB_TOKEN" && GITHUB_TOKEN= GH_TOKEN="$AMELIA_GITHUB_TOKEN" bun scripts/pi-ai-watch/update-tracker.ts \
+  --tracker-issue <tracker-issue> \
+  --analysis-file /tmp/pi-ai-watch-analysis.json \
+  --outcome no_upgrade \
+  --notes "<specific reason this release does not warrant adoption>"
+```
+
+PR created or recovered:
+
+```bash
+test -n "$AMELIA_GITHUB_TOKEN" && GITHUB_TOKEN= GH_TOKEN="$AMELIA_GITHUB_TOKEN" bun scripts/pi-ai-watch/update-tracker.ts \
+  --tracker-issue <tracker-issue> \
+  --analysis-file /tmp/pi-ai-watch-analysis.json \
+  --outcome pr_created \
+  --pr-url "$PR_URL" \
+  --expected-github-login <expected-login> \
+  --notes "<dependency and application integration summary>"
+```
+
+Blocked or uncertain:
+
+```bash
+test -n "$AMELIA_GITHUB_TOKEN" && GITHUB_TOKEN= GH_TOKEN="$AMELIA_GITHUB_TOKEN" bun scripts/pi-ai-watch/update-tracker.ts \
+  --tracker-issue <tracker-issue> \
+  --analysis-file /tmp/pi-ai-watch-analysis.json \
+  --outcome needs_human_review \
+  --notes "<exact uncertainty or blocker>"
+```
+
+A `pr_created` outcome remains pending and blocks later upgrade PRs until that PR merges or closes. `no_upgrade` and `needs_human_review` advance the adjacent release audit cursor. Errors remain retryable.
+
+## Slack notification
+
+Only for `pr_created`, after the tracker update succeeds, call the native `MessageChannel` tool with `action="send"`, `channel="slack"`, and `target="C0871ER46KT"`. Send exactly one line using the selected Slack owner ID and PR URL:
+
+```text
+<@U079W8F9Z7G> https://github.com/letta-ai/letta-code/pull/1234
+```
+
+Replace the example values. Do not include a watcher prefix, tracker URL, workflow URL, or other text. Do not notify Slack for `no_upgrade` or `needs_human_review`.
+
+## Final response
+
+After the tracker update and any required Slack notification succeed, respond with exactly one line:
+
+- `PR_CREATED <url>`
+- `NO_UPGRADE <current-version>`
+- `NEEDS_HUMAN_REVIEW <current-version>`

--- a/.github/workflows/pi-ai-agent-watch.yml
+++ b/.github/workflows/pi-ai-agent-watch.yml
@@ -1,0 +1,174 @@
+name: pi-ai Agent Watch
+
+on:
+  schedule:
+    - cron: "34 */2 * * *"
+  workflow_dispatch:
+    inputs:
+      previous_version:
+        description: "Previous exact stable pi-ai version"
+        required: false
+        type: string
+      current_version:
+        description: "Current exact stable pi-ai version"
+        required: false
+        type: string
+      dry_run:
+        description: "Build analysis only; do not update the tracker or invoke Amelia"
+        required: false
+        default: false
+        type: boolean
+
+concurrency:
+  group: pi-ai-agent-watch
+  cancel-in-progress: false
+
+jobs:
+  watch:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.10
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Detect next stable pi-ai release
+        id: detect
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PREVIOUS_VERSION: ${{ inputs.previous_version }}
+          CURRENT_VERSION: ${{ inputs.current_version }}
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          ARGS=(--analysis-file "$RUNNER_TEMP/pi-ai-watch-analysis.json")
+          if [ -n "$PREVIOUS_VERSION" ]; then
+            ARGS+=(--previous-version "$PREVIOUS_VERSION")
+          fi
+          if [ -n "$CURRENT_VERSION" ]; then
+            ARGS+=(--current-version "$CURRENT_VERSION")
+          fi
+          if [ "$DRY_RUN" = "true" ]; then
+            ARGS+=(--dry-run)
+          fi
+          bun scripts/pi-ai-watch/agent-watch.ts "${ARGS[@]}"
+
+      - name: Resolve Amelia GitHub identity
+        id: github-identity
+        if: steps.detect.outputs.should_run_agent == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.AMELIA_GITHUB_TOKEN }}
+        run: |
+          login=$(gh api user --jq .login)
+          echo "login=$login" >> "$GITHUB_OUTPUT"
+          echo "Authenticated GitHub login: $login"
+
+      - name: Build Amelia prompt
+        id: prompt
+        if: steps.detect.outputs.should_run_agent == 'true'
+        env:
+          TRACKER_ISSUE: ${{ steps.detect.outputs.tracker_issue }}
+          TRACKER_ISSUE_URL: ${{ steps.detect.outputs.tracker_issue_url }}
+          INSTALLED_VERSION: ${{ steps.detect.outputs.installed_version }}
+          PREVIOUS_VERSION: ${{ steps.detect.outputs.previous_version }}
+          CURRENT_VERSION: ${{ steps.detect.outputs.current_version }}
+          EXPECTED_GITHUB_LOGIN: ${{ steps.github-identity.outputs.login }}
+          OWNERS: ${{ vars.PI_AI_WATCH_OWNERS }}
+        run: |
+          jq -e '
+            type == "array" and length > 0 and
+            all(.[];
+              ((.github | type) == "string" and (.github | length) > 0) and
+              ((.slack | type) == "string" and (.slack | test("^U[A-Z0-9]+$")))
+            )
+          ' <<< "$OWNERS" > /dev/null
+          owner_count=$(jq 'length' <<< "$OWNERS")
+          selected_owner=$(jq --argjson index "$((RANDOM % owner_count))" '.[$index]' <<< "$OWNERS")
+          github_reviewer=$(jq -r '.github' <<< "$selected_owner")
+          slack_owner_id=$(jq -r '.slack' <<< "$selected_owner")
+          {
+            echo "prompt<<AMELIA_PROMPT_EOF"
+            cat .github/agent-prompts/pi-ai-agent-watch.md
+            echo
+            echo "## Run inputs"
+            echo
+            echo "- Tracker issue: #$TRACKER_ISSUE ($TRACKER_ISSUE_URL)"
+            echo "- Workflow run: $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+            echo "- Expected GitHub login: $EXPECTED_GITHUB_LOGIN"
+            echo "- GitHub reviewer: $github_reviewer"
+            echo "- Slack owner ID: $slack_owner_id"
+            echo "- Installed package: @earendil-works/pi-ai@$INSTALLED_VERSION"
+            echo "- Previous release: $PREVIOUS_VERSION"
+            echo "- Current release: $CURRENT_VERSION"
+            echo
+            echo "## Sandbox bootstrap"
+            echo
+            echo "Run this exact block before reviewing the release:"
+            echo
+            echo '```bash'
+            echo 'set -euo pipefail'
+            echo 'rm -rf /tmp/letta-code-pi-ai-watch'
+            echo 'test -n "$AMELIA_GITHUB_TOKEN" && GITHUB_TOKEN= GH_TOKEN="$AMELIA_GITHUB_TOKEN" gh repo clone letta-ai/letta-code /tmp/letta-code-pi-ai-watch'
+            echo 'cd /tmp/letta-code-pi-ai-watch'
+            echo 'bun install --frozen-lockfile'
+            echo "test -n \"\$AMELIA_GITHUB_TOKEN\" && GITHUB_TOKEN= GH_TOKEN=\"\$AMELIA_GITHUB_TOKEN\" GITHUB_SERVER_URL=https://github.com GITHUB_REPOSITORY=letta-ai/letta-code GITHUB_RUN_ID=\"$GITHUB_RUN_ID\" bun scripts/pi-ai-watch/agent-watch.ts --dry-run --previous-version \"$PREVIOUS_VERSION\" --current-version \"$CURRENT_VERSION\" --analysis-file /tmp/pi-ai-watch-analysis.json > /tmp/pi-ai-watch-analysis.log"
+            echo "jq -e '.previous_version == \"$PREVIOUS_VERSION\" and .current_version == \"$CURRENT_VERSION\" and .installed_version == \"$INSTALLED_VERSION\" and (.changed_files | type == \"array\")' /tmp/pi-ai-watch-analysis.json > /dev/null"
+            echo '```'
+            echo "AMELIA_PROMPT_EOF"
+          } >> "$GITHUB_OUTPUT"
+          echo "conversation_name=$GITHUB_WORKFLOW $(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> "$GITHUB_OUTPUT"
+
+      - name: Ask Amelia to review pi-ai release
+        if: steps.detect.outputs.should_run_agent == 'true'
+        uses: letta-ai/letta-code-action@244cc9e80c77cfebdb3ec8e146e018a5fe0af027
+        with:
+          letta_api_key: ${{ secrets.AMELIA_LETTA_API_KEY }}
+          github_token: ${{ secrets.AMELIA_GITHUB_TOKEN }}
+          agent_id: agent-cd664b86-4d28-49b7-8ad6-60677eaff9be
+          environment: cloud
+          letta_args: >-
+            --new --name "${{ steps.prompt.outputs.conversation_name }}"
+          track_progress: ""
+          tracking_comment: "false"
+          model: auto
+          prompt: ${{ steps.prompt.outputs.prompt }}
+
+      - name: Verify recorded outcome
+        if: steps.detect.outputs.should_run_agent == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          bun scripts/pi-ai-watch/update-tracker.ts \
+            --tracker-issue "${{ steps.detect.outputs.tracker_issue }}" \
+            --previous-version "${{ steps.detect.outputs.previous_version }}" \
+            --current-version "${{ steps.detect.outputs.current_version }}" \
+            --assert-recorded
+
+      - name: Record failed review attempt
+        if: failure() && steps.detect.outputs.should_run_agent == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if bun scripts/pi-ai-watch/update-tracker.ts \
+            --tracker-issue "${{ steps.detect.outputs.tracker_issue }}" \
+            --previous-version "${{ steps.detect.outputs.previous_version }}" \
+            --current-version "${{ steps.detect.outputs.current_version }}" \
+            --assert-recorded; then
+            echo "The agent recorded an outcome before its action failed"
+            exit 0
+          fi
+          bun scripts/pi-ai-watch/update-tracker.ts \
+            --tracker-issue "${{ steps.detect.outputs.tracker_issue }}" \
+            --analysis-file "$RUNNER_TEMP/pi-ai-watch-analysis.json" \
+            --outcome error \
+            --notes "Amelia review failed before recording an outcome; retry this release"

--- a/scripts/pi-ai-watch/agent-watch.ts
+++ b/scripts/pi-ai-watch/agent-watch.ts
@@ -1,0 +1,253 @@
+#!/usr/bin/env bun
+
+import { appendFileSync, writeFileSync } from "node:fs";
+import {
+  createIssueWithBody,
+  editIssueBody,
+  ensureLabels,
+  findIssueByExactTitle,
+  getIssueBody,
+  getPullRequestStatus,
+} from "./github.ts";
+import {
+  analyzePiAiRelease,
+  compareStableVersions,
+  DEFAULT_TARGET_REPO,
+  findNextStableRelease,
+  listStableReleases,
+  readInstalledVersion,
+} from "./release-analysis.ts";
+import {
+  advanceMergedPr,
+  getPendingPrForCursor,
+  hasCompletedRange,
+  initialTrackerState,
+  parseTrackerState,
+  renderTrackerBody,
+} from "./tracker.ts";
+
+const DEFAULT_TRACKER_TITLE = "pi-ai dependency upgrade tracker";
+const DEFAULT_ANALYSIS_FILE = "pi-ai-watch-analysis.json";
+
+interface Args {
+  dryRun: boolean;
+  previousVersion: string | null;
+  currentVersion: string | null;
+  repo: string;
+  trackerTitle: string;
+  analysisFile: string;
+}
+
+interface TrackerIssue {
+  number: number;
+  url: string;
+  body: string;
+}
+
+function parseArgs(argv: string[]): Args {
+  const args: Args = {
+    dryRun: false,
+    previousVersion: null,
+    currentVersion: null,
+    repo: DEFAULT_TARGET_REPO,
+    trackerTitle: DEFAULT_TRACKER_TITLE,
+    analysisFile: DEFAULT_ANALYSIS_FILE,
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    if (argument === "--dry-run") args.dryRun = true;
+    else if (argument === "--previous-version") {
+      args.previousVersion = argv[++index] ?? null;
+    } else if (argument === "--current-version") {
+      args.currentVersion = argv[++index] ?? null;
+    } else if (argument === "--repo") {
+      args.repo = argv[++index] ?? args.repo;
+    } else if (argument === "--tracker-title") {
+      args.trackerTitle = argv[++index] ?? args.trackerTitle;
+    } else if (argument === "--analysis-file") {
+      args.analysisFile = argv[++index] ?? args.analysisFile;
+    } else if (argument === "--help" || argument === "-h") {
+      console.log(
+        "Usage: bun scripts/pi-ai-watch/agent-watch.ts [--dry-run] [--previous-version VERSION] [--current-version VERSION] [--repo OWNER/REPO] [--tracker-title TITLE] [--analysis-file FILE]",
+      );
+      process.exit(0);
+    } else {
+      throw new Error(`Unknown argument: ${argument}`);
+    }
+  }
+  return args;
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+  const installedVersion = readInstalledVersion();
+  const tracker = ensureTrackerIssue(args, installedVersion);
+  let state = parseTrackerState(tracker.body);
+  const releases = await listStableReleases();
+  let previousVersion = args.previousVersion;
+  let currentVersion = args.currentVersion;
+  const isScheduledSelection = !previousVersion && !currentVersion;
+
+  if (isScheduledSelection) {
+    const pending = getPendingPrForCursor(state);
+    if (pending?.pr_url) {
+      const status = getPullRequestStatus(pending.pr_url);
+      if (status.state === "OPEN") {
+        console.log(`Waiting for pending pi-ai upgrade PR: ${status.url}`);
+        writeCommonOutputs(tracker, {
+          installedVersion,
+          previousVersion: pending.previous_version,
+          currentVersion: pending.version,
+        });
+        writeOutput("pending_pr_url", status.url);
+        writeOutput("should_run_agent", "false");
+        return;
+      }
+      if (status.state === "MERGED") {
+        if (compareStableVersions(installedVersion, pending.version) < 0) {
+          throw new Error(
+            `Merged pi-ai PR ${status.url} targets ${pending.version}, but main still declares ${installedVersion}`,
+          );
+        }
+        state = advanceMergedPr(state, pending.version);
+        if (!args.dryRun) {
+          editIssueBody(args.repo, tracker.number, renderTrackerBody(state));
+        }
+      } else {
+        console.log(
+          `Retrying ${pending.version}; prior PR was closed unmerged.`,
+        );
+      }
+    }
+
+    const next = findNextStableRelease(releases, state.audit_cursor_version);
+    if (!next) {
+      console.log(
+        `No stable pi-ai release after ${state.audit_cursor_version}.`,
+      );
+      writeCommonOutputs(tracker, {
+        installedVersion,
+        previousVersion: state.audit_cursor_version,
+        currentVersion: state.audit_cursor_version,
+      });
+      writeOutput("should_run_agent", "false");
+      return;
+    }
+    previousVersion = state.audit_cursor_version;
+    currentVersion = next.version;
+  }
+
+  const analysis = await analyzePiAiRelease({
+    previousVersion,
+    currentVersion,
+    installedVersion,
+    stableReleases: releases,
+  });
+  writeFileSync(args.analysisFile, `${JSON.stringify(analysis, null, 2)}\n`);
+  writeCommonOutputs(tracker, {
+    installedVersion,
+    previousVersion: analysis.previous_version,
+    currentVersion: analysis.current_version,
+  });
+  writeOutput("analysis_file", args.analysisFile);
+
+  if (
+    !args.dryRun &&
+    hasCompletedRange(
+      state,
+      analysis.previous_version,
+      analysis.current_version,
+    )
+  ) {
+    console.log(
+      `Already completed pi-ai review ${analysis.previous_version}...${analysis.current_version}.`,
+    );
+    writeOutput("should_run_agent", "false");
+    return;
+  }
+
+  if (args.dryRun) {
+    console.log(JSON.stringify(analysis, null, 2));
+    writeOutput("should_run_agent", "false");
+    return;
+  }
+
+  console.log(
+    `pi-ai ${analysis.previous_version}...${analysis.current_version} needs Amelia review.`,
+  );
+  writeOutput("should_run_agent", "true");
+}
+
+function ensureTrackerIssue(
+  args: Args,
+  installedVersion: string,
+): TrackerIssue {
+  const existing = args.dryRun
+    ? null
+    : findIssueByExactTitle(args.repo, args.trackerTitle);
+  if (existing) {
+    return {
+      number: existing.number,
+      url: `https://github.com/${args.repo}/issues/${existing.number}`,
+      body: getIssueBody(args.repo, existing.number),
+    };
+  }
+
+  const body = renderTrackerBody(initialTrackerState(installedVersion));
+  if (args.dryRun) {
+    return {
+      number: 0,
+      url: `https://github.com/${args.repo}/issues/0`,
+      body,
+    };
+  }
+
+  const labels = ["pi-ai-watch", "automation"];
+  ensureLabels(args.repo, labels);
+  const issueUrl = createIssueWithBody(
+    args.repo,
+    args.trackerTitle,
+    body,
+    labels,
+  );
+  return {
+    number: issueNumberFromUrl(issueUrl),
+    url: issueUrl,
+    body,
+  };
+}
+
+function issueNumberFromUrl(issueUrl: string): number {
+  const issueNumber = Number(issueUrl.trim().split("/").at(-1));
+  if (!Number.isInteger(issueNumber) || issueNumber <= 0) {
+    throw new Error(`Could not parse issue number from ${issueUrl}`);
+  }
+  return issueNumber;
+}
+
+function writeCommonOutputs(
+  tracker: TrackerIssue,
+  versions: {
+    installedVersion: string;
+    previousVersion: string;
+    currentVersion: string;
+  },
+): void {
+  writeOutput("tracker_issue", String(tracker.number));
+  writeOutput("tracker_issue_url", tracker.url);
+  writeOutput("installed_version", versions.installedVersion);
+  writeOutput("previous_version", versions.previousVersion);
+  writeOutput("current_version", versions.currentVersion);
+}
+
+function writeOutput(name: string, value: string): void {
+  const outputPath = process.env.GITHUB_OUTPUT;
+  if (!outputPath) return;
+  appendFileSync(outputPath, `${name}=${value}\n`);
+}
+
+main().catch((error) => {
+  console.error(error);
+  writeOutput("should_run_agent", "false");
+  process.exit(1);
+});

--- a/scripts/pi-ai-watch/github.ts
+++ b/scripts/pi-ai-watch/github.ts
@@ -1,0 +1,145 @@
+import { spawnSync } from "node:child_process";
+import { rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+export interface PullRequestStatus {
+  state: "OPEN" | "CLOSED" | "MERGED";
+  url: string;
+}
+
+export function runGh(args: string[], input?: string): string {
+  const result = spawnSync("gh", args, {
+    encoding: "utf8",
+    input,
+    maxBuffer: 50 * 1024 * 1024,
+    stdio: input ? ["pipe", "pipe", "pipe"] : ["ignore", "pipe", "pipe"],
+  });
+  if (result.status !== 0) {
+    throw new Error(`gh ${args.join(" ")} failed:\n${result.stderr}`);
+  }
+  return result.stdout;
+}
+
+export function ghJson<T>(args: string[], input?: string): T {
+  return JSON.parse(runGh(args, input)) as T;
+}
+
+export function ensureLabels(repo: string, labels: string[]): void {
+  for (const label of labels) {
+    const result = spawnSync("gh", ["label", "create", label, "--repo", repo], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    if (result.status !== 0 && !result.stderr.includes("already exists")) {
+      throw new Error(`gh label create ${label} failed:\n${result.stderr}`);
+    }
+  }
+}
+
+export function createIssueWithBody(
+  repo: string,
+  title: string,
+  body: string,
+  labels: string[],
+): string {
+  const bodyFile = writeTempMarkdown(body, "pi-ai-watch-issue");
+  try {
+    const args = [
+      "issue",
+      "create",
+      "--repo",
+      repo,
+      "--title",
+      title,
+      "--body-file",
+      bodyFile,
+    ];
+    for (const label of labels) args.push("--label", label);
+    return runGh(args).trim();
+  } finally {
+    rmSync(bodyFile, { force: true });
+  }
+}
+
+export function editIssueBody(
+  repo: string,
+  issueNumber: number,
+  body: string,
+): void {
+  const bodyFile = writeTempMarkdown(body, "pi-ai-watch-tracker");
+  try {
+    runGh([
+      "issue",
+      "edit",
+      String(issueNumber),
+      "--repo",
+      repo,
+      "--body-file",
+      bodyFile,
+    ]);
+  } finally {
+    rmSync(bodyFile, { force: true });
+  }
+}
+
+export function getIssueBody(repo: string, issueNumber: number): string {
+  const issue = ghJson<{ body: string | null }>([
+    "issue",
+    "view",
+    String(issueNumber),
+    "--repo",
+    repo,
+    "--json",
+    "body",
+  ]);
+  return issue.body ?? "";
+}
+
+export function findIssueByExactTitle(
+  repo: string,
+  title: string,
+): { number: number; title: string } | null {
+  const issues = ghJson<Array<{ number: number; title: string }>>([
+    "issue",
+    "list",
+    "--repo",
+    repo,
+    "--state",
+    "all",
+    "--search",
+    `${title} in:title`,
+    "--limit",
+    "20",
+    "--json",
+    "number,title",
+  ]);
+  return issues.find((issue) => issue.title === title) ?? null;
+}
+
+export function getPullRequestStatus(prUrl: string): PullRequestStatus {
+  const match = /^https:\/\/github\.com\/([^/]+)\/([^/]+)\/pull\/(\d+)$/.exec(
+    prUrl,
+  );
+  if (!match) throw new Error(`Invalid GitHub pull request URL ${prUrl}`);
+  const [, owner, repo, number] = match;
+  const pull = ghJson<{ state: "OPEN" | "CLOSED"; mergedAt: string | null }>([
+    "pr",
+    "view",
+    number as string,
+    "--repo",
+    `${owner}/${repo}`,
+    "--json",
+    "state,mergedAt",
+  ]);
+  return {
+    state: pull.mergedAt ? "MERGED" : pull.state,
+    url: prUrl,
+  };
+}
+
+function writeTempMarkdown(body: string, prefix: string): string {
+  const path = join(tmpdir(), `${prefix}-${Date.now()}.md`);
+  writeFileSync(path, body);
+  return path;
+}

--- a/scripts/pi-ai-watch/release-analysis.test.ts
+++ b/scripts/pi-ai-watch/release-analysis.test.ts
@@ -1,0 +1,137 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  areAdjacentStableReleases,
+  compareStableVersions,
+  extractChangelogSection,
+  findNextStableRelease,
+  type PackageRelease,
+  parseRegistryMetadata,
+  readInstalledVersion,
+} from "./release-analysis.ts";
+
+const temporaryDirectories: string[] = [];
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe("pi-ai npm releases", () => {
+  test("filters prereleases and orders stable versions semantically", () => {
+    const releases = parseRegistryMetadata({
+      versions: {
+        "0.10.0": {
+          version: "0.10.0",
+          gitHead: "new",
+          dist: { integrity: "sha-new", tarball: "https://example/new.tgz" },
+        },
+        "0.9.1-beta.0": { version: "0.9.1-beta.0" },
+        "0.9.2": { version: "0.9.2" },
+      },
+      time: {
+        "0.10.0": "2026-01-03T00:00:00Z",
+        "0.9.1-beta.0": "2026-01-01T00:00:00Z",
+        "0.9.2": "2026-01-02T00:00:00Z",
+      },
+    });
+
+    expect(releases.map((release) => release.version)).toEqual([
+      "0.9.2",
+      "0.10.0",
+    ]);
+    expect(releases[1]).toMatchObject({
+      integrity: "sha-new",
+      tarball_url: "https://example/new.tgz",
+      git_head: "new",
+    });
+  });
+
+  test("rejects stable releases without publication times", () => {
+    expect(() =>
+      parseRegistryMetadata({
+        versions: { "0.82.1": { version: "0.82.1" } },
+        time: {},
+      }),
+    ).toThrow("missing publication time for 0.82.1");
+  });
+
+  test("selects exactly the next stable version after the cursor", () => {
+    const releases = releaseList("0.82.1", "0.83.0", "0.84.0");
+    expect(findNextStableRelease(releases, "0.82.1")?.version).toBe("0.83.0");
+    expect(findNextStableRelease(releases, "0.84.0")).toBeNull();
+    expect(() => findNextStableRelease(releases, "0.80.0")).toThrow(
+      "Could not find pi-ai cursor release 0.80.0",
+    );
+  });
+
+  test("recognizes only adjacent release pairs", () => {
+    const releases = releaseList("0.82.1", "0.83.0", "0.84.0");
+    expect(areAdjacentStableReleases(releases, "0.82.1", "0.83.0")).toBe(true);
+    expect(areAdjacentStableReleases(releases, "0.82.1", "0.84.0")).toBe(false);
+  });
+});
+
+describe("pi-ai release evidence", () => {
+  test("extracts only the requested changelog section", () => {
+    const changelog = `# Changelog
+
+## [0.84.0] - 2026-08-06
+
+### Added
+
+- Current feature.
+
+## [0.83.0] - 2026-07-29
+
+- Previous feature.
+`;
+    expect(
+      extractChangelogSection(changelog, "0.84.0"),
+    ).toBe(`## [0.84.0] - 2026-08-06
+
+### Added
+
+- Current feature.`);
+    expect(() => extractChangelogSection(changelog, "0.82.1")).toThrow(
+      "Could not find pi-ai changelog section 0.82.1",
+    );
+  });
+
+  test("reads the exact resolved version from bun.lock", () => {
+    const directory = mkdtempSync(join(tmpdir(), "pi-ai-watch-test-"));
+    temporaryDirectories.push(directory);
+    const lockfile = join(directory, "bun.lock");
+    writeFileSync(
+      lockfile,
+      `{
+  "workspaces": {
+    "": { "dependencies": { "@earendil-works/pi-ai": "^0.82.0" } }
+  },
+  "packages": {
+    "@earendil-works/pi-ai": ["@earendil-works/pi-ai@0.82.1", ""]
+  }
+}`,
+    );
+    expect(readInstalledVersion(lockfile)).toBe("0.82.1");
+  });
+
+  test("compares multi-digit semantic version components", () => {
+    expect(compareStableVersions("0.9.9", "0.10.0")).toBeLessThan(0);
+    expect(compareStableVersions("1.0.0", "0.99.99")).toBeGreaterThan(0);
+    expect(compareStableVersions("0.84.2", "0.84.2")).toBe(0);
+  });
+});
+
+function releaseList(...versions: string[]): PackageRelease[] {
+  return versions.map((version, index) => ({
+    version,
+    published_at: `2026-08-${String(index + 1).padStart(2, "0")}T00:00:00Z`,
+    integrity: null,
+    tarball_url: null,
+    git_head: null,
+  }));
+}

--- a/scripts/pi-ai-watch/release-analysis.ts
+++ b/scripts/pi-ai-watch/release-analysis.ts
@@ -1,0 +1,371 @@
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+export const PI_AI_PACKAGE = "@earendil-works/pi-ai";
+export const PI_AI_REPO = "earendil-works/pi";
+export const DEFAULT_TARGET_REPO =
+  process.env.GITHUB_REPOSITORY || "letta-ai/letta-code";
+
+interface RegistryVersion {
+  version: string;
+  gitHead?: string;
+  dist?: {
+    integrity?: string;
+    tarball?: string;
+  };
+}
+
+interface RegistryMetadata {
+  versions?: Record<string, RegistryVersion>;
+  time?: Record<string, string>;
+}
+
+export interface PackageRelease {
+  version: string;
+  published_at: string;
+  integrity: string | null;
+  tarball_url: string | null;
+  git_head: string | null;
+}
+
+export interface AnalyzePiAiReleaseOptions {
+  previousVersion: string | null;
+  currentVersion: string | null;
+  installedVersion?: string;
+  stableReleases?: PackageRelease[];
+}
+
+export interface PiAiWatchAnalysis {
+  package: typeof PI_AI_PACKAGE;
+  installed_version: string;
+  previous_version: string;
+  current_version: string;
+  is_adjacent_release: boolean;
+  published_at: string;
+  integrity: string | null;
+  tarball_url: string | null;
+  git_head: string | null;
+  release_url: string;
+  compare_url: string;
+  changelog_md: string;
+  changed_files: string[];
+  diff_stat: string;
+  package_json_diff: string | null;
+  workflow_run_url: string;
+}
+
+export async function analyzePiAiRelease(
+  options: AnalyzePiAiReleaseOptions,
+): Promise<PiAiWatchAnalysis> {
+  const releases = options.stableReleases ?? (await listStableReleases());
+  if (releases.length === 0) throw new Error("No stable pi-ai releases found");
+
+  const current = options.currentVersion
+    ? releases.find((release) => release.version === options.currentVersion)
+    : releases.at(-1);
+  if (!current) {
+    throw new Error(
+      `Could not find current pi-ai release ${options.currentVersion}`,
+    );
+  }
+
+  const previous = options.previousVersion
+    ? releases.find((release) => release.version === options.previousVersion)
+    : findPreviousStableRelease(releases, current.version);
+  if (!previous) {
+    throw new Error(
+      `Could not find previous pi-ai release before ${current.version}`,
+    );
+  }
+
+  const installedVersion = options.installedVersion ?? readInstalledVersion();
+  const previousTag = `v${previous.version}`;
+  const currentTag = `v${current.version}`;
+  const temp = mkdtempSync(join(tmpdir(), "pi-ai-watch-"));
+  try {
+    const repoDir = clonePi(temp);
+    fetchTag(repoDir, previousTag);
+    fetchTag(repoDir, currentTag);
+    verifyTagMatchesPackage(repoDir, previousTag, previous);
+    verifyTagMatchesPackage(repoDir, currentTag, current);
+    const changelog = showFile(repoDir, currentTag, "packages/ai/CHANGELOG.md");
+    if (changelog === null) {
+      throw new Error(`packages/ai/CHANGELOG.md is missing at ${currentTag}`);
+    }
+
+    return {
+      package: PI_AI_PACKAGE,
+      installed_version: installedVersion,
+      previous_version: previous.version,
+      current_version: current.version,
+      is_adjacent_release: areAdjacentStableReleases(
+        releases,
+        previous.version,
+        current.version,
+      ),
+      published_at: current.published_at,
+      integrity: current.integrity,
+      tarball_url: current.tarball_url,
+      git_head: current.git_head,
+      release_url: `https://github.com/${PI_AI_REPO}/releases/tag/${currentTag}`,
+      compare_url: `https://github.com/${PI_AI_REPO}/compare/${previousTag}...${currentTag}`,
+      changelog_md: extractChangelogSection(changelog, current.version),
+      changed_files: changedFiles(repoDir, previousTag, currentTag),
+      diff_stat: diffStat(repoDir, previousTag, currentTag),
+      package_json_diff: diffPreview(
+        repoDir,
+        previousTag,
+        currentTag,
+        "packages/ai/package.json",
+      ),
+      workflow_run_url: workflowRunUrl(),
+    };
+  } finally {
+    rmSync(temp, { recursive: true, force: true });
+  }
+}
+
+export async function listStableReleases(): Promise<PackageRelease[]> {
+  const response = await fetch(
+    "https://registry.npmjs.org/@earendil-works%2Fpi-ai",
+  );
+  if (!response.ok) {
+    throw new Error(
+      `npm registry request failed (${response.status}): ${await response.text()}`,
+    );
+  }
+  return parseRegistryMetadata((await response.json()) as RegistryMetadata);
+}
+
+export function parseRegistryMetadata(
+  metadata: RegistryMetadata,
+): PackageRelease[] {
+  if (!metadata.versions || !metadata.time) {
+    throw new Error(
+      "pi-ai npm metadata is missing versions or publication times",
+    );
+  }
+
+  return Object.entries(metadata.versions)
+    .filter(([version]) => isStableVersion(version))
+    .map(([version, details]) => {
+      const publishedAt = metadata.time?.[version];
+      if (!publishedAt) {
+        throw new Error(
+          `pi-ai npm metadata is missing publication time for ${version}`,
+        );
+      }
+      return {
+        version,
+        published_at: publishedAt,
+        integrity: details.dist?.integrity ?? null,
+        tarball_url: details.dist?.tarball ?? null,
+        git_head: details.gitHead ?? null,
+      };
+    })
+    .sort((left, right) => compareStableVersions(left.version, right.version));
+}
+
+export function readInstalledVersion(lockfilePath = "bun.lock"): string {
+  const lockfile = readFileSync(lockfilePath, "utf8");
+  const escapedPackage = escapeRegExp(PI_AI_PACKAGE);
+  const match = new RegExp(
+    `"${escapedPackage}": \\["${escapedPackage}@(\\d+\\.\\d+\\.\\d+)"`,
+  ).exec(lockfile);
+  if (!match?.[1]) {
+    throw new Error(
+      `Could not parse resolved ${PI_AI_PACKAGE} version from ${lockfilePath}`,
+    );
+  }
+  return match[1];
+}
+
+export function findNextStableRelease(
+  releases: PackageRelease[],
+  cursorVersion: string,
+): PackageRelease | null {
+  const index = releases.findIndex(
+    (release) => release.version === cursorVersion,
+  );
+  if (index < 0) {
+    throw new Error(`Could not find pi-ai cursor release ${cursorVersion}`);
+  }
+  return releases[index + 1] ?? null;
+}
+
+export function areAdjacentStableReleases(
+  releases: PackageRelease[],
+  previousVersion: string,
+  currentVersion: string,
+): boolean {
+  return (
+    findPreviousStableRelease(releases, currentVersion)?.version ===
+    previousVersion
+  );
+}
+
+export function extractChangelogSection(
+  changelog: string,
+  version: string,
+): string {
+  const heading = new RegExp(`^## \\[${escapeRegExp(version)}\\].*$`, "m");
+  const match = heading.exec(changelog);
+  if (!match)
+    throw new Error(`Could not find pi-ai changelog section ${version}`);
+  const start = match.index;
+  const remaining = changelog.slice(start + match[0].length);
+  const next = /^## \[/m.exec(remaining);
+  const end = next ? start + match[0].length + next.index : changelog.length;
+  return changelog.slice(start, end).trim();
+}
+
+function findPreviousStableRelease(
+  releases: PackageRelease[],
+  currentVersion: string,
+): PackageRelease | null {
+  const index = releases.findIndex(
+    (release) => release.version === currentVersion,
+  );
+  if (index <= 0) return null;
+  return releases[index - 1] ?? null;
+}
+
+export function compareStableVersions(left: string, right: string): number {
+  const leftParts = parseVersion(left);
+  const rightParts = parseVersion(right);
+  for (let index = 0; index < leftParts.length; index += 1) {
+    const difference = leftParts[index]! - rightParts[index]!;
+    if (difference !== 0) return difference;
+  }
+  return 0;
+}
+
+function parseVersion(version: string): [number, number, number] {
+  const match = /^(\d+)\.(\d+)\.(\d+)$/.exec(version);
+  if (!match) throw new Error(`Invalid stable pi-ai version ${version}`);
+  return [Number(match[1]), Number(match[2]), Number(match[3])];
+}
+
+function isStableVersion(version: string): boolean {
+  return /^\d+\.\d+\.\d+$/.test(version);
+}
+
+function clonePi(temp: string): string {
+  const directory = join(temp, "pi");
+  git([
+    "clone",
+    "--filter=blob:none",
+    "--no-checkout",
+    `https://github.com/${PI_AI_REPO}.git`,
+    directory,
+  ]);
+  return directory;
+}
+
+function fetchTag(repoDir: string, tag: string): void {
+  git(
+    [
+      "fetch",
+      "--filter=blob:none",
+      "origin",
+      `refs/tags/${tag}:refs/tags/${tag}`,
+    ],
+    repoDir,
+  );
+}
+
+function verifyTagMatchesPackage(
+  repoDir: string,
+  tag: string,
+  release: PackageRelease,
+): void {
+  if (!release.git_head) return;
+  const tagCommit = git(["rev-list", "-n", "1", tag], repoDir).trim();
+  if (tagCommit !== release.git_head) {
+    throw new Error(
+      `pi-ai npm ${release.version} gitHead ${release.git_head} does not match ${tag} commit ${tagCommit}`,
+    );
+  }
+}
+
+function showFile(repoDir: string, tag: string, path: string): string | null {
+  const result = spawnSync("git", ["show", `${tag}:${path}`], {
+    cwd: repoDir,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  return result.status === 0 ? result.stdout : null;
+}
+
+function changedFiles(
+  repoDir: string,
+  previousTag: string,
+  currentTag: string,
+): string[] {
+  return git(
+    [
+      "diff",
+      "--name-only",
+      `${previousTag}..${currentTag}`,
+      "--",
+      "packages/ai",
+    ],
+    repoDir,
+  )
+    .split("\n")
+    .filter(Boolean);
+}
+
+function diffStat(
+  repoDir: string,
+  previousTag: string,
+  currentTag: string,
+): string {
+  return git(
+    ["diff", "--stat", `${previousTag}..${currentTag}`, "--", "packages/ai"],
+    repoDir,
+  ).trim();
+}
+
+function diffPreview(
+  repoDir: string,
+  previousTag: string,
+  currentTag: string,
+  path: string,
+): string | null {
+  const output = git(
+    ["diff", "--unified=3", `${previousTag}..${currentTag}`, "--", path],
+    repoDir,
+  );
+  return output.trim() ? output.split("\n").slice(0, 160).join("\n") : null;
+}
+
+function git(args: string[], cwd?: string): string {
+  const result = spawnSync("git", args, {
+    cwd,
+    encoding: "utf8",
+    maxBuffer: 50 * 1024 * 1024,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  if (result.status !== 0) {
+    throw new Error(`git ${args.join(" ")} failed:\n${result.stderr}`);
+  }
+  return result.stdout;
+}
+
+function workflowRunUrl(): string {
+  if (
+    process.env.GITHUB_SERVER_URL &&
+    process.env.GITHUB_REPOSITORY &&
+    process.env.GITHUB_RUN_ID
+  ) {
+    return `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`;
+  }
+  return "local dry-run";
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/scripts/pi-ai-watch/tracker.test.ts
+++ b/scripts/pi-ai-watch/tracker.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, test } from "bun:test";
+import type { PiAiWatchAnalysis } from "./release-analysis.ts";
+import {
+  advanceMergedPr,
+  getPendingPrForCursor,
+  hasCompletedRange,
+  hasRecordedOutcome,
+  initialTrackerState,
+  parseTrackerState,
+  recordAnalysis,
+  renderTrackerBody,
+} from "./tracker.ts";
+
+describe("pi-ai watch tracker", () => {
+  test("round trips the initial installed-version cursor", () => {
+    const state = initialTrackerState("0.82.1");
+    expect(parseTrackerState(renderTrackerBody(state))).toEqual(state);
+  });
+
+  test("advances after a no-upgrade decision", () => {
+    const state = recordAnalysis(initialTrackerState("0.82.1"), {
+      analysis: analysis("0.82.1", "0.83.0"),
+      outcome: "no_upgrade",
+      notes: "upstream-only provider change",
+      processedAt: "2026-08-21T00:00:00Z",
+    });
+    expect(state.audit_cursor_version).toBe("0.83.0");
+    expect(hasCompletedRange(state, "0.82.1", "0.83.0")).toBe(true);
+    expect(hasRecordedOutcome(state, "0.82.1", "0.83.0")).toBe(true);
+  });
+
+  test("keeps a created PR pending until it merges", () => {
+    const pending = recordAnalysis(initialTrackerState("0.82.1"), {
+      analysis: analysis("0.82.1", "0.83.0"),
+      outcome: "pr_created",
+      notes: "upgrade",
+      prUrl: "https://github.com/letta-ai/letta-code/pull/123",
+      processedAt: "2026-08-21T00:00:00Z",
+    });
+    expect(pending.audit_cursor_version).toBe("0.82.1");
+    expect(getPendingPrForCursor(pending)?.version).toBe("0.83.0");
+    expect(hasCompletedRange(pending, "0.82.1", "0.83.0")).toBe(false);
+    expect(hasRecordedOutcome(pending, "0.82.1", "0.83.0")).toBe(true);
+
+    const merged = advanceMergedPr(pending, "0.83.0");
+    expect(merged.audit_cursor_version).toBe("0.83.0");
+    expect(getPendingPrForCursor(merged)).toBeNull();
+  });
+
+  test("keeps errors retryable and replaces them with a later outcome", () => {
+    const failed = recordAnalysis(initialTrackerState("0.82.1"), {
+      analysis: analysis("0.82.1", "0.83.0"),
+      outcome: "error",
+      notes: "agent failed",
+      processedAt: "2026-08-21T00:00:00Z",
+    });
+    expect(failed.audit_cursor_version).toBe("0.82.1");
+    expect(hasRecordedOutcome(failed, "0.82.1", "0.83.0")).toBe(false);
+
+    const retried = recordAnalysis(failed, {
+      analysis: analysis("0.82.1", "0.83.0"),
+      outcome: "no_upgrade",
+      notes: "reviewed on retry",
+      processedAt: "2026-08-21T01:00:00Z",
+    });
+    expect(retried.audit_cursor_version).toBe("0.83.0");
+    expect(retried.processed).toHaveLength(1);
+    expect(retried.processed[0]?.outcome).toBe("no_upgrade");
+  });
+
+  test("advances uncertain releases but not explicit non-adjacent replays", () => {
+    const human = recordAnalysis(initialTrackerState("0.82.1"), {
+      analysis: analysis("0.82.1", "0.83.0"),
+      outcome: "needs_human_review",
+      notes: "product decision",
+    });
+    expect(human.audit_cursor_version).toBe("0.83.0");
+
+    const replay = recordAnalysis(initialTrackerState("0.82.1"), {
+      analysis: analysis("0.82.1", "0.84.0", false),
+      outcome: "no_upgrade",
+      notes: "explicit replay",
+    });
+    expect(replay.audit_cursor_version).toBe("0.82.1");
+  });
+
+  test("rejects malformed hidden state", () => {
+    expect(() => parseTrackerState("missing")).toThrow(
+      "pi-ai tracker hidden state is missing",
+    );
+    expect(() =>
+      parseTrackerState(`<!-- pi-ai-watch-state
+{"audit_cursor_version":"latest","last_checked_version":null,"last_checked_at":null,"processed":[]}
+-->`),
+    ).toThrow("pi-ai tracker hidden state is invalid");
+  });
+
+  test("bounds tracker history", () => {
+    let state = initialTrackerState("0.1.0");
+    for (let index = 1; index <= 60; index += 1) {
+      const previous = `0.${index}.0`;
+      const current = `0.${index}.1`;
+      state = recordAnalysis(state, {
+        analysis: analysis(previous, current, false),
+        outcome: "error",
+        notes: `attempt ${index}`,
+        processedAt: `2026-08-21T00:${String(index).padStart(2, "0")}:00Z`,
+      });
+    }
+    expect(state.processed).toHaveLength(50);
+    expect(state.processed[0]?.version).toBe("0.60.1");
+  });
+});
+
+function analysis(
+  previousVersion: string,
+  currentVersion: string,
+  adjacent = true,
+): PiAiWatchAnalysis {
+  return {
+    package: "@earendil-works/pi-ai",
+    installed_version: "0.82.1",
+    previous_version: previousVersion,
+    current_version: currentVersion,
+    is_adjacent_release: adjacent,
+    published_at: "2026-08-14T00:00:00Z",
+    integrity: "sha512-test",
+    tarball_url: "https://example.test/pi-ai.tgz",
+    git_head: "abc123",
+    release_url: `https://github.com/earendil-works/pi/releases/tag/v${currentVersion}`,
+    compare_url: `https://github.com/earendil-works/pi/compare/v${previousVersion}...v${currentVersion}`,
+    changelog_md: "## Added",
+    changed_files: ["packages/ai/src/index.ts"],
+    diff_stat: "1 file changed",
+    package_json_diff: null,
+    workflow_run_url: "https://github.com/letta-ai/letta-code/actions/runs/1",
+  };
+}

--- a/scripts/pi-ai-watch/tracker.ts
+++ b/scripts/pi-ai-watch/tracker.ts
@@ -1,0 +1,303 @@
+import type { PiAiWatchAnalysis } from "./release-analysis.ts";
+
+const STATE_START = "<!-- pi-ai-watch-state";
+const STATE_END = "-->";
+const HISTORY_LIMIT = 50;
+const VISIBLE_LIMIT = 20;
+
+export type TrackerOutcome =
+  | "no_upgrade"
+  | "pr_created"
+  | "needs_human_review"
+  | "error";
+
+export interface TrackerEntry {
+  version: string;
+  previous_version: string;
+  installed_version: string;
+  outcome: TrackerOutcome;
+  pr_url: string | null;
+  notes: string;
+  processed_at: string;
+  compare_url: string;
+  workflow_run_url: string;
+}
+
+export interface TrackerState {
+  audit_cursor_version: string;
+  last_checked_version: string | null;
+  last_checked_at: string | null;
+  processed: TrackerEntry[];
+}
+
+export interface RecordAnalysisOptions {
+  analysis: PiAiWatchAnalysis;
+  outcome: TrackerOutcome;
+  notes: string;
+  prUrl?: string | null;
+  processedAt?: string;
+}
+
+export function initialTrackerState(installedVersion: string): TrackerState {
+  assertStableVersion(installedVersion);
+  return {
+    audit_cursor_version: installedVersion,
+    last_checked_version: null,
+    last_checked_at: null,
+    processed: [],
+  };
+}
+
+export function parseTrackerState(body: string): TrackerState {
+  const start = body.indexOf(STATE_START);
+  if (start === -1) throw new Error("pi-ai tracker hidden state is missing");
+  const jsonStart = start + STATE_START.length;
+  const end = body.indexOf(STATE_END, jsonStart);
+  if (end === -1) throw new Error("pi-ai tracker hidden state is incomplete");
+
+  try {
+    return normalizeState(JSON.parse(body.slice(jsonStart, end).trim()));
+  } catch (error) {
+    throw new Error("pi-ai tracker hidden state is invalid", { cause: error });
+  }
+}
+
+export function recordAnalysis(
+  state: TrackerState,
+  options: RecordAnalysisOptions,
+): TrackerState {
+  const entry: TrackerEntry = {
+    version: options.analysis.current_version,
+    previous_version: options.analysis.previous_version,
+    installed_version: options.analysis.installed_version,
+    outcome: options.outcome,
+    pr_url: options.prUrl ?? null,
+    notes: options.notes,
+    processed_at: options.processedAt ?? new Date().toISOString(),
+    compare_url: options.analysis.compare_url,
+    workflow_run_url: options.analysis.workflow_run_url,
+  };
+  const processed = [
+    entry,
+    ...state.processed.filter(
+      (existing) =>
+        existing.version !== entry.version ||
+        existing.previous_version !== entry.previous_version,
+    ),
+  ].slice(0, HISTORY_LIMIT);
+
+  const advancesCursor =
+    options.analysis.is_adjacent_release &&
+    entry.previous_version === state.audit_cursor_version &&
+    (entry.outcome === "no_upgrade" || entry.outcome === "needs_human_review");
+
+  return {
+    audit_cursor_version: advancesCursor
+      ? entry.version
+      : state.audit_cursor_version,
+    last_checked_version: entry.version,
+    last_checked_at: entry.processed_at,
+    processed,
+  };
+}
+
+export function hasRecordedOutcome(
+  state: TrackerState,
+  previousVersion: string,
+  currentVersion: string,
+): boolean {
+  return state.processed.some(
+    (entry) =>
+      entry.previous_version === previousVersion &&
+      entry.version === currentVersion &&
+      entry.outcome !== "error",
+  );
+}
+
+export function hasCompletedRange(
+  state: TrackerState,
+  previousVersion: string,
+  currentVersion: string,
+): boolean {
+  return state.processed.some(
+    (entry) =>
+      entry.previous_version === previousVersion &&
+      entry.version === currentVersion &&
+      (entry.outcome === "no_upgrade" ||
+        entry.outcome === "needs_human_review"),
+  );
+}
+
+export function getPendingPrForCursor(
+  state: TrackerState,
+): TrackerEntry | null {
+  return (
+    state.processed.find(
+      (entry) =>
+        entry.previous_version === state.audit_cursor_version &&
+        entry.outcome === "pr_created" &&
+        entry.pr_url,
+    ) ?? null
+  );
+}
+
+export function advanceMergedPr(
+  state: TrackerState,
+  currentVersion: string,
+): TrackerState {
+  const pending = getPendingPrForCursor(state);
+  if (!pending || pending.version !== currentVersion) {
+    throw new Error(`No pending pi-ai PR for ${currentVersion}`);
+  }
+  return { ...state, audit_cursor_version: currentVersion };
+}
+
+export function renderTrackerBody(state: TrackerState): string {
+  const normalized = normalizeState(state);
+  return `${[
+    "Central tracker for Amelia-driven pi-ai dependency upgrade reviews.",
+    "",
+    `_Audit cursor: ${normalized.audit_cursor_version}._`,
+    renderLastChecked(normalized),
+    "",
+    "## Recent reviews",
+    "",
+    renderTable(normalized),
+    "",
+    "## Hidden state",
+    "",
+    "The workflow uses the hidden JSON block below for ordered release processing and dedupe.",
+    "",
+    serializeTrackerState(normalized),
+  ].join("\n")}\n`;
+}
+
+export function serializeTrackerState(state: TrackerState): string {
+  const normalized = normalizeState(state);
+  return `${STATE_START}\n${JSON.stringify(normalized, null, 2)}\n${STATE_END}`;
+}
+
+function renderLastChecked(state: TrackerState): string {
+  if (!state.last_checked_version || !state.last_checked_at) {
+    return "_Last checked: never._";
+  }
+  const latest = state.processed.find(
+    (entry) => entry.version === state.last_checked_version,
+  );
+  const suffix = latest ? `, ${statusSummary(latest)}.` : ".";
+  return `_Last checked: ${state.last_checked_version} at ${state.last_checked_at}${suffix}_`;
+}
+
+function renderTable(state: TrackerState): string {
+  const entries = state.processed.slice(0, VISIBLE_LIMIT);
+  if (entries.length === 0) return "_No pi-ai releases reviewed yet._";
+
+  const rows = [
+    "| Release | Installed | Outcome | PR | Notes |",
+    "|---|---|---|---|---|",
+  ];
+  for (const entry of entries) {
+    rows.push(
+      `| [${entry.version}](${entry.compare_url}) | ${entry.installed_version} | ${entry.outcome} | ${renderPr(entry.pr_url)} | ${escapeTable(entry.notes)} |`,
+    );
+  }
+  return rows.join("\n");
+}
+
+function statusSummary(entry: TrackerEntry): string {
+  if (entry.outcome === "pr_created" && entry.pr_url) {
+    return `PR created: ${entry.pr_url}`;
+  }
+  return entry.notes || entry.outcome;
+}
+
+function renderPr(prUrl: string | null): string {
+  return prUrl ? `[PR](${prUrl})` : "-";
+}
+
+function escapeTable(value: string): string {
+  return value.replaceAll("|", "\\|").replaceAll("\n", " ");
+}
+
+function normalizeState(value: unknown): TrackerState {
+  if (!isRecord(value)) throw new TypeError("tracker state must be an object");
+  if (typeof value.audit_cursor_version !== "string") {
+    throw new TypeError("tracker audit cursor is invalid");
+  }
+  assertStableVersion(value.audit_cursor_version);
+  if (
+    !Array.isArray(value.processed) ||
+    !value.processed.every(isTrackerEntry)
+  ) {
+    throw new TypeError("tracker processed entries are invalid");
+  }
+  if (
+    value.last_checked_version !== null &&
+    typeof value.last_checked_version !== "string"
+  ) {
+    throw new TypeError("tracker last checked version is invalid");
+  }
+  if (
+    value.last_checked_at !== null &&
+    typeof value.last_checked_at !== "string"
+  ) {
+    throw new TypeError("tracker last checked time is invalid");
+  }
+
+  const processed = value.processed.slice(0, HISTORY_LIMIT) as TrackerEntry[];
+  const lastCheckedVersion = value.last_checked_version as string | null;
+  if (
+    lastCheckedVersion !== null &&
+    !processed.some((entry) => entry.version === lastCheckedVersion)
+  ) {
+    throw new TypeError("tracker last checked version is inconsistent");
+  }
+
+  return {
+    audit_cursor_version: value.audit_cursor_version,
+    last_checked_version: lastCheckedVersion,
+    last_checked_at: value.last_checked_at as string | null,
+    processed,
+  };
+}
+
+function isTrackerEntry(value: unknown): value is TrackerEntry {
+  if (!isRecord(value)) return false;
+  return (
+    typeof value.version === "string" &&
+    isStableVersion(value.version) &&
+    typeof value.previous_version === "string" &&
+    isStableVersion(value.previous_version) &&
+    typeof value.installed_version === "string" &&
+    isStableVersion(value.installed_version) &&
+    isOutcome(value.outcome) &&
+    (typeof value.pr_url === "string" || value.pr_url === null) &&
+    typeof value.notes === "string" &&
+    typeof value.processed_at === "string" &&
+    typeof value.compare_url === "string" &&
+    typeof value.workflow_run_url === "string"
+  );
+}
+
+function isOutcome(value: unknown): value is TrackerOutcome {
+  return (
+    value === "no_upgrade" ||
+    value === "pr_created" ||
+    value === "needs_human_review" ||
+    value === "error"
+  );
+}
+
+function assertStableVersion(version: string): void {
+  if (!isStableVersion(version)) {
+    throw new TypeError(`Invalid stable pi-ai version ${version}`);
+  }
+}
+
+function isStableVersion(version: string): boolean {
+  return /^\d+\.\d+\.\d+$/.test(version);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}

--- a/scripts/pi-ai-watch/update-tracker.ts
+++ b/scripts/pi-ai-watch/update-tracker.ts
@@ -1,0 +1,215 @@
+#!/usr/bin/env bun
+
+import { readFileSync } from "node:fs";
+import { editIssueBody, getIssueBody, ghJson } from "./github.ts";
+import {
+  DEFAULT_TARGET_REPO,
+  type PiAiWatchAnalysis,
+} from "./release-analysis.ts";
+import {
+  hasRecordedOutcome,
+  parseTrackerState,
+  recordAnalysis,
+  renderTrackerBody,
+  type TrackerOutcome,
+} from "./tracker.ts";
+
+interface Args {
+  repo: string;
+  trackerIssue: number | null;
+  analysisFile: string | null;
+  outcome: TrackerOutcome | null;
+  notes: string;
+  prUrl: string | null;
+  expectedGithubLogin: string | null;
+  previousVersion: string | null;
+  currentVersion: string | null;
+  assertRecorded: boolean;
+  dryRun: boolean;
+}
+
+function parseArgs(argv: string[]): Args {
+  const args: Args = {
+    repo: DEFAULT_TARGET_REPO,
+    trackerIssue: null,
+    analysisFile: null,
+    outcome: null,
+    notes: "",
+    prUrl: null,
+    expectedGithubLogin: null,
+    previousVersion: null,
+    currentVersion: null,
+    assertRecorded: false,
+    dryRun: false,
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    if (argument === "--repo") args.repo = argv[++index] ?? args.repo;
+    else if (argument === "--tracker-issue") {
+      args.trackerIssue = Number(argv[++index]);
+    } else if (argument === "--analysis-file") {
+      args.analysisFile = argv[++index] ?? null;
+    } else if (argument === "--outcome") {
+      args.outcome = parseOutcome(argv[++index]);
+    } else if (argument === "--notes") args.notes = argv[++index] ?? "";
+    else if (argument === "--pr-url") args.prUrl = argv[++index] ?? null;
+    else if (argument === "--expected-github-login") {
+      args.expectedGithubLogin = argv[++index] ?? null;
+    } else if (argument === "--previous-version") {
+      args.previousVersion = argv[++index] ?? null;
+    } else if (argument === "--current-version") {
+      args.currentVersion = argv[++index] ?? null;
+    } else if (argument === "--assert-recorded") args.assertRecorded = true;
+    else if (argument === "--dry-run") args.dryRun = true;
+    else if (argument === "--help" || argument === "-h") {
+      console.log(
+        "Usage: bun scripts/pi-ai-watch/update-tracker.ts --tracker-issue ISSUE [--analysis-file FILE --outcome OUTCOME --notes TEXT --pr-url URL --expected-github-login LOGIN] [--assert-recorded --previous-version VERSION --current-version VERSION] [--repo OWNER/REPO] [--dry-run]",
+      );
+      process.exit(0);
+    } else {
+      throw new Error(`Unknown argument: ${argument}`);
+    }
+  }
+
+  if (!args.trackerIssue || Number.isNaN(args.trackerIssue)) {
+    throw new Error("--tracker-issue is required");
+  }
+  if (args.assertRecorded) {
+    if (!args.previousVersion || !args.currentVersion) {
+      throw new Error(
+        "--previous-version and --current-version are required with --assert-recorded",
+      );
+    }
+    return args;
+  }
+  if (!args.analysisFile) throw new Error("--analysis-file is required");
+  if (!args.outcome) throw new Error("--outcome is required");
+  if (args.outcome === "pr_created") {
+    if (!args.prUrl) throw new Error("--pr-url is required for pr_created");
+    if (!args.expectedGithubLogin) {
+      throw new Error("--expected-github-login is required for pr_created");
+    }
+  }
+  return args;
+}
+
+function main(): void {
+  const args = parseArgs(process.argv.slice(2));
+  const issueNumber = args.trackerIssue as number;
+  const body = getIssueBody(args.repo, issueNumber);
+  const state = parseTrackerState(body);
+
+  if (args.assertRecorded) {
+    if (
+      !hasRecordedOutcome(
+        state,
+        args.previousVersion as string,
+        args.currentVersion as string,
+      )
+    ) {
+      throw new Error(
+        `No recorded pi-ai outcome for ${args.previousVersion}...${args.currentVersion}`,
+      );
+    }
+    console.log(
+      `Verified pi-ai outcome ${args.previousVersion}...${args.currentVersion}`,
+    );
+    return;
+  }
+
+  const analysis = JSON.parse(
+    readFileSync(args.analysisFile as string, "utf8"),
+  ) as PiAiWatchAnalysis;
+  if (args.outcome === "pr_created") {
+    verifyUpgradePr(
+      args.prUrl as string,
+      args.repo,
+      args.expectedGithubLogin as string,
+      analysis,
+    );
+  }
+
+  const next = recordAnalysis(state, {
+    analysis,
+    outcome: args.outcome as TrackerOutcome,
+    notes: args.notes || defaultNotes(args.outcome as TrackerOutcome),
+    prUrl: args.prUrl,
+  });
+  const nextBody = renderTrackerBody(next);
+  if (args.dryRun) {
+    console.log(nextBody);
+    return;
+  }
+  editIssueBody(args.repo, issueNumber, nextBody);
+  console.log(
+    `Recorded pi-ai ${analysis.current_version} as ${args.outcome} in #${issueNumber}`,
+  );
+}
+
+function verifyUpgradePr(
+  prUrl: string,
+  expectedRepo: string,
+  expectedGithubLogin: string,
+  analysis: PiAiWatchAnalysis,
+): void {
+  const match = /^https:\/\/github\.com\/([^/]+)\/([^/]+)\/pull\/(\d+)$/.exec(
+    prUrl,
+  );
+  if (!match) throw new Error(`Invalid GitHub pull request URL ${prUrl}`);
+  const [, owner, repo, number] = match;
+  if (`${owner}/${repo}` !== expectedRepo) {
+    throw new Error(`pi-ai upgrade PR must belong to ${expectedRepo}`);
+  }
+  const pull = ghJson<{
+    author: { login: string };
+    body: string;
+    isDraft: boolean;
+    state: string;
+  }>([
+    "pr",
+    "view",
+    number as string,
+    "--repo",
+    `${owner}/${repo}`,
+    "--json",
+    "author,body,isDraft,state",
+  ]);
+  const marker = `Pi-ai-watch: ${analysis.previous_version}...${analysis.current_version}`;
+  if (pull.author.login !== expectedGithubLogin) {
+    throw new Error(
+      `pi-ai PR author ${pull.author.login} does not match ${expectedGithubLogin}`,
+    );
+  }
+  if (!pull.isDraft) throw new Error("pi-ai upgrade PR must be a draft");
+  if (pull.state !== "OPEN") throw new Error("pi-ai upgrade PR must be open");
+  if (!pull.body.includes(marker)) {
+    throw new Error(`pi-ai upgrade PR is missing marker: ${marker}`);
+  }
+}
+
+function parseOutcome(value: string | undefined): TrackerOutcome {
+  if (
+    value === "no_upgrade" ||
+    value === "pr_created" ||
+    value === "needs_human_review" ||
+    value === "error"
+  ) {
+    return value;
+  }
+  throw new Error(`Unknown outcome: ${value}`);
+}
+
+function defaultNotes(outcome: TrackerOutcome): string {
+  switch (outcome) {
+    case "no_upgrade":
+      return "reviewed; no upgrade needed for this release";
+    case "pr_created":
+      return "opened pi-ai dependency upgrade PR";
+    case "needs_human_review":
+      return "needs human review";
+    case "error":
+      return "automation hit an error; retry this release";
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary

- watch stable `@earendil-works/pi-ai` releases every two hours and audit missed versions in order
- inspect exact npm artifacts, changelog entries, and upstream source diffs before deciding whether to upgrade
- dispatch Amelia to open complete dependency and application-integration PRs, with pending-PR gating and retryable failures
- randomly assign Charles, Caren, or Cameron as the output PR reviewer

## Validation

- `bun run check`
- `bun test scripts/pi-ai-watch/release-analysis.test.ts scripts/pi-ai-watch/tracker.test.ts`
- live dry-run analysis for `0.82.1...0.83.0`

Linear: https://linear.app/letta/issue/LET-11225/add-automated-pi-ai-package-upgrade-watcher