### PR TITLE
fix(hooks): match model-facing tool aliases

### DIFF
--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -29,11 +29,20 @@ export * from "./types";
 // ============================================================================
 
 /**
+ * Tool names may include aliases for the same call. The first name is the
+ * canonical, model-facing name reported to hook commands; every name
+ * participates in matcher resolution.
+ */
+function canonicalToolName(toolName: string | readonly string[]): string {
+  return typeof toolName === "string" ? toolName : (toolName[0] ?? "");
+}
+
+/**
  * Run PreToolUse hooks before a tool is executed
  * Can block the tool call by returning blocked: true
  */
 export async function runPreToolUseHooks(
-  toolName: string,
+  toolName: string | readonly string[],
   toolInput: Record<string, unknown>,
   toolCallId?: string,
   workingDirectory: string = process.cwd(),
@@ -51,7 +60,7 @@ export async function runPreToolUseHooks(
   const input: PreToolUseHookInput = {
     event_type: "PreToolUse",
     working_directory: workingDirectory,
-    tool_name: toolName,
+    tool_name: canonicalToolName(toolName),
     tool_input: toolInput,
     tool_call_id: toolCallId,
     agent_id: agentId,
@@ -66,7 +75,7 @@ export async function runPreToolUseHooks(
  * These run in parallel since they cannot block
  */
 export async function runPostToolUseHooks(
-  toolName: string,
+  toolName: string | readonly string[],
   toolInput: Record<string, unknown>,
   toolResult: { status: "success" | "error"; output?: string },
   toolCallId?: string,
@@ -87,7 +96,7 @@ export async function runPostToolUseHooks(
   const input: PostToolUseHookInput = {
     event_type: "PostToolUse",
     working_directory: workingDirectory,
-    tool_name: toolName,
+    tool_name: canonicalToolName(toolName),
     tool_input: toolInput,
     tool_call_id: toolCallId,
     tool_result: toolResult,
@@ -106,7 +115,7 @@ export async function runPostToolUseHooks(
  * Stderr from hooks with exit code 2 is fed back to the agent
  */
 export async function runPostToolUseFailureHooks(
-  toolName: string,
+  toolName: string | readonly string[],
   toolInput: Record<string, unknown>,
   errorMessage: string,
   errorType?: string,
@@ -128,7 +137,7 @@ export async function runPostToolUseFailureHooks(
   const input: PostToolUseFailureHookInput = {
     event_type: "PostToolUseFailure",
     working_directory: workingDirectory,
-    tool_name: toolName,
+    tool_name: canonicalToolName(toolName),
     tool_input: toolInput,
     tool_call_id: toolCallId,
     error_message: errorMessage,

--- a/src/hooks/loader.test.ts
+++ b/src/hooks/loader.test.ts
@@ -307,6 +307,45 @@ describe("Hooks Loader", () => {
       expect(hooks).toHaveLength(1);
     });
 
+    test("matches model-facing and internal aliases", () => {
+      const config: HooksConfig = {
+        PreToolUse: [
+          {
+            matcher: "Agent",
+            hooks: [{ type: "command", command: "agent hook" }],
+          },
+          {
+            matcher: "Task",
+            hooks: [{ type: "command", command: "task hook" }],
+          },
+          {
+            matcher: "Bash",
+            hooks: [{ type: "command", command: "bash hook" }],
+          },
+        ],
+      };
+
+      const hooks = getMatchingHooks(config, "PreToolUse", ["Agent", "Task"]);
+      expect(hooks).toHaveLength(2);
+      expect(asCommand(hooks[0])?.command).toBe("agent hook");
+      expect(asCommand(hooks[1])?.command).toBe("task hook");
+    });
+
+    test("runs each matcher only once when several aliases match", () => {
+      const config: HooksConfig = {
+        PreToolUse: [
+          {
+            matcher: "Agent|Task",
+            hooks: [{ type: "command", command: "either hook" }],
+          },
+        ],
+      };
+
+      const hooks = getMatchingHooks(config, "PreToolUse", ["Agent", "Task"]);
+      expect(hooks).toHaveLength(1);
+      expect(asCommand(hooks[0])?.command).toBe("either hook");
+    });
+
     test("returns hooks from multiple matchers in order", () => {
       const config: HooksConfig = {
         PreToolUse: [

--- a/src/hooks/loader.ts
+++ b/src/hooks/loader.ts
@@ -234,11 +234,14 @@ function filterHooksForEvent(
 
 /**
  * Get all hooks that match a specific event and tool name
+ *
+ * A tool call may provide model-facing and internal aliases. A matcher fires
+ * once when it matches any alias.
  */
 export function getMatchingHooks(
   config: HooksConfig,
   event: HookEvent,
-  toolName?: string,
+  toolName?: string | readonly string[],
 ): HookCommand[] {
   if (isToolEvent(event)) {
     // Tool events use HookMatcher[] - need to match against tool name
@@ -249,9 +252,14 @@ export function getMatchingHooks(
       return [];
     }
 
+    const toolNames =
+      typeof toolName === "string" ? [toolName] : (toolName ?? []);
     const hooks: HookCommand[] = [];
     for (const matcher of matchers) {
-      if (!toolName || matchesTool(matcher.matcher, toolName)) {
+      if (
+        toolNames.length === 0 ||
+        toolNames.some((name) => matchesTool(matcher.matcher, name))
+      ) {
         hooks.push(...matcher.hooks);
       }
     }
@@ -373,7 +381,7 @@ export function areHooksDisabled(
  */
 export async function getHooksForEvent(
   event: HookEvent,
-  toolName?: string,
+  toolName?: string | readonly string[],
   workingDirectory: string = process.cwd(),
 ): Promise<HookCommand[]> {
   // Check if all hooks are disabled

--- a/src/hooks/tool-alias-integration.test.ts
+++ b/src/hooks/tool-alias-integration.test.ts
@@ -1,0 +1,220 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  runPostToolUseFailureHooks,
+  runPostToolUseHooks,
+  runPreToolUseHooks,
+} from "@/hooks";
+import { runWithRuntimeContext } from "@/runtime-context";
+import { settingsManager } from "@/settings-manager";
+import {
+  clearCapturedToolExecutionContexts,
+  executeTool,
+  prepareToolExecutionContextForSpecificTools,
+} from "@/tools/manager";
+
+function shellQuote(value: string): string {
+  if (process.platform === "win32") return `'${value.replaceAll("'", "''")}'`;
+  return `'${value.replaceAll("'", `'\\''`)}'`;
+}
+
+function nodeCommand(scriptPath: string, block = false): string {
+  return `node ${shellQuote(scriptPath)}${block ? "; exit 2" : ""}`;
+}
+
+function readPayload(
+  directory: string,
+  event: string,
+): Record<string, unknown> {
+  return JSON.parse(
+    readFileSync(join(directory, `${event}.json`), "utf8"),
+  ) as Record<string, unknown>;
+}
+
+function readPayloads(directory: string): Array<Record<string, unknown>> {
+  return readFileSync(join(directory, "hook-events.ndjson"), "utf8")
+    .trim()
+    .split("\n")
+    .map((line) => JSON.parse(line) as Record<string, unknown>);
+}
+
+describe("model-facing tool hook aliases", () => {
+  let fakeHome: string;
+  let originalHome: string | undefined;
+  let tempDir: string;
+  let hookScript: string;
+
+  beforeEach(async () => {
+    await settingsManager.reset();
+    const root = mkdtempSync(join(tmpdir(), "hook-tool-alias-"));
+    fakeHome = join(root, "home");
+    tempDir = join(root, "project");
+    mkdirSync(fakeHome, { recursive: true });
+    mkdirSync(join(tempDir, ".letta"), { recursive: true });
+    originalHome = process.env.HOME;
+    process.env.HOME = fakeHome;
+    await settingsManager.initialize();
+
+    hookScript = join(tempDir, "capture-hook.mjs");
+    writeFileSync(
+      hookScript,
+      `import { appendFileSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+const input = JSON.parse(readFileSync(0, "utf8"));
+writeFileSync(join(process.cwd(), input.event_type + ".json"), JSON.stringify(input));
+appendFileSync(join(process.cwd(), "hook-events.ndjson"), JSON.stringify(input) + "\\n");
+`,
+    );
+  });
+
+  afterEach(async () => {
+    clearCapturedToolExecutionContexts();
+    await settingsManager.reset();
+    process.env.HOME = originalHome;
+    rmSync(join(tempDir, ".."), { recursive: true, force: true });
+  });
+
+  test("matches aliases and reports Agent for every tool outcome", async () => {
+    const hook = { type: "command", command: nodeCommand(hookScript) };
+    writeFileSync(
+      join(tempDir, ".letta", "settings.json"),
+      JSON.stringify({
+        hooks: {
+          PreToolUse: [{ matcher: "Agent", hooks: [hook] }],
+          PostToolUse: [{ matcher: "Agent", hooks: [hook] }],
+          PostToolUseFailure: [{ matcher: "Agent", hooks: [hook] }],
+        },
+      }),
+    );
+
+    const names = ["Agent", "Task"] as const;
+    const pre = await runPreToolUseHooks(names, {}, "call-1", tempDir);
+    const post = await runPostToolUseHooks(
+      names,
+      {},
+      { status: "success", output: "done" },
+      "call-1",
+      tempDir,
+    );
+    const failure = await runPostToolUseFailureHooks(
+      names,
+      {},
+      "failed",
+      "Error",
+      "call-1",
+      tempDir,
+    );
+
+    expect(pre.results).toHaveLength(1);
+    expect(post.results).toHaveLength(1);
+    expect(failure.results).toHaveLength(1);
+    for (const event of ["PreToolUse", "PostToolUse", "PostToolUseFailure"]) {
+      expect(readPayload(tempDir, event).tool_name).toBe("Agent");
+    }
+  });
+
+  test("maps internal Task execution to an Agent matcher", async () => {
+    writeFileSync(
+      join(tempDir, ".letta", "settings.json"),
+      JSON.stringify({
+        hooks: {
+          PreToolUse: [
+            {
+              matcher: "Task",
+              hooks: [{ type: "command", command: nodeCommand(hookScript) }],
+            },
+            {
+              matcher: "Agent",
+              hooks: [
+                { type: "command", command: nodeCommand(hookScript, true) },
+              ],
+            },
+          ],
+        },
+      }),
+    );
+
+    const prepared = await runWithRuntimeContext(
+      { workingDirectory: tempDir },
+      () => prepareToolExecutionContextForSpecificTools(["Task"]),
+    );
+    const result = await runWithRuntimeContext(
+      { workingDirectory: tempDir },
+      () =>
+        executeTool(
+          "Agent",
+          {
+            description: "invalid test dispatch",
+            prompt: "reject the unknown test agent type",
+            subagent_type: "nonexistent-test-agent",
+          },
+          { toolContextId: prepared.contextId },
+        ),
+    );
+
+    expect(result.status).toBe("error");
+    expect(String(result.toolReturn)).toContain("blocked by hook");
+    const payloads = readPayloads(tempDir);
+    expect(payloads).toHaveLength(2);
+    expect(payloads.map((payload) => payload.tool_name)).toEqual([
+      "Agent",
+      "Agent",
+    ]);
+  });
+
+  test("reports mapped names from built-in post and exception paths", async () => {
+    const hook = { type: "command", command: nodeCommand(hookScript) };
+    writeFileSync(
+      join(tempDir, ".letta", "settings.json"),
+      JSON.stringify({
+        hooks: {
+          PostToolUse: [{ matcher: "glob|read_file", hooks: [hook] }],
+          PostToolUseFailure: [{ matcher: "read_file", hooks: [hook] }],
+        },
+      }),
+    );
+
+    const prepared = await runWithRuntimeContext(
+      { workingDirectory: tempDir },
+      () =>
+        prepareToolExecutionContextForSpecificTools([
+          "glob_gemini",
+          "read_file_gemini",
+        ]),
+    );
+    const globResult = await runWithRuntimeContext(
+      { workingDirectory: tempDir },
+      () =>
+        executeTool(
+          "glob",
+          { dir_path: tempDir, pattern: "*.missing" },
+          { toolContextId: prepared.contextId },
+        ),
+    );
+    expect(globResult.status).toBe("success");
+    expect(readPayload(tempDir, "PostToolUse").tool_name).toBe("glob");
+
+    const readResult = await runWithRuntimeContext(
+      { workingDirectory: tempDir },
+      () =>
+        executeTool(
+          "read_file",
+          { file_path: join(tempDir, "missing.txt") },
+          { toolContextId: prepared.contextId },
+        ),
+    );
+    expect(readResult.status).toBe("error");
+    expect(readPayload(tempDir, "PostToolUse").tool_name).toBe("read_file");
+    expect(readPayload(tempDir, "PostToolUseFailure").tool_name).toBe(
+      "read_file",
+    );
+  });
+});

--- a/src/tools/manager.ts
+++ b/src/tools/manager.ts
@@ -1971,7 +1971,7 @@ type ToolHookContext = {
   debugLabel: string;
   scopedAgentId?: string;
   toolCallId?: string;
-  toolName: string;
+  toolName: string | readonly string[];
   workingDirectory: string;
 };
 
@@ -2562,7 +2562,7 @@ async function executeToolInner(
   const run = async (): Promise<ToolExecutionResult> => {
     // Run PreToolUse hooks - can block tool execution
     const preHookResult = await runPreToolUseHooks(
-      internalName,
+      [getServerToolName(internalName), internalName],
       args as Record<string, unknown>,
       options?.toolCallId,
       workingDirectory,
@@ -2748,7 +2748,7 @@ async function executeToolInner(
           debugLabel: "tool result path",
           scopedAgentId,
           toolCallId: options?.toolCallId,
-          toolName: internalName,
+          toolName: [getServerToolName(internalName), internalName],
           workingDirectory,
         },
         {
@@ -2807,7 +2807,7 @@ async function executeToolInner(
           debugLabel: "tool exception path",
           scopedAgentId,
           toolCallId: options?.toolCallId,
-          toolName: internalName,
+          toolName: [getServerToolName(internalName), internalName],
           workingDirectory,
         },
         {


### PR DESCRIPTION
## Problem

When a user configures a PreToolUse hook for the `Agent` tool, it never fires. The hook system matches against the internal tool name (`Task`), but the model sees and calls it as `Agent`. The same mismatch affects PostToolUse and PostToolUseFailure payloads â€” they report `Task` instead of the name the user configured.

This means cost gates, safety hooks, and audit rules set up for `Agent` silently don't run.

## Fix

Match built-in tool hooks against both the model-facing name (`Agent`) and the internal name (`Task`). Report the model-facing name in hook payloads. Each matcher runs once even if multiple aliases match it.

## Files changed

- `src/hooks/loader.ts` â€” resolve tool aliases when matching hooks
- `src/tools/manager.ts` â€” pass model-facing name to hook payloads (3 call sites)
- `src/hooks/index.ts` â€” export alias resolution
- `src/hooks/loader.test.ts` â€” updated matcher tests
- `src/hooks/tool-alias-integration.test.ts` â€” new integration test (real `executeTool(Agent)` path, legacy `Task` compatibility, blocking, error/exception paths)

## Compatibility

- Existing hooks matching `Task` still work (legacy compatibility preserved)
- No changes to shell launchers, bash tool, exec-command, or shell-command
- No new dependencies

## Attribution

Refresh of #3236 by @abhay-codes07. Production approach is theirs; commit retains Abhay Singh as co-author. Rebased on current main â€” old hooks-reference path no longer exists.

Fixes #3150. Supersedes #3236.

## Validation

- 38 focused tests passed
- `bun run check` â€” 12/12 checks passed
- Mutation check: reverting alias call sites makes lifecycle tests fail
- Windows-portable integration test verified

## Scope note

This is a cross-platform fix (affects all platforms, not just Windows). Identified during Windows/Desktop QA work. Ready for review by whoever owns the hooks/tooling layer.

## AI disclosure

Developed with Letta Code assistance. Independently verified before publication.
