### PR TITLE
fix(app-server): avoid false pong timeouts after event-loop stalls

### DIFF
--- a/src/websocket/app-server.test.ts
+++ b/src/websocket/app-server.test.ts
@@ -537,22 +537,27 @@ describe("app-server native websocket", () => {
     }
   });
 
-  test("terminates sockets that exceed the pong timeout", async () => {
+  test("terminates sockets only after an unanswered heartbeat probe", async () => {
     let handle: AppServerHandle | null = null;
     let stream: WebSocket | null = null;
     try {
-      // A 1ms pong timeout means the seeded connect timestamp is already stale
-      // by the first interval tick, so the watchdog reaps the socket.
       handle = await startAppServer({
         listen: "ws://127.0.0.1:0",
         heartbeatIntervalMs: 25,
         pongTimeoutMs: 1,
+        shouldRecordPong: () => false,
       });
       stream = new WebSocket(handle.controlUrl);
+      const ping = waitForClientPing(stream);
       await waitForOpen(stream);
-
-      await waitForClientClose(stream);
-      expect(stream.readyState).not.toBe(WebSocket.OPEN);
+      const close = waitForClientClose(stream);
+      const firstEvent = await Promise.race([
+        ping.then(() => "ping"),
+        close.then(() => "close"),
+      ]);
+      expect(firstEvent).toBe("ping");
+      expect(stream.readyState).toBe(WebSocket.OPEN);
+      await close;
     } finally {
       closeClient(stream);
       await handle?.close();

--- a/src/websocket/app-server.ts
+++ b/src/websocket/app-server.ts
@@ -30,16 +30,20 @@ import {
   setActiveRuntime,
 } from "@/websocket/listener/runtime";
 import type { ListenerRuntime } from "@/websocket/listener/types";
+import {
+  createMissedPongWatchdog,
+  type MissedPongWatchdog,
+} from "@/websocket/missed-pong-watchdog";
 
 const DEFAULT_LISTEN_URL = "ws://127.0.0.1:0";
 const DEFAULT_WS_PATH = "/ws";
-// App-server liveness watchdog. Here letta-code is the WS *server* (the client
-// is the Desktop/relay), so we use protocol-level ws.ping()/pong rather than
-// the app-level ping/pong the outbound listener uses. Ping every 30s and reap
-// any client that has not ponged within 90s (3 missed pings). A half-open
-// client connection (Desktop sleep, network switch, NAT idle timeout) never
-// emits a `close` event. Terminating the dead socket fires its connection-
-// scoped cleanup without disturbing healthy peers.
+// App-server liveness watchdog. Here letta-code is the WebSocket server, so it
+// uses protocol-level ws.ping()/pong rather than the app-level heartbeat used
+// by the outbound listener. Ping every 30s and reap a client after three
+// unanswered probes. Counting probes prevents a delayed callback after sleep
+// or an event-loop stall from terminating a healthy client. A genuinely
+// half-open connection may never emit `close`, so termination triggers its
+// connection-scoped cleanup without disturbing healthy peers.
 const APP_SERVER_HEARTBEAT_INTERVAL_MS = 30000;
 const APP_SERVER_PONG_TIMEOUT_MS = 90000;
 
@@ -205,10 +209,17 @@ export async function startAppServer(
     });
     return startupReady;
   };
-  // Tracks the last time each connected client responded to a ping. Seeded on
-  // connection so a freshly-accepted socket gets a full grace window before the
-  // watchdog can reap it. WeakMap so entries are GC'd with their sockets.
+  // Track each client's last pong and unanswered-probe state. WeakMap entries
+  // are collected with their sockets.
   const lastPongAtBySocket = new WeakMap<WebSocket, number>();
+  const watchdogBySocket = new WeakMap<WebSocket, MissedPongWatchdog>();
+  const heartbeatIntervalMs =
+    options.heartbeatIntervalMs ?? APP_SERVER_HEARTBEAT_INTERVAL_MS;
+  const pongTimeoutMs = options.pongTimeoutMs ?? APP_SERVER_PONG_TIMEOUT_MS;
+  const maxUnansweredPings = Math.max(
+    1,
+    Math.ceil(pongTimeoutMs / heartbeatIntervalMs),
+  );
 
   const handleWebSocketConnection = (socket: WebSocket): void => {
     const connectionId = `app-server-${nextConnectionOrdinal}`;
@@ -216,6 +227,7 @@ export async function startAppServer(
     // The `ws` library auto-replies to ping frames with a pong, so any client
     // whose TCP is still alive refreshes this connection-scoped timestamp.
     lastPongAtBySocket.set(socket, Date.now());
+    watchdogBySocket.set(socket, createMissedPongWatchdog(maxUnansweredPings));
     socket.on("pong", () => {
       if (options.shouldRecordPong?.(connectionId) !== false) {
         lastPongAtBySocket.set(socket, Date.now());
@@ -340,17 +352,17 @@ export async function startAppServer(
     });
   });
 
-  const heartbeatIntervalMs =
-    options.heartbeatIntervalMs ?? APP_SERVER_HEARTBEAT_INTERVAL_MS;
-  const pongTimeoutMs = options.pongTimeoutMs ?? APP_SERVER_PONG_TIMEOUT_MS;
   const heartbeatInterval = setInterval(() => {
-    const now = Date.now();
     for (const client of wss.clients) {
-      const lastPongAt = lastPongAtBySocket.get(client) ?? now;
-      if (now - lastPongAt > pongTimeoutMs) {
-        // No pong within the timeout: the socket is half-open. Terminating it
-        // fires the `close` handler that clears activeSession and frees the
-        // control channel for a reconnecting client.
+      let watchdog = watchdogBySocket.get(client);
+      if (!watchdog) {
+        watchdog = createMissedPongWatchdog(maxUnansweredPings);
+        watchdogBySocket.set(client, watchdog);
+      }
+      const lastPongAt = lastPongAtBySocket.get(client) ?? null;
+      if (watchdog.shouldTerminate(lastPongAt)) {
+        // The configured number of probes went unanswered. Termination fires
+        // connection-scoped cleanup without disturbing healthy peers.
         options.onLog?.(
           `App-server terminating unresponsive socket (no pong in ${pongTimeoutMs}ms)`,
         );
@@ -359,6 +371,7 @@ export async function startAppServer(
       }
       if (client.readyState === WebSocket.OPEN) {
         client.ping();
+        watchdog.recordPing(Date.now());
       }
     }
   }, heartbeatIntervalMs);

--- a/src/websocket/listener/heartbeat.test.ts
+++ b/src/websocket/listener/heartbeat.test.ts
@@ -1,10 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { __listenClientTestUtils } from "./client";
 import { openListenerConnection } from "./connection";
-import {
-  createMissedPongWatchdog,
-  startConnectionHeartbeat,
-} from "./heartbeat";
+import { startConnectionHeartbeat } from "./heartbeat";
 import { clearRuntimeTimers } from "./runtime";
 import type { ListenerTransport } from "./transport";
 import type { StartListenerOptions } from "./types";
@@ -42,38 +39,6 @@ function createOptions(connectionId: string): StartListenerOptions {
 }
 
 describe("listener heartbeat watchdog", () => {
-  test("does not treat a delayed first interval as missed peer responses", () => {
-    const watchdog = createMissedPongWatchdog(3);
-
-    expect(watchdog.shouldTerminate(0)).toBe(false);
-    watchdog.recordPing(120_000);
-
-    expect(watchdog.shouldTerminate(0)).toBe(false);
-  });
-
-  test("terminates only after the configured number of unanswered probes", () => {
-    const watchdog = createMissedPongWatchdog(3);
-
-    for (const sentAt of [30_000, 60_000, 90_000]) {
-      expect(watchdog.shouldTerminate(0)).toBe(false);
-      watchdog.recordPing(sentAt);
-    }
-
-    expect(watchdog.shouldTerminate(0)).toBe(true);
-  });
-
-  test("a pong at or after the latest ping resets the missed-probe count", () => {
-    const watchdog = createMissedPongWatchdog(3);
-
-    watchdog.recordPing(30_000);
-    watchdog.recordPing(60_000);
-    expect(watchdog.shouldTerminate(60_000)).toBe(false);
-
-    watchdog.recordPing(90_000);
-    watchdog.recordPing(120_000);
-    expect(watchdog.shouldTerminate(120_000)).toBe(false);
-  });
-
   test("split listeners ping control and the current stream transport", async () => {
     const runtime = __listenClientTestUtils.createListenerRuntime();
     const connectionId = "split-heartbeat";

--- a/src/websocket/listener/heartbeat.ts
+++ b/src/websocket/listener/heartbeat.ts
@@ -1,3 +1,4 @@
+import { createMissedPongWatchdog } from "@/websocket/missed-pong-watchdog";
 import {
   LISTENER_HEARTBEAT_INTERVAL_MS,
   LISTENER_PONG_TIMEOUT_MS,
@@ -5,45 +6,8 @@ import {
 import { getListenerTransportKind, type ListenerTransport } from "./transport";
 import type { ListenerRuntime } from "./types";
 
-export interface MissedPongWatchdog {
-  shouldTerminate(lastPongAt: number | null): boolean;
-  recordPing(sentAt: number): void;
-}
-
 export interface ConnectionHeartbeatOptions {
   intervalMs?: number;
-}
-
-/**
- * Count actual unanswered heartbeat probes instead of elapsed wall time.
- *
- * A wall-clock-only watchdog cannot distinguish a dead peer from a locally
- * starved event loop. If the interval callback itself is delayed beyond the
- * timeout (CPU saturation, sleep/wake), it otherwise kills a healthy socket
- * before giving the peer a fresh ping to answer.
- */
-export function createMissedPongWatchdog(
-  maxUnansweredPings: number,
-): MissedPongWatchdog {
-  let lastPingAt: number | null = null;
-  let unansweredPings = 0;
-
-  return {
-    shouldTerminate(lastPongAt) {
-      if (
-        lastPingAt !== null &&
-        lastPongAt !== null &&
-        lastPongAt >= lastPingAt
-      ) {
-        unansweredPings = 0;
-      }
-      return unansweredPings >= maxUnansweredPings;
-    },
-    recordPing(sentAt) {
-      lastPingAt = sentAt;
-      unansweredPings += 1;
-    },
-  };
 }
 
 function getCurrentStreamTransport(

--- a/src/websocket/missed-pong-watchdog.test.ts
+++ b/src/websocket/missed-pong-watchdog.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "bun:test";
+import { createMissedPongWatchdog } from "./missed-pong-watchdog";
+
+describe("missed pong watchdog", () => {
+  test("does not treat a delayed first interval as missed peer responses", () => {
+    const watchdog = createMissedPongWatchdog(3);
+
+    expect(watchdog.shouldTerminate(0)).toBe(false);
+    watchdog.recordPing(120_000);
+
+    expect(watchdog.shouldTerminate(0)).toBe(false);
+  });
+
+  test("terminates only after the configured number of unanswered probes", () => {
+    const watchdog = createMissedPongWatchdog(3);
+
+    for (const sentAt of [30_000, 60_000, 90_000]) {
+      expect(watchdog.shouldTerminate(0)).toBe(false);
+      watchdog.recordPing(sentAt);
+    }
+
+    expect(watchdog.shouldTerminate(0)).toBe(true);
+  });
+
+  test("a pong at or after the latest ping resets the missed-probe count", () => {
+    const watchdog = createMissedPongWatchdog(3);
+
+    watchdog.recordPing(30_000);
+    watchdog.recordPing(60_000);
+    expect(watchdog.shouldTerminate(60_000)).toBe(false);
+
+    watchdog.recordPing(90_000);
+    watchdog.recordPing(120_000);
+    expect(watchdog.shouldTerminate(120_000)).toBe(false);
+  });
+});

--- a/src/websocket/missed-pong-watchdog.ts
+++ b/src/websocket/missed-pong-watchdog.ts
@@ -1,0 +1,36 @@
+export interface MissedPongWatchdog {
+  shouldTerminate(lastPongAt: number | null): boolean;
+  recordPing(sentAt: number): void;
+}
+
+/**
+ * Count actual unanswered heartbeat probes instead of elapsed wall time.
+ *
+ * A wall-clock-only watchdog cannot distinguish a dead peer from a locally
+ * starved event loop. If the interval callback itself is delayed beyond the
+ * timeout (CPU saturation, sleep/wake), it otherwise kills a healthy socket
+ * before giving the peer a fresh ping to answer.
+ */
+export function createMissedPongWatchdog(
+  maxUnansweredPings: number,
+): MissedPongWatchdog {
+  let lastPingAt: number | null = null;
+  let unansweredPings = 0;
+
+  return {
+    shouldTerminate(lastPongAt) {
+      if (
+        lastPingAt !== null &&
+        lastPongAt !== null &&
+        lastPongAt >= lastPingAt
+      ) {
+        unansweredPings = 0;
+      }
+      return unansweredPings >= maxUnansweredPings;
+    },
+    recordPing(sentAt) {
+      lastPingAt = sentAt;
+      unansweredPings += 1;
+    },
+  };
+}


### PR DESCRIPTION
## Summary

- Fixes the app-server WebSocket watchdog falsely terminating a healthy session after macOS sleep or other long stalls.
- Reuses the listener’s existing missed-pong state machine (from [#3547](https://github.com/letta-ai/letta-code/pull/3547)).
- Keeps watchdog state isolated per socket. This ensures that healthy clients reset the missed-probe count, so they aren’t terminated.
- Moves the watchdog and tests to a shared module in `src/websocket/` and replaces the app-server timeout test with a regression test proving a fresh probe is sent prior to termination.

Note: the added regression test brings `src/websocket/app-server.test.ts` to the repo’s 1000-line limit. I avoided refactoring further to keep the PR clean.

## Verification

- Reproduced the original failure with the new regression test: before the fix, the socket closed before receiving a fresh ping.
- Ran the focused WebSocket tests and `bun run check`.
- Built the CLI and smoke-tested the app-server under Node with an isolated backend directory, confirming both a request/response and the protocol heartbeat.

## AI Disclosure

- [ ] This pull request was written entirely by a human
- [x] This pull request was written with AI assistance and reviewed and edited by a human
- [x] I have read the [AI Policy](https://github.com/letta-ai/letta-code/blob/main/AI_POLICY.md) and agree to its terms

## AI Tool(s) Used

- OpenAI Codex (GPT 5.6 Sol) — investigated the regression, implemented the change, wrote and ran tests, and performed initial verification.
- Claude Code (Claude Fable 5) — performed read-only external review and identified a timing race in the regression test; the finding was verified and fixed.
- OpenAI GPT-5.6 Sol via Codex review — performed an independent read-only review of the final working-tree diff and reran the focused test suite.

## Human Verification

I have reviewed and understand every change in this pull request and take responsibility for its correctness.
