### PR TITLE
fix(cli): support Kitty CSI-u Alt word navigation

### DIFF
--- a/src/cli/components/PasteAwareTextInput.test.tsx
+++ b/src/cli/components/PasteAwareTextInput.test.tsx
@@ -152,8 +152,7 @@ describe("detectOptionWordDirection", () => {
     instance.unmount();
     instance.cleanup();
 
-    expect(changes).not.toContain("alpha betab");
-    expect(changes).not.toContain("alpha betaf");
+    expect(changes).toEqual([]);
     expect(cursorOffsets).toContain(6);
   });
 });

--- a/src/cli/components/PasteAwareTextInput.test.tsx
+++ b/src/cli/components/PasteAwareTextInput.test.tsx
@@ -1,7 +1,54 @@
 import { describe, expect, test } from "bun:test";
-import { detectOptionWordDirection } from "@/cli/components/PasteAwareTextInput";
+import { EventEmitter } from "node:events";
+import { Readable, Writable } from "node:stream";
+import { render } from "ink";
+import {
+  detectOptionWordDirection,
+  PasteAwareTextInput,
+} from "@/cli/components/PasteAwareTextInput";
 
 const ESC = "\u001b";
+
+class CaptureStream extends Writable {
+  columns = 80;
+  rows = 24;
+  isTTY = true;
+
+  override _write(
+    _chunk: Buffer | string,
+    _encoding: BufferEncoding,
+    callback: (error?: Error | null) => void,
+  ) {
+    callback();
+  }
+}
+
+function createInputStream(): NodeJS.ReadStream {
+  const input = new Readable({ read() {} }) as NodeJS.ReadStream;
+  input.isTTY = true;
+  input.setRawMode = () => input;
+  input.ref = () => input;
+  input.unref = () => input;
+  return input;
+}
+
+const existingNavigationSequences: ReadonlyArray<
+  readonly [string, "left" | "right"]
+> = [
+  [`${ESC}b`, "left"],
+  [`${ESC}B`, "left"],
+  [`${ESC}f`, "right"],
+  [`${ESC}F`, "right"],
+  ...[3, 4, 7, 8, 9].flatMap(
+    (modifier) =>
+      [
+        [`${ESC}[${modifier}D`, "left"],
+        [`${ESC}[${modifier}C`, "right"],
+        [`${ESC}[1;${modifier}D`, "left"],
+        [`${ESC}[1;${modifier}C`, "right"],
+      ] as const,
+  ),
+];
 
 describe("detectOptionWordDirection", () => {
   test.each([
@@ -46,14 +93,7 @@ describe("detectOptionWordDirection", () => {
     expect(detectOptionWordDirection(sequence)).toBeNull();
   });
 
-  test.each([
-    [`${ESC}b`, "left"],
-    [`${ESC}B`, "left"],
-    [`${ESC}f`, "right"],
-    [`${ESC}F`, "right"],
-    [`${ESC}[1;3D`, "left"],
-    [`${ESC}[1;3C`, "right"],
-  ] as const)(
+  test.each(existingNavigationSequences)(
     "preserves existing navigation sequences: %s",
     (sequence, direction) => {
       expect(detectOptionWordDirection(sequence)).toBe(direction);
@@ -66,5 +106,54 @@ describe("detectOptionWordDirection", () => {
     [`${ESC}[98;195u`, "left"], // Alt + Caps Lock + Num Lock
   ] as const)("normalizes Kitty lock bits: %s", (sequence, direction) => {
     expect(detectOptionWordDirection(sequence)).toBe(direction);
+  });
+
+  test("handles CSI-u through the raw input path without inserting b or f", async () => {
+    const stdin = createInputStream();
+    const stdout = new CaptureStream();
+    const eventEmitter = new EventEmitter();
+    const changes: string[] = [];
+    const cursorOffsets: number[] = [];
+    const { default: StdinContext } = await import(
+      new URL(
+        "../../../node_modules/ink/build/components/StdinContext.js",
+        import.meta.url,
+      ).href
+    );
+
+    const contextValue = {
+      stdin,
+      setRawMode: () => {},
+      isRawModeSupported: true,
+      internal_eventEmitter: eventEmitter,
+      internal_exitOnCtrlC: false,
+    };
+    const instance = render(
+      <StdinContext.Provider value={contextValue}>
+        <PasteAwareTextInput
+          value="alpha beta"
+          onChange={(value) => changes.push(value)}
+          cursorPosition={10}
+          onCursorMove={(position) => cursorOffsets.push(position)}
+        />
+      </StdinContext.Provider>,
+      {
+        stdout: stdout as CaptureStream & NodeJS.WriteStream,
+        stdin,
+        debug: false,
+        patchConsole: false,
+        exitOnCtrlC: false,
+      },
+    );
+
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    eventEmitter.emit("input", `${ESC}[98;3u`);
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    instance.unmount();
+    instance.cleanup();
+
+    expect(changes).not.toContain("alpha betab");
+    expect(changes).not.toContain("alpha betaf");
+    expect(cursorOffsets).toContain(6);
   });
 });

--- a/src/cli/components/PasteAwareTextInput.test.tsx
+++ b/src/cli/components/PasteAwareTextInput.test.tsx
@@ -1,0 +1,70 @@
+import { describe, expect, test } from "bun:test";
+import { detectOptionWordDirection } from "@/cli/components/PasteAwareTextInput";
+
+const ESC = "\u001b";
+
+describe("detectOptionWordDirection", () => {
+  test.each([
+    [`${ESC}[98;3u`, "left"],
+    [`${ESC}[102;3u`, "right"],
+  ] as const)(
+    "recognizes observed CSI-u Alt+b/f input: %s",
+    (sequence, direction) => {
+      expect(detectOptionWordDirection(sequence)).toBe(direction);
+    },
+  );
+
+  test.each([
+    [`${ESC}[98;3:1u`, "left"],
+    [`${ESC}[98;3:2u`, "left"],
+    [`${ESC}[102;3:1u`, "right"],
+    [`${ESC}[102;3:2u`, "right"],
+  ] as const)(
+    "accepts CSI-u press and repeat events: %s",
+    (sequence, direction) => {
+      expect(detectOptionWordDirection(sequence)).toBe(direction);
+    },
+  );
+
+  test.each([
+    `${ESC}[98;3:3u`,
+    `${ESC}[102;3:3u`,
+    `${ESC}[98;3:4u`,
+    `${ESC}[102;3:0u`,
+  ])("rejects CSI-u release and unknown events: %s", (sequence) => {
+    expect(detectOptionWordDirection(sequence)).toBeNull();
+  });
+
+  test.each([
+    `${ESC}[97;3u`,
+    `${ESC}[103;3u`,
+    `${ESC}[98;1u`,
+    `${ESC}[98;2u`,
+    `${ESC}[98;5u`,
+    `${ESC}[98;35u`,
+  ])("rejects wrong codepoints and non-Alt modifiers: %s", (sequence) => {
+    expect(detectOptionWordDirection(sequence)).toBeNull();
+  });
+
+  test.each([
+    [`${ESC}b`, "left"],
+    [`${ESC}B`, "left"],
+    [`${ESC}f`, "right"],
+    [`${ESC}F`, "right"],
+    [`${ESC}[1;3D`, "left"],
+    [`${ESC}[1;3C`, "right"],
+  ] as const)(
+    "preserves existing navigation sequences: %s",
+    (sequence, direction) => {
+      expect(detectOptionWordDirection(sequence)).toBe(direction);
+    },
+  );
+
+  test.each([
+    [`${ESC}[98;67u`, "left"], // Alt + Caps Lock
+    [`${ESC}[102;131u`, "right"], // Alt + Num Lock
+    [`${ESC}[98;195u`, "left"], // Alt + Caps Lock + Num Lock
+  ] as const)("normalizes Kitty lock bits: %s", (sequence, direction) => {
+    expect(detectOptionWordDirection(sequence)).toBe(direction);
+  });
+});

--- a/src/cli/components/PasteAwareTextInput.test.tsx
+++ b/src/cli/components/PasteAwareTextInput.test.tsx
@@ -1,5 +1,4 @@
 import { describe, expect, test } from "bun:test";
-import { EventEmitter } from "node:events";
 import { Readable, Writable } from "node:stream";
 import { render } from "ink";
 import {
@@ -111,32 +110,22 @@ describe("detectOptionWordDirection", () => {
   test("handles CSI-u through the raw input path without inserting b or f", async () => {
     const stdin = createInputStream();
     const stdout = new CaptureStream();
-    const eventEmitter = new EventEmitter();
     const changes: string[] = [];
     const cursorOffsets: number[] = [];
-    const { default: StdinContext } = await import(
-      new URL(
-        "../../../node_modules/ink/build/components/StdinContext.js",
-        import.meta.url,
-      ).href
-    );
-
-    const contextValue = {
-      stdin,
-      setRawMode: () => {},
-      isRawModeSupported: true,
-      internal_eventEmitter: eventEmitter,
-      internal_exitOnCtrlC: false,
-    };
+    let resolveCursorMove: (() => void) | undefined;
+    const cursorMoved = new Promise<void>((resolve) => {
+      resolveCursorMove = resolve;
+    });
     const instance = render(
-      <StdinContext.Provider value={contextValue}>
-        <PasteAwareTextInput
-          value="alpha beta"
-          onChange={(value) => changes.push(value)}
-          cursorPosition={10}
-          onCursorMove={(position) => cursorOffsets.push(position)}
-        />
-      </StdinContext.Provider>,
+      <PasteAwareTextInput
+        value="alpha beta"
+        onChange={(value) => changes.push(value)}
+        cursorPosition={10}
+        onCursorMove={(position) => {
+          cursorOffsets.push(position);
+          if (position === 6) resolveCursorMove?.();
+        }}
+      />,
       {
         stdout: stdout as CaptureStream & NodeJS.WriteStream,
         stdin,
@@ -146,9 +135,16 @@ describe("detectOptionWordDirection", () => {
       },
     );
 
-    await new Promise((resolve) => setTimeout(resolve, 20));
-    eventEmitter.emit("input", `${ESC}[98;3u`);
-    await new Promise((resolve) => setTimeout(resolve, 20));
+    stdin.push(`${ESC}[98;3u`);
+    await Promise.race([
+      cursorMoved,
+      new Promise<never>((_, reject) =>
+        setTimeout(
+          () => reject(new Error("CSI-u cursor move timed out")),
+          1000,
+        ),
+      ),
+    ]);
     instance.unmount();
     instance.cleanup();
 

--- a/src/cli/components/PasteAwareTextInput.tsx
+++ b/src/cli/components/PasteAwareTextInput.tsx
@@ -111,12 +111,40 @@ const OPTION_LEFT_PATTERN = /^\u001b\[(?:1;)?(?:3|4|7|8|9)D$/;
 // biome-ignore lint/suspicious/noControlCharactersInRegex: Terminal escape sequences require ESC control character
 const OPTION_RIGHT_PATTERN = /^\u001b\[(?:1;)?(?:3|4|7|8|9)C$/;
 
-function detectOptionWordDirection(sequence: string): WordDirection | null {
+// Kitty CSI-u modifiers use bit 0 as the base value, bit 1 for Alt, and
+// higher bits for Shift/Ctrl/Super/Meta. Caps Lock and Num Lock occupy bits
+// 6 and 7 and do not change the meaning of an Alt+b/f word movement.
+const CSI_U_LOCK_BITS = 64 | 128;
+
+// biome-ignore lint/suspicious/noControlCharactersInRegex: Terminal escape sequences require ESC control character
+const OPTION_WORD_CSI_U_PATTERN = /^\u001b\[(\d+);(\d+)(?::(\d+))?u$/;
+
+export function detectOptionWordDirection(
+  sequence: string,
+): WordDirection | null {
   if (!sequence.startsWith("\u001b")) return null;
   if (sequence === "\u001bb" || sequence === "\u001bB") return "left";
   if (sequence === "\u001bf" || sequence === "\u001bF") return "right";
   if (OPTION_LEFT_PATTERN.test(sequence)) return "left";
   if (OPTION_RIGHT_PATTERN.test(sequence)) return "right";
+
+  const csiU = sequence.match(OPTION_WORD_CSI_U_PATTERN);
+  if (!csiU) return null;
+
+  const codepoint = Number(csiU[1]);
+  const modifiers = Number(csiU[2]);
+  const event = csiU[3] === undefined ? 1 : Number(csiU[3]);
+
+  // Event 1 is a press and event 2 is a repeat. A release must not move the
+  // cursor, and unknown event values are rejected rather than guessed.
+  if (event !== 1 && event !== 2) return null;
+
+  // The base modifier value is 1, so Alt alone is 3. Ignore only the Kitty
+  // lock bits; Shift/Ctrl/Super/Hyper/Meta remain rejected.
+  if ((modifiers & ~CSI_U_LOCK_BITS) !== 3) return null;
+
+  if (codepoint === 98) return "left";
+  if (codepoint === 102) return "right";
   return null;
 }
 


### PR DESCRIPTION
## Summary

Some terminal setups, including Herdr and iTerm2, send Option+Left/Right as Kitty CSI-u Alt+b/f sequences. Letta handled the legacy sequences, but not these.

This adds strict handling for Alt+b/f, including press/repeat events and lock bits, while ignoring releases and other modifiers. Existing navigation behavior stays unchanged.

## Verification

- `bun test src/cli/components/PasteAwareTextInput.test.tsx` (44 passed)
- `bun run typecheck` (passed)
- `bunx --bun @biomejs/biome@2.2.5 check src/cli/components/PasteAwareTextInput.tsx src/cli/components/PasteAwareTextInput.test.tsx` (passed)

The full repository check reports unrelated existing lint findings outside this change.

## AI Disclosure

- [ ] This pull request was written entirely by a human
- [x] This pull request was written with AI assistance and reviewed and edited by a human
- [x] I have read the [AI Policy](https://github.com/letta-ai/letta-code/blob/main/AI_POLICY.md) and agree to its terms

## AI Tool(s) Used

Letta Code (Winston), including its Sol review subagent, was used to research, write, test, and review this pull request. The submitter reviewed and directed the final submission.

## Human Verification

I have reviewed and understand every change in this pull request and take responsibility for its correctness.
