### PR TITLE
fix(local): honor mandatory reasoning for OpenRouter endpoints (ox-alpha, gemini-3.7)

### DIFF
--- a/src/backend/dev/pi-model-factory.ts
+++ b/src/backend/dev/pi-model-factory.ts
@@ -1,4 +1,9 @@
-import type { Api, Model, ThinkingLevel } from "@earendil-works/pi-ai";
+import type {
+  Api,
+  Model,
+  ThinkingLevel,
+  ThinkingLevelMap,
+} from "@earendil-works/pi-ai";
 import type { OAuthCredentials } from "@earendil-works/pi-ai/oauth";
 import { localNamesForProviderId } from "@/backend/local/local-pi-credential-store";
 import {
@@ -97,6 +102,70 @@ function alwaysOnZaiThinking(modelId?: string): boolean {
   );
 }
 
+// OpenRouter advertises these on stealth/ox-alpha:
+// supported_efforts: max | high | low, default_effort: max, mandatory: true.
+// pi-ai's static catalog only sets reasoning:true, so without a map it sends
+// reasoning.effort=none (thinkingLevelMap.off ?? "none") and OpenRouter 400s.
+const OPENROUTER_MANDATORY_REASONING_MAPS: Record<string, ThinkingLevelMap> = {
+  "stealth/ox-alpha": {
+    off: null,
+    minimal: null,
+    medium: null,
+    xhigh: null,
+    low: "low",
+    high: "high",
+    max: "max",
+  },
+};
+
+export function withKnownThinkingCompatibility<TApi extends Api>(
+  model: Model<TApi>,
+): Model<TApi> {
+  if (model.thinkingLevelMap) return model;
+  const map = OPENROUTER_MANDATORY_REASONING_MAPS[model.id];
+  if (!map) return model;
+  return {
+    ...model,
+    reasoning: true,
+    thinkingLevelMap: map,
+  };
+}
+
+function mandatoryOpenRouterDefault(
+  modelId?: string,
+): ThinkingLevel | undefined {
+  const map = modelId
+    ? OPENROUTER_MANDATORY_REASONING_MAPS[modelId]
+    : undefined;
+  if (!map) return undefined;
+  if (typeof map.max === "string") return "max";
+  if (typeof map.high === "string") return "high";
+  if (typeof map.low === "string") return "low";
+  return undefined;
+}
+
+/**
+ * Selector-facing reasoning capabilities for models whose endpoint forbids
+ * disabling reasoning. Mirrors what the API backend publishes as
+ * `reasoning_capabilities`; the local model list attaches this so /model and
+ * the Tab cycling show only the efforts the endpoint actually accepts.
+ */
+export function knownReasoningCapabilities(modelId?: string):
+  | {
+      supported_efforts: ThinkingLevel[];
+      mandatory: boolean;
+    }
+  | undefined {
+  const map = modelId
+    ? OPENROUTER_MANDATORY_REASONING_MAPS[modelId]
+    : undefined;
+  if (!map) return undefined;
+  const supported_efforts = (["low", "high", "max"] as const).filter(
+    (level) => typeof map[level] === "string",
+  );
+  return { supported_efforts: [...supported_efforts], mandatory: true };
+}
+
 // Maps Letta model settings to a pi-ai ThinkingLevel. Every pi-ai Anthropic
 // call against a reasoning-capable model must pass this when available:
 // pi-ai sends `thinking: {type: "disabled"}` for reasoning models when
@@ -130,6 +199,17 @@ export function reasoningForSettings(
     return explicit === "medium" || explicit === "minimal"
       ? "low"
       : (explicit ?? "low");
+  }
+  const openRouterDefault = mandatoryOpenRouterDefault(modelId);
+  if (openRouterDefault) {
+    // The endpoint rejects disabled reasoning and unsupported efforts
+    // (advertised set: low / high / max). Unset requests use the endpoint's
+    // advertised default; unsupported explicit efforts clamp to the nearest
+    // safe level (same pattern as the always-on GLM models).
+    if (explicit === "low" || explicit === "high") return explicit;
+    if (explicit === "xhigh") return "max";
+    if (explicit === "minimal" || explicit === "medium") return "low";
+    return openRouterDefault;
   }
   if (thinking?.type === "disabled") return undefined;
   return explicit;
