### PR TITLE
fix(ci): audit latest pi-ai release from cursor

### DIFF
--- a/.github/agent-prompts/pi-ai-agent-watch.md
+++ b/.github/agent-prompts/pi-ai-agent-watch.md
@@ -1,6 +1,6 @@
 You are Amelia running in your managed cloud sandbox for `letta-ai/letta-code`, dispatched by GitHub Actions.
 
-Your job is to review one stable `@earendil-works/pi-ai` release, decide whether Letta Code should adopt it, and either open one complete dependency/integration PR or record why no upgrade is currently needed.
+Your job is to review the cumulative stable `@earendil-works/pi-ai` changes since the last audited release, decide whether Letta Code should adopt the current latest release, and either open one complete dependency/integration PR or record why no upgrade is currently needed.
 
 ## GitHub authentication
 
@@ -10,12 +10,14 @@ Before running the sandbox bootstrap, resolve the watcher credential identity wi
 
 The detector ran on a GitHub Actions runner, but your turn does not. Runner files and environment variables are unavailable in the sandbox. Run the exact `Sandbox bootstrap` block appended to this prompt, then use `SetWorkingDirectory` to select `/tmp/letta-code-pi-ai-watch`. If `SetWorkingDirectory` is unavailable, pass that absolute directory as `workdir` for every command.
 
-The rebuilt `/tmp/pi-ai-watch-analysis.json` is the source of truth for the exact adjacent release pair. It includes the installed Letta Code dependency version, npm artifact metadata, the release changelog section, upstream changed files, and compare URL.
+The rebuilt `/tmp/pi-ai-watch-analysis.json` is the source of truth for the exact last-audited-to-latest release range. It includes the installed Letta Code dependency version, npm artifact metadata, the cumulative release changelog, upstream changed files, and compare URL.
+
+The analysis uses each npm artifact's `gitHead` as the published source revision and records the corresponding release-tag commit separately. If they differ, account for the provenance mismatch explicitly; the npm artifact and its `gitHead` define the code Letta Code consumes.
 
 ## Required review behavior
 
 1. Read the complete analysis JSON and changelog section.
-2. Clone `earendil-works/pi` separately and inspect the complete `packages/ai/**` diff for the exact adjacent release pair. Do not classify from changelog prose or commit titles alone.
+2. Clone `earendil-works/pi` separately and inspect the complete `packages/ai/**` diff between the exact published source revisions from the analysis. Do not classify from changelog prose or commit titles alone.
 3. Run `npm diff` for the two exact package versions when generated declarations, exports, catalogs, or shipped JavaScript matter. The npm artifacts, not only the monorepo source, define the dependency Letta Code consumes.
 4. Compare the release against every implicated Letta Code integration surface. Check types, runtime behavior, cancellation, auth, provider catalogs, model defaults, message/stream semantics, error handling, standalone bundling, and tests as applicable.
 5. If the installed version is older than the Previous release in the run inputs, also inspect the cumulative installed-to-current changelog and source/package diff before opening a PR. A skipped release must not create a migration gap later.
