### PR TITLE
fix(listener): publish approval boundary state [LET-11246]

### DIFF
--- a/src/websocket/listener/auth-lifecycle-approval-reconnect.test.ts
+++ b/src/websocket/listener/auth-lifecycle-approval-reconnect.test.ts
@@ -373,6 +373,7 @@ describe("listener approval reconnect timing", () => {
     });
 
     await new Promise((resolve) => setTimeout(resolve, 75));
+    expect(conversationRuntime.loopStatus).toBe("WAITING_ON_APPROVAL");
     expect(deps.executeApprovalBatch).toHaveBeenCalledTimes(0);
     expect(deps.ensureSecretsHydrated).toHaveBeenCalledTimes(0);
     expect(deps.sendApprovalContinuation).toHaveBeenCalledTimes(0);

--- a/src/websocket/listener/turn-approval.ts
+++ b/src/websocket/listener/turn-approval.ts
@@ -216,6 +216,17 @@ export async function handleApprovalStop(params: {
 
   clearPendingApprovalBatchIds(runtime, approvals);
   rememberPendingApprovalBatchIds(runtime, approvals, dequeuedBatchId);
+  // Publish the approval boundary before classification or transport recovery.
+  // If the listener disappears during either phase, runtime-status history can
+  // distinguish an orphaned approval from a run still processing model output.
+  setTurnLoopStatus(runtime, turnLease, "WAITING_ON_APPROVAL", {
+    agent_id: agentId,
+    conversation_id: conversationId,
+  });
+  emitRuntimeStateUpdates(runtime, {
+    agent_id: agentId,
+    conversation_id: conversationId,
+  });
 
   const { autoAllowed, autoDenied, needsUserInput } = await classifyApprovals(
     approvals,


### PR DESCRIPTION
## Summary
- publish `WAITING_ON_APPROVAL` before approval classification or transport recovery
- preserve a diagnosable runtime boundary if a cloud sandbox listener disappears before executing a client tool
- cover disconnected auto-approved tools with a regression assertion

Paired with cloud logging PR https://github.com/letta-ai/letta-cloud/pull/14854.

## Test plan
- [x] `bun test src/websocket/listener/auth-lifecycle-approval-reconnect.test.ts`
- [x] `bun run check`

👾 Generated with [Letta Code](https://letta.com)