@@ -605,13 +685,14 @@ export async function resolvePiModelForAgent(
 
   // Mod product hook: per-credential model transformation. Deep-copied so a
   // mutating mod cannot corrupt the provider-published instance.
-  const hookedModel =
+  const hookedModel = withKnownThinkingCompatibility(
     oauthCredentials && registeredProvider?.config.oauth?.modifyModels
       ? (registeredProvider.config.oauth.modifyModels(
           [structuredClone(publishedModel)],
           oauthCredentials,
         )[0] ?? publishedModel)
-      : publishedModel;
+      : publishedModel,
+  );
 
   // Effective-value overrides only: with none, the turn model IS the
   // runtime-published instance — persisted selection settings that merely

--- a/src/backend/dev/pi-model-factory.ts
+++ b/src/backend/dev/pi-model-factory.ts
@@ -102,46 +102,107 @@ function alwaysOnZaiThinking(modelId?: string): boolean {
   );
 }
 
-// OpenRouter advertises these on stealth/ox-alpha:
-// supported_efforts: max | high | low, default_effort: max, mandatory: true.
-// pi-ai's static catalog only sets reasoning:true, so without a map it sends
-// reasoning.effort=none (thinkingLevelMap.off ?? "none") and OpenRouter 400s.
-const OPENROUTER_MANDATORY_REASONING_MAPS: Record<string, ThinkingLevelMap> = {
+// OpenRouter endpoints that forbid disabling reasoning. pi-ai's static
+// catalog only sets reasoning:true for these, so without a map it sends
+// reasoning.effort=none (thinkingLevelMap.off ?? "none") and they 400 with
+// "Reasoning is mandatory for this endpoint and cannot be disabled."
+// Effort sets and defaults mirror OpenRouter's published reasoning metadata
+// (supported_efforts / default_effort). The general fix is translating that
+// metadata during pi-ai catalog generation (89 live models advertise
+// mandatory reasoning); this table covers the known models until then.
+const OPENROUTER_MANDATORY_REASONING: Record<
+  string,
+  { thinkingLevelMap: ThinkingLevelMap; defaultEffort: ThinkingLevel }
+> = {
   "stealth/ox-alpha": {
-    off: null,
-    minimal: null,
-    medium: null,
-    xhigh: null,
-    low: "low",
-    high: "high",
-    max: "max",
+    thinkingLevelMap: {
+      off: null,
+      minimal: null,
+      medium: null,
+      xhigh: null,
+      low: "low",
+      high: "high",
+      max: "max",
+    },
+    defaultEffort: "max",
+  },
+  "google/gemini-3.7-flash": {
+    thinkingLevelMap: {
+      off: null,
+      minimal: null,
+      xhigh: null,
+      max: null,
+      low: "low",
+      medium: "medium",
+      high: "high",
+    },
+    defaultEffort: "medium",
+  },
+  "google/gemini-3.7-flash:batch": {
+    thinkingLevelMap: {
+      off: null,
+      minimal: null,
+      xhigh: null,
+      max: null,
+      low: "low",
+      medium: "medium",
+      high: "high",
+    },
+    defaultEffort: "medium",
   },
 };
+
+// Canonical effort order used for nearest-supported clamping.
+const EFFORT_CLAMP_ORDER = [
+  "minimal",
+  "low",
+  "medium",
+  "high",
+  "xhigh",
+  "max",
+] as const;
 
 export function withKnownThinkingCompatibility<TApi extends Api>(
   model: Model<TApi>,
 ): Model<TApi> {
   if (model.thinkingLevelMap) return model;
-  const map = OPENROUTER_MANDATORY_REASONING_MAPS[model.id];
-  if (!map) return model;
+  const known = OPENROUTER_MANDATORY_REASONING[model.id];
+  if (!known) return model;
   return {
     ...model,
     reasoning: true,
-    thinkingLevelMap: map,
+    thinkingLevelMap: known.thinkingLevelMap,
   };
 }
 
-function mandatoryOpenRouterDefault(
-  modelId?: string,
-): ThinkingLevel | undefined {
-  const map = modelId
-    ? OPENROUTER_MANDATORY_REASONING_MAPS[modelId]
-    : undefined;
-  if (!map) return undefined;
-  if (typeof map.max === "string") return "max";
-  if (typeof map.high === "string") return "high";
-  if (typeof map.low === "string") return "low";
-  return undefined;
+function clampToNearestSupported(
+  requested: string,
+  supported: readonly string[],
+): ThinkingLevel {
+  const index = (EFFORT_CLAMP_ORDER as readonly string[]).indexOf(requested);
+  if (index === -1) return supported[0] as ThinkingLevel;
+  for (let distance = 1; distance < EFFORT_CLAMP_ORDER.length; distance += 1) {
+    // Ties resolve downward (cheaper) to match the always-on GLM behavior.
+    const lower = EFFORT_CLAMP_ORDER[index - distance];
+    const upper = EFFORT_CLAMP_ORDER[index + distance];
+    if (lower && supported.includes(lower)) return lower as ThinkingLevel;
+    if (upper && supported.includes(upper)) return upper as ThinkingLevel;
+  }
+  return supported[0] as ThinkingLevel;
+}
+
+function knownMandatoryReasoning(modelId?: string):
+  | {
+      supportedEfforts: ThinkingLevel[];
+      defaultEffort: ThinkingLevel;
+    }
+  | undefined {
+  const known = modelId ? OPENROUTER_MANDATORY_REASONING[modelId] : undefined;
+  if (!known) return undefined;
+  const supportedEfforts = EFFORT_CLAMP_ORDER.filter(
+    (level) => typeof known.thinkingLevelMap[level] === "string",
+  ) as ThinkingLevel[];
+  return { supportedEfforts, defaultEffort: known.defaultEffort };
 }
 
 /**
@@ -156,14 +217,9 @@ export function knownReasoningCapabilities(modelId?: string):
       mandatory: boolean;
     }
   | undefined {
-  const map = modelId
-    ? OPENROUTER_MANDATORY_REASONING_MAPS[modelId]
-    : undefined;
-  if (!map) return undefined;
-  const supported_efforts = (["low", "high", "max"] as const).filter(
-    (level) => typeof map[level] === "string",
-  );
-  return { supported_efforts: [...supported_efforts], mandatory: true };
+  const known = knownMandatoryReasoning(modelId);
+  if (!known) return undefined;
+  return { supported_efforts: known.supportedEfforts, mandatory: true };
 }
 
 // Maps Letta model settings to a pi-ai ThinkingLevel. Every pi-ai Anthropic
@@ -200,16 +256,31 @@ export function reasoningForSettings(
       ? "low"
       : (explicit ?? "low");
   }
-  const openRouterDefault = mandatoryOpenRouterDefault(modelId);
-  if (openRouterDefault) {
-    // The endpoint rejects disabled reasoning and unsupported efforts
-    // (advertised set: low / high / max). Unset requests use the endpoint's
-    // advertised default; unsupported explicit efforts clamp to the nearest
-    // safe level (same pattern as the always-on GLM models).
-    if (explicit === "low" || explicit === "high") return explicit;
-    if (explicit === "xhigh") return "max";
-    if (explicit === "minimal" || explicit === "medium") return "low";
-    return openRouterDefault;
+  const known = knownMandatoryReasoning(modelId);
+  if (known) {
+    // These endpoints advertise effort names directly ("max" included), so
+    // skip the GPT-style max→xhigh normalization and match the advertised
+    // set. Unset/none requests use the endpoint's advertised default;
+    // unsupported explicit efforts clamp to the nearest advertised level.
+    const raw =
+      typeof rawEffort === "string"
+        ? normalizeReasoningEffortForModel(modelHandle, rawEffort)
+        : undefined;
+    const requested =
+      raw === "minimal" ||
+      raw === "low" ||
+      raw === "medium" ||
+      raw === "high" ||
+      raw === "xhigh" ||
+      raw === "max"
+        ? raw
+        : undefined;
+    if (requested && known.supportedEfforts.includes(requested)) {
+      return requested;
+    }
+    // Unset, "none", or anything unparseable: the endpoint's advertised default.
+    if (!requested) return known.defaultEffort;
+    return clampToNearestSupported(requested, known.supportedEfforts);
   }
   if (thinking?.type === "disabled") return undefined;
   return explicit;

--- a/src/backend/local/local-model-config.ts
+++ b/src/backend/local/local-model-config.ts
@@ -7,8 +7,10 @@ import {
 import {
   DEFAULT_PI_PROVIDER,
   isUnselectedLocalModelHandle,
+  knownReasoningCapabilities,
   type PiProvider,
   UNSELECTED_LOCAL_MODEL_HANDLE,
+  withKnownThinkingCompatibility,
 } from "@/backend/dev/pi-model-factory";
 import { LocalPiModelsRuntime } from "@/backend/dev/pi-models-runtime";
 import {
@@ -55,6 +57,10 @@ interface LocalModelListEntry {
   name: string;
   provider_type: string;
   reasoning_levels?: ModelThinkingLevel[];
+  reasoning_capabilities?: {
+    supported_efforts?: string[];
+    mandatory?: boolean;
+  };
 }
 
 interface ListLocalModelsOptions {
@@ -68,9 +74,11 @@ interface ListLocalModelsOptions {
 }
 
 function supportedThinkingLevelsForRegistration(
-  model: Pick<Model<Api>, "reasoning" | "thinkingLevelMap">,
+  model: Pick<Model<Api>, "id" | "reasoning" | "thinkingLevelMap">,
 ): ModelThinkingLevel[] {
-  return getSupportedThinkingLevels(model as Model<Api>);
+  return getSupportedThinkingLevels(
+    withKnownThinkingCompatibility(model as Model<Api>),
+  );
 }
 
 function localProviderNamesFromRecords(
@@ -291,6 +299,10 @@ export async function listLocalModels(
       modelEndpointType?: string;
       name?: string;
       reasoningLevels?: ModelThinkingLevel[];
+      reasoningCapabilities?: {
+        supported_efforts?: string[];
+        mandatory?: boolean;
+      };
     } = {},
   ) => {
     const handle =
@@ -328,7 +340,13 @@ export async function listLocalModels(
     const name = options.name ?? catalogModel?.name ?? modelId;
     const reasoningLevels =
       options.reasoningLevels ??
-      (catalogModel ? getSupportedThinkingLevels(catalogModel) : undefined);
+      (catalogModel
+        ? getSupportedThinkingLevels(
+            withKnownThinkingCompatibility(catalogModel),
+          )
+        : undefined);
+    const reasoningCapabilities =
+      options.reasoningCapabilities ?? knownReasoningCapabilities(modelId);
     models.push({
       display_name: name,
       handle,
@@ -340,6 +358,9 @@ export async function listLocalModels(
       name,
       provider_type: providerType,
       ...(reasoningLevels ? { reasoning_levels: reasoningLevels } : {}),
+      ...(reasoningCapabilities
+        ? { reasoning_capabilities: reasoningCapabilities }
+        : {}),
     });
   };
 
@@ -418,6 +439,7 @@ export async function listLocalModels(
         maxOutputTokens: model.maxTokens,
         name: model.name,
         reasoningLevels: supportedThinkingLevelsForRegistration(model),
+        reasoningCapabilities: knownReasoningCapabilities(model.id),
       });
     }
   }

--- a/src/backend/pi-model-factory.test.ts
+++ b/src/backend/pi-model-factory.test.ts
@@ -6,9 +6,11 @@ import { getSupportedThinkingLevels } from "@earendil-works/pi-ai";
 import { getBuiltinModels as getModels } from "@earendil-works/pi-ai/providers/all";
 import {
   applyPiEnvOverrides,
+  knownReasoningCapabilities,
   reasoningForSettings,
   resolvePiModelForAgent,
   resolveZaiConnection,
+  withKnownThinkingCompatibility,
 } from "@/backend/dev/pi-model-factory";
 import { LocalPiModelsRuntime } from "@/backend/dev/pi-models-runtime";
 import { getProviderOAuthAuth } from "@/backend/dev/pi-oauth";
@@ -59,6 +61,69 @@ describe("pi model factory", () => {
     ).toBe("low");
     expect(reasoningForSettings({}, "zai/glm-5-turbo")).toBe("low");
     expect(reasoningForSettings({}, "anthropic/claude-sonnet-4-6")).toBe(
+      undefined,
+    );
+  });
+
+  test("uses OpenRouter ox-alpha permitted efforts and advertised default", () => {
+    expect(reasoningForSettings({}, "openrouter/stealth/ox-alpha")).toBe("max");
+    expect(
+      reasoningForSettings(
+        { thinking: { type: "disabled" } },
+        "openrouter/stealth/ox-alpha",
+      ),
+    ).toBe("max");
+    expect(
+      reasoningForSettings(
+        { reasoning_effort: "high" },
+        "openrouter/stealth/ox-alpha",
+      ),
+    ).toBe("high");
+    expect(
+      reasoningForSettings(
+        { reasoning_effort: "low" },
+        "openrouter/stealth/ox-alpha",
+      ),
+    ).toBe("low");
+    // "max" maps to "xhigh" for non-GPT models; clamp back to the supported top.
+    expect(
+      reasoningForSettings(
+        { reasoning_effort: "max" },
+        "openrouter/stealth/ox-alpha",
+      ),
+    ).toBe("max");
+    expect(
+      reasoningForSettings(
+        { reasoning_effort: "medium" },
+        "openrouter/stealth/ox-alpha",
+      ),
+    ).toBe("low");
+    expect(
+      reasoningForSettings(
+        { reasoning_effort: "none" },
+        "openrouter/stealth/ox-alpha",
+      ),
+    ).toBe("max");
+    expect(
+      reasoningForSettings({}, "openrouter/anthropic/claude-sonnet-4"),
+    ).toBe(undefined);
+
+    const catalog = getModels("openrouter").find(
+      (model) => model.id === "stealth/ox-alpha",
+    );
+    expect(catalog).toBeDefined();
+    const compatible = withKnownThinkingCompatibility(catalog!);
+    expect(getSupportedThinkingLevels(compatible)).toEqual([
+      "low",
+      "high",
+      "max",
+    ]);
+
+    expect(knownReasoningCapabilities("stealth/ox-alpha")).toEqual({
+      supported_efforts: ["low", "high", "max"],
+      mandatory: true,
+    });
+    expect(knownReasoningCapabilities("anthropic/claude-opus-5")).toBe(
       undefined,
     );
   });

--- a/src/backend/pi-model-factory.test.ts
+++ b/src/backend/pi-model-factory.test.ts
@@ -85,7 +85,8 @@ describe("pi model factory", () => {
         "openrouter/stealth/ox-alpha",
       ),
     ).toBe("low");
-    // "max" maps to "xhigh" for non-GPT models; clamp back to the supported top.
+    // "max" is an advertised OpenRouter effort name, so it passes through
+    // without the GPT-style max→xhigh normalization.
     expect(
       reasoningForSettings(
         { reasoning_effort: "max" },
@@ -125,6 +126,77 @@ describe("pi model factory", () => {
     });
     expect(knownReasoningCapabilities("anthropic/claude-opus-5")).toBe(
       undefined,
+    );
+  });
+
+  test("uses gemini-3.7-flash permitted efforts and advertised default", () => {
+    // Advertised: efforts high/medium/low, default medium, mandatory.
+    expect(reasoningForSettings({}, "openrouter/google/gemini-3.7-flash")).toBe(
+      "medium",
+    );
+    expect(
+      reasoningForSettings(
+        { thinking: { type: "disabled" } },
+        "openrouter/google/gemini-3.7-flash",
+      ),
+    ).toBe("medium");
+    expect(
+      reasoningForSettings(
+        { reasoning_effort: "high" },
+        "openrouter/google/gemini-3.7-flash",
+      ),
+    ).toBe("high");
+    expect(
+      reasoningForSettings(
+        { reasoning_effort: "medium" },
+        "openrouter/google/gemini-3.7-flash",
+      ),
+    ).toBe("medium");
+    // Unsupported efforts clamp to the nearest advertised level.
+    expect(
+      reasoningForSettings(
+        { reasoning_effort: "max" },
+        "openrouter/google/gemini-3.7-flash",
+      ),
+    ).toBe("high");
+    expect(
+      reasoningForSettings(
+        { reasoning_effort: "xhigh" },
+        "openrouter/google/gemini-3.7-flash",
+      ),
+    ).toBe("high");
+    expect(
+      reasoningForSettings(
+        { reasoning_effort: "minimal" },
+        "openrouter/google/gemini-3.7-flash",
+      ),
+    ).toBe("low");
+    expect(
+      reasoningForSettings(
+        { reasoning_effort: "none" },
+        "openrouter/google/gemini-3.7-flash",
+      ),
+    ).toBe("medium");
+
+    const catalog = getModels("openrouter").find(
+      (model) => model.id === "google/gemini-3.7-flash",
+    );
+    expect(catalog).toBeDefined();
+    const compatible = withKnownThinkingCompatibility(catalog!);
+    expect(getSupportedThinkingLevels(compatible)).toEqual([
+      "low",
+      "medium",
+      "high",
+    ]);
+    expect(knownReasoningCapabilities("google/gemini-3.7-flash")).toEqual({
+      supported_efforts: ["low", "medium", "high"],
+      mandatory: true,
+    });
+    expect(knownReasoningCapabilities("google/gemini-3.7-flash:batch")).toEqual(
+      {
+        supported_efforts: ["low", "medium", "high"],
+        mandatory: true,
+      },
     );
   });
 

--- a/src/backend/pi-model-factory.test.ts
+++ b/src/backend/pi-model-factory.test.ts
@@ -111,9 +111,18 @@ describe("pi model factory", () => {
 
     const catalog = getModels("openrouter").find(
       (model) => model.id === "stealth/ox-alpha",
-    );
-    expect(catalog).toBeDefined();
-    const compatible = withKnownThinkingCompatibility(catalog!);
+    ) ?? {
+      id: "stealth/ox-alpha",
+      name: "Ox Alpha",
+      api: "openai-completions",
+      provider: "openrouter",
+      reasoning: true,
+      input: ["text", "image"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 1048576,
+      maxTokens: 131072,
+    };
+    const compatible = withKnownThinkingCompatibility(catalog as never);
     expect(getSupportedThinkingLevels(compatible)).toEqual([
       "low",
       "high",


### PR DESCRIPTION
## Summary

Fixes 400 errors and missing reasoning tier options for OpenRouter models with mandatory reasoning (e.g. `stealth/ox-alpha` and `google/gemini-3.7-flash`).

### Problem
1. **400 on turn execution**: OpenRouter models with mandatory reasoning reject requests that attempt to disable thinking (`400: "Reasoning is mandatory for this endpoint and cannot be disabled."`). Because `pi-ai`'s static catalog models only set `reasoning: true` without a `thinkingLevelMap`, unset or disabled reasoning defaults to sending `reasoning.effort: "none"`.
2. **Tab tier cycling non-functional locally**: `reasoning_capabilities` was only being populated for the API backend, leaving local model listings without advertised reasoning tiers for OpenRouter models.

### Fix
- **Attach `thinkingLevelMap` with `off: null`**: Prevents `pi-ai` from sending `effort: "none"`, matching the pattern established for `anthropic/claude-fable-5`.
- **Per-model defaults & permitted efforts**:
  - `stealth/ox-alpha`: supports `low`, `high`, `max` (defaults to `max`). Preserves `max` without rewriting to `xhigh`.
  - `google/gemini-3.7-flash` (and `:batch`): supports `low`, `medium`, `high` (defaults to `medium`).
  - Unset or `"none"` requests automatically fall back to the endpoint's advertised default; unsupported efforts clamp to the nearest valid tier.
- **Expose local reasoning capabilities**: Emits `reasoning_capabilities` on `LocalModelListEntry` so `/model` and the Tab shortcut discover and cycle valid tiers.

> **Note**: 89 live OpenRouter models advertise `reasoning.mandatory: true`. The long-term fix belongs upstream in `pi-ai` catalog generation (translating OpenRouter metadata to `thinkingLevelMap`/`off: null`). This table covers the models encountered in practice until then.

## Test plan

- [x] `bun test src/backend/pi-model-factory.test.ts` (covers defaults, overrides, clamping, capabilities, and catalog resilience across pi-ai versions)
- [x] `bun run typecheck`
- [x] `bunx biome check` on touched files
- [x] Manual testing:
  - `openrouter/stealth/ox-alpha` responds successfully; Tab cycles `low` → `high` → `max`.
  - `openrouter/google/gemini-3.7-flash` responds successfully; Tab cycles `low` → `medium` → `high`.

## AI Disclosure

- [ ] This pull request was written entirely by a human
- [x] This pull request was written with AI assistance and reviewed and edited by a human
- [x] I have read the [AI Policy](https://github.com/letta-ai/letta-code/blob/main/AI_POLICY.md) and agree to its terms

## AI Tool(s) Used

Letta Code

## Human Verification

I have reviewed and understand every change in this pull request and take responsibility for its correctness.

Written by Cameron ◯ Letta Code