### PR TITLE
fix(compaction): keep custom prompt in automatic full-summarization fallback

### DIFF
--- a/src/backend/local/local-backend.ts
+++ b/src/backend/local/local-backend.ts
@@ -816,7 +816,7 @@ export class LocalBackend extends HeadlessBackend {
       {
         ...settings,
         mode: "all",
-        prompt: settings.mode === "all" ? settings.prompt : undefined,
+        prompt: settings.prompt, // not a user mode switch: keep it (#3955)
       },
     );
     await this.compileAndMaybePersistSystemPrompt(conversationId, agentId, {

--- a/src/backend/local/local-compaction-fallback.test.ts
+++ b/src/backend/local/local-compaction-fallback.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { AssistantMessage, Context } from "@earendil-works/pi-ai";
+import type { Stream } from "@letta-ai/letta-client/core/streaming";
+import type { LettaStreamingResponse } from "@letta-ai/letta-client/resources/agents/messages";
+import type { ConversationMessageCreateBody } from "@/backend";
+import type { HeadlessTurnExecutor } from "@/backend/dev/headless-turn-executor";
+import { LocalBackend } from "@/backend/local/local-backend";
+import { emptyLocalUsage } from "@/backend/local/local-message";
+
+async function drain(stream: AsyncIterable<unknown>): Promise<void> {
+  for await (const _chunk of stream) {
+    // drain
+  }
+}
+
+function lettaStreamFromChunks(
+  chunks: LettaStreamingResponse[],
+): Stream<LettaStreamingResponse> {
+  const controller = new AbortController();
+  return {
+    controller,
+    async *[Symbol.asyncIterator]() {
+      for (const chunk of chunks) yield chunk;
+    },
+  } as unknown as Stream<LettaStreamingResponse>;
+}
+
+function assistantMessage(input: {
+  content: AssistantMessage["content"];
+  stopReason: AssistantMessage["stopReason"];
+  responseId: string;
+}): AssistantMessage {
+  return {
+    role: "assistant",
+    content: input.content,
+    api: "openai-responses",
+    provider: "openai",
+    model: "gpt-5.5",
+    responseId: input.responseId,
+    usage: emptyLocalUsage(),
+    stopReason: input.stopReason,
+    timestamp: Date.now(),
+  };
+}
+
+function turnExecutor(): HeadlessTurnExecutor {
+  return {
+    async execute() {
+      return lettaStreamFromChunks([
+        {
+          message_type: "assistant_message",
+          content: [{ type: "text", text: "ok" }],
+        } as LettaStreamingResponse,
+        {
+          message_type: "stop_reason",
+          stop_reason: "end_turn",
+        } as LettaStreamingResponse,
+      ]);
+    },
+  };
+}
+
+describe("local compaction fallback keeps custom prompt", () => {
+  test("keeps custom compaction prompt when sliding-window planning falls back to full summarization", async () => {
+    const storageDir = await mkdtemp(
+      join(tmpdir(), "local-compaction-fallback-plan-"),
+    );
+    const customPrompt = "CUSTOM-SUMMARY-PROMPT: summarize as haiku";
+    const systemPromptsSeen: Array<string | undefined> = [];
+    const complete = async (
+      _model: unknown,
+      context: Context,
+    ): Promise<AssistantMessage> => {
+      systemPromptsSeen.push(context.systemPrompt);
+      return assistantMessage({
+        responseId: `summary-${systemPromptsSeen.length}`,
+        stopReason: "stop",
+        content: [{ type: "text", text: "Compacted summary." }],
+      });
+    };
+    const backend = new LocalBackend({
+      storageDir,
+      executor: turnExecutor(),
+      complete,
+      memfsEnabled: false,
+    });
+    const agent = await backend.createAgent({ name: "Local" } as never);
+    await backend.updateAgent(agent.id, {
+      compaction_settings: { mode: "sliding_window", prompt: customPrompt },
+    } as never);
+    const conversation = await backend.createConversation({
+      agent_id: agent.id,
+    } as never);
+    await drain(
+      await backend.createConversationMessageStream(conversation.id, {
+        agent_id: agent.id,
+        messages: [{ role: "user", content: "only message" }],
+      } as ConversationMessageCreateBody),
+    );
+
+    // Fewer than 4 messages: sliding-window planning fails and compaction
+    // falls back to full summarization. The user's custom prompt must
+    // survive the automatic mode fallback.
+    await backend.compactConversationMessages(conversation.id, {
+      agent_id: agent.id,
+    } as never);
+
+    expect(systemPromptsSeen).toHaveLength(1);
+    expect(systemPromptsSeen[0]).toBe(customPrompt);
+
+    await rm(storageDir, { recursive: true, force: true });
+  });
+
+  test("keeps custom compaction prompt when sliding window still exceeds the context window", async () => {
+    const storageDir = await mkdtemp(
+      join(tmpdir(), "local-compaction-fallback-overflow-"),
+    );
+    const customPrompt = "CUSTOM-SUMMARY-PROMPT: summarize as haiku";
+    const systemPromptsSeen: Array<string | undefined> = [];
+    const complete = async (
+      _model: unknown,
+      context: Context,
+    ): Promise<AssistantMessage> => {
+      systemPromptsSeen.push(context.systemPrompt);
+      // A long summary keeps the post-compaction estimate above the tiny
+      // configured context window, forcing the full-summarization fallback.
+      return assistantMessage({
+        responseId: `summary-${systemPromptsSeen.length}`,
+        stopReason: "stop",
+        content: [{ type: "text", text: "x".repeat(8000) }],
+      });
+    };
+    const backend = new LocalBackend({
+      storageDir,
+      executor: turnExecutor(),
+      complete,
+      memfsEnabled: false,
+    });
+    const agent = await backend.createAgent({
+      name: "Local",
+      model_settings: { context_window_limit: 1000 },
+    } as never);
+    await backend.updateAgent(agent.id, {
+      compaction_settings: { mode: "sliding_window", prompt: customPrompt },
+    } as never);
+    const conversation = await backend.createConversation({
+      agent_id: agent.id,
+    } as never);
+    for (const content of ["first", "second"]) {
+      await drain(
+        await backend.createConversationMessageStream(conversation.id, {
+          agent_id: agent.id,
+          messages: [{ role: "user", content }],
+        } as ConversationMessageCreateBody),
+      );
+    }
+
+    // Sliding-window compaction runs with the custom prompt, but the result
+    // still exceeds the context window, so compaction falls back to full
+    // summarization. That fallback must keep the user's custom prompt too.
+    await backend.compactConversationMessages(conversation.id, {
+      agent_id: agent.id,
+    } as never);
+
+    expect(systemPromptsSeen).toHaveLength(2);
+    expect(systemPromptsSeen[0]).toBe(customPrompt);
+    expect(systemPromptsSeen[1]).toBe(customPrompt);
+
+    await rm(storageDir, { recursive: true, force: true });
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #3955.

When an agent's `compaction_settings` use `mode: "sliding_window"` with a custom `prompt`, automatic compaction can silently fall back to full summarization in two cases:

1. sliding-window planning fails (`LocalSlidingWindowCompactionPlanningError`, e.g. fewer than 4 messages),
2. the sliding-window result still meets or exceeds the context window (`context_tokens_after >= context_window`) — the exact condition tool-heavy turns produce (see also #3956).

The fallback call built its settings as:

```ts
prompt: settings.mode === "all" ? settings.prompt : undefined,
```

Since `settings.mode` is still "sliding_window" at that point, the user's custom prompt was dropped and the built-in `LOCAL_ALL_COMPACTION_PROMPT` was used instead. This is why #3955 sees auto-compaction **alternating** between custom-format and generic default-format summaries within one conversation: custom prompt on normal sliding passes, default prompt whenever the fallback fires.

The existing cross-mode guard in `resolveCompactionSettings` deliberately deletes the prompt only for explicit, user-initiated mode switches (request changes mode without supplying a prompt). An internal fallback is not a user mode switch, so this change carries the configured prompt over:

```ts
prompt: settings.prompt,
```

Behavior for explicit "/compact all" requests is unchanged — those still go through the resolver's cross-mode guard.

## Verification

- New regression tests in `src/backend/local/local-compaction-fallback.test.ts`:
  - planning-failure fallback: with a custom prompt configured and <4 messages, the full-summarization LLM call receives the custom prompt (failed before the fix: received `LOCAL_ALL_COMPACTION_PROMPT`).
  - overflow fallback: with a custom prompt and a tiny `context_window_limit` plus a long summary, both compaction calls receive the custom prompt (the second call failed before the fix).
- Both tests fail on the unpatched code and pass with the fix.
- `bun test src/backend`: 258 passed, 0 failed.
- `bun run check`: 12/12 checks passed.
- `bun run check:file-size`: passes (no baseline growth).

## AI Disclosure

- [ ] This pull request was written entirely by a human
- [x] This pull request was written with AI assistance and reviewed and edited by a human
- [x] I have read the [AI Policy](https://github.com/letta-ai/letta-code/blob/main/AI_POLICY.md) and agree to its terms

## AI Tool(s) Used

ox-alpha (autonomous coding agent via opencode) operating on behalf of the submitting human. Extent: root-cause analysis of the compaction code paths, implementation of the one-line settings change, and regression tests; verified locally with `bun test src/backend` (258 passed) and `bun run check` (12/12).

## Human Verification

I have reviewed and understand every change in this pull request and take responsibility for its correctness.