### PR TITLE
feat(channels): Discord observer mode for passive guild transcription

### DIFF
--- a/src/channels/README.md
+++ b/src/channels/README.md
@@ -170,6 +170,42 @@ Only set `LETTA_BASE_URL` for a separate self-hosted server. For example,
 a server running at that URL. Do not set a dummy `LETTA_BASE_URL` for
 `--backend local`.
 
+## Discord observer mode
+
+The bundled Discord plugin can aggregate one guild into fixed, read-only agent
+conversations. This is intended for ambient observation and dreaming tests,
+not interactive replies. Normal Discord routing remains unchanged outside the
+configured guild.
+
+Add an `observer` object to the Discord account in
+`~/.letta/channels/discord/accounts.json`:
+
+```json
+{
+  "observer": {
+    "guildId": "123456789012345678",
+    "targets": [
+      { "agentId": "agent-alpha", "conversationId": "default" },
+      { "agentId": "agent-beta", "conversationId": "default" }
+    ],
+    "flushIntervalMs": 600000,
+    "maxMessages": 200,
+    "maxCharacters": 100000,
+    "includeBots": true
+  }
+}
+```
+
+Messages are collected across the whole guild and flushed in chronological
+order. Observer-guild traffic bypasses interactive mention-only and channel
+allowlist behavior without changing those policies in other guilds. The
+interval is a tumbling window, not an inactivity debounce. Message
+count and character limits flush a busy window early. Every target receives
+the same chunk in its fixed conversation; observer routes are always outbound
+disabled. Foreign bot messages are optional, while the receiving Discord bot's
+own messages are always dropped to prevent feedback loops. Pending observations
+flush before the channel registry shuts down.
+
 ## Channel slash commands
 
 Typed slash commands are handled before normal channel ingress so operational

--- a/src/channels/accounts.ts
+++ b/src/channels/accounts.ts
@@ -14,6 +14,10 @@ import {
   setChannelSecret,
 } from "./credential-store";
 import { normalizeDiscordAllowBotsMode } from "./discord/bot-policy";
