### PR TITLE
fix(ci): audit latest Claude release from cursor

### DIFF
--- a/.github/agent-prompts/claude-agent-watch.md
+++ b/.github/agent-prompts/claude-agent-watch.md
@@ -1,6 +1,6 @@
 You are Amelia running in your managed cloud sandbox for `letta-ai/letta-code`, dispatched by GitHub Actions.
 
-Your job is to review one exact published Claude Code candidate against the local Letta Code harness and either open one focused parity PR, record that no local change is needed, or explicitly request human review.
+Your job is to review one exact current Claude Code candidate against the local Letta Code harness and either open one focused parity PR, record that no local change is needed, or explicitly request human review.
 
 ## Evidence model
 
@@ -13,6 +13,8 @@ Claude Code is closed source. Use these independent public/observable signals:
 Do not invent or rely on a private prompt dump, schema dump, `--list-tools`, or undocumented introspection API. `system/init.tools` establishes only the names advertised in that exact session. Model-generated tool inputs and black-box probe results are observations, not complete schemas or proof of internal implementation.
 
 The detector has already captured and committed the normalized candidate snapshot on `claude-watch-state`. Use the rebuilt analysis from the exact state commit as your starting point.
+
+For a package update, the detector compares the last audited snapshot directly to the current latest release. The release notes contain every stable release in that cumulative range; the docs and runtime evidence compare the two exact endpoint snapshots.
 
 ## GitHub authentication
 

--- a/scripts/claude-watch/release-source.test.ts
+++ b/scripts/claude-watch/release-source.test.ts
@@ -2,6 +2,7 @@ import {
   ClaudeReleaseSourceDisagreementError,
   parseClaudeGitHubReleases,
   parseClaudeNpmMetadata,
+  releaseNotesForRange,
   selectClaudeReleaseCandidate,
 } from "./release-source.ts";
 import type { ClaudeGitHubRelease, ClaudeNpmMetadata } from "./types.ts";
@@ -109,15 +110,19 @@ describe("selectClaudeReleaseCandidate", () => {
     }
   });
 
-  test("takes the oldest release after the terminal processed version", () => {
+  test("takes the latest release after the terminal processed version", () => {
     const candidate = selectClaudeReleaseCandidate({
       githubReleases: releases,
       npmMetadata: npm(),
       processedPackageVersions: ["1.0.0"],
     });
 
-    expect(candidate?.version).toBe("1.1.0");
-    expect(candidate?.integrity).toBe("sha512-1.1.0");
+    expect(candidate?.version).toBe("1.2.0");
+    expect(candidate?.integrity).toBe("sha512-1.2.0");
+    expect(candidate?.release_notes_md).toContain("## [1.1.0]");
+    expect(candidate?.release_notes_md).toContain("notes 1.1.0");
+    expect(candidate?.release_notes_md).toContain("## [1.2.0]");
+    expect(candidate?.release_notes_md).not.toContain("notes 1.0.0");
   });
 
   test("bootstrap selects only the current npm latest release", () => {
@@ -139,7 +144,8 @@ describe("selectClaudeReleaseCandidate", () => {
     });
 
     expect(candidate?.version).toBe("1.2.0");
-    expect(candidate?.release_notes_md).toBe("notes 1.2.0");
+    expect(candidate?.release_notes_md).toContain("notes 1.1.0");
+    expect(candidate?.release_notes_md).toContain("notes 1.2.0");
   });
 
   test("validation can replay exact npm versions omitted from the GitHub feed", () => {
@@ -175,5 +181,11 @@ describe("selectClaudeReleaseCandidate", () => {
         processedPackageVersions: ["1.0.0", "1.1.0", "1.2.0"],
       }),
     ).toBeNull();
+  });
+
+  test("rejects a reversed release-note range", () => {
+    expect(() => releaseNotesForRange(releases, "1.2.0", "1.1.0")).toThrow(
+      "Previous Claude release 1.2.0 must precede 1.1.0",
+    );
   });
 });

--- a/scripts/claude-watch/release-source.ts
+++ b/scripts/claude-watch/release-source.ts
@@ -275,7 +275,10 @@ export function selectClaudeReleaseCandidate(
         `Terminal version ${terminalVersion} is not present in GitHub releases.`,
       );
     }
-    release = githubReleases[terminalIndex + 1];
+    release =
+      terminalIndex === githubReleases.length - 1
+        ? undefined
+        : githubReleases.at(-1);
   }
 
   if (!release) return null;
@@ -290,10 +293,46 @@ export function selectClaudeReleaseCandidate(
   return {
     ...npmVersion,
     release_url: release.html_url,
-    release_notes_md: release.body ?? "",
+    release_notes_md: releaseNotesForRange(
+      githubReleases,
+      terminalVersion,
+      release.tag_name,
+    ),
     release_published_at: release.published_at,
     dist_tags: options.npmMetadata.dist_tags,
   };
+}
+
+export function releaseNotesForRange(
+  releases: ClaudeGitHubRelease[],
+  previousVersion: string | null,
+  currentVersion: string,
+): string {
+  const currentIndex = releases.findIndex(
+    (release) => release.tag_name === currentVersion,
+  );
+  if (currentIndex < 0) {
+    throw new Error(`Could not find Claude release ${currentVersion}`);
+  }
+  const previousIndex = previousVersion
+    ? releases.findIndex((release) => release.tag_name === previousVersion)
+    : -1;
+  if (previousIndex >= currentIndex) {
+    throw new Error(
+      `Previous Claude release ${previousVersion} must precede ${currentVersion}`,
+    );
+  }
+  const included = releases.slice(
+    previousIndex < 0 ? currentIndex : previousIndex + 1,
+    currentIndex + 1,
+  );
+  if (included.length === 1) return included[0]?.body ?? "";
+  return included
+    .map(
+      (release) =>
+        `## [${release.tag_name}](${release.html_url})\n\n${release.body?.trim() || "_No release notes._"}`,
+    )
+    .join("\n\n");
 }
 
 async function fetchJson(


### PR DESCRIPTION
## Summary

- select the current latest Claude Code release directly after the durable package snapshot instead of replaying releases one by one
- include every available GitHub release note between the snapshot and latest in the review evidence
- preserve pending-candidate reconciliation and same-package docs/runtime drift scans

## Validation

- `bun test scripts/claude-watch/*.test.ts`
- `bun run check`
- live release-source validation selecting `2.1.245` directly from `2.1.238`, with cumulative notes for the intervening GitHub releases

The current unreviewed `2.1.238` state candidate will still retry to a terminal outcome first. The next run then compares that audited snapshot directly to latest.
