### PR TITLE
fix: only request scopes mcp server supports

### DIFF
--- a/src/skills/builtin/converting-mcps-to-skills/scripts/mcp-http.ts
+++ b/src/skills/builtin/converting-mcps-to-skills/scripts/mcp-http.ts
@@ -521,10 +521,15 @@ async function runOAuthLogin(
   authUrl.searchParams.set("code_challenge", challenge);
   authUrl.searchParams.set("code_challenge_method", "S256");
   authUrl.searchParams.set("resource", serverUrl);
-  const scopes = metadata.scopes_supported?.includes("offline_access")
-    ? "openid offline_access"
-    : "openid";
-  authUrl.searchParams.set("scope", scopes);
+  const supported = metadata.scopes_supported;
+  if (supported && supported.length > 0) {
+    const wanted = ["openid", "offline_access"].filter((s) =>
+      supported.includes(s),
+    );
+    if (wanted.length > 0) {
+      authUrl.searchParams.set("scope", wanted.join(" "));
+    }
+  }
 
   process.stderr.write(
     `Opening browser to sign in:\n  ${authUrl.toString()}\n`,


### PR DESCRIPTION
## Summary

If `scopes_supported` is missing, send no scope at all. Many MCP servers (e.g. Cloudflare) don't support `"openid"` and reject it with `invalid_scope`.

## Verification

Installing Cloudflare MCP before failed, after this fix it worked.

## AI Disclosure

<!-- Select exactly one authorship option, then acknowledge the policy. -->

- [ ] This pull request was written entirely by a human
- [x] This pull request was written with AI assistance and reviewed and edited by a human
- [x] I have read the [AI Policy](https://github.com/letta-ai/letta-code/blob/main/AI_POLICY.md) and agree to its terms

## AI Tool(s) Used

Letta Code (bug was originally discovered when using harness)

## Human Verification

<!-- Copy the following phrase exactly, without the surrounding comment:
I have reviewed and understand every change in this pull request and take responsibility for its correctness.
-->
I have reviewed and understand every change in this pull request and take responsibility for its correctness.
