### PR TITLE
Add Cursor Cloud Agent environment bootstrap

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,4 @@
+{
+  "name": "letta-code",
+  "install": "bash .cursor/install.sh"
+}

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Pin the same Bun version as package.json "packageManager".
+export BUN_INSTALL="${HOME}/.bun"
+export PATH="${BUN_INSTALL}/bin:${PATH}"
+
+if ! command -v bun >/dev/null 2>&1 || [ "$(bun --version 2>/dev/null || true)" != "1.3.10" ]; then
+  curl -fsSL https://bun.sh/install | bash -s "bun-v1.3.10"
+fi
+
+if [ -x "${BUN_INSTALL}/bin/bun" ]; then
+  sudo ln -sfn "${BUN_INSTALL}/bin/bun" /usr/local/bin/bun
+fi
+if [ -e "${BUN_INSTALL}/bin/bunx" ]; then
+  sudo ln -sfn "${BUN_INSTALL}/bin/bunx" /usr/local/bin/bunx
+fi
+
+bun install --frozen-lockfile


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a repository-managed Cursor Cloud Agent environment so new agents can bootstrap this CLI repo from git instead of a dashboard Save panel (that panel is not available for this greenfield draft).

`.cursor/environment.json` runs `.cursor/install.sh`, which:
- installs Bun 1.3.10 (the version pinned in `package.json`)
- puts `bun` and `bunx` on `/usr/local/bin` (`bunx` is required for `bun run check` / biome)
- runs `bun install --frozen-lockfile`

No long-running `start` process is included: Letta Code is a CLI, not a web server.

## Verification

- Install script ran twice on the setup VM (idempotent)
- `bun run check`: 12/12 passed
- Headless local CLI (`--backend local --ephemeral` + deterministic executor): JSON `result` was `"pong"`
- Fresh Cloud Agent from this branch's snapshot: bun 1.3.10, bunx on PATH, `.cursor` files present, 12/12 checks, CLI `"pong"`

## AI Disclosure

- [ ] This pull request was written entirely by a human
- [x] This pull request was written with AI assistance and reviewed and edited by a human
- [x] I have read the [AI Policy](https://github.com/letta-ai/letta-code/blob/main/AI_POLICY.md) and agree to its terms

## AI Tool(s) Used

Cursor Cloud Agent (Grok 4.6)

## Human Verification

I have reviewed and understand every change in this pull request and take responsibility for its correctness.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-11c9b545-56a6-4aad-b5e9-bc64dde1f79b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-11c9b545-56a6-4aad-b5e9-bc64dde1f79b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

