### PR TITLE
fix(mods): batch registry updates during lifecycle

### DIFF
--- a/src/mods/mod-change-batcher.test.ts
+++ b/src/mods/mod-change-batcher.test.ts
@@ -1,0 +1,42 @@
+import { expect, test } from "bun:test";
+import { createModChangeBatcher } from "@/mods/mod-change-batcher";
+
+test("batches lifecycle notifications while preserving runtime updates", async () => {
+  let changes = 0;
+  const batcher = createModChangeBatcher(() => {
+    changes += 1;
+  });
+
+  const dispose = await batcher.run(async () => {
+    for (let index = 0; index < 20; index += 1) batcher.notify();
+    await Promise.resolve();
+    for (let index = 0; index < 20; index += 1) batcher.notify();
+    return () => {
+      for (let index = 0; index < 20; index += 1) batcher.notify();
+    };
+  });
+
+  expect(changes).toBe(1);
+  batcher.notify();
+  expect(changes).toBe(2);
+  batcher.runSync(dispose);
+  expect(changes).toBe(3);
+});
+
+test("discards pending notifications when activation fails", async () => {
+  let changes = 0;
+  const batcher = createModChangeBatcher(() => {
+    changes += 1;
+  });
+
+  await expect(
+    batcher.run(async () => {
+      batcher.notify();
+      throw new Error("activation failed");
+    }),
+  ).rejects.toThrow("activation failed");
+
+  expect(changes).toBe(0);
+  batcher.notify();
+  expect(changes).toBe(1);
+});

--- a/src/mods/mod-change-batcher.test.ts
+++ b/src/mods/mod-change-batcher.test.ts
@@ -1,42 +1,118 @@
 import { expect, test } from "bun:test";
-import { createModChangeBatcher } from "@/mods/mod-change-batcher";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import type Letta from "@letta-ai/letta-client";
+import {
+  disposeLocalMods,
+  type LocalModRegistry,
+  loadLocalMods,
+} from "@/mods/mod-engine";
+import type { ModPanelHandle } from "@/mods/types";
 
