### PR TITLE
fix(ci): audit latest Codex release from cursor

### DIFF
--- a/.github/agent-prompts/codex-agent-watch.md
+++ b/.github/agent-prompts/codex-agent-watch.md
@@ -1,12 +1,12 @@
 You are Amelia running in your managed cloud sandbox for `letta-ai/letta-code`, dispatched by GitHub Actions.
 
-Your job is to review one stable `openai/codex` release against the local Letta Code harness and either open a focused PR or record that no local change is needed.
+Your job is to review the cumulative stable `openai/codex` changes since the last audited release against the local Letta Code harness and either open a focused PR or record that no local change is needed.
 
 ## Context
 
 The central tracker issue is the source of truth for release dedupe and terminal outcomes.
 
-The detector already compared the latest stable Codex release to the previous stable release. Use the rebuilt analysis file as your starting point.
+The detector already compared the tracker cursor directly to the latest stable Codex release. Use the rebuilt cumulative analysis file as your starting point.
 
 ## GitHub authentication
 
@@ -20,14 +20,14 @@ Before reviewing the release, run the exact `Sandbox bootstrap` block below. It:
 
 1. Clones `letta-ai/letta-code` into `/tmp/letta-code-codex-watch`.
 2. Installs the repository dependencies.
-3. Rebuilds the detector analysis for the exact release pair at `/tmp/codex-watch-analysis.json`.
+3. Rebuilds the detector analysis for the exact cursor-to-latest release range at `/tmp/codex-watch-analysis.json`.
 
 Perform all repository inspection, edits, tests, and tracker updates from that sandbox clone. Use the tracker issue number and tags from the `Run inputs` block directly rather than relying on environment variables.
 
 ## Required behavior
 
 1. Inspect the analysis payload and upstream compare URL.
-2. Open the actual upstream diff for every changed watched path. Do not classify a change from its commit subject alone.
+2. Open the actual upstream diff for every changed watched path across the full release range. Do not classify a change from its commit subject alone.
 3. Review each upstream change against the corresponding local Letta Code mirror and account for it in the tracker note.
 4. If a local mirror should change, make the minimal local fix, run targeted validation, push a branch, and open a PR.
 5. If no local mirror should change, do not open a PR. Record `no_local_impact` in the tracker.

