### PR TITLE
chore(git): ignore generated Husky hook files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@
 # Letta Code file index exclusions (auto-created per-project, not for repo)
 .lettaignore
 
+# Generated Husky hook machinery (including worktree hook links)
+/.husky/_
+
 .idea
 node_modules
 bun.lockb


### PR DESCRIPTION
## Summary

- Ignore `/.husky/_`, which contains Husky-generated hook machinery
- Keep the symlink provisioned in Letta Code worktrees from appearing as an untracked file
- Preserve the tracked project hook definitions in `.husky/pre-commit` and `.husky/install.mjs`

## Validation

- `git check-ignore -v .husky/_` resolves to the new repository rule
- `bun run check` passes all 12 checks

Written by Cameron ◯ Letta Code