-test("batches lifecycle notifications while preserving runtime updates", async () => {
-  let changes = 0;
-  const batcher = createModChangeBatcher(() => {
-    changes += 1;
-  });
+type ModBatchingTestGlobal = typeof globalThis & {
+  __modBatchingPanel?: ModPanelHandle;
+};
 
-  const dispose = await batcher.run(async () => {
-    for (let index = 0; index < 20; index += 1) batcher.notify();
-    await Promise.resolve();
-    for (let index = 0; index < 20; index += 1) batcher.notify();
-    return () => {
-      for (let index = 0; index < 20; index += 1) batcher.notify();
-    };
-  });
+function createTempDir(): string {
+  return mkdtempSync(path.join(tmpdir(), "letta-mod-change-batcher-"));
+}
 
-  expect(changes).toBe(1);
-  batcher.notify();
-  expect(changes).toBe(2);
-  batcher.runSync(dispose);
-  expect(changes).toBe(3);
+function createLoadOptions(root: string) {
+  return {
+    cacheDirectory: path.join(root, "mod-cache"),
+    getClient: async () => ({}) as unknown as Letta,
+    globalModsDirectory: path.join(root, "global-mods"),
+    registerCapabilitiesGlobally: false,
+  };
+}
+
+test("coalesces real mod lifecycle changes without delaying runtime updates", async () => {
+  const root = createTempDir();
+  const testGlobal = globalThis as ModBatchingTestGlobal;
+  let registry: LocalModRegistry | null = null;
+  delete testGlobal.__modBatchingPanel;
+
+  try {
+    const options = createLoadOptions(root);
+    mkdirSync(options.globalModsDirectory, { recursive: true });
+    writeFileSync(
+      path.join(options.globalModsDirectory, "many-panels.ts"),
+      `export default async function(letta) {
+        const panels = [];
+        const register = (index) => {
+          panels.push(letta.ui.openPanel({
+            id: "status-" + index,
+            render: () => "panel-" + index,
+          }));
+        };
+        for (let index = 0; index < 10; index += 1) register(index);
+        await Promise.resolve();
+        for (let index = 10; index < 20; index += 1) register(index);
+        globalThis.__modBatchingPanel = panels[0];
+        return () => {
+          for (const panel of panels) panel.close();
+        };
+      }`,
+    );
+
+    let changes = 0;
+    registry = await loadLocalMods({
+      ...options,
+      onChange: () => {
+        changes += 1;
+      },
+    });
+
+    expect(Object.values(registry.ui.panels)).toHaveLength(20);
+    expect(changes).toBe(1);
+
+    const panel = testGlobal.__modBatchingPanel as ModPanelHandle | undefined;
+    expect(panel).toBeDefined();
+    panel?.update();
+    expect(changes).toBe(2);
+
+    disposeLocalMods(registry);
+    registry = null;
+    expect(changes).toBe(3);
+  } finally {
+    if (registry) disposeLocalMods(registry);
+    delete testGlobal.__modBatchingPanel;
+    rmSync(root, { force: true, recursive: true });
+  }
 });
 
-test("discards pending notifications when activation fails", async () => {
-  let changes = 0;
-  const batcher = createModChangeBatcher(() => {
-    changes += 1;
-  });
+test("does not publish capabilities from a failed activation", async () => {
+  const root = createTempDir();
+  let registry: LocalModRegistry | null = null;
 
-  await expect(
-    batcher.run(async () => {
-      batcher.notify();
-      throw new Error("activation failed");
-    }),
-  ).rejects.toThrow("activation failed");
+  try {
+    const options = createLoadOptions(root);
+    mkdirSync(options.globalModsDirectory, { recursive: true });
+    writeFileSync(
+      path.join(options.globalModsDirectory, "failed.ts"),
+      `export default function(letta) {
+        letta.ui.openPanel({ id: "partial", render: () => "partial" });
+        throw new Error("activation failed");
+      }`,
+    );
 
-  expect(changes).toBe(0);
-  batcher.notify();
-  expect(changes).toBe(1);
+    let changes = 0;
+    registry = await loadLocalMods({
+      ...options,
+      onChange: () => {
+        changes += 1;
+      },
+    });
+
+    expect(changes).toBe(0);
+    expect(registry.ui.panels).toEqual({});
+    expect(registry.loadedPaths).toEqual([]);
+    expect(registry.diagnostics).toContainEqual(
+      expect.objectContaining({ phase: "activate" }),
+    );
+  } finally {
+    if (registry) disposeLocalMods(registry);
+    rmSync(root, { force: true, recursive: true });
+  }
 });

--- a/src/mods/mod-change-batcher.ts
+++ b/src/mods/mod-change-batcher.ts
@@ -1,0 +1,42 @@
+export function createModChangeBatcher(onChange: () => void) {
+  let batching = false;
+  let changePending = false;
+
+  const notify = () => {
+    if (batching) {
+      changePending = true;
+      return;
+    }
+    onChange();
+  };
+
+  const finish = (publish: boolean) => {
+    batching = false;
+    if (!changePending) return;
+    changePending = false;
+    if (publish) onChange();
+  };
+
+  return {
+    notify,
+    async run<T>(operation: () => Promise<T> | T): Promise<T> {
+      batching = true;
+      try {
+        const result = await operation();
+        finish(true);
+        return result;
+      } catch (error) {
+        finish(false);
+        throw error;
+      }
+    },
+    runSync<T>(operation: () => T): T {
+      batching = true;
+      try {
+        return operation();
+      } finally {
+        finish(true);
+      }
+    },
+  };
+}

--- a/src/mods/mod-engine.ts
+++ b/src/mods/mod-engine.ts
@@ -33,6 +33,7 @@ import {
 } from "@/mods/deprecated-api";
 import { isTypeScriptModFileExtension } from "@/mods/file-extensions";
 import * as modInvocationContext from "@/mods/invocation-context";
+import { createModChangeBatcher } from "@/mods/mod-change-batcher";
 import {
   appendModDiagnostic,
   recordModDiagnostic,
@@ -1453,31 +1454,30 @@ export async function loadLocalMods(
         )) as LocalModModule;
         const factory = getModFactory(module);
         failurePhase = "activate";
-
         if (typeof factory !== "function") {
           throw new Error(
             "Mod must export a default function or activate() function",
           );
         }
-
-        const dispose = await (factory as LettaModFactory)(
-          createLettaModApi(
-            registry,
-            owner,
-            capabilities,
-            getConfiguredClient,
-            onChange,
-            options.onDiagnostic,
-            options.onNotification,
-            builtinCommandIds,
-            reservedToolNames,
-            abortController.signal,
-          ),
+        const changes = createModChangeBatcher(onChange);
+        const api = createLettaModApi(
+          registry,
+          owner,
+          capabilities,
+          getConfiguredClient,
+          changes.notify,
+          options.onDiagnostic,
+          options.onNotification,
+          builtinCommandIds,
+          reservedToolNames,
+          abortController.signal,
         );
+        const activate = factory as LettaModFactory;
+        const dispose = await changes.run(() => activate(api));
         if (typeof dispose === "function") {
           registry.disposers.push({
             abortController,
-            dispose,
+            dispose: () => changes.runSync(dispose),
             owner,
           });
         }


### PR DESCRIPTION
## Why
Loading a capability-heavy mod could print `Maximum update depth exceeded` during CLI startup. The Sprite mod exposed the problem because it registers a panel, several lifecycle hooks, tools, and a command during one activation, but it was using supported mod APIs correctly. Any sufficiently feature-rich mod could cross the same threshold, so fixing Sprite alone would only hide the underlying Letta Code bug.

## Root cause
Every capability registration mutated the same local mod registry and immediately called `onChange()`. Each call published a new adapter snapshot, which notified the `useSyncExternalStore` subscriber and scheduled another React update. A mod that registered many capabilities therefore produced a large synchronous burst of updates during activation. In the Ink React runtime, that burst could exceed the nested-update limit and trigger the warning.

Disposal followed the same pattern: a mod closing many handles could publish once per capability while reloading or shutting down.

## What changed
- add a per-mod change batcher that emits one registry notification after successful activation instead of one notification per registration
- apply the same batching around synchronous disposal
- continue publishing runtime changes such as `panel.update()` immediately after activation
- discard a pending activation notification when the factory throws, allowing the existing rollback and diagnostic path to publish the clean state

This changes notification frequency, not the resulting registry contents or capability ownership behavior.

## Test coverage
The tests exercise the production loader rather than the batching helper in isolation. A temporary asynchronous mod registers 20 real panels across an `await`, verifies that activation emits one change notification, confirms a later `panel.update()` publishes immediately, and confirms closing all 20 handles during disposal emits one notification. A second temporary mod registers a partial capability and throws; the test verifies that no partial state is published, the registry is rolled back, the mod is not marked loaded, and an activation diagnostic is retained.

The production bundle was also launched with the Sprite mod enabled to verify that startup completes without the React warning.

## Test plan
- [x] `bun run check`
- [x] `bun test ./src/mods`
- [x] `bun run build`
- [x] launch the built CLI with the Sprite mod enabled and confirm zero `Maximum update depth exceeded` warnings

> "One notification is enough."

Written by Cameron ◯ Letta Code