--- a/scripts/codex-watch/agent-watch.ts
+++ b/scripts/codex-watch/agent-watch.ts
@@ -17,7 +17,7 @@ import {
 import {
   analyzeCodexRelease,
   DEFAULT_TARGET_REPO,
-  findNextStableRelease,
+  findLatestStableReleaseAfter,
   listStableReleases,
   type Release,
 } from "./release-analysis.ts";
@@ -104,8 +104,11 @@ async function main() {
     const cursorTag = getCodexAuditCursorTag(state);
     if (cursorTag) {
       stableReleases ??= await listStableReleases();
-      const nextRelease = findNextStableRelease(stableReleases, cursorTag);
-      if (!nextRelease) {
+      const latestRelease = findLatestStableReleaseAfter(
+        stableReleases,
+        cursorTag,
+      );
+      if (!latestRelease) {
         console.log(`No stable release after ${cursorTag}; nothing to do.`);
         writeOutput("tracker_issue", String(tracker.number));
         writeOutput("tracker_issue_url", tracker.url);
@@ -116,7 +119,7 @@ async function main() {
         return;
       }
       sinceTag = cursorTag;
-      currentTag = nextRelease.tag_name;
+      currentTag = latestRelease.tag_name;
     }
   }
 
@@ -142,7 +145,7 @@ async function main() {
       state,
       analysis.previous_tag,
       analysis.current_tag,
-      analysis.is_adjacent_release,
+      analysis.is_latest_release,
     );
     if (next !== state) {
       editIssueBody(args.repo, tracker.number, renderTrackerBody(next));

--- a/scripts/codex-watch/release-analysis.test.ts
+++ b/scripts/codex-watch/release-analysis.test.ts
@@ -1,7 +1,7 @@
 import {
-  areAdjacentStableReleases,
-  findNextStableRelease,
+  findLatestStableReleaseAfter,
   type Release,
+  releaseNotesForRange,
 } from "./release-analysis.ts";
 
 function release(tag: string, publishedAt: string): Release {
@@ -10,7 +10,7 @@ function release(tag: string, publishedAt: string): Release {
     draft: false,
     prerelease: false,
     html_url: `https://github.com/openai/codex/releases/tag/${tag}`,
-    body: null,
+    body: `Notes for ${tag}`,
     published_at: publishedAt,
   };
 }
@@ -21,28 +21,30 @@ const STABLES = [
   release("rust-v0.3.0", "2026-08-03T00:00:00Z"),
 ];
 
-describe("Codex stable release backlog", () => {
-  test("selects the first release after the durable cursor", () => {
-    expect(findNextStableRelease(STABLES, "rust-v0.1.0")?.tag_name).toBe(
-      "rust-v0.2.0",
+describe("Codex stable release range", () => {
+  test("selects the latest release after the durable cursor", () => {
+    expect(findLatestStableReleaseAfter(STABLES, "rust-v0.1.0")?.tag_name).toBe(
+      "rust-v0.3.0",
     );
   });
 
-  test("identifies only adjacent stable release pairs", () => {
-    expect(
-      areAdjacentStableReleases(STABLES, "rust-v0.1.0", "rust-v0.2.0"),
-    ).toBe(true);
-    expect(
-      areAdjacentStableReleases(STABLES, "rust-v0.1.0", "rust-v0.3.0"),
-    ).toBe(false);
+  test("includes release notes for the full cursor-to-latest range", () => {
+    const notes = releaseNotesForRange(STABLES, "rust-v0.1.0", "rust-v0.3.0");
+    expect(notes).toContain("## [rust-v0.2.0]");
+    expect(notes).toContain("Notes for rust-v0.2.0");
+    expect(notes).toContain("## [rust-v0.3.0]");
+    expect(notes).not.toContain("Notes for rust-v0.1.0");
+    expect(() =>
+      releaseNotesForRange(STABLES, "rust-v0.3.0", "rust-v0.2.0"),
+    ).toThrow("Previous release rust-v0.3.0 must precede rust-v0.2.0");
   });
 
   test("returns null when the durable cursor is current", () => {
-    expect(findNextStableRelease(STABLES, "rust-v0.3.0")).toBeNull();
+    expect(findLatestStableReleaseAfter(STABLES, "rust-v0.3.0")).toBeNull();
   });
 
   test("fails instead of skipping an unavailable cursor", () => {
-    expect(() => findNextStableRelease(STABLES, "rust-v0.0.9")).toThrow(
+    expect(() => findLatestStableReleaseAfter(STABLES, "rust-v0.0.9")).toThrow(
       "Could not find terminal release rust-v0.0.9",
     );
   });

--- a/scripts/codex-watch/release-analysis.ts
+++ b/scripts/codex-watch/release-analysis.ts
@@ -45,7 +45,7 @@ export interface PathChangeSummary {
 export interface CodexWatchAnalysis {
   previous_tag: string;
   current_tag: string;
-  is_adjacent_release: boolean;
+  is_latest_release: boolean;
   release_url: string;
   release_notes_md: string;
   verdict: Verdict;
@@ -139,13 +139,13 @@ export async function analyzeCodexRelease(
     return {
       previous_tag: previous.tag_name,
       current_tag: current.tag_name,
-      is_adjacent_release: areAdjacentStableReleases(
+      is_latest_release: current.tag_name === stables.at(-1)?.tag_name,
+      release_url: current.html_url,
+      release_notes_md: releaseNotesForRange(
         stables,
         previous.tag_name,
         current.tag_name,
       ),
-      release_url: current.html_url,
-      release_notes_md: current.body ?? "",
       verdict,
       models_diff: modelsDiff,
       prompt_md_changed: promptMdChanged,
@@ -207,15 +207,37 @@ function findPreviousStable(
   return stables[idx - 1] ?? null;
 }
 
-export function areAdjacentStableReleases(
+export function releaseNotesForRange(
   stables: Release[],
   previousTag: string,
   currentTag: string,
-): boolean {
-  return findPreviousStable(stables, currentTag)?.tag_name === previousTag;
+): string {
+  const currentIndex = stables.findIndex(
+    (release) => release.tag_name === currentTag,
+  );
+  if (currentIndex < 0) {
+    throw new Error(`Could not find current release ${currentTag}`);
+  }
+  const previousIndex = stables.findIndex(
+    (release) => release.tag_name === previousTag,
+  );
+  if (previousIndex >= currentIndex) {
+    throw new Error(
+      `Previous release ${previousTag} must precede ${currentTag}`,
+    );
+  }
+  const firstIncludedIndex =
+    previousIndex < 0 ? currentIndex : previousIndex + 1;
+  return stables
+    .slice(firstIncludedIndex, currentIndex + 1)
+    .map(
+      (release) =>
+        `## [${release.tag_name}](${release.html_url})\n\n${release.body?.trim() || "_No release notes._"}`,
+    )
+    .join("\n\n");
 }
 
-export function findNextStableRelease(
+export function findLatestStableReleaseAfter(
   stables: Release[],
   terminalTag: string,
 ): Release | null {
@@ -225,7 +247,7 @@ export function findNextStableRelease(
   if (terminalIndex < 0) {
     throw new Error(`Could not find terminal release ${terminalTag}`);
   }
-  return stables[terminalIndex + 1] ?? null;
+  return terminalIndex === stables.length - 1 ? null : (stables.at(-1) ?? null);
 }
 
 function cloneCodex(tmp: string): string {

--- a/scripts/codex-watch/tracker.test.ts
+++ b/scripts/codex-watch/tracker.test.ts
@@ -21,7 +21,7 @@ function analysis(
   return {
     previous_tag: "rust-v0.1.0",
     current_tag: tag,
-    is_adjacent_release: true,
+    is_latest_release: true,
     release_url: `https://github.com/openai/codex/releases/tag/${tag}`,
     release_notes_md: "",
     verdict,
@@ -166,7 +166,7 @@ describe("tracker state", () => {
   test("fails closed on a cumulative legacy replay", () => {
     const cumulative = {
       ...analysis("rust-v0.5.0", "tool-surface review needed"),
-      is_adjacent_release: false,
+      is_latest_release: false,
     };
     const state = recordAnalysis(emptyTrackerState(), {
       analysis: cumulative,
@@ -250,14 +250,14 @@ describe("tracker state", () => {
     expect(getCodexAuditCursorTag(state)).toBe("rust-v0.2.0");
   });
 
-  test("does not advance for an explicit non-adjacent range", () => {
+  test("does not advance for an explicit non-latest range", () => {
     const initial = upsertTrackerEntry(
       emptyTrackerState(),
       entry(1, "no_local_impact"),
     );
     const cumulative = {
       ...analysis("rust-v0.5.0", "tool-surface review needed"),
-      is_adjacent_release: false,
+      is_latest_release: false,
     };
     const state = recordAnalysis(initial, {
       analysis: cumulative,
@@ -273,7 +273,7 @@ describe("tracker state", () => {
     ).toBe("rust-v0.1.0");
   });
 
-  test("advances across an already audited adjacent range", () => {
+  test("advances across an already audited latest range", () => {
     let state = upsertTrackerEntry(
       emptyTrackerState(),
       entry(1, "no_local_impact"),

--- a/scripts/codex-watch/tracker.ts
+++ b/scripts/codex-watch/tracker.ts
@@ -119,10 +119,9 @@ export function advanceCodexAuditCursor(
   state: TrackerState,
   previousTag: string,
   currentTag: string,
-  isAdjacentRelease: boolean,
+  isLatestRelease: boolean,
 ): TrackerState {
-  if (!isAdjacentRelease || state.audit_cursor_tag !== previousTag)
-    return state;
+  if (!isLatestRelease || state.audit_cursor_tag !== previousTag) return state;
   if (!hasProcessedRange(state, previousTag, currentTag)) {
     throw new Error(
       `Cannot advance Codex audit cursor without terminal ${previousTag}...${currentTag}`,
@@ -149,26 +148,26 @@ export function recordAnalysis(
       compare_url: options.analysis.compare_url,
       workflow_run_url: options.analysis.workflow_run_url,
     },
-    options.analysis.is_adjacent_release,
+    options.analysis.is_latest_release,
   );
 }
 
 export function upsertTrackerEntry(
   state: TrackerState,
   entry: TrackerEntry,
-  advanceAuditCursor = true,
+  isLatestRelease = true,
 ): TrackerState {
   let auditCursorTag = state.audit_cursor_tag;
-  if (auditCursorTag === null && !advanceAuditCursor) {
+  if (auditCursorTag === null && !isLatestRelease) {
     auditCursorTag = entry.previous_tag;
   } else if (
-    advanceAuditCursor &&
+    isLatestRelease &&
     entry.outcome === "error" &&
     auditCursorTag === null
   ) {
     auditCursorTag = entry.previous_tag;
   } else if (
-    advanceAuditCursor &&
+    isLatestRelease &&
     isTerminalOutcome(entry.outcome) &&
     (auditCursorTag === null || entry.previous_tag === auditCursorTag)
   ) {


### PR DESCRIPTION
## Summary

- compare the Codex tracker cursor directly to the latest stable release instead of replaying adjacent releases
- include release notes for every release in the cumulative range
- advance the durable cursor only for a terminal cursor-to-latest outcome, while preserving error retries and historical replay isolation

## Validation

- `bun test scripts/codex-watch/release-analysis.test.ts scripts/codex-watch/diff-models-json.test.ts scripts/codex-watch/tracker.test.ts`
- `bun run check`
- live dry-run for `rust-v0.148.0...rust-v0.149.1`, including both releases' notes and the cumulative watched-path diff
- dry-run against tracker #3192 verifying terminal outcomes advance to `rust-v0.149.1` and errors preserve `rust-v0.148.0`