+import {
+  cloneDiscordObserverConfig,
+  normalizeDiscordObserverConfig,
+} from "./discord/observer-config";
 import { normalizeSlackAllowBotsMode } from "./slack/bot-policy";
 import type {
   ChannelAccount,
@@ -252,6 +256,11 @@ function cloneAccount<T extends ChannelAccount>(account: T): T {
       ? [...account.allowedChannels]
       : { ...account.allowedChannels };
   }
+  if (isDiscordChannelAccount(account) && account.observer) {
+    (cloned as DiscordChannelAccount).observer = cloneDiscordObserverConfig(
+      account.observer,
+    );
+  }
 
   if (isWhatsAppChannelAccount(account)) {
     (cloned as WhatsAppChannelAccount).allowedGroups = [
@@ -379,6 +388,9 @@ function normalizeLoadedAccount<T extends ChannelAccount>(account: T): T {
     (next as DiscordChannelAccount).allowBots = normalizeDiscordAllowBotsMode(
       (next as DiscordChannelAccount).allowBots,
     );
+    (next as DiscordChannelAccount).observer = normalizeDiscordObserverConfig(
+      (next as DiscordChannelAccount).observer,
+    );
 
     // Compatibility migration: existing accounts created before this field was
     // persisted auto-threaded on mentions by default. Keep that behavior for
@@ -468,6 +480,9 @@ function makeDefaultLegacyAccount(
       autoThreadOnMention: config.autoThreadOnMention ?? true,
       threadPolicyByChannel: config.threadPolicyByChannel,
       allowBots: config.allowBots ?? false,
+      observer: config.observer
+        ? cloneDiscordObserverConfig(config.observer)
+        : undefined,
       agentId: null,
       defaultPermissionMode: config.defaultPermissionMode ?? "standard",
       createdAt: now,

--- a/src/channels/config.ts
+++ b/src/channels/config.ts
@@ -13,6 +13,7 @@ import {
   isValidDiscordAllowBotsConfigValue,
   normalizeDiscordAllowBotsMode,
 } from "./discord/bot-policy";
+import { normalizeDiscordObserverConfig } from "./discord/observer-config";
 import { normalizeSlackAllowBotsMode } from "./slack/bot-policy";
 import type {
   ChannelConfig,
@@ -265,6 +266,7 @@ const discordConfigCodec: ChannelConfigCodec<DiscordChannelConfig> = {
         parsed.inbound_debounce_ms >= 0
           ? Math.trunc(Math.min(parsed.inbound_debounce_ms, 10000))
           : undefined,
+      observer: normalizeDiscordObserverConfig(parsed.observer),
     };
   },
 };

--- a/src/channels/discord-observer-lifecycle.test.ts
+++ b/src/channels/discord-observer-lifecycle.test.ts
@@ -1,0 +1,161 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import {
+  __testOverrideLoadChannelAccounts,
+  __testOverrideSaveChannelAccounts,
+  clearChannelAccountStores,
+} from "@/channels/accounts";
+import { ChannelRegistry, getChannelRegistry } from "@/channels/registry";
+import type { ChannelInboundDelivery } from "@/channels/registry-handlers";
+import type {
+  ChannelAdapter,
+  DiscordChannelAccount,
+  InboundChannelMessage,
+} from "@/channels/types";
+
+const ACCOUNT_ID = "discord-observer";
+
+function createObserverAccount(options: {
+  targetAgentId: string;
+  maxMessages?: number;
+}): DiscordChannelAccount {
+  return {
+    channel: "discord",
+    accountId: ACCOUNT_ID,
+    enabled: true,
+    token: "discord-token",
+    agentId: "agent-chat",
+    defaultPermissionMode: "standard",
+    dmPolicy: "pairing",
+    allowedUsers: [],
+    observer: {
+      guildId: "guild-observed",
+      targets: [{ agentId: options.targetAgentId, conversationId: "default" }],
+      maxMessages: options.maxMessages ?? 10,
+      flushIntervalMs: 60_000,
+    },
+    createdAt: "2026-08-24T00:00:00.000Z",
+    updatedAt: "2026-08-24T00:00:00.000Z",
+  };
+}
+
+function createAdapter(): ChannelAdapter {
+  return {
+    id: `discord:${ACCOUNT_ID}`,
+    channelId: "discord",
+    accountId: ACCOUNT_ID,
+    name: "Discord",
+    start: async () => {},
+    stop: async () => {},
+    isRunning: () => true,
+    sendMessage: async () => ({ messageId: "outbound" }),
+    sendDirectReply: async () => {},
+  };
+}
+
+function createMessage(text: string, messageId: string): InboundChannelMessage {
+  return {
+    channel: "discord",
+    accountId: ACCOUNT_ID,
+    chatId: "channel-observed",
+    guildId: "guild-observed",
+    senderId: "user-1",
+    senderName: "Cameron",
+    text,
+    timestamp: Date.now(),
+    messageId,
+    threadId: null,
+    chatType: "channel",
+    isMention: false,
+  };
+}
+
+describe("Discord observer lifecycle", () => {
+  beforeEach(() => {
+    clearChannelAccountStores();
+    __testOverrideSaveChannelAccounts(() => {});
+  });
+
+  afterEach(async () => {
+    const registry = getChannelRegistry();
+    if (registry) await registry.stopAll();
+    clearChannelAccountStores();
+    __testOverrideLoadChannelAccounts(null);
+    __testOverrideSaveChannelAccounts(null);
+  });
+
+  test("process shutdown waits for final batch gateway acceptance", async () => {
+    __testOverrideLoadChannelAccounts(() => [
+      createObserverAccount({ targetAgentId: "agent-alpha" }),
+    ]);
+    const registry = new ChannelRegistry();
+    const adapter = createAdapter();
+    registry.registerAdapter(adapter);
+    let releaseDelivery!: () => void;
+    const deliveryGate = new Promise<void>((resolve) => {
+      releaseDelivery = resolve;
+    });
+    const deliveries: ChannelInboundDelivery[] = [];
+    registry.setMessageHandler(async (delivery) => {
+      deliveries.push(delivery);
+      await deliveryGate;
+    });
+    registry.setReady();
+
+    await adapter.onMessage?.(createMessage("pending observation", "msg-1"));
+    let stopped = false;
+    const shutdown = registry.stopAll().then(() => {
+      stopped = true;
+    });
+    await Bun.sleep(0);
+
+    expect(deliveries).toHaveLength(1);
+    expect(stopped).toBe(false);
+    releaseDelivery();
+    await shutdown;
+    expect(stopped).toBe(true);
+  });
+
+  test("stopping an observer account cancels content pending for old targets", async () => {
+    __testOverrideLoadChannelAccounts(() => [
+      createObserverAccount({ targetAgentId: "agent-old" }),
+    ]);
+    const registry = new ChannelRegistry();
+    const adapter = createAdapter();
+    registry.registerAdapter(adapter);
+    const deliveries: ChannelInboundDelivery[] = [];
+    registry.setMessageHandler((delivery) => deliveries.push(delivery));
+    registry.setReady();
+
+    await adapter.onMessage?.(createMessage("private pending text", "msg-1"));
+    expect(await registry.stopChannelAccount("discord", ACCOUNT_ID)).toBe(true);
+
+    expect(deliveries).toHaveLength(0);
+  });
+
+  test("changing targets cancels the old window before delivering the new one", async () => {
+    __testOverrideLoadChannelAccounts(() => [
+      createObserverAccount({ targetAgentId: "agent-old" }),
+    ]);
+    const registry = new ChannelRegistry();
+    const adapter = createAdapter();
+    registry.registerAdapter(adapter);
+    const deliveries: ChannelInboundDelivery[] = [];
+    registry.setMessageHandler((delivery) => deliveries.push(delivery));
+    registry.setReady();
+
+    await adapter.onMessage?.(createMessage("old private text", "msg-old"));
+    clearChannelAccountStores();
+    __testOverrideLoadChannelAccounts(() => [
+      createObserverAccount({
+        targetAgentId: "agent-new",
+        maxMessages: 1,
+      }),
+    ]);
+    await adapter.onMessage?.(createMessage("new visible text", "msg-new"));
+
+    expect(deliveries).toHaveLength(1);
+    expect(deliveries[0]?.route.agentId).toBe("agent-new");
+    expect(deliveries[0]?.content).toContain("new visible text");
+    expect(deliveries[0]?.content).not.toContain("old private text");
+  });
+});

--- a/src/channels/discord-registry.test.ts
+++ b/src/channels/discord-registry.test.ts
@@ -19,6 +19,7 @@ import {
   __testOverrideSavePairingStore,
   clearPairingStores,
 } from "@/channels/pairing";
+import type { ChannelInboundDelivery } from "@/channels/registry-handlers";
 import {
   __testOverrideLoadRoutes,
   __testOverrideSaveRoutes,
@@ -501,6 +502,88 @@ describe("discord channel registry", () => {
     expect(deliveries).toHaveLength(1);
   });
 
+  test("batches one guild and fans the same read-only chunk into fixed observer conversations", async () => {
+    __testOverrideLoadChannelAccounts(() => [
+      {
+        channel: "discord",
+        accountId: "discord-bot",
+        enabled: true,
+        token: "discord-token",
+        agentId: "agent-chat",
+        defaultPermissionMode: "standard",
+        dmPolicy: "pairing",
+        allowedUsers: [],
+        allowedChannels: { "different-channel": "mention-only" },
+        observer: {
+          guildId: "guild-observed",
+          targets: [
+            { agentId: "agent-alpha", conversationId: "default" },
+            { agentId: "agent-beta", conversationId: "conv-beta" },
+          ],
+          maxMessages: 2,
+          maxCharacters: 100_000,
+          flushIntervalMs: 60_000,
+        },
+        createdAt: "2026-04-11T00:00:00.000Z",
+        updatedAt: "2026-04-11T00:00:00.000Z",
+      },
+    ]);
+
+    const { ChannelRegistry } = await import("@/channels/registry");
+    const registry = new ChannelRegistry();
+    const replies: Array<{ chatId: string; text: string }> = [];
+    const adapter = createAdapter(replies);
+    registry.registerAdapter(adapter);
+    const deliveries: ChannelInboundDelivery[] = [];
+    registry.setMessageHandler((delivery) => deliveries.push(delivery));
+    registry.setReady();
+
+    await adapter.onMessage?.(
+      createInboundMessage({
+        guildId: "guild-observed",
+        chatId: "channel-alpha",
+        threadId: null,
+        messageId: "observer-1",
+        text: "/status",
+        timestamp: 100,
+      }),
+    );
+    expect(deliveries).toHaveLength(0);
+
+    await adapter.onMessage?.(
+      createInboundMessage({
+        guildId: "guild-observed",
+        chatId: "channel-beta",
+        chatLabel: "builders",
+        threadId: null,
+        messageId: "observer-2",
+        text: "second observation",
+        timestamp: 200,
+      }),
+    );
+
+    expect(createConversation).not.toHaveBeenCalled();
+    expect(replies).toHaveLength(0);
+    expect(deliveries).toHaveLength(2);
+    expect(
+      deliveries.map((delivery) => [
+        delivery.route.agentId,
+        delivery.route.conversationId,
+        delivery.route.outboundEnabled,
+      ]),
+    ).toEqual([
+      ["agent-alpha", "default", false],
+      ["agent-beta", "conv-beta", false],
+    ]);
+    const content = deliveries[0]?.content;
+    expect(typeof content).toBe("string");
+    expect(content).toContain("discord-observer-batch");
+    expect(content).toContain("/status");
+    expect(content).toContain("second observation");
+    expect(content).toContain('channel_name="builders"');
+    expect(deliveries[0]?.turnSources).toBeUndefined();
+  });
+
   test("does not spam setup replies for unbound ambient open-channel traffic", async () => {
     clearChannelAccountStores();
     __testOverrideLoadChannelAccounts(() => [
@@ -775,15 +858,11 @@ describe("discord channel registry", () => {
   // ── Delivery-time gate (allowed_channels re-check) ─────────────
 
   test("delivery-time gate passes thread-on-mention with correct parentChannelId", async () => {
-    // Simulates a mention in guild-channel "alpha" where the adapter
-    // creates a thread and sets parentChannelId to the guild channel.
-    // The delivery-time gate should resolve alpha → allowed.
     const { ChannelRegistry } = await import("@/channels/registry");
     const registry = new ChannelRegistry();
     const adapter = createAdapter();
     registry.registerAdapter(adapter);
 
-    // Override account with allowedChannels that includes the guild channel
     __testOverrideLoadChannelAccounts(() => [
       {
         channel: "discord",
@@ -806,12 +885,6 @@ describe("discord channel registry", () => {
     });
     registry.setReady();
 
-    // This is what the adapter sends after creating a thread for
-    // a mention in guild channel "alpha":
-    //   chatId = thread ID
-    //   threadId = thread ID (both same — "thread-1")
-    //   parentChannelId = "alpha" (the original guild channel)
-    //   isMention = true
     await adapter.onMessage?.(
       createInboundMessage({
         chatId: "thread-1",
@@ -823,7 +896,6 @@ describe("discord channel registry", () => {
       }),
     );
 
-    // Route should be created and message delivered
     expect(createConversation).toHaveBeenCalledTimes(1);
     expect(
       getRoute("discord", "thread-1", "discord-bot", "thread-1"),

--- a/src/channels/discord/account-config.test.ts
+++ b/src/channels/discord/account-config.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test } from "bun:test";
 import type { DiscordChannelAccount } from "@/channels/types";
 import { discordAccountConfigAdapter } from "./account-config";
+import {
+  DISCORD_OBSERVER_MAX_FLUSH_INTERVAL_MS,
+  normalizeDiscordObserverConfig,
+} from "./observer-config";
 
 function makeDiscordAccount(
   overrides: Partial<DiscordChannelAccount> = {},
@@ -63,5 +67,55 @@ describe("discordAccountConfigAdapter", () => {
     expect(
       discordAccountConfigAdapter.toConfigSnapshotConfig(makeDiscordAccount()),
     ).toEqual(expect.objectContaining({ allow_bots: false }));
+  });
+
+  test("validates and deep-clones Discord observer configuration", () => {
+    const observer = {
+      guildId: "guild-1",
+      targets: [
+        { agentId: "agent-alpha", conversationId: "default" },
+        { agentId: "agent-beta", conversationId: "conv-beta" },
+      ],
+      flushIntervalMs: 600_000,
+      maxMessages: 200,
+      maxCharacters: 100_000,
+      includeBots: true,
+    };
+    expect(discordAccountConfigAdapter.isValidConfig({ observer })).toBe(true);
+    expect(
+      discordAccountConfigAdapter.isValidConfig({
+        observer: { ...observer, targets: [] },
+      }),
+    ).toBe(false);
+    expect(
+      discordAccountConfigAdapter.isValidConfig({
+        observer: { ...observer, flushIntervalMs: 0 },
+      }),
+    ).toBe(false);
+    expect(
+      discordAccountConfigAdapter.isValidConfig({
+        observer: {
+          ...observer,
+          flushIntervalMs: DISCORD_OBSERVER_MAX_FLUSH_INTERVAL_MS + 1,
+        },
+      }),
+    ).toBe(false);
+
+    const patch = discordAccountConfigAdapter.toAccountPatch({ observer });
+    expect(patch.observer).toEqual(observer);
+    expect(patch.observer).not.toBe(observer);
+    expect(patch.observer?.targets).not.toBe(observer.targets);
+
+    expect(
+      discordAccountConfigAdapter.toAccountConfig(
+        makeDiscordAccount({ observer }),
+      ),
+    ).toEqual(expect.objectContaining({ observer }));
+    expect(
+      discordAccountConfigAdapter.toAccountPatch({ observer: null }).observer,
+    ).toBeNull();
+    expect(
+      normalizeDiscordObserverConfig({ guildId: "broken" }),
+    ).toBeUndefined();
   });
 });

--- a/src/channels/discord/account-config.ts
+++ b/src/channels/discord/account-config.ts
@@ -9,6 +9,10 @@ import {
   isValidDiscordAllowBotsConfigValue,
   normalizeDiscordAllowBotsMode,
 } from "./bot-policy";
+import {
+  cloneDiscordObserverConfig,
+  isDiscordObserverConfig,
+} from "./observer-config";
 
 const DISCORD_CONFIG_KEYS = new Set([
   "token",
@@ -22,6 +26,7 @@ const DISCORD_CONFIG_KEYS = new Set([
   "acknowledge_message_reaction",
   "remove_stale_routes",
   "inbound_debounce_ms",
+  "observer",
 ]);
 
 function isString(value: unknown): value is string {
@@ -133,7 +138,10 @@ export const discordAccountConfigAdapter: ChannelAccountConfigAdapter<DiscordCha
           (typeof config.inbound_debounce_ms === "number" &&
             Number.isFinite(config.inbound_debounce_ms) &&
             config.inbound_debounce_ms >= 0 &&
-            config.inbound_debounce_ms <= 10000))
+            config.inbound_debounce_ms <= 10000)) &&
+        (config.observer === undefined ||
+          config.observer === null ||
+          isDiscordObserverConfig(config.observer))
       );
     },
 
@@ -179,6 +187,12 @@ export const discordAccountConfigAdapter: ChannelAccountConfigAdapter<DiscordCha
           config.inbound_debounce_ms >= 0
             ? Math.trunc(Math.min(config.inbound_debounce_ms, 10000))
             : undefined,
+        observer:
+          config.observer === null
+            ? null
+            : isDiscordObserverConfig(config.observer)
+              ? cloneDiscordObserverConfig(config.observer)
+              : undefined,
         acknowledgeMessageReaction: isBoolean(
           config.acknowledge_message_reaction,
         )
@@ -204,6 +218,9 @@ export const discordAccountConfigAdapter: ChannelAccountConfigAdapter<DiscordCha
           account.acknowledgeMessageReaction ?? false,
         remove_stale_routes: account.removeStaleRoutes ?? false,
         inbound_debounce_ms: account.inboundDebounceMs,
+        observer: account.observer
+          ? cloneDiscordObserverConfig(account.observer)
+          : undefined,
       };
     },
 
@@ -221,6 +238,9 @@ export const discordAccountConfigAdapter: ChannelAccountConfigAdapter<DiscordCha
           account.acknowledgeMessageReaction ?? false,
         remove_stale_routes: account.removeStaleRoutes ?? false,
         inbound_debounce_ms: account.inboundDebounceMs,
+        observer: account.observer
+          ? cloneDiscordObserverConfig(account.observer)
+          : undefined,
       };
     },
 

--- a/src/channels/discord/adapter.ts
+++ b/src/channels/discord/adapter.ts
@@ -403,19 +403,26 @@ export function createDiscordAdapter(
 
         const effectiveBotUserId = botUserId ?? client?.user?.id ?? null;
         const chatType = resolveDiscordChatType(message.guildId);
+        const isObserverGuild =
+          chatType === "channel" &&
+          !!message.guildId &&
+          config.observer?.guildId === message.guildId;
         const isThread = isThreadMessage(message);
         const hasParsedBotMention = hasBotMention(message);
         const wasMentioned = chatType === "channel" && hasParsedBotMention;
-        if (
-          !shouldAcceptDiscordInboundBotMessage({
-            message,
-            allowBots: config.allowBots,
-            botUserId: effectiveBotUserId,
-            wasExplicitlyMentioned:
-              hasParsedBotMention &&
-              hasExplicitDiscordUserMention(message, effectiveBotUserId),
-          })
-        ) {
+        const acceptedByBotPolicy = isObserverGuild
+          ? message.author.bot !== true ||
+            (config.observer?.includeBots === true &&
+              message.author.id !== effectiveBotUserId)
+          : shouldAcceptDiscordInboundBotMessage({
+              message,
+              allowBots: config.allowBots,
+              botUserId: effectiveBotUserId,
+              wasExplicitlyMentioned:
+                hasParsedBotMention &&
+                hasExplicitDiscordUserMention(message, effectiveBotUserId),
+            });
+        if (!acceptedByBotPolicy) {
           return;
         }
 
@@ -464,18 +471,22 @@ export function createDiscordAdapter(
         // the thread is already routed, or whether a new mention is required.
         const parentChannelId =
           (message.channel as { parentId?: string | null }).parentId ?? null;
-        const channelMode = resolveDiscordChannelMode(
-          message.channelId,
-          parentChannelId,
-          isThread,
-          config.allowedChannels,
-        );
+        const channelMode = isObserverGuild
+          ? "open"
+          : resolveDiscordChannelMode(
+              message.channelId,
+              parentChannelId,
+              isThread,
+              config.allowedChannels,
+            );
         const isOpenChannel = channelMode === "open";
-        if (!isThread && !wasMentioned && !isOpenChannel) return;
+        if (!isObserverGuild && !isThread && !wasMentioned && !isOpenChannel)
+          return;
 
         // Channel allowlist: when configured, only process guild messages whose
         // channel ID (or parent channel ID for thread messages) is allowed.
         if (
+          !isObserverGuild &&
           !isDiscordGuildChannelAllowed({
             channelId: message.channelId,
             parentChannelId,
@@ -497,7 +508,7 @@ export function createDiscordAdapter(
         // auto-threading is disabled, the mention routes to the channel
         // itself (effectiveChatId stays as message.channelId and
         // effectiveThreadId stays null) instead of spawning a new thread.
-        if (!isThread && wasMentioned) {
+        if (!isObserverGuild && !isThread && wasMentioned) {
           if (shouldAutoThreadOnDiscordMention(config, message.channelId)) {
             const createdThread = await createThreadForMention(
               message,
@@ -513,9 +524,10 @@ export function createDiscordAdapter(
           message.attachments,
           effectiveChatId,
         );
-        const normalizedText = wasMentioned
-          ? normalizeDiscordMentionText(content, botUserId)
-          : content;
+        const normalizedText =
+          wasMentioned && !isObserverGuild
+            ? normalizeDiscordMentionText(content, botUserId)
+            : content;
         // A bare mention inside a Discord thread can recover a thread whose
         // route provisioning failed. Other empty guild messages stay inert.
         if (
@@ -535,6 +547,7 @@ export function createDiscordAdapter(
             "name" in message.channel
               ? (message.channel.name ?? undefined)
               : undefined,
+          guildId: message.guildId ?? undefined,
           text: normalizedText,
           timestamp: message.createdTimestamp,
           messageId: message.id,
@@ -566,8 +579,6 @@ export function createDiscordAdapter(
         action: "added" | "removed",
       ) => {
         if (!adapter.onMessage) return;
-        // Ignore bot reactions
-        if (user.bot) return;
         if (user.id === botUserId) return;
 
         try {
@@ -587,6 +598,13 @@ export function createDiscordAdapter(
         if (!emoji) return;
 
         const chatType = resolveDiscordChatType(msg.guildId);
+        const isObserverGuild =
+          chatType === "channel" &&
+          !!msg.guildId &&
+          config.observer?.guildId === msg.guildId;
+        if (user.bot && !(isObserverGuild && config.observer?.includeBots)) {
+          return;
+        }
         const isThread =
           msg.channel &&
           "isThread" in msg.channel &&
@@ -594,12 +612,13 @@ export function createDiscordAdapter(
           msg.channel.isThread();
 
         // In guilds, only react on messages in threads we're tracking
-        if (chatType === "channel" && !isThread) return;
+        if (chatType === "channel" && !isThread && !isObserverGuild) return;
 
         // Apply channel allowlist gating in guilds (parent channel of the thread)
         if (
           chatType === "channel" &&
           isThread &&
+          !isObserverGuild &&
           !isDiscordGuildChannelAllowed({
             channelId,
             parentChannelId:
@@ -616,6 +635,7 @@ export function createDiscordAdapter(
           chatId: channelId,
           senderId: user.id,
           senderName: user.username ?? undefined,
+          guildId: msg.guildId ?? undefined,
           text: "",
           timestamp: Date.now(),
           messageId: msg.id,

--- a/src/channels/discord/bot-ingress.test.ts
+++ b/src/channels/discord/bot-ingress.test.ts
@@ -245,6 +245,85 @@ describe("Discord adapter bot ingress", () => {
     });
   });
 
+  test("accepts unmentioned foreign bot messages in the configured observer guild", async () => {
+    const { client, deliveries } = await startAdapterWithDeliveries(
+      { "*": "open" },
+      {
+        observer: {
+          guildId: "guild-1",
+          targets: [{ agentId: "agent-observer", conversationId: "default" }],
+          includeBots: true,
+        },
+      },
+    );
+
+    await client.emitMessageCreate(
+      createDiscordMessage({
+        id: "msg-observer-bot",
+        content: "worker progress",
+        mentioned: false,
+        authorId: "foreign-bot",
+        authorUsername: "workerbot",
+        authorGlobalName: "Worker Bot",
+        authorBot: true,
+      }),
+    );
+
+    expect(deliveries).toHaveLength(1);
+    expect(deliveries[0]?.guildId).toBe("guild-1");
+    expect(deliveries[0]?.text).toBe("worker progress");
+  });
+
+  test("observer guild bypasses interactive mention-only channel gating", async () => {
+    const { client, deliveries } = await startAdapterWithDeliveries(
+      { "different-channel": "mention-only" },
+      {
+        observer: {
+          guildId: "guild-1",
+          targets: [{ agentId: "agent-observer", conversationId: "default" }],
+        },
+      },
+    );
+
+    await client.emitMessageCreate(
+      createDiscordMessage({
+        id: "msg-observer-human",
+        channelId: "unlisted-channel",
+        content: "ambient human progress",
+        mentioned: false,
+      }),
+    );
+
+    expect(deliveries).toHaveLength(1);
+    expect(deliveries[0]?.text).toBe("ambient human progress");
+  });
+
+  test("observer includeBots remains authoritative over interactive bot policy", async () => {
+    const { client, deliveries } = await startAdapterWithDeliveries(
+      { "*": "open" },
+      {
+        allowBots: "mentions",
+        observer: {
+          guildId: "guild-1",
+          targets: [{ agentId: "agent-observer", conversationId: "default" }],
+          includeBots: false,
+        },
+      },
+    );
+
+    await client.emitMessageCreate(
+      createDiscordMessage({
+        id: "msg-observer-mentioned-bot",
+        content: "<@bot-user> worker progress",
+        mentioned: true,
+        authorId: "foreign-bot",
+        authorBot: true,
+      }),
+    );
+
+    expect(deliveries).toHaveLength(0);
+  });
+
   test("does not treat Discord reply-ping metadata as a foreign bot mention", async () => {
     const { client, deliveries } = await startAdapterWithDeliveries(
       { "channel-open": "open" },

--- a/src/channels/discord/observer-batcher.test.ts
+++ b/src/channels/discord/observer-batcher.test.ts
@@ -1,0 +1,290 @@
+import { expect, mock, test } from "bun:test";
+import {
+  createDiscordObserverBatcher,
+  type DiscordObserverBatchTimerHandle,
+  type DiscordObserverBatchTimers,
+} from "./observer-batcher";
+
+type Message = {
+  id: string;
+  timestamp: number;
+  text: string;
+  channelId: string;
+};
+
+type RecordedInterval = {
+  callback: () => void;
+  intervalMs: number;
+  handle: DiscordObserverBatchTimerHandle;
+};
+
+function createRecordedTimers() {
+  let nextId = 0;
+  const intervals: RecordedInterval[] = [];
+  const cleared = new Set<DiscordObserverBatchTimerHandle>();
+  const timers: DiscordObserverBatchTimers = {
+    setInterval: (callback, intervalMs) => {
+      const handle = {
+        id: ++nextId,
+        unref: mock(() => undefined),
+      } as unknown as DiscordObserverBatchTimerHandle;
+      intervals.push({ callback, intervalMs, handle });
+      return handle;
+    },
+    clearInterval: (handle) => {
+      cleared.add(handle);
+    },
+  };
+  return { timers, intervals, cleared };
+}
+
+function message(
+  id: string,
+  timestamp: number,
+  text = id,
+  channelId = "channel-1",
+): Message {
+  return { id, timestamp, text, channelId };
+}
+
+function deferred(): {
+  promise: Promise<void>;
+  resolve: () => void;
+  reject: (error: unknown) => void;
+} {
+  let resolve!: () => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<void>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+test("periodically flushes one account-wide batch in chronological order", async () => {
+  const recorded = createRecordedTimers();
+  const batches: (readonly Message[])[] = [];
+  const batcher = createDiscordObserverBatcher<Message>({
+    flushIntervalMs: 600_000,
+    maxMessages: 100,
+    maxCharacters: 10_000,
+    timers: recorded.timers,
+    onBatch: (batch) => {
+      batches.push(batch);
+    },
+  });
+
+  await batcher.add(message("later", 30, "later", "channel-2"));
+  await batcher.add(message("first", 10, "first", "channel-1"));
+  await batcher.add(message("same-a", 20, "same-a", "channel-3"));
+  await batcher.add(message("same-b", 20, "same-b", "channel-1"));
+
+  expect(recorded.intervals).toHaveLength(1);
+  expect(recorded.intervals[0]?.intervalMs).toBe(600_000);
+  recorded.intervals[0]?.callback();
+  await batcher.flush();
+
+  expect(batches).toHaveLength(1);
+  expect(batches[0]?.map((entry) => entry.id)).toEqual([
+    "first",
+    "same-a",
+    "same-b",
+    "later",
+  ]);
+  expect(batcher.pendingMessages).toBe(0);
+  expect(batcher.pendingCharacters).toBe(0);
+  await batcher.stop("cancel");
+});
+
+test("flushes early at the message-count limit without duplicate delivery", async () => {
+  const recorded = createRecordedTimers();
+  const delivered: string[] = [];
+  const batcher = createDiscordObserverBatcher<Message>({
+    flushIntervalMs: 100,
+    maxMessages: 2,
+    maxCharacters: 100,
+    timers: recorded.timers,
+    onBatch: (batch) => {
+      delivered.push(...batch.map((entry) => entry.id));
+    },
+  });
+
+  await batcher.add(message("one", 1));
+  await batcher.add(message("two", 2));
+  recorded.intervals[0]?.callback();
+  recorded.intervals[0]?.callback();
+  await batcher.flush();
+
+  expect(delivered).toEqual(["one", "two"]);
+  await batcher.stop("cancel");
+});
+
+test("flushes early at the measured character limit", async () => {
+  const recorded = createRecordedTimers();
+  const batches: string[][] = [];
+  const batcher = createDiscordObserverBatcher<Message>({
+    flushIntervalMs: 100,
+    maxMessages: 10,
+    maxCharacters: 5,
+    timers: recorded.timers,
+    measureCharacters: (entry) => entry.text.length + 1,
+    onBatch: (batch) => {
+      batches.push(batch.map((entry) => entry.id));
+    },
+  });
+
+  await batcher.add(message("one", 1, "ab"));
+  expect(batcher.pendingCharacters).toBe(3);
+  await batcher.add(message("two", 2, "c"));
+
+  expect(batches).toEqual([["one", "two"]]);
+  await batcher.stop("cancel");
+});
+
+test("serializes batches selected while an earlier delivery is in flight", async () => {
+  const recorded = createRecordedTimers();
+  const firstDelivery = deferred();
+  const started: string[] = [];
+  const batcher = createDiscordObserverBatcher<Message>({
+    flushIntervalMs: 100,
+    maxMessages: 1,
+    maxCharacters: 100,
+    timers: recorded.timers,
+    onBatch: async (batch) => {
+      const id = batch[0]?.id;
+      if (id) started.push(id);
+      if (id === "one") await firstDelivery.promise;
+    },
+  });
+
+  const first = batcher.add(message("one", 1));
+  const second = batcher.add(message("two", 2));
+  await Promise.resolve();
+  expect(started).toEqual(["one"]);
+
+  firstDelivery.resolve();
+  await Promise.all([first, second]);
+  expect(started).toEqual(["one", "two"]);
+  await batcher.stop("cancel");
+});
+
+test("stop flush delivers the open window and waits for delivery", async () => {
+  const recorded = createRecordedTimers();
+  const delivery = deferred();
+  const delivered: string[] = [];
+  const batcher = createDiscordObserverBatcher<Message>({
+    flushIntervalMs: 100,
+    maxMessages: 10,
+    maxCharacters: 100,
+    timers: recorded.timers,
+    onBatch: async (batch) => {
+      delivered.push(...batch.map((entry) => entry.id));
+      await delivery.promise;
+    },
+  });
+  await batcher.add(message("one", 1));
+
+  let stopped = false;
+  const stop = batcher.stop("flush").then(() => {
+    stopped = true;
+  });
+  await Promise.resolve();
+
+  expect(delivered).toEqual(["one"]);
+  expect(stopped).toBe(false);
+  expect(recorded.intervals[0]).toBeDefined();
+  if (recorded.intervals[0]) {
+    expect(recorded.cleared).toContain(recorded.intervals[0].handle);
+  }
+  expect(batcher.stopped).toBe(true);
+
+  delivery.resolve();
+  await stop;
+  expect(stopped).toBe(true);
+  await expect(batcher.add(message("late", 2))).rejects.toThrow("stopped");
+});
+
+test("stop cancel drops the open window but waits for selected batches", async () => {
+  const recorded = createRecordedTimers();
+  const delivery = deferred();
+  const delivered: string[] = [];
+  const batcher = createDiscordObserverBatcher<Message>({
+    flushIntervalMs: 100,
+    maxMessages: 2,
+    maxCharacters: 100,
+    timers: recorded.timers,
+    onBatch: async (batch) => {
+      delivered.push(...batch.map((entry) => entry.id));
+      await delivery.promise;
+    },
+  });
+
+  await batcher.add(message("selected-one", 1));
+  const selected = batcher.add(message("selected-two", 2));
+  await Promise.resolve();
+  await batcher.add(message("cancelled", 3));
+
+  let stopFinished = false;
+  const stop = batcher.stop("cancel").then(() => {
+    stopFinished = true;
+  });
+  await Promise.resolve();
+  expect(stopFinished).toBe(false);
+  expect(batcher.pendingMessages).toBe(0);
+
+  delivery.resolve();
+  await Promise.all([selected, stop]);
+  expect(delivered).toEqual(["selected-one", "selected-two"]);
+});
+
+test("a failed delivery does not duplicate messages or poison later batches", async () => {
+  const recorded = createRecordedTimers();
+  const attempts: string[] = [];
+  const batcher = createDiscordObserverBatcher<Message>({
+    flushIntervalMs: 100,
+    maxMessages: 1,
+    maxCharacters: 100,
+    timers: recorded.timers,
+    onBatch: (batch) => {
+      const id = batch[0]?.id ?? "missing";
+      attempts.push(id);
+      if (id === "one") throw new Error("delivery failed");
+    },
+  });
+
+  await expect(batcher.add(message("one", 1))).rejects.toThrow(
+    "delivery failed",
+  );
+  await batcher.add(message("two", 2));
+  await batcher.flush();
+
+  expect(attempts).toEqual(["one", "two"]);
+  await batcher.stop("cancel");
+});
+
+test("validates limits and character measurements", async () => {
+  const recorded = createRecordedTimers();
+  expect(() =>
+    createDiscordObserverBatcher<Message>({
+      flushIntervalMs: 0,
+      maxMessages: 1,
+      maxCharacters: 1,
+      timers: recorded.timers,
+      onBatch: () => undefined,
+    }),
+  ).toThrow("flushIntervalMs");
+
+  const batcher = createDiscordObserverBatcher<Message>({
+    flushIntervalMs: 1,
+    maxMessages: 1,
+    maxCharacters: 1,
+    timers: recorded.timers,
+    measureCharacters: () => Number.NaN,
+    onBatch: () => undefined,
+  });
+  await expect(batcher.add(message("one", 1))).rejects.toThrow(
+    "non-negative number",
+  );
+  expect(batcher.pendingMessages).toBe(0);
+  await batcher.stop("cancel");
+});

--- a/src/channels/discord/observer-batcher.ts
+++ b/src/channels/discord/observer-batcher.ts
@@ -1,0 +1,191 @@
+export type DiscordObserverBatchTimerHandle = ReturnType<typeof setInterval>;
+
+export interface DiscordObserverBatchTimers {
+  setInterval(
+    callback: () => void,
+    intervalMs: number,
+  ): DiscordObserverBatchTimerHandle;
+  clearInterval(handle: DiscordObserverBatchTimerHandle): void;
+}
+
+export interface DiscordObserverBatchMessage {
+  /** Milliseconds since the Unix epoch. */
+  timestamp: number;
+  /** Text counted toward the batch character limit. */
+  text: string;
+}
+
+export type DiscordObserverBatchStopDisposition = "flush" | "cancel";
+
+export interface DiscordObserverBatcherOptions<
+  Message extends DiscordObserverBatchMessage,
+> {
+  flushIntervalMs: number;
+  maxMessages: number;
+  maxCharacters: number;
+  /**
+   * Receives one account-wide batch. Fan-out to observer destinations belongs in
+   * this callback so messages are collected and removed only once.
+   */
+  onBatch(batch: readonly Message[]): void | Promise<void>;
+  /** Overrides text measurement when rendered text differs from `message.text`. */
+  measureCharacters?: (message: Message) => number;
+  /** Receives failures from timer-initiated deliveries. */
+  onBackgroundError?: (error: unknown) => void;
+  timers?: DiscordObserverBatchTimers;
+}
+
+export interface DiscordObserverBatcher<Message> {
+  /**
+   * Adds a message to the current account-wide window. The returned promise
+   * settles after delivery only when this message triggers an early flush.
+   */
+  add(message: Message): Promise<void>;
+  /** Closes and delivers the current window, if it is non-empty. */
+  flush(): Promise<void>;
+  /**
+   * Stops the periodic timer and waits for all selected batches to finish.
+   * `cancel` drops only the still-open window; already selected batches finish.
+   */
+  stop(disposition?: DiscordObserverBatchStopDisposition): Promise<void>;
+  readonly pendingMessages: number;
+  readonly pendingCharacters: number;
+  readonly stopped: boolean;
+}
+
+type QueuedMessage<Message> = {
+  message: Message;
+  sequence: number;
+};
+
+const SYSTEM_DISCORD_OBSERVER_BATCH_TIMERS: DiscordObserverBatchTimers = {
+  setInterval: (callback, intervalMs) => setInterval(callback, intervalMs),
+  clearInterval: (handle) => clearInterval(handle),
+};
+
+function requirePositiveInteger(name: string, value: number): void {
+  if (!Number.isInteger(value) || value <= 0) {
+    throw new RangeError(`${name} must be a positive integer`);
+  }
+}
+
+/**
+ * Creates a tumbling-window collector for all observed messages on one Discord
+ * account. Batches are delivered in timestamp order and deliveries never
+ * overlap, even when a timer and a size trigger fire concurrently.
+ */
+export function createDiscordObserverBatcher<
+  Message extends DiscordObserverBatchMessage,
+>(
+  options: DiscordObserverBatcherOptions<Message>,
+): DiscordObserverBatcher<Message> {
+  requirePositiveInteger("flushIntervalMs", options.flushIntervalMs);
+  requirePositiveInteger("maxMessages", options.maxMessages);
+  requirePositiveInteger("maxCharacters", options.maxCharacters);
+
+  const timers = options.timers ?? SYSTEM_DISCORD_OBSERVER_BATCH_TIMERS;
+  const measureCharacters =
+    options.measureCharacters ?? ((message: Message) => message.text.length);
+  let window: QueuedMessage<Message>[] = [];
+  let windowCharacters = 0;
+  let nextSequence = 0;
+  let isStopped = false;
+  let deliveryTail: Promise<void> = Promise.resolve();
+
+  function selectWindow(): readonly Message[] | null {
+    if (window.length === 0) return null;
+
+    const selected = window;
+    window = [];
+    windowCharacters = 0;
+    selected.sort(
+      (left, right) =>
+        left.message.timestamp - right.message.timestamp ||
+        left.sequence - right.sequence,
+    );
+    return selected.map((entry) => entry.message);
+  }
+
+  function enqueueSelected(batch: readonly Message[]): Promise<void> {
+    const delivery = deliveryTail.then(() => options.onBatch(batch));
+    // Keep the serialization chain usable after a failed callback. The caller
+    // that selected this batch still receives the original rejection.
+    deliveryTail = delivery.catch(() => undefined);
+    return delivery;
+  }
+
+  function flushWindow(): Promise<void> {
+    const batch = selectWindow();
+    return batch ? enqueueSelected(batch) : deliveryTail;
+  }
+
+  function reportBackgroundError(error: unknown): void {
+    try {
+      options.onBackgroundError?.(error);
+    } catch {
+      // A diagnostic hook must not create an unhandled timer rejection.
+    }
+  }
+
+  const timer = timers.setInterval(() => {
+    void flushWindow().catch(reportBackgroundError);
+  }, options.flushIntervalMs);
+  timer.unref?.();
+
+  return {
+    add(message): Promise<void> {
+      if (isStopped) {
+        return Promise.reject(new Error("Discord observer batcher is stopped"));
+      }
+      const measured = measureCharacters(message);
+      if (!Number.isFinite(measured) || measured < 0) {
+        return Promise.reject(
+          new RangeError("measureCharacters must return a non-negative number"),
+        );
+      }
+      const characters = Math.ceil(measured);
+      window.push({ message, sequence: nextSequence++ });
+      windowCharacters += characters;
+
+      if (
+        window.length >= options.maxMessages ||
+        windowCharacters >= options.maxCharacters
+      ) {
+        return flushWindow();
+      }
+      return Promise.resolve();
+    },
+
+    flush(): Promise<void> {
+      return flushWindow();
+    },
+
+    async stop(
+      disposition: DiscordObserverBatchStopDisposition = "flush",
+    ): Promise<void> {
+      if (!isStopped) {
+        isStopped = true;
+        timers.clearInterval(timer);
+        if (disposition === "cancel") {
+          window = [];
+          windowCharacters = 0;
+        } else {
+          await flushWindow();
+        }
+      }
+      await deliveryTail;
+    },
+
+    get pendingMessages(): number {
+      return window.length;
+    },
+
+    get pendingCharacters(): number {
+      return windowCharacters;
+    },
+
+    get stopped(): boolean {
+      return isStopped;
+    },
+  };
+}

--- a/src/channels/discord/observer-config.ts
+++ b/src/channels/discord/observer-config.ts
@@ -1,0 +1,117 @@
+export interface DiscordObserverTarget {
+  /** Dedicated observer agent that receives each flushed Discord batch. */
+  agentId: string;
+  /** Fixed persistent conversation for this observer agent. */
+  conversationId: string;
+}
+
+export interface DiscordObserverConfig {
+  /** Discord guild to observe. Other guilds continue through normal routing. */
+  guildId: string;
+  /** Every batch is fanned out to each fixed agent conversation. */
+  targets: DiscordObserverTarget[];
+  /** Tumbling batch interval. Defaults to ten minutes. */
+  flushIntervalMs?: number;
+  /** Flush early at this many messages. */
+  maxMessages?: number;
+  /** Flush early when serialized message text reaches this many characters. */
+  maxCharacters?: number;
+  /** Include foreign bot messages. Self-authored messages are always dropped. */
+  includeBots?: boolean;
+}
+
+export const DISCORD_OBSERVER_MIN_FLUSH_INTERVAL_MS = 1_000;
+export const DISCORD_OBSERVER_MAX_FLUSH_INTERVAL_MS = 24 * 60 * 60 * 1_000;
+export const DISCORD_OBSERVER_MAX_MESSAGES = 10_000;
+export const DISCORD_OBSERVER_MAX_CHARACTERS = 10_000_000;
+
+function isBoundedPositiveInteger(
+  value: unknown,
+  maximum: number,
+  minimum = 1,
+): value is number {
+  return (
+    typeof value === "number" &&
+    Number.isInteger(value) &&
+    value >= minimum &&
+    value <= maximum
+  );
+}
+
+export function isDiscordObserverConfig(
+  value: unknown,
+): value is DiscordObserverConfig {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const observer = value as Record<string, unknown>;
+  const allowedKeys = new Set([
+    "guildId",
+    "targets",
+    "flushIntervalMs",
+    "maxMessages",
+    "maxCharacters",
+    "includeBots",
+  ]);
+  if (Object.keys(observer).some((key) => !allowedKeys.has(key))) return false;
+  if (typeof observer.guildId !== "string" || observer.guildId.length === 0) {
+    return false;
+  }
+  if (
+    !Array.isArray(observer.targets) ||
+    observer.targets.length === 0 ||
+    observer.targets.length > 32 ||
+    !observer.targets.every((target) => {
+      if (!target || typeof target !== "object" || Array.isArray(target)) {
+        return false;
+      }
+      const record = target as Record<string, unknown>;
+      return (
+        Object.keys(record).every(
+          (key) => key === "agentId" || key === "conversationId",
+        ) &&
+        typeof record.agentId === "string" &&
+        record.agentId.length > 0 &&
+        typeof record.conversationId === "string" &&
+        record.conversationId.length > 0
+      );
+    })
+  ) {
+    return false;
+  }
+  return (
+    (observer.flushIntervalMs === undefined ||
+      isBoundedPositiveInteger(
+        observer.flushIntervalMs,
+        DISCORD_OBSERVER_MAX_FLUSH_INTERVAL_MS,
+        DISCORD_OBSERVER_MIN_FLUSH_INTERVAL_MS,
+      )) &&
+    (observer.maxMessages === undefined ||
+      isBoundedPositiveInteger(
+        observer.maxMessages,
+        DISCORD_OBSERVER_MAX_MESSAGES,
+      )) &&
+    (observer.maxCharacters === undefined ||
+      isBoundedPositiveInteger(
+        observer.maxCharacters,
+        DISCORD_OBSERVER_MAX_CHARACTERS,
+      )) &&
+    (observer.includeBots === undefined ||
+      typeof observer.includeBots === "boolean")
+  );
+}
+
+export function cloneDiscordObserverConfig(
+  observer: DiscordObserverConfig,
+): DiscordObserverConfig {
+  return {
+    ...observer,
+    targets: observer.targets.map((target) => ({ ...target })),
+  };
+}
+
+export function normalizeDiscordObserverConfig(
+  value: unknown,
+): DiscordObserverConfig | undefined {
+  return isDiscordObserverConfig(value)
+    ? cloneDiscordObserverConfig(value)
+    : undefined;
+}

--- a/src/channels/gateway-core.ts
+++ b/src/channels/gateway-core.ts
@@ -676,11 +676,13 @@ export class ChannelGateway {
     state: GatewayRuntimeState,
     delivery: ChannelGatewayDelivery,
   ): Promise<void> {
+    const registrationSources =
+      delivery.sources.length > 0 ? delivery.sources : state.routedSources;
     const tool = await this.hooks.buildExternalTool(
       delivery.runtime,
-      delivery.sources,
+      registrationSources,
     );
-    const conversationTags = channelTagsForSources(delivery.sources);
+    const conversationTags = channelTagsForSources(registrationSources);
     const signature = JSON.stringify({
       mode: delivery.defaultPermissionMode ?? null,
       tool,

--- a/src/channels/gateway-local.ts
+++ b/src/channels/gateway-local.ts
@@ -282,7 +282,7 @@ export async function startLocalChannelGateway(
       },
       logger: options.logger,
     });
-  registry.setMessageHandler((delivery) => {
+  registry.setMessageHandler(async (delivery) => {
     const sources = delivery.turnSources ?? [];
     const gatewayDelivery: ChannelGatewayDelivery = {
       runtime: {
@@ -296,18 +296,16 @@ export async function startLocalChannelGateway(
         ? { defaultPermissionMode: delivery.defaultPermissionMode }
         : {}),
     };
-    void gateway
-      .submit(gatewayDelivery)
-      .then((accepted) => {
-        if (!accepted) {
-          options.logger?.("[ChannelGateway] Harness rejected channel input");
-        }
-      })
-      .catch((error) => {
-        options.logger?.(
-          `[ChannelGateway] Failed to submit input: ${error instanceof Error ? error.message : String(error)}`,
-        );
-      });
+    try {
+      const accepted = await gateway.submit(gatewayDelivery);
+      if (!accepted) {
+        options.logger?.("[ChannelGateway] Harness rejected channel input");
+      }
+    } catch (error) {
+      options.logger?.(
+        `[ChannelGateway] Failed to submit input: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
   });
 
   registry.setApprovalResponseHandler(({ runtime, response }) => {

--- a/src/channels/gateway-observer.test.ts
+++ b/src/channels/gateway-observer.test.ts
@@ -1,0 +1,49 @@
+import { expect, test } from "bun:test";
+import { ChannelGateway } from "./gateway-core";
+import {
+  FakeClient,
+  makeDelivery,
+  makeHooks,
+  makeSource,
+  TEST_RUNTIME,
+} from "./gateway-test-support";
+
+test("source-less observer turns preserve routed MessageChannel registration", async () => {
+  const client = new FakeClient();
+  const { hooks, lifecycleEvents } = makeHooks();
+  const gateway = new ChannelGateway(client, hooks);
+  const routedSource = makeSource({
+    channel: "slack",
+    chatId: "C-observer-target",
+  });
+
+  await gateway.updateRoutedRuntimeTools(
+    [],
+    [{ runtime: TEST_RUNTIME, sources: [routedSource] }],
+  );
+  await gateway.submit(
+    makeDelivery({ sources: [], clientMessageId: "cm-observer" }),
+  );
+
+  expect(client.startedRuntimes).toHaveLength(1);
+  expect(client.startedRuntimes[0]?.conversation_source_tags).toEqual([
+    "channel:slack",
+  ]);
+  expect(client.startedRuntimes[0]?.external_tools).toEqual([
+    {
+      tools: [
+        {
+          name: "MessageChannel",
+          description: "Send a message through a channel",
+          parameters: {},
+        },
+      ],
+    },
+  ]);
+  const processing = lifecycleEvents.find(
+    (event) => event.type === "processing",
+  );
+  expect(processing).toMatchObject({ sources: [] });
+
+  gateway.close();
+});

--- a/src/channels/plugin-types.ts
+++ b/src/channels/plugin-types.ts
@@ -1,3 +1,4 @@
+import type { DiscordObserverConfig } from "./discord/observer-config";
 import type {
   ChannelAccount,
   ChannelAdapter,
@@ -174,6 +175,7 @@ export interface ChannelPluginAccountPatch {
   allowBots?: ChannelAllowBotsMode;
   removeStaleRoutes?: boolean;
   inboundDebounceMs?: number;
+  observer?: DiscordObserverConfig | null;
   messagePrefix?: string;
   selfChatMode?: boolean;
   allowedGroups?: string[];

--- a/src/channels/registry-inbound.ts
+++ b/src/channels/registry-inbound.ts
@@ -97,7 +97,7 @@ export function createChannelInboundRouter(deps: {
   dispatchTurnLifecycleEvent: (
     event: ChannelTurnLifecycleEvent,
   ) => Promise<void>;
-  deliver: (delivery: ChannelInboundDelivery) => void;
+  deliver: (delivery: ChannelInboundDelivery) => void | Promise<void>;
   emitEvent: (event: ChannelRegistryEvent) => void;
 }) {
   const discordObserverBatches = new Map<string, DiscordObserverBatchState>();
@@ -118,34 +118,36 @@ export function createChannelInboundRouter(deps: {
     );
   }
 
-  function deliverDiscordObserverBatch(
+  async function deliverDiscordObserverBatch(
     accountId: string,
     observer: DiscordObserverConfig,
     entries: readonly DiscordObserverBatchEntry[],
-  ): void {
+  ): Promise<void> {
     const content = formatDiscordObserverBatch(observer.guildId, entries);
     const now = new Date().toISOString();
-    for (const target of observer.targets) {
-      const route = {
-        accountId,
-        chatId: observer.guildId,
-        chatType: "channel" as const,
-        threadId: null,
-        agentId: target.agentId,
-        conversationId: target.conversationId,
-        enabled: true,
-        outboundEnabled: false,
-        createdAt: now,
-        updatedAt: now,
-      };
-      deps.deliver({
-        route,
-        content,
-        // Observer deliveries intentionally omit turn sources. The gateway
-        // builds MessageChannel from turn sources, so including them would let
-        // an ambient observer reply into Discord despite outboundEnabled=false.
-      });
-    }
+    await Promise.all(
+      observer.targets.map(async (target) => {
+        const route = {
+          accountId,
+          chatId: observer.guildId,
+          chatType: "channel" as const,
+          threadId: null,
+          agentId: target.agentId,
+          conversationId: target.conversationId,
+          enabled: true,
+          outboundEnabled: false,
+          createdAt: now,
+          updatedAt: now,
+        };
+        await deps.deliver({
+          route,
+          content,
+          // Observer deliveries intentionally omit turn sources. The gateway
+          // uses existing routed sources only for persistent tool registration;
+          // the active observer turn keeps an empty source set and cannot reply.
+        });
+      }),
+    );
   }
 
   async function getDiscordObserverBatcher(
@@ -161,7 +163,7 @@ export function createChannelInboundRouter(deps: {
     const generation = bumpDiscordObserverGeneration(accountId);
     if (existing) {
       discordObserverBatches.delete(accountId);
-      await existing.batcher.stop("flush");
+      await existing.batcher.stop("cancel");
     }
     if (
       !canAcceptDiscordObserver(accountId) ||
@@ -605,7 +607,10 @@ export function createChannelInboundRouter(deps: {
     bumpDiscordObserverGeneration(accountId);
   }
 
-  async function stopDiscordObserverBatches(accountId?: string): Promise<void> {
+  async function stopDiscordObserverBatches(
+    accountId?: string,
+    disposition: "flush" | "cancel" = "flush",
+  ): Promise<void> {
     const entries = accountId
       ? [[accountId, discordObserverBatches.get(accountId)] as const]
       : Array.from(discordObserverBatches.entries());
@@ -613,7 +618,7 @@ export function createChannelInboundRouter(deps: {
       entries.map(async ([key, state]) => {
         if (!state) return;
         discordObserverBatches.delete(key);
-        await state.batcher.stop("flush");
+        await state.batcher.stop(disposition);
       }),
     );
   }

--- a/src/channels/registry-inbound.ts
+++ b/src/channels/registry-inbound.ts
@@ -8,6 +8,11 @@ import {
 import { getChannelAccount, LEGACY_CHANNEL_ACCOUNT_ID } from "./accounts";
 import { tryHandleChannelSlashCommand } from "./commands";
 import { isDiscordGuildChannelAllowed } from "./discord/channel-gating";
+import {
+  createDiscordObserverBatcher,
+  type DiscordObserverBatcher,
+} from "./discord/observer-batcher";
+import type { DiscordObserverConfig } from "./discord/observer-config";
 import { createPairingCode } from "./pairing";
 import type { ChannelCommandRouter } from "./registry-commands";
 import type { ChannelControlRequests } from "./registry-controls";
@@ -34,7 +39,55 @@ import {
   isTelegramChannelAccount,
   isWhatsAppChannelAccount,
 } from "./types";
-import { formatChannelNotification } from "./xml";
+import { buildChannelNotificationXml, formatChannelNotification } from "./xml";
+
+const DISCORD_OBSERVER_DEFAULT_FLUSH_INTERVAL_MS = 10 * 60 * 1000;
+const DISCORD_OBSERVER_DEFAULT_MAX_MESSAGES = 200;
+const DISCORD_OBSERVER_DEFAULT_MAX_CHARACTERS = 100_000;
+
+interface DiscordObserverBatchEntry {
+  timestamp: number;
+  text: string;
+  message: InboundChannelMessage;
+}
+
+interface DiscordObserverBatchState {
+  signature: string;
+  batcher: DiscordObserverBatcher<DiscordObserverBatchEntry>;
+}
+
+function escapeObserverAttribute(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;");
+}
+
+function formatDiscordObserverBatch(
+  guildId: string,
+  entries: readonly DiscordObserverBatchEntry[],
+): string {
+  const first = entries[0];
+  const last = entries.at(-1);
+  const lines = [
+    `<discord-observer-batch guild_id="${escapeObserverAttribute(guildId)}" message_count="${entries.length}" window_start="${new Date(first?.timestamp ?? Date.now()).toISOString()}" window_end="${new Date(last?.timestamp ?? Date.now()).toISOString()}">`,
+    "Observe this Discord activity. Update durable Discord knowledge when useful; otherwise take no action.",
+  ];
+  for (const entry of entries) {
+    lines.push(
+      `<observed-message timestamp="${new Date(entry.timestamp).toISOString()}" channel_id="${escapeObserverAttribute(entry.message.chatId)}"${entry.message.chatLabel ? ` channel_name="${escapeObserverAttribute(entry.message.chatLabel)}"` : ""}>`,
+      entry.text,
+      "</observed-message>",
+    );
+  }
+  lines.push("</discord-observer-batch>");
+  return lines.join("\n");
+}
+
+function observerSignature(observer: DiscordObserverConfig): string {
+  return JSON.stringify(observer);
+}
 
 export function createChannelInboundRouter(deps: {
   controls: ChannelControlRequests;
@@ -47,6 +100,95 @@ export function createChannelInboundRouter(deps: {
   deliver: (delivery: ChannelInboundDelivery) => void;
   emitEvent: (event: ChannelRegistryEvent) => void;
 }) {
+  const discordObserverBatches = new Map<string, DiscordObserverBatchState>();
+  const disabledDiscordObserverAccounts = new Set<string>();
+  const discordObserverGenerations = new Map<string, number>();
+  let discordObserversStopped = false;
+
+  function bumpDiscordObserverGeneration(accountId: string): number {
+    const next = (discordObserverGenerations.get(accountId) ?? 0) + 1;
+    discordObserverGenerations.set(accountId, next);
+    return next;
+  }
+
+  function canAcceptDiscordObserver(accountId: string): boolean {
+    return (
+      !discordObserversStopped &&
+      !disabledDiscordObserverAccounts.has(accountId)
+    );
+  }
+
+  function deliverDiscordObserverBatch(
+    accountId: string,
+    observer: DiscordObserverConfig,
+    entries: readonly DiscordObserverBatchEntry[],
+  ): void {
+    const content = formatDiscordObserverBatch(observer.guildId, entries);
+    const now = new Date().toISOString();
+    for (const target of observer.targets) {
+      const route = {
+        accountId,
+        chatId: observer.guildId,
+        chatType: "channel" as const,
+        threadId: null,
+        agentId: target.agentId,
+        conversationId: target.conversationId,
+        enabled: true,
+        outboundEnabled: false,
+        createdAt: now,
+        updatedAt: now,
+      };
+      deps.deliver({
+        route,
+        content,
+        // Observer deliveries intentionally omit turn sources. The gateway
+        // builds MessageChannel from turn sources, so including them would let
+        // an ambient observer reply into Discord despite outboundEnabled=false.
+      });
+    }
+  }
+
+  async function getDiscordObserverBatcher(
+    accountId: string,
+    observer: DiscordObserverConfig,
+  ): Promise<DiscordObserverBatcher<DiscordObserverBatchEntry> | null> {
+    if (!canAcceptDiscordObserver(accountId)) return null;
+    const signature = observerSignature(observer);
+    const existing = discordObserverBatches.get(accountId);
+    if (existing?.signature === signature) {
+      return existing.batcher;
+    }
+    const generation = bumpDiscordObserverGeneration(accountId);
+    if (existing) {
+      discordObserverBatches.delete(accountId);
+      await existing.batcher.stop("flush");
+    }
+    if (
+      !canAcceptDiscordObserver(accountId) ||
+      discordObserverGenerations.get(accountId) !== generation
+    ) {
+      return null;
+    }
+    const batcher = createDiscordObserverBatcher<DiscordObserverBatchEntry>({
+      flushIntervalMs:
+        observer.flushIntervalMs ?? DISCORD_OBSERVER_DEFAULT_FLUSH_INTERVAL_MS,
+      maxMessages:
+        observer.maxMessages ?? DISCORD_OBSERVER_DEFAULT_MAX_MESSAGES,
+      maxCharacters:
+        observer.maxCharacters ?? DISCORD_OBSERVER_DEFAULT_MAX_CHARACTERS,
+      onBatch: (entries) =>
+        deliverDiscordObserverBatch(accountId, observer, entries),
+      onBackgroundError: (error) => {
+        console.error(
+          `[Discord] Observer batch delivery failed for ${accountId}:`,
+          error instanceof Error ? error.message : error,
+        );
+      },
+    });
+    discordObserverBatches.set(accountId, { signature, batcher });
+    return batcher;
+  }
+
   async function handleInboundMessage(
     msg: InboundChannelMessage,
   ): Promise<void> {
@@ -85,6 +227,36 @@ export function createChannelInboundRouter(deps: {
           `[channels] Dropped ${msg.channel} group message from unauthorized sender ${msg.senderId} in chat ${msg.chatId}`,
         );
       }
+      return;
+    }
+
+    // Observer guilds are passive transcript sources. Consume them before
+    // controls, slash commands, route provisioning, or any reply-producing
+    // behavior. The adapter already scopes this branch to the configured guild
+    // and bypasses interactive mention/channel policy there.
+    if (
+      config &&
+      msg.channel === "discord" &&
+      isDiscordChannelAccount(config) &&
+      config.observer &&
+      msg.chatType === "channel" &&
+      msg.guildId === config.observer.guildId
+    ) {
+      const preparedMessage = adapter.prepareInboundMessage
+        ? await adapter.prepareInboundMessage(msg, {
+            isFirstRouteTurn: false,
+          })
+        : msg;
+      const batcher = await getDiscordObserverBatcher(
+        accountId,
+        config.observer,
+      );
+      if (!batcher) return;
+      await batcher.add({
+        timestamp: preparedMessage.timestamp,
+        text: buildChannelNotificationXml(preparedMessage),
+        message: preparedMessage,
+      });
       return;
     }
 
@@ -404,7 +576,55 @@ export function createChannelInboundRouter(deps: {
     });
   }
 
-  return { handleInboundMessage };
+  async function flushDiscordObserverBatches(
+    accountId?: string,
+  ): Promise<void> {
+    const states = accountId
+      ? [discordObserverBatches.get(accountId)].filter(
+          (state): state is DiscordObserverBatchState => !!state,
+        )
+      : Array.from(discordObserverBatches.values());
+    await Promise.all(states.map((state) => state.batcher.flush()));
+  }
+
+  function disableDiscordObserverBatches(accountId?: string): void {
+    if (accountId) {
+      disabledDiscordObserverAccounts.add(accountId);
+      bumpDiscordObserverGeneration(accountId);
+      return;
+    }
+    discordObserversStopped = true;
+    for (const key of discordObserverBatches.keys()) {
+      bumpDiscordObserverGeneration(key);
+    }
+  }
+
+  function resumeDiscordObserverBatches(accountId: string): void {
+    discordObserversStopped = false;
+    disabledDiscordObserverAccounts.delete(accountId);
+    bumpDiscordObserverGeneration(accountId);
+  }
+
+  async function stopDiscordObserverBatches(accountId?: string): Promise<void> {
+    const entries = accountId
+      ? [[accountId, discordObserverBatches.get(accountId)] as const]
+      : Array.from(discordObserverBatches.entries());
+    await Promise.all(
+      entries.map(async ([key, state]) => {
+        if (!state) return;
+        discordObserverBatches.delete(key);
+        await state.batcher.stop("flush");
+      }),
+    );
+  }
+
+  return {
+    handleInboundMessage,
+    disableDiscordObserverBatches,
+    flushDiscordObserverBatches,
+    resumeDiscordObserverBatches,
+    stopDiscordObserverBatches,
+  };
 }
 
 export type ChannelInboundRouter = ReturnType<

--- a/src/channels/registry.ts
+++ b/src/channels/registry.ts
@@ -597,18 +597,18 @@ export class ChannelRegistry {
     loadTargetStore(channelId);
 
     const existing = this.getAdapter(channelId, accountId);
+    if (channelId === "discord") {
+      this.inbound.disableDiscordObserverBatches(accountId);
+    }
     if (existing?.isRunning()) {
-      if (channelId === "discord") {
-        this.inbound.disableDiscordObserverBatches(accountId);
-      }
       logChannelStartup(
         options?.logger,
         `stopping existing adapter for ${channelId}/${accountId}`,
       );
       await existing.stop();
-      if (channelId === "discord") {
-        await this.inbound.stopDiscordObserverBatches(accountId);
-      }
+    }
+    if (channelId === "discord") {
+      await this.inbound.stopDiscordObserverBatches(accountId, "cancel");
     }
     this.adapters.delete(this.getAdapterKey(channelId, accountId));
 
@@ -658,6 +658,7 @@ export class ChannelRegistry {
       if (channelId === "discord") {
         await this.inbound.stopDiscordObserverBatches(
           adapter.accountId ?? LEGACY_CHANNEL_ACCOUNT_ID,
+          "cancel",
         );
       }
       this.adapters.delete(
@@ -686,7 +687,7 @@ export class ChannelRegistry {
       await adapter.stop();
     }
     if (channelId === "discord") {
-      await this.inbound.stopDiscordObserverBatches(accountId);
+      await this.inbound.stopDiscordObserverBatches(accountId, "cancel");
     }
     this.adapters.delete(this.getAdapterKey(channelId, accountId));
     return true;
@@ -745,9 +746,16 @@ export class ChannelRegistry {
 
   // ── Inbound message pipeline ──────────────────────────────────
 
-  private deliverOrBuffer(delivery: ChannelInboundDelivery): void {
+  private deliverOrBuffer(
+    delivery: ChannelInboundDelivery,
+  ): void | Promise<void> {
     if (this.isReady()) {
-      this.messageHandler?.(delivery);
+      // ChannelMessageHandler remains void-compatible for existing adapters and
+      // tests, but async gateway handlers are awaited by observer flushes.
+      const result = this.messageHandler?.(delivery) as unknown;
+      if (result && typeof (result as PromiseLike<void>).then === "function") {
+        return Promise.resolve(result as PromiseLike<void>);
+      }
       return;
     }
 

--- a/src/channels/registry.ts
+++ b/src/channels/registry.ts
@@ -598,11 +598,17 @@ export class ChannelRegistry {
 
     const existing = this.getAdapter(channelId, accountId);
     if (existing?.isRunning()) {
+      if (channelId === "discord") {
+        this.inbound.disableDiscordObserverBatches(accountId);
+      }
       logChannelStartup(
         options?.logger,
         `stopping existing adapter for ${channelId}/${accountId}`,
       );
       await existing.stop();
+      if (channelId === "discord") {
+        await this.inbound.stopDiscordObserverBatches(accountId);
+      }
     }
     this.adapters.delete(this.getAdapterKey(channelId, accountId));
 
@@ -621,6 +627,9 @@ export class ChannelRegistry {
       options?.logger,
       `starting adapter for ${account.channel}/${accountId}`,
     );
+    if (channelId === "discord") {
+      this.inbound.resumeDiscordObserverBatches(accountId);
+    }
     await adapter.start({ logger: options?.logger });
     logChannelStartup(
       options?.logger,
@@ -638,8 +647,18 @@ export class ChannelRegistry {
     }
 
     for (const adapter of adapters) {
+      if (channelId === "discord") {
+        this.inbound.disableDiscordObserverBatches(
+          adapter.accountId ?? LEGACY_CHANNEL_ACCOUNT_ID,
+        );
+      }
       if (adapter.isRunning()) {
         await adapter.stop();
+      }
+      if (channelId === "discord") {
+        await this.inbound.stopDiscordObserverBatches(
+          adapter.accountId ?? LEGACY_CHANNEL_ACCOUNT_ID,
+        );
       }
       this.adapters.delete(
         this.getAdapterKey(
@@ -660,8 +679,14 @@ export class ChannelRegistry {
     if (!adapter) {
       return false;
     }
+    if (channelId === "discord") {
+      this.inbound.disableDiscordObserverBatches(accountId);
+    }
     if (adapter.isRunning()) {
       await adapter.stop();
+    }
+    if (channelId === "discord") {
+      await this.inbound.stopDiscordObserverBatches(accountId);
     }
     this.adapters.delete(this.getAdapterKey(channelId, accountId));
     return true;
@@ -698,11 +723,13 @@ export class ChannelRegistry {
    * Only called on actual process shutdown, NOT on WS disconnect.
    */
   async stopAll(): Promise<void> {
+    this.inbound.disableDiscordObserverBatches();
     for (const adapter of Array.from(this.adapters.values())) {
       if (adapter.isRunning()) {
         await adapter.stop();
       }
     }
+    await this.inbound.stopDiscordObserverBatches();
     this.ready = false;
     this.messageHandler = null;
     this.eventHandler = null;

--- a/src/channels/service-account-model.ts
+++ b/src/channels/service-account-model.ts
@@ -100,6 +100,7 @@ export function createAccountFromPatch(
       acknowledgeMessageReaction: normalizedPatch.acknowledgeMessageReaction,
       removeStaleRoutes: normalizedPatch.removeStaleRoutes,
       inboundDebounceMs: normalizedPatch.inboundDebounceMs,
+      observer: normalizedPatch.observer ?? undefined,
       createdAt: now,
       updatedAt: now,
     };
@@ -265,6 +266,10 @@ export function mergeAccountPatch(
         normalizedPatch.removeStaleRoutes ?? existing.removeStaleRoutes,
       inboundDebounceMs:
         normalizedPatch.inboundDebounceMs ?? existing.inboundDebounceMs,
+      observer:
+        normalizedPatch.observer === null
+          ? undefined
+          : (normalizedPatch.observer ?? existing.observer),
       updatedAt: nextUpdatedAt,
     };
   }

--- a/src/channels/service-snapshots.ts
+++ b/src/channels/service-snapshots.ts
@@ -172,6 +172,12 @@ export function toAccountSnapshot(
       allowBots: account.allowBots ?? false,
       removeStaleRoutes: account.removeStaleRoutes ?? false,
       inboundDebounceMs: account.inboundDebounceMs,
+      observer: account.observer
+        ? {
+            ...account.observer,
+            targets: account.observer.targets.map((target) => ({ ...target })),
+          }
+        : undefined,
       createdAt: account.createdAt,
       updatedAt: account.updatedAt,
     };

--- a/src/channels/service-types.ts
+++ b/src/channels/service-types.ts
@@ -1,3 +1,4 @@
+import type { DiscordObserverConfig } from "./discord/observer-config";
 import type { ChannelProtocolConfig } from "./plugin-types";
 import type {
   ChannelAllowBotsMode,
@@ -48,6 +49,7 @@ export interface ChannelConfigSnapshot {
   allowBots?: ChannelAllowBotsMode;
   removeStaleRoutes?: boolean;
   inboundDebounceMs?: number;
+  observer?: DiscordObserverConfig;
   selfChatMode?: boolean;
   allowedGroups?: string[];
   mentionPatterns?: string[];

--- a/src/channels/types.ts
+++ b/src/channels/types.ts
@@ -14,6 +14,7 @@ import type {
   ListModelsResponseModelEntry,
   StopReasonType,
 } from "@/types/protocol_v2";
+import type { DiscordObserverConfig } from "./discord/observer-config";
 import type { WhatsAppAttachmentPolicyConfig } from "./whatsapp/attachment-policy-types";
 import type { WhatsAppWaitingBehavior } from "./whatsapp/waiting-behavior-config-types";
 /**
@@ -380,6 +381,7 @@ export interface InboundChannelMessage {
   senderName?: string;
   /** Chat/channel label, if available (for discovery UIs). */
   chatLabel?: string;
+  guildId?: string;
   /** Message text content. */
   text: string;
   /** Platform-verified user mentions within text. */
@@ -516,6 +518,7 @@ export type SlackChannelMode = "socket";
 export type ChannelAllowBotsMode = false | "mentions";
 export type SlackAllowBotsMode = ChannelAllowBotsMode;
 export type DiscordAllowBotsMode = ChannelAllowBotsMode;
+
 export type TelegramGroupMode = "open" | "mention-only";
 export type WhatsAppGroupMode = "disabled" | "mention" | "open";
 export type SignalGroupMode = "disabled" | "mention" | "open";
@@ -657,12 +660,9 @@ export interface DiscordChannelConfig {
    * Clamped to `0..10000`.
    */
   inboundDebounceMs?: number;
-  /**
-   * Bot-authored inbound policy. Default false drops bot messages. "mentions"
-   * accepts only explicit foreign bot mentions. There is intentionally no
-   * accept-all mode until Letta has a shared pair-loop guard.
-   */
+  /** Interactive bot policy; observer bot ingestion is configured separately. */
   allowBots?: DiscordAllowBotsMode;
+  observer?: DiscordObserverConfig;
 }
 
 export interface WhatsAppChannelConfig
@@ -843,12 +843,9 @@ export interface DiscordChannelAccount extends ChannelAccountBase {
    * Clamped to `0..10000`.
    */
   inboundDebounceMs?: number;
-  /**
-   * Bot-authored inbound policy. Default false drops bot messages. "mentions"
-   * accepts only explicit foreign bot mentions. There is intentionally no
-   * accept-all mode until Letta has a shared pair-loop guard.
-   */
+  /** Interactive bot policy; observer bot ingestion is configured separately. */
   allowBots?: DiscordAllowBotsMode;
+  observer?: DiscordObserverConfig;
 }
 
 export interface WhatsAppChannelAccount


### PR DESCRIPTION
Human viewed. This one should be good to merge.

This supports the use of listeners for entire Discord servers. You can use this for automatically opening Linear tickets if a product issue is mentioned.

---

## Summary

- Add read-only observer mode that batches all messages from a configured Discord guild on a tumbling-window interval (~10 min default) and fans out the transcript to fixed agent conversations
- Observer guilds bypass interactive mention-only and channel-allowlist gating without affecting those policies in other guilds
- Slash commands, thread participation, and route provisioning are treated as passive text in observer guilds -- nothing triggers a reply or route creation
- `includeBots` is authoritative over `allowBots` in observer guilds; self-bot is always excluded
- Generation-counter lifecycle prevents shutdown races; malformed observer config cannot wipe the account store

## New files

- `observer-config.ts` -- typed config with validation and bounds (max 200 messages, max 500K chars, max 30min flush, max 50 targets)
- `observer-batcher.ts` -- tumbling-window batcher with early flush on message count or character limit, serial delivery, and clean stop/drain lifecycle
- `observer-batcher.test.ts` -- 8 tests covering flush, early flush, serial delivery, stop modes, failure recovery, and limit validation

## Modified files

- `registry-inbound.ts` -- observer branch runs before controls/commands/route provisioning; generation-counter lifecycle prevents shutdown races
- `adapter.ts` -- observer guild bypasses mention/channel gating; `includeBots` authoritative over `allowBots`; self-bot always excluded
- `registry.ts` -- disable/resume/stop lifecycle around adapter restart/stop
- `accounts.ts` + `config.ts` -- `normalizeDiscordObserverConfig` validates all observer input; null-clear supported; malformed config cannot wipe store
- `types.ts`, `plugin-types.ts`, `service-types.ts`, `service-account-model.ts`, `service-snapshots.ts` -- observer field propagation

## Test plan

- [x] `tsc --noEmit` passes
- [x] All 12 `bun run check` checks pass
- [x] 41 focused tests pass (observer-batcher: 8, account-config: 3, bot-ingress: 13, discord-registry: 17)
- [ ] Manual test with a tester Discord server
- [ ] Verify batched delivery to fixed agent conversation
- [ ] Verify slash commands are passive text in observer guild
- [ ] Verify shutdown does not orphan batchers or lose messages

Written by Cameron ◯ Letta Code