### PR TITLE
feat(local): classify OpenRouter traffic as cloud agent

### DIFF
--- a/src/backend/dev/pi-provider-registry.ts
+++ b/src/backend/dev/pi-provider-registry.ts
@@ -176,7 +176,7 @@ const PI_PROVIDER_OVERRIDES: Partial<
     headers: () => ({
       "HTTP-Referer": "https://letta.com",
       "X-OpenRouter-Title": "Letta Code",
-      "X-OpenRouter-Categories": "cloud-agent,cli-agent,personal-agent",
+      "X-OpenRouter-Categories": "cloud-agent,personal-agent",
     }),
   },
   zai: {

--- a/src/backend/dev/pi-provider-registry.ts
+++ b/src/backend/dev/pi-provider-registry.ts
@@ -176,7 +176,7 @@ const PI_PROVIDER_OVERRIDES: Partial<
     headers: () => ({
       "HTTP-Referer": "https://letta.com",
       "X-OpenRouter-Title": "Letta Code",
-      "X-OpenRouter-Categories": "cli-agent,personal-agent",
+      "X-OpenRouter-Categories": "cloud-agent,cli-agent,personal-agent",
     }),
   },
   zai: {

--- a/src/providers/local-pi-provider-catalog.test.ts
+++ b/src/providers/local-pi-provider-catalog.test.ts
@@ -136,7 +136,7 @@ describe("local pi provider catalog", () => {
     expect(openRouter?.headers?.()).toEqual({
       "HTTP-Referer": "https://letta.com",
       "X-OpenRouter-Title": "Letta Code",
-      "X-OpenRouter-Categories": "cloud-agent,cli-agent,personal-agent",
+      "X-OpenRouter-Categories": "cloud-agent,personal-agent",
     });
   });
 

--- a/src/providers/local-pi-provider-catalog.test.ts
+++ b/src/providers/local-pi-provider-catalog.test.ts
@@ -128,12 +128,14 @@ describe("local pi provider catalog", () => {
     }
   });
 
-  test("OpenRouter attribution includes all Letta app categories", () => {
+  test("OpenRouter attribution includes leaderboard headers and app categories", () => {
     const openRouter = PI_PROVIDER_SPECS.find(
       (provider) => provider.id === "openrouter",
     );
 
-    expect(openRouter?.headers?.()).toMatchObject({
+    expect(openRouter?.headers?.()).toEqual({
+      "HTTP-Referer": "https://letta.com",
+      "X-OpenRouter-Title": "Letta Code",
       "X-OpenRouter-Categories": "cloud-agent,cli-agent,personal-agent",
     });
   });

--- a/src/providers/local-pi-provider-catalog.test.ts
+++ b/src/providers/local-pi-provider-catalog.test.ts
@@ -128,6 +128,16 @@ describe("local pi provider catalog", () => {
     }
   });
 
+  test("OpenRouter attribution includes all Letta app categories", () => {
+    const openRouter = PI_PROVIDER_SPECS.find(
+      (provider) => provider.id === "openrouter",
+    );
+
+    expect(openRouter?.headers?.()).toMatchObject({
+      "X-OpenRouter-Categories": "cloud-agent,cli-agent,personal-agent",
+    });
+  });
+
   test("pi-ai providers without Pi TUI defaults are explicit", () => {
     const defaultedProviders = new Set(Object.keys(PI_TUI_DEFAULT_MODEL_IDS));
 


### PR DESCRIPTION
## Summary

- classify Letta Code's OpenRouter requests as `cloud-agent` and `personal-agent`
- remove the `cli-agent` category so OpenRouter receives only the intended two-category attribution
- lock the complete attribution header in provider catalog coverage

## Verification

- `bun test src/providers/local-pi-provider-catalog.test.ts` — 19 passed
- `bun run check` — all 12 checks passed

👾 Generated with [Letta Code](https://letta.com)
