### PR TITLE
fix(skills): use deflateRawSync for .skill zip entries

### DIFF
--- a/src/skills/builtin/creating-skills/scripts/package-skill.ts
+++ b/src/skills/builtin/creating-skills/scripts/package-skill.ts
@@ -22,7 +22,7 @@ import { basename, dirname, join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 // Simple zip implementation using Node.js built-in zlib
 // For a proper zip file, we'll create the structure manually
-import { deflateSync } from "node:zlib";
+import { deflateRawSync } from "node:zlib";
 import { validateSkill } from "./validate-skill";
 
 interface ZipEntry {
@@ -43,7 +43,7 @@ function createZip(entries: ZipEntry[]): Buffer {
     const pathBuffer = Buffer.from(entry.path, "utf8");
     const compressedData = entry.isDirectory
       ? Buffer.alloc(0)
-      : deflateSync(entry.data);
+      : deflateRawSync(entry.data);
     const uncompressedSize = entry.isDirectory ? 0 : entry.data.length;
     const compressedSize = compressedData.length;
 


### PR DESCRIPTION
## Summary

Fixes #3971

`package-skill.ts` compressed entries with `deflateSync` (zlib format) but marked the ZIP local header compression method as 8 (deflate), which requires raw deflate. Resulting `.skill` files failed `unzip -t`.

**Fix:** Switch to `deflateRawSync`.

## Verification

- `npx tsx package-skill.ts <skill-folder>` → `.skill` produced
- `unzip -t output.skill` → "No errors detected"

## AI Disclosure

- [ ] This pull request was written entirely by a human
- [x] This pull request was written with AI assistance and reviewed and edited by a human
- [x] I have read the [AI Policy](https://github.com/letta-ai/letta-code/blob/main/AI_POLICY.md) and agree to its terms

## AI Tool(s) Used

Claude Code

## Human Verification

I have reviewed and understand every change in this pull request and take responsibility for its correctness.