@@ -100,7 +102,7 @@ test -n "$AMELIA_GITHUB_TOKEN" && GITHUB_TOKEN= GH_TOKEN="$AMELIA_GITHUB_TOKEN" 
   --notes "<exact uncertainty or blocker>"
 ```
 
-A `pr_created` outcome remains pending and blocks later upgrade PRs until that PR merges or closes. `no_upgrade` and `needs_human_review` advance the adjacent release audit cursor. Errors remain retryable.
+A `pr_created` outcome remains pending and blocks later upgrade PRs until that PR merges or closes. `pr_created`, `no_upgrade`, and `needs_human_review` advance the audit cursor to the latest release reviewed. Errors leave the cursor unchanged so the full range retries.
 
 ## Slack notification
 

--- a/.github/workflows/pi-ai-agent-watch.yml
+++ b/.github/workflows/pi-ai-agent-watch.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
-      - name: Detect next stable pi-ai release
+      - name: Detect latest stable pi-ai release
         id: detect
         env:
           GH_TOKEN: ${{ github.token }}
@@ -186,4 +186,4 @@ jobs:
             --tracker-issue "${{ steps.detect.outputs.tracker_issue }}" \
             --analysis-file "$RUNNER_TEMP/pi-ai-watch-analysis.json" \
             --outcome error \
-            --notes "Amelia review failed before recording an outcome; retry this release"
+            --notes "Amelia review failed before recording an outcome; retry this release range"

--- a/scripts/pi-ai-watch/agent-watch.ts
+++ b/scripts/pi-ai-watch/agent-watch.ts
@@ -3,7 +3,6 @@
 import { appendFileSync, writeFileSync } from "node:fs";
 import {
   createIssueWithBody,
-  editIssueBody,
   ensureLabels,
   findIssueByExactTitle,
   getIssueBody,
@@ -13,12 +12,11 @@ import {
   analyzePiAiRelease,
   compareStableVersions,
   DEFAULT_TARGET_REPO,
-  findNextStableRelease,
+  findLatestStableReleaseAfter,
   listStableReleases,
   readInstalledVersion,
 } from "./release-analysis.ts";
 import {
-  advanceMergedPr,
   getPendingPrForCursor,
   hasCompletedRange,
   initialTrackerState,
@@ -82,7 +80,7 @@ async function main(): Promise<void> {
   const args = parseArgs(process.argv.slice(2));
   const installedVersion = readInstalledVersion();
   const tracker = ensureTrackerIssue(args, installedVersion);
-  let state = parseTrackerState(tracker.body);
+  const state = parseTrackerState(tracker.body);
   const releases = await listStableReleases();
   let previousVersion = args.previousVersion;
   let currentVersion = args.currentVersion;
@@ -109,19 +107,16 @@ async function main(): Promise<void> {
             `Merged pi-ai PR ${status.url} targets ${pending.version}, but main still declares ${installedVersion}`,
           );
         }
-        state = advanceMergedPr(state, pending.version);
-        if (!args.dryRun) {
-          editIssueBody(args.repo, tracker.number, renderTrackerBody(state));
-        }
       } else {
-        console.log(
-          `Retrying ${pending.version}; prior PR was closed unmerged.`,
-        );
+        console.log(`Prior pi-ai PR ${status.url} was closed unmerged.`);
       }
     }
 
-    const next = findNextStableRelease(releases, state.audit_cursor_version);
-    if (!next) {
+    const latest = findLatestStableReleaseAfter(
+      releases,
+      state.audit_cursor_version,
+    );
+    if (!latest) {
       console.log(
         `No stable pi-ai release after ${state.audit_cursor_version}.`,
       );
@@ -134,7 +129,7 @@ async function main(): Promise<void> {
       return;
     }
     previousVersion = state.audit_cursor_version;
-    currentVersion = next.version;
+    currentVersion = latest.version;
   }
 
   const analysis = await analyzePiAiRelease({

--- a/scripts/pi-ai-watch/release-analysis.test.ts
+++ b/scripts/pi-ai-watch/release-analysis.test.ts
@@ -3,10 +3,9 @@ import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
-  areAdjacentStableReleases,
   compareStableVersions,
-  extractChangelogSection,
-  findNextStableRelease,
+  extractChangelogRange,
+  findLatestStableReleaseAfter,
   type PackageRelease,
   parseRegistryMetadata,
   readInstalledVersion,
@@ -59,24 +58,20 @@ describe("pi-ai npm releases", () => {
     ).toThrow("missing publication time for 0.82.1");
   });
 
-  test("selects exactly the next stable version after the cursor", () => {
+  test("selects the latest stable version after the cursor", () => {
     const releases = releaseList("0.82.1", "0.83.0", "0.84.0");
-    expect(findNextStableRelease(releases, "0.82.1")?.version).toBe("0.83.0");
-    expect(findNextStableRelease(releases, "0.84.0")).toBeNull();
-    expect(() => findNextStableRelease(releases, "0.80.0")).toThrow(
+    expect(findLatestStableReleaseAfter(releases, "0.82.1")?.version).toBe(
+      "0.84.0",
+    );
+    expect(findLatestStableReleaseAfter(releases, "0.84.0")).toBeNull();
+    expect(() => findLatestStableReleaseAfter(releases, "0.80.0")).toThrow(
       "Could not find pi-ai cursor release 0.80.0",
     );
-  });
-
-  test("recognizes only adjacent release pairs", () => {
-    const releases = releaseList("0.82.1", "0.83.0", "0.84.0");
-    expect(areAdjacentStableReleases(releases, "0.82.1", "0.83.0")).toBe(true);
-    expect(areAdjacentStableReleases(releases, "0.82.1", "0.84.0")).toBe(false);
   });
 });
 
 describe("pi-ai release evidence", () => {
-  test("extracts only the requested changelog section", () => {
+  test("extracts the cumulative changelog after the cursor", () => {
     const changelog = `# Changelog
 
 ## [0.84.0] - 2026-08-06
@@ -88,16 +83,27 @@ describe("pi-ai release evidence", () => {
 ## [0.83.0] - 2026-07-29
 
 - Previous feature.
+
+## [0.82.1] - 2026-07-20
+
+- Cursor release.
 `;
     expect(
-      extractChangelogSection(changelog, "0.84.0"),
+      extractChangelogRange(changelog, "0.82.1", "0.84.0"),
     ).toBe(`## [0.84.0] - 2026-08-06
 
 ### Added
 
-- Current feature.`);
-    expect(() => extractChangelogSection(changelog, "0.82.1")).toThrow(
-      "Could not find pi-ai changelog section 0.82.1",
+- Current feature.
+
+## [0.83.0] - 2026-07-29
+
+- Previous feature.`);
+    expect(() => extractChangelogRange(changelog, "0.80.0", "0.84.0")).toThrow(
+      "Could not find pi-ai changelog section 0.80.0",
+    );
+    expect(() => extractChangelogRange(changelog, "0.82.1", "0.85.0")).toThrow(
+      "Could not find pi-ai changelog section 0.85.0",
     );
   });
 

--- a/scripts/pi-ai-watch/release-analysis.ts
+++ b/scripts/pi-ai-watch/release-analysis.ts
@@ -42,11 +42,14 @@ export interface PiAiWatchAnalysis {
   installed_version: string;
   previous_version: string;
   current_version: string;
-  is_adjacent_release: boolean;
+  is_latest_release: boolean;
   published_at: string;
   integrity: string | null;
   tarball_url: string | null;
+  previous_git_head: string | null;
   git_head: string | null;
+  previous_tag_commit: string;
+  current_tag_commit: string;
   release_url: string;
   compare_url: string;
   changelog_md: string;
@@ -79,6 +82,11 @@ export async function analyzePiAiRelease(
       `Could not find previous pi-ai release before ${current.version}`,
     );
   }
+  if (compareStableVersions(previous.version, current.version) >= 0) {
+    throw new Error(
+      `Previous pi-ai release ${previous.version} must precede ${current.version}`,
+    );
+  }
 
   const installedVersion = options.installedVersion ?? readInstalledVersion();
   const previousTag = `v${previous.version}`;
@@ -86,11 +94,13 @@ export async function analyzePiAiRelease(
   const temp = mkdtempSync(join(tmpdir(), "pi-ai-watch-"));
   try {
     const repoDir = clonePi(temp);
-    fetchTag(repoDir, previousTag);
-    fetchTag(repoDir, currentTag);
-    verifyTagMatchesPackage(repoDir, previousTag, previous);
-    verifyTagMatchesPackage(repoDir, currentTag, current);
-    const changelog = showFile(repoDir, currentTag, "packages/ai/CHANGELOG.md");
+    const previousSource = resolveReleaseSource(repoDir, previousTag, previous);
+    const currentSource = resolveReleaseSource(repoDir, currentTag, current);
+    const changelog = showFile(
+      repoDir,
+      currentSource.sourceCommit,
+      "packages/ai/CHANGELOG.md",
+    );
     if (changelog === null) {
       throw new Error(`packages/ai/CHANGELOG.md is missing at ${currentTag}`);
     }
@@ -100,24 +110,35 @@ export async function analyzePiAiRelease(
       installed_version: installedVersion,
       previous_version: previous.version,
       current_version: current.version,
-      is_adjacent_release: areAdjacentStableReleases(
-        releases,
-        previous.version,
-        current.version,
-      ),
+      is_latest_release: current.version === releases.at(-1)?.version,
       published_at: current.published_at,
       integrity: current.integrity,
       tarball_url: current.tarball_url,
+      previous_git_head: previous.git_head,
       git_head: current.git_head,
+      previous_tag_commit: previousSource.tagCommit,
+      current_tag_commit: currentSource.tagCommit,
       release_url: `https://github.com/${PI_AI_REPO}/releases/tag/${currentTag}`,
-      compare_url: `https://github.com/${PI_AI_REPO}/compare/${previousTag}...${currentTag}`,
-      changelog_md: extractChangelogSection(changelog, current.version),
-      changed_files: changedFiles(repoDir, previousTag, currentTag),
-      diff_stat: diffStat(repoDir, previousTag, currentTag),
+      compare_url: `https://github.com/${PI_AI_REPO}/compare/${previousSource.sourceCommit}...${currentSource.sourceCommit}`,
+      changelog_md: extractChangelogRange(
+        changelog,
+        previous.version,
+        current.version,
+      ),
+      changed_files: changedFiles(
+        repoDir,
+        previousSource.sourceCommit,
+        currentSource.sourceCommit,
+      ),
+      diff_stat: diffStat(
+        repoDir,
+        previousSource.sourceCommit,
+        currentSource.sourceCommit,
+      ),
       package_json_diff: diffPreview(
         repoDir,
-        previousTag,
-        currentTag,
+        previousSource.sourceCommit,
+        currentSource.sourceCommit,
         "packages/ai/package.json",
       ),
       workflow_run_url: workflowRunUrl(),
@@ -182,7 +203,7 @@ export function readInstalledVersion(lockfilePath = "bun.lock"): string {
   return match[1];
 }
 
-export function findNextStableRelease(
+export function findLatestStableReleaseAfter(
   releases: PackageRelease[],
   cursorVersion: string,
 ): PackageRelease | null {
@@ -192,33 +213,33 @@ export function findNextStableRelease(
   if (index < 0) {
     throw new Error(`Could not find pi-ai cursor release ${cursorVersion}`);
   }
-  return releases[index + 1] ?? null;
+  return index === releases.length - 1 ? null : (releases.at(-1) ?? null);
 }
 
-export function areAdjacentStableReleases(
-  releases: PackageRelease[],
+export function extractChangelogRange(
+  changelog: string,
   previousVersion: string,
   currentVersion: string,
-): boolean {
-  return (
-    findPreviousStableRelease(releases, currentVersion)?.version ===
-    previousVersion
-  );
-}
-
-export function extractChangelogSection(
-  changelog: string,
-  version: string,
 ): string {
-  const heading = new RegExp(`^## \\[${escapeRegExp(version)}\\].*$`, "m");
-  const match = heading.exec(changelog);
-  if (!match)
-    throw new Error(`Could not find pi-ai changelog section ${version}`);
-  const start = match.index;
-  const remaining = changelog.slice(start + match[0].length);
-  const next = /^## \[/m.exec(remaining);
-  const end = next ? start + match[0].length + next.index : changelog.length;
-  return changelog.slice(start, end).trim();
+  const currentHeading = new RegExp(
+    `^## \\[${escapeRegExp(currentVersion)}\\].*$`,
+    "m",
+  ).exec(changelog);
+  if (!currentHeading) {
+    throw new Error(`Could not find pi-ai changelog section ${currentVersion}`);
+  }
+  const previousHeading = new RegExp(
+    `^## \\[${escapeRegExp(previousVersion)}\\].*$`,
+    "m",
+  ).exec(changelog.slice(currentHeading.index + currentHeading[0].length));
+  if (!previousHeading) {
+    throw new Error(
+      `Could not find pi-ai changelog section ${previousVersion}`,
+    );
+  }
+  const end =
+    currentHeading.index + currentHeading[0].length + previousHeading.index;
+  return changelog.slice(currentHeading.index, end).trim();
 }
 
 function findPreviousStableRelease(
@@ -276,18 +297,37 @@ function fetchTag(repoDir: string, tag: string): void {
   );
 }
 
-function verifyTagMatchesPackage(
+function resolveReleaseSource(
   repoDir: string,
   tag: string,
   release: PackageRelease,
-): void {
-  if (!release.git_head) return;
+): { sourceCommit: string; tagCommit: string } {
+  fetchTag(repoDir, tag);
   const tagCommit = git(["rev-list", "-n", "1", tag], repoDir).trim();
-  if (tagCommit !== release.git_head) {
+  const sourceCommit = release.git_head ?? tagCommit;
+  if (sourceCommit !== tagCommit) {
+    fetchCommit(repoDir, sourceCommit);
+  }
+  const packageJson = showFile(
+    repoDir,
+    sourceCommit,
+    "packages/ai/package.json",
+  );
+  if (packageJson === null) {
+    throw new Error(`packages/ai/package.json is missing at ${sourceCommit}`);
+  }
+  const sourceVersion = (JSON.parse(packageJson) as { version?: unknown })
+    .version;
+  if (sourceVersion !== release.version) {
     throw new Error(
-      `pi-ai npm ${release.version} gitHead ${release.git_head} does not match ${tag} commit ${tagCommit}`,
+      `pi-ai npm ${release.version} source ${sourceCommit} declares version ${String(sourceVersion)}`,
     );
   }
+  return { sourceCommit, tagCommit };
+}
+
+function fetchCommit(repoDir: string, commit: string): void {
+  git(["fetch", "--filter=blob:none", "origin", commit], repoDir);
 }
 
 function showFile(repoDir: string, tag: string, path: string): string | null {

--- a/scripts/pi-ai-watch/tracker.test.ts
+++ b/scripts/pi-ai-watch/tracker.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import type { PiAiWatchAnalysis } from "./release-analysis.ts";
 import {
-  advanceMergedPr,
   getPendingPrForCursor,
   hasCompletedRange,
   hasRecordedOutcome,
@@ -19,17 +18,18 @@ describe("pi-ai watch tracker", () => {
 
   test("advances after a no-upgrade decision", () => {
     const state = recordAnalysis(initialTrackerState("0.82.1"), {
-      analysis: analysis("0.82.1", "0.83.0"),
+      analysis: analysis("0.82.1", "0.84.0"),
       outcome: "no_upgrade",
       notes: "upstream-only provider change",
       processedAt: "2026-08-21T00:00:00Z",
     });
-    expect(state.audit_cursor_version).toBe("0.83.0");
-    expect(hasCompletedRange(state, "0.82.1", "0.83.0")).toBe(true);
-    expect(hasRecordedOutcome(state, "0.82.1", "0.83.0")).toBe(true);
+    expect(state.audit_cursor_version).toBe("0.84.0");
+    expect(hasCompletedRange(state, "0.82.1", "0.84.0")).toBe(true);
+    expect(hasRecordedOutcome(state, "0.82.1", "0.84.0")).toBe(true);
+    expect(renderTrackerBody(state)).toContain("[0.82.1...0.84.0]");
   });
 
-  test("keeps a created PR pending until it merges", () => {
+  test("advances a created PR and keeps it pending at the cursor", () => {
     const pending = recordAnalysis(initialTrackerState("0.82.1"), {
       analysis: analysis("0.82.1", "0.83.0"),
       outcome: "pr_created",
@@ -37,14 +37,18 @@ describe("pi-ai watch tracker", () => {
       prUrl: "https://github.com/letta-ai/letta-code/pull/123",
       processedAt: "2026-08-21T00:00:00Z",
     });
-    expect(pending.audit_cursor_version).toBe("0.82.1");
+    expect(pending.audit_cursor_version).toBe("0.83.0");
     expect(getPendingPrForCursor(pending)?.version).toBe("0.83.0");
-    expect(hasCompletedRange(pending, "0.82.1", "0.83.0")).toBe(false);
+    expect(hasCompletedRange(pending, "0.82.1", "0.83.0")).toBe(true);
     expect(hasRecordedOutcome(pending, "0.82.1", "0.83.0")).toBe(true);
 
-    const merged = advanceMergedPr(pending, "0.83.0");
-    expect(merged.audit_cursor_version).toBe("0.83.0");
-    expect(getPendingPrForCursor(merged)).toBeNull();
+    const later = recordAnalysis(pending, {
+      analysis: analysis("0.83.0", "0.84.0"),
+      outcome: "no_upgrade",
+      notes: "later release range",
+    });
+    expect(later.audit_cursor_version).toBe("0.84.0");
+    expect(getPendingPrForCursor(later)).toBeNull();
   });
 
   test("keeps errors retryable and replaces them with a later outcome", () => {
@@ -68,16 +72,16 @@ describe("pi-ai watch tracker", () => {
     expect(retried.processed[0]?.outcome).toBe("no_upgrade");
   });
 
-  test("advances uncertain releases but not explicit non-adjacent replays", () => {
+  test("advances cumulative reviews but not replays behind the cursor", () => {
     const human = recordAnalysis(initialTrackerState("0.82.1"), {
-      analysis: analysis("0.82.1", "0.83.0"),
+      analysis: analysis("0.82.1", "0.84.0"),
       outcome: "needs_human_review",
       notes: "product decision",
     });
-    expect(human.audit_cursor_version).toBe("0.83.0");
+    expect(human.audit_cursor_version).toBe("0.84.0");
 
     const replay = recordAnalysis(initialTrackerState("0.82.1"), {
-      analysis: analysis("0.82.1", "0.84.0", false),
+      analysis: analysis("0.82.1", "0.83.0", false),
       outcome: "no_upgrade",
       notes: "explicit replay",
     });
@@ -101,7 +105,7 @@ describe("pi-ai watch tracker", () => {
       const previous = `0.${index}.0`;
       const current = `0.${index}.1`;
       state = recordAnalysis(state, {
-        analysis: analysis(previous, current, false),
+        analysis: analysis(previous, current),
         outcome: "error",
         notes: `attempt ${index}`,
         processedAt: `2026-08-21T00:${String(index).padStart(2, "0")}:00Z`,
@@ -115,18 +119,21 @@ describe("pi-ai watch tracker", () => {
 function analysis(
   previousVersion: string,
   currentVersion: string,
-  adjacent = true,
+  isLatestRelease = true,
 ): PiAiWatchAnalysis {
   return {
     package: "@earendil-works/pi-ai",
     installed_version: "0.82.1",
     previous_version: previousVersion,
     current_version: currentVersion,
-    is_adjacent_release: adjacent,
+    is_latest_release: isLatestRelease,
     published_at: "2026-08-14T00:00:00Z",
     integrity: "sha512-test",
     tarball_url: "https://example.test/pi-ai.tgz",
+    previous_git_head: "previous123",
     git_head: "abc123",
+    previous_tag_commit: "previous123",
+    current_tag_commit: "abc123",
     release_url: `https://github.com/earendil-works/pi/releases/tag/v${currentVersion}`,
     compare_url: `https://github.com/earendil-works/pi/compare/v${previousVersion}...v${currentVersion}`,
     changelog_md: "## Added",

--- a/scripts/pi-ai-watch/tracker.ts
+++ b/scripts/pi-ai-watch/tracker.ts
@@ -87,9 +87,9 @@ export function recordAnalysis(
   ].slice(0, HISTORY_LIMIT);
 
   const advancesCursor =
-    options.analysis.is_adjacent_release &&
+    options.analysis.is_latest_release &&
     entry.previous_version === state.audit_cursor_version &&
-    (entry.outcome === "no_upgrade" || entry.outcome === "needs_human_review");
+    entry.outcome !== "error";
 
   return {
     audit_cursor_version: advancesCursor
@@ -123,8 +123,7 @@ export function hasCompletedRange(
     (entry) =>
       entry.previous_version === previousVersion &&
       entry.version === currentVersion &&
-      (entry.outcome === "no_upgrade" ||
-        entry.outcome === "needs_human_review"),
+      entry.outcome !== "error",
   );
 }
 
@@ -134,22 +133,11 @@ export function getPendingPrForCursor(
   return (
     state.processed.find(
       (entry) =>
-        entry.previous_version === state.audit_cursor_version &&
+        entry.version === state.audit_cursor_version &&
         entry.outcome === "pr_created" &&
         entry.pr_url,
     ) ?? null
   );
-}
-
-export function advanceMergedPr(
-  state: TrackerState,
-  currentVersion: string,
-): TrackerState {
-  const pending = getPendingPrForCursor(state);
-  if (!pending || pending.version !== currentVersion) {
-    throw new Error(`No pending pi-ai PR for ${currentVersion}`);
-  }
-  return { ...state, audit_cursor_version: currentVersion };
 }
 
 export function renderTrackerBody(state: TrackerState): string {
@@ -166,7 +154,7 @@ export function renderTrackerBody(state: TrackerState): string {
     "",
     "## Hidden state",
     "",
-    "The workflow uses the hidden JSON block below for ordered release processing and dedupe.",
+    "The workflow uses the hidden JSON block below for cumulative release processing and dedupe.",
     "",
     serializeTrackerState(normalized),
   ].join("\n")}\n`;
@@ -193,12 +181,12 @@ function renderTable(state: TrackerState): string {
   if (entries.length === 0) return "_No pi-ai releases reviewed yet._";
 
   const rows = [
-    "| Release | Installed | Outcome | PR | Notes |",
+    "| Range | Installed | Outcome | PR | Notes |",
     "|---|---|---|---|---|",
   ];
   for (const entry of entries) {
     rows.push(
-      `| [${entry.version}](${entry.compare_url}) | ${entry.installed_version} | ${entry.outcome} | ${renderPr(entry.pr_url)} | ${escapeTable(entry.notes)} |`,
+      `| [${entry.previous_version}...${entry.version}](${entry.compare_url}) | ${entry.installed_version} | ${entry.outcome} | ${renderPr(entry.pr_url)} | ${escapeTable(entry.notes)} |`,
     );
   }
   return rows.join("\n");

--- a/scripts/pi-ai-watch/update-tracker.ts
+++ b/scripts/pi-ai-watch/update-tracker.ts
@@ -202,13 +202,13 @@ function parseOutcome(value: string | undefined): TrackerOutcome {
 function defaultNotes(outcome: TrackerOutcome): string {
   switch (outcome) {
     case "no_upgrade":
-      return "reviewed; no upgrade needed for this release";
+      return "reviewed; no upgrade needed for this release range";
     case "pr_created":
       return "opened pi-ai dependency upgrade PR";
     case "needs_human_review":
       return "needs human review";
     case "error":
-      return "automation hit an error; retry this release";
+      return "automation hit an error; retry this release range";
   }
 }
 


### PR DESCRIPTION
## Summary

- audit one cumulative stable pi-ai range from the tracker cursor to the current latest release
- advance the cursor to that latest release after every recorded non-error decision, while preserving pending upgrade PR blocking
- compare exact npm `gitHead` revisions and expose release-tag drift instead of failing before review

## Validation

- `bun test scripts/pi-ai-watch/release-analysis.test.ts scripts/pi-ai-watch/tracker.test.ts`
- `bun run check`
- live dry-run for `0.83.0...0.84.3`, including cumulative changelog/source evidence
- dry-run against tracker #3953 verifying success advances `0.83.0 → 0.84.3` and errors preserve `0.83.0`
