### PR TITLE
ci: add native binary verification step after install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,13 +168,18 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: bun install --frozen-lockfile
 
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22.19'
+
       - name: Verify native binaries
         run: |
           node -e "try { require('sharp'); console.log('sharp: OK') } catch(e) { console.error('sharp: FAIL —', e.message); process.exit(1) }"
           node -e "try { require('node-pty'); console.log('node-pty: OK') } catch(e) { console.error('node-pty: FAIL —', e.message); process.exit(1) }"
-          # @janhapke/sharp-electron only has a patched build for linux-x64;
-          # the code only imports it on linux-x64 + Electron. Verify it loads
-          # where it's actually used, skip elsewhere.
+          # @janhapke/sharp-electron only has a patched artifact for linux-x64.
+          # Plain Node verifies that artifact is installed and loadable; Electron
+          # runtime behavior is exercised elsewhere.
           if [ "${{ runner.os }}" = "Linux" ] && [ "${{ runner.arch }}" = "X64" ]; then
             node -e "try { require('@janhapke/sharp-electron'); console.log('@janhapke/sharp-electron: OK') } catch(e) { console.error('@janhapke/sharp-electron: FAIL —', e.message); process.exit(1) }"
           else

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,8 +171,15 @@ jobs:
       - name: Verify native binaries
         run: |
           node -e "try { require('sharp'); console.log('sharp: OK') } catch(e) { console.error('sharp: FAIL —', e.message); process.exit(1) }"
-          node -e "try { require('@janhapke/sharp-electron'); console.log('@janhapke/sharp-electron: OK') } catch(e) { console.error('@janhapke/sharp-electron: FAIL —', e.message); process.exit(1) }"
           node -e "try { require('node-pty'); console.log('node-pty: OK') } catch(e) { console.error('node-pty: FAIL —', e.message); process.exit(1) }"
+          # @janhapke/sharp-electron only has a patched build for linux-x64;
+          # the code only imports it on linux-x64 + Electron. Verify it loads
+          # where it's actually used, skip elsewhere.
+          if [ "${{ runner.os }}" = "Linux" ] && [ "${{ runner.arch }}" = "X64" ]; then
+            node -e "try { require('@janhapke/sharp-electron'); console.log('@janhapke/sharp-electron: OK') } catch(e) { console.error('@janhapke/sharp-electron: FAIL —', e.message); process.exit(1) }"
+          else
+            echo "@janhapke/sharp-electron: skipped (not linux-x64)"
+          fi
 
       - name: Unlock GNOME Keyring
         if: runner.os == 'Linux'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,6 +168,12 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: bun install --frozen-lockfile
 
+      - name: Verify native binaries
+        run: |
+          node -e "try { require('sharp'); console.log('sharp: OK') } catch(e) { console.error('sharp: FAIL —', e.message); process.exit(1) }"
+          node -e "try { require('@janhapke/sharp-electron'); console.log('@janhapke/sharp-electron: OK') } catch(e) { console.error('@janhapke/sharp-electron: FAIL —', e.message); process.exit(1) }"
+          node -e "try { require('node-pty'); console.log('node-pty: OK') } catch(e) { console.error('node-pty: FAIL —', e.message); process.exit(1) }"
+
       - name: Unlock GNOME Keyring
         if: runner.os == 'Linux'
         uses: t1m0thyj/unlock-keyring@v1


### PR DESCRIPTION
## Problem

CI could report a healthy install even when supported Node could not load `sharp` or `node-pty`, leaving native-module failures to appear at startup.

## Fix

Pin Node 22.19-the package's supported minimum-before the post-install loadability checks on every matrix platform. Verify `sharp` and `node-pty` load everywhere, and verify the Linux x64 `@janhapke/sharp-electron` artifact under plain Node without claiming Electron-runtime coverage.

## Validation

Workflow YAML lint and focused workflow assertions pass. Fresh matrix CI is running on the pinned runtime.

## Tracking

Closes #3035

## Attribution

Developed with Letta Code assistance and independently verified before publication.