### PR TITLE
fix(ci): name agent watcher conversations

### DIFF
--- a/.github/workflows/claude-agent-watch.yml
+++ b/.github/workflows/claude-agent-watch.yml
@@ -162,8 +162,10 @@ jobs:
             echo '```'
             echo "AMELIA_PROMPT_EOF"
           } >> "$GITHUB_OUTPUT"
+          echo "conversation_name=$GITHUB_WORKFLOW $(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> "$GITHUB_OUTPUT"
 
       - name: Ask Amelia to review Claude Code drift
+        id: review
         if: steps.detect.outputs.should_run_agent == 'true'
         uses: letta-ai/letta-code-action@4b8e508a523ff576fee09be1432d6f39158c272c
         with:
@@ -176,6 +178,21 @@ jobs:
           tracking_comment: "false"
           model: auto
           prompt: ${{ steps.prompt.outputs.prompt }}
+
+      - name: Name watcher conversation
+        if: always() && steps.review.outputs.conversation_id != ''
+        env:
+          LETTA_API_KEY: ${{ secrets.AMELIA_LETTA_API_KEY }}
+          CONVERSATION_ID: ${{ steps.review.outputs.conversation_id }}
+          CONVERSATION_NAME: ${{ steps.prompt.outputs.conversation_name }}
+        run: |
+          curl --fail-with-body --silent --show-error \
+            --request PATCH \
+            --header "Authorization: Bearer $LETTA_API_KEY" \
+            --header "Content-Type: application/json" \
+            --data "$(jq -nc --arg summary "$CONVERSATION_NAME" '{summary: $summary}')" \
+            --output /dev/null \
+            "https://api.letta.com/v1/conversations/$CONVERSATION_ID"
 
       - name: Verify terminal outcome
         if: steps.detect.outputs.should_run_agent == 'true'

--- a/.github/workflows/codex-agent-watch.yml
+++ b/.github/workflows/codex-agent-watch.yml
@@ -116,8 +116,10 @@ jobs:
             echo '```'
             echo "AMELIA_PROMPT_EOF"
           } >> "$GITHUB_OUTPUT"
+          echo "conversation_name=$GITHUB_WORKFLOW $(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> "$GITHUB_OUTPUT"
 
       - name: Ask Amelia to review actionable Codex drift
+        id: review
         if: steps.detect.outputs.should_run_agent == 'true'
         uses: letta-ai/letta-code-action@4b8e508a523ff576fee09be1432d6f39158c272c
         with:
@@ -130,3 +132,18 @@ jobs:
           tracking_comment: "false"
           model: auto
           prompt: ${{ steps.prompt.outputs.prompt }}
+
+      - name: Name watcher conversation
+        if: always() && steps.review.outputs.conversation_id != ''
+        env:
+          LETTA_API_KEY: ${{ secrets.AMELIA_LETTA_API_KEY }}
+          CONVERSATION_ID: ${{ steps.review.outputs.conversation_id }}
+          CONVERSATION_NAME: ${{ steps.prompt.outputs.conversation_name }}
+        run: |
+          curl --fail-with-body --silent --show-error \
+            --request PATCH \
+            --header "Authorization: Bearer $LETTA_API_KEY" \
+            --header "Content-Type: application/json" \
+            --data "$(jq -nc --arg summary "$CONVERSATION_NAME" '{summary: $summary}')" \
+            --output /dev/null \
+            "https://api.letta.com/v1/conversations/$CONVERSATION_ID"

--- a/.github/workflows/pi-ai-agent-watch.yml
+++ b/.github/workflows/pi-ai-agent-watch.yml
@@ -126,8 +126,10 @@ jobs:
             echo '```'
             echo "AMELIA_PROMPT_EOF"
           } >> "$GITHUB_OUTPUT"
+          echo "conversation_name=$GITHUB_WORKFLOW $(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> "$GITHUB_OUTPUT"
 
       - name: Ask Amelia to review pi-ai release
+        id: review
         if: steps.detect.outputs.should_run_agent == 'true'
         uses: letta-ai/letta-code-action@244cc9e80c77cfebdb3ec8e146e018a5fe0af027
         with:
@@ -140,6 +142,21 @@ jobs:
           tracking_comment: "false"
           model: auto
           prompt: ${{ steps.prompt.outputs.prompt }}
+
+      - name: Name watcher conversation
+        if: always() && steps.review.outputs.conversation_id != ''
+        env:
+          LETTA_API_KEY: ${{ secrets.AMELIA_LETTA_API_KEY }}
+          CONVERSATION_ID: ${{ steps.review.outputs.conversation_id }}
+          CONVERSATION_NAME: ${{ steps.prompt.outputs.conversation_name }}
+        run: |
+          curl --fail-with-body --silent --show-error \
+            --request PATCH \
+            --header "Authorization: Bearer $LETTA_API_KEY" \
+            --header "Content-Type: application/json" \
+            --data "$(jq -nc --arg summary "$CONVERSATION_NAME" '{summary: $summary}')" \
+            --output /dev/null \
+            "https://api.letta.com/v1/conversations/$CONVERSATION_ID"
 
       - name: Verify recorded outcome
         if: steps.detect.outputs.should_run_agent == 'true'


### PR DESCRIPTION
## Summary
- restore predictable `<workflow> <UTC timestamp>` names for Claude, Codex, and pi-ai watcher conversations
- use the action-provided conversation ID to update the conversation summary after dispatch
- attempt naming even when the agent review fails so failed runs remain discoverable

## Why
[#4036](https://github.com/letta-ai/letta-code/pull/4036) removed the invalid CLI `--name` argument because it selects an agent rather than naming a conversation. This restores the intended labels through conversation metadata instead.

## Validation
- `bun run check`
- parsed all three workflows and verified the review output/name-step wiring
- verified the generated conversation summary payload