### PR TITLE
fix(agent): lazy-load the Tutor profile asset [LET-9901]

### DIFF
--- a/build.js
+++ b/build.js
@@ -197,6 +197,11 @@ await Bun.build({
 
 // Browser-safe agent creation presets (personalities, prompts, tags) for
 // surfaces that create Letta Code agents through Core (e.g. the chat web app).
+for (const output of readdirSync(join(__dirname, "dist"))) {
+  if (/^agent-presets-.+\.js(?:\.map)?$/.test(output)) {
+    rmSync(join(__dirname, "dist", output));
+  }
+}
 await Bun.build({
   entrypoints: ["./src/agent-presets.ts"],
   outdir: "./dist",
@@ -204,8 +209,13 @@ await Bun.build({
   format: "esm",
   minify: false,
   sourcemap: "external",
+  splitting: true,
   naming: {
     entry: "agent-presets.js",
+    chunk: "agent-presets-[name].js",
+  },
+  define: {
+    __AGENT_PRESETS_BUNDLE__: "true",
   },
   loader: {
     ".md": "text",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,9 @@
     "dist/channels-telegram.js",
     "dist/channels-telegram.js.map",
     "dist/types",
-    "docs"
+    "docs",
+    "dist/agent-presets-*.js",
+    "dist/agent-presets-*.js.map"
   ],
   "exports": {
     ".": "./letta.js",

--- a/src/agent/create-agent-request.test.ts
+++ b/src/agent/create-agent-request.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import {
   GIT_MEMORY_ENABLED_TAG,
   LETTA_CODE_ORIGIN_TAG,
@@ -191,6 +193,22 @@ describe("buildCreateAgentRequestForPersonality", () => {
       request.memory_blocks.find((block) => block.label === "onboarding")
         ?.value,
     ).toContain("Offer to create one yourself.");
+  });
+
+  test("includes the Tutor profile picture without changing other presets", async () => {
+    const tutor = await buildCreateAgentRequestForPersonality({
+      personalityId: "tutorial",
+    });
+    expect(tutor.profile_picture?.content).toBe(
+      readFileSync(
+        join(import.meta.dir, "../../assets/tutor-profile.png"),
+      ).toString("base64"),
+    );
+
+    const memo = await buildCreateAgentRequestForPersonality({
+      personalityId: "memo",
+    });
+    expect(memo.profile_picture).toBeUndefined();
   });
 
   test("appends extra tags after the Letta Code tags", async () => {

--- a/src/agent/create-agent-request.ts
+++ b/src/agent/create-agent-request.ts
@@ -19,6 +19,7 @@ import { getDefaultModel, resolveModel } from "./model-catalog";
 import {
   buildPersonalityMemoryBlocks,
   getPersonalityCreationTags,
+  getPersonalityDefaultMemoryFiles,
   getPersonalityOption,
   type PersonalityId,
   type PersonalityMemoryBlock,
@@ -86,6 +87,9 @@ export type CreateAgentRequestForPersonality = CreateAgentRequest & {
   name: string;
   description: string;
   memory_blocks: PersonalityMemoryBlock[];
+  profile_picture?: {
+    content: string;
+  };
 };
 
 function mergeMemoryBlocks(
@@ -195,7 +199,22 @@ export async function buildCreateAgentRequestForPersonality(params: {
   model?: string;
   extraTags?: string[];
 }): Promise<CreateAgentRequestForPersonality> {
-  return (await buildCreateAgentRequest(
+  const request = (await buildCreateAgentRequest(
     params,
   )) as CreateAgentRequestForPersonality;
+  const profilePicture = getPersonalityDefaultMemoryFiles(
+    params.personalityId,
+  ).find((file) => file.path === "profile.png");
+  if (!profilePicture) {
+    return request;
+  }
+  const { getPersonalityAssetBase64 } = await import(
+    "./personality-asset-content"
+  );
+  return {
+    ...request,
+    profile_picture: {
+      content: await getPersonalityAssetBase64(profilePicture.assetId),
+    },
+  };
 }

--- a/src/agent/personality-asset-content.ts
+++ b/src/agent/personality-asset-content.ts
@@ -1,0 +1,46 @@
+import type { PersonalityAssetId } from "./personality-presets";
+
+declare const __AGENT_PRESETS_BUNDLE__: boolean | undefined;
+
+function encodeBase64(bytes: Uint8Array): string {
+  let binary = "";
+  const chunkSize = 32_768;
+  for (let offset = 0; offset < bytes.length; offset += chunkSize) {
+    binary += String.fromCharCode(
+      ...bytes.subarray(offset, offset + chunkSize),
+    );
+  }
+  return btoa(binary);
+}
+
+function tutorProfilePictureUrl(): URL {
+  if (typeof __AGENT_PRESETS_BUNDLE__ !== "undefined") {
+    return new URL("../assets/tutor-profile.png", import.meta.url);
+  }
+  const sourceAssetPath = "../../assets/tutor-profile.png";
+  return new URL(sourceAssetPath, import.meta.url);
+}
+
+async function readAsset(asset: URL): Promise<string> {
+  if (asset.protocol === "file:") {
+    if (typeof Bun === "undefined") {
+      throw new Error("Personality asset is unavailable");
+    }
+    return encodeBase64(new Uint8Array(await Bun.file(asset).arrayBuffer()));
+  }
+
+  const response = await fetch(asset);
+  if (!response.ok) {
+    throw new Error(`Failed to load personality asset: ${response.status}`);
+  }
+  return encodeBase64(new Uint8Array(await response.arrayBuffer()));
+}
+
+export async function getPersonalityAssetBase64(
+  assetId: PersonalityAssetId,
+): Promise<string> {
+  switch (assetId) {
+    case "tutor-profile":
+      return readAsset(tutorProfilePictureUrl());
+  }
+}


### PR DESCRIPTION
## Summary

**Type:** Bug fix

**Goal:** Include Tutor's default profile picture in the original agent-create payload so hosted memory can seed `profile.png` in its first commit.

**What was missing:** Tutor's bundled profile picture was only available to the listener's post-creation MemFS seeding path. Browser creation surfaces could build the personality request, but could not include the binary asset.

**What changed:**

- `buildCreateAgentRequestForPersonality({ personalityId: "tutorial" })` now returns `profile_picture.content` using the existing Tutor PNG.
- The browser-safe `agent-presets` build emits the asset reader as a split chunk and keeps the PNG as a separate package asset. Non-Tutor creation does not load either.
- The split chunks are explicitly included in the published package and use stable names so repeated builds do not accumulate stale package files.

This replaces the reverted inline approach from #4017. The main `agent-presets.js` bundle changes from **50,185 B to 50,389 B gzip** (+204 B), rather than embedding the 100,124-byte PNG into every load.

## Review notes

**Merge when:** CI passes and a human reviewer confirms that the split package files and `profile_picture` request ownership are appropriate.

**Start here:** `src/agent/create-agent-request.ts` for request ownership, then `src/agent/personality-asset-content.ts` and the `agent-presets` build block in `build.js` for lazy asset loading.

**Product check:** Create a Tutor through a browser consumer of `@letta-ai/letta-code/agent-presets`. The request should contain the exact 100,124-byte PNG. Create another personality and confirm `profile_picture` is absent.

**Risk:** Browser package consumers must preserve the dynamic chunk and resolve `assets/tutor-profile.png`. A production Next build and browser execution were used to verify that boundary.

## Verification

- `bun test src/agent/create-agent-request.test.ts` (10 passed)
- `bun run check` (12 checks passed)
- `bun run build` (passed)
- `npm pack --dry-run --json` (confirmed both split chunks and one canonical `assets/tutor-profile.png` are published)
- Production Next build + Playwright browser execution (emitted `tutor-profile.c0ea1ea1.png`; Tutor payload decoded to 100,124 bytes)
- Comparable bundle build: `agent-presets.js` gzip **50,185 B before / 50,389 B after**

## Breadcrumbs

- Linear: LET-9901
- Origin: #3458 added Tutor profile seeding after listener initialization; history did not identify a later regression that introduced the initial delay.
- Replaces: #4017 and its revert #4030

## AI Disclosure

- [ ] This pull request was written entirely by a human
- [ ] This pull request was written with AI assistance and reviewed and edited by a human
- [x] I have read the [AI Policy](https://github.com/letta-ai/letta-code/blob/main/AI_POLICY.md) and agree to its terms

## AI Tool(s) Used

Letta Code researched, implemented, and tested the change. Human review is pending before this draft is marked ready.

## Human Verification

Pending human review before this draft is marked ready.
