### PR TITLE
fix(ci): restore agent watcher launches

### DIFF
--- a/.github/workflows/claude-agent-watch.yml
+++ b/.github/workflows/claude-agent-watch.yml
@@ -162,7 +162,6 @@ jobs:
             echo '```'
             echo "AMELIA_PROMPT_EOF"
           } >> "$GITHUB_OUTPUT"
-          echo "conversation_name=$GITHUB_WORKFLOW $(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> "$GITHUB_OUTPUT"
 
       - name: Ask Amelia to review Claude Code drift
         if: steps.detect.outputs.should_run_agent == 'true'
@@ -172,8 +171,7 @@ jobs:
           github_token: ${{ secrets.AMELIA_GITHUB_TOKEN }}
           agent_id: agent-cd664b86-4d28-49b7-8ad6-60677eaff9be
           environment: cloud
-          letta_args: >-
-            --new --name "${{ steps.prompt.outputs.conversation_name }}"
+          letta_args: --new
           track_progress: ""
           tracking_comment: "false"
           model: auto

--- a/.github/workflows/codex-agent-watch.yml
+++ b/.github/workflows/codex-agent-watch.yml
@@ -116,7 +116,6 @@ jobs:
             echo '```'
             echo "AMELIA_PROMPT_EOF"
           } >> "$GITHUB_OUTPUT"
-          echo "conversation_name=$GITHUB_WORKFLOW $(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> "$GITHUB_OUTPUT"
 
       - name: Ask Amelia to review actionable Codex drift
         if: steps.detect.outputs.should_run_agent == 'true'
@@ -126,8 +125,7 @@ jobs:
           github_token: ${{ secrets.AMELIA_GITHUB_TOKEN }}
           agent_id: agent-cd664b86-4d28-49b7-8ad6-60677eaff9be
           environment: cloud
-          letta_args: >-
-            --new --name "${{ steps.prompt.outputs.conversation_name }}"
+          letta_args: --new
           track_progress: ""
           tracking_comment: "false"
           model: auto

--- a/.github/workflows/pi-ai-agent-watch.yml
+++ b/.github/workflows/pi-ai-agent-watch.yml
@@ -126,7 +126,6 @@ jobs:
             echo '```'
             echo "AMELIA_PROMPT_EOF"
           } >> "$GITHUB_OUTPUT"
-          echo "conversation_name=$GITHUB_WORKFLOW $(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> "$GITHUB_OUTPUT"
 
       - name: Ask Amelia to review pi-ai release
         if: steps.detect.outputs.should_run_agent == 'true'
@@ -136,8 +135,7 @@ jobs:
           github_token: ${{ secrets.AMELIA_GITHUB_TOKEN }}
           agent_id: agent-cd664b86-4d28-49b7-8ad6-60677eaff9be
           environment: cloud
-          letta_args: >-
-            --new --name "${{ steps.prompt.outputs.conversation_name }}"
+          letta_args: --new
           track_progress: ""
           tracking_comment: "false"
           model: auto


### PR DESCRIPTION
## Summary
- stop passing conversation display names through the agent-selecting `--name` flag
- keep Claude, Codex, and pi-ai reviews in fresh conversations with `--new`
- remove the now-unused conversation name outputs

## Why
Recent watcher runs fail before cloud dispatch because the action combines the configured `agent_id` with `--name`, which newer Letta Code versions reject.

## Validation
- `bun run check`