### PR TITLE
fix(channels): detach lifecycle hooks from delivery queues [LET-11424]

### DIFF
--- a/src/channels/gateway-core.test.ts
+++ b/src/channels/gateway-core.test.ts
@@ -447,6 +447,7 @@ test("terminal turn_finished with end_turn emits finished with completed outcome
   await gateway.submit(makeDelivery({ clientMessageId: "cm-end" }));
 
   client.emit(makeTurnFinished("end_turn"));
+  await Bun.sleep(0);
 
   const finishedEvents = lifecycleEvents.filter((e) => e.type === "finished");
   expect(finishedEvents).toHaveLength(1);
@@ -467,6 +468,7 @@ test("terminal turn_finished with cancelled emits finished with cancelled outcom
   await gateway.submit(makeDelivery({ clientMessageId: "cm-cancel" }));
 
   client.emit(makeTurnFinished("cancelled"));
+  await Bun.sleep(0);
 
   const finishedEvents = lifecycleEvents.filter((e) => e.type === "finished");
   expect(finishedEvents).toHaveLength(1);
@@ -487,6 +489,7 @@ test("terminal turn_finished with error emits finished with error outcome and er
   await gateway.submit(makeDelivery({ clientMessageId: "cm-err" }));
 
   client.emit(makeTurnFinished("error", TEST_RUNTIME, { error: "API failed" }));
+  await Bun.sleep(0);
 
   const finishedEvents = lifecycleEvents.filter((e) => e.type === "finished");
   expect(finishedEvents).toHaveLength(1);
@@ -783,35 +786,18 @@ test("idle runtime cleanup is explicit, guarded, and retryable", async () => {
       ...(shouldFail ? { error: "tool update failed" } : {}),
     };
   };
-  let failAdoption = false;
-  const gateway = new ChannelGateway(
-    client,
-    makeHooks({
-      onLifecycle: (event) => {
-        if (failAdoption && event.type === "processing") {
-          throw new Error("adoption failed");
-        }
-      },
-    }).hooks,
-  );
+  const gateway = new ChannelGateway(client, makeHooks().hooks);
   const clean = () =>
     gateway.releaseRuntimeTools(TEST_RUNTIME, [], { cleanupIdleRuntime: true });
   await gateway.registerRuntime(TEST_RUNTIME);
   await gateway.releaseRuntimeTools(TEST_RUNTIME);
   expect(gateway.getKnownRuntimes()).toEqual([TEST_RUNTIME]);
-  failAdoption = true;
-  await expect(
-    gateway.adoptActiveDelivery(
-      makeDelivery({ sources: [], clientMessageId: "failed-adoption" }),
-    ),
-  ).rejects.toThrow("adoption failed");
   await expect(clean()).rejects.toThrow("tool update failed");
   expect(gateway.getKnownRuntimes()).toEqual([]);
   await expect(clean()).resolves.toBeUndefined();
   expect(client.runtimeToolUpdates).toHaveLength(2);
   expect(client.runtimeToolUpdates[0]?.external_tools).toEqual([]);
   expect(client.runtimeToolUpdates[1]?.external_tools).toEqual([]);
-  failAdoption = false;
   await gateway.adoptActiveDelivery(
     makeDelivery({ sources: [], clientMessageId: "active" }),
   );
@@ -939,6 +925,7 @@ test("control request with single source dispatches to onControlRequest", async 
     agent_id: "agent-1",
     conversation_id: "conv-1",
   } as unknown as WsProtocolMessage);
+  await Bun.sleep(0);
 
   expect(controlRequestEvents).toHaveLength(1);
   const event = controlRequestEvents[0];

--- a/src/channels/gateway-core.ts
+++ b/src/channels/gateway-core.ts
@@ -300,11 +300,11 @@ export class ChannelGateway {
         return false;
       }
       this.rememberAcceptedClientMessageId(state, delivery.clientMessageId);
-      const queuedEvents = delivery.sources.map((source) =>
-        this.enqueueHook(state, () =>
+      for (const source of delivery.sources) {
+        void this.enqueueHook(state, () =>
           this.hooks.onLifecycle({ type: "queued", source }),
-        ),
-      );
+        );
+      }
       if (response.disposition === "started") {
         this.activateSources(state, delivery.clientMessageId, delivery.sources);
         state.pendingSourcesByClientMessageId.delete(delivery.clientMessageId);
@@ -317,7 +317,6 @@ export class ChannelGateway {
         }
         this.reconcileExplicitQueueRemovals(state);
       }
-      await Promise.all(queuedEvents);
       return true;
     } catch (error) {
       state.pendingSourcesByClientMessageId.delete(delivery.clientMessageId);
@@ -440,7 +439,7 @@ export class ChannelGateway {
             batchId,
             sources: routingSources,
           }) ?? null;
-        await this.enqueueHook(state, () =>
+        void this.enqueueHook(state, () =>
           this.hooks.onLifecycle({
             type: "processing",
             batchId,

--- a/src/channels/gateway-handoff.test.ts
+++ b/src/channels/gateway-handoff.test.ts
@@ -166,28 +166,45 @@ test("routes approval replay that arrives during destination registration", asyn
   gateway.close();
 });
 
-test("adoption waits for processing ownership to be recorded", async () => {
+test("hung processing lifecycle does not block adoption or later delivery", async () => {
   const client = new FakeClient();
-  let releaseProcessing: (() => void) | undefined;
-  let processingRecorded = false;
+  let markProcessingStarted!: () => void;
+  const processingStarted = new Promise<void>((resolve) => {
+    markProcessingStarted = resolve;
+  });
+  let releaseProcessing!: () => void;
+  const processingGate = new Promise<void>((resolve) => {
+    releaseProcessing = resolve;
+  });
   const gateway = new ChannelGateway(
     client,
     makeHooks({
-      onLifecycle: async () => {
-        await new Promise<void>((resolve) => {
-          releaseProcessing = resolve;
-        });
-        processingRecorded = true;
+      onLifecycle: async (event) => {
+        if (event.type !== "processing") return;
+        markProcessingStarted();
+        await processingGate;
       },
     }).hooks,
   );
+  const source = makeSource({ channel: "slack", chatId: "C-hung-hook" });
 
-  const adoption = gateway.adoptActiveDelivery(makeHandoff());
-  await Bun.sleep(0);
-  expect(processingRecorded).toBe(false);
-  releaseProcessing?.();
+  const adoption = gateway.adoptActiveDelivery(
+    makeHandoff({ sources: [source] }),
+  );
+  await processingStarted;
   await adoption;
-  expect(processingRecorded).toBe(true);
+  await expect(
+    gateway.submit(
+      makeDelivery({
+        sources: [source],
+        clientMessageId: "cm-after-hung-hook",
+      }),
+    ),
+  ).resolves.toBe(true);
+  expect(client.submittedInputs).toHaveLength(1);
+
+  releaseProcessing();
+  await Bun.sleep(0);
   gateway.close();
 });
 

--- a/src/channels/gateway-turn-lifecycle.test.ts
+++ b/src/channels/gateway-turn-lifecycle.test.ts
@@ -22,6 +22,7 @@ test("stream stop reason waits for turn_finished error detail", async () => {
       run_id: "run-1",
     }),
   );
+  await Bun.sleep(0);
   expect(progressEvents.length).toBeGreaterThan(0);
 
   client.emit(
@@ -42,6 +43,7 @@ test("stream stop reason waits for turn_finished error detail", async () => {
       error: "The usage limit has been reached.",
     }),
   );
+  await Bun.sleep(0);
 
   const finishedEvents = lifecycleEvents.filter(
     (event) => event.type === "finished",


### PR DESCRIPTION
## Summary

- keep active-delivery adoption from awaiting channel lifecycle I/O inside the gateway-wide registration queue
- return accepted inputs without awaiting queued lifecycle hooks, so a previously hung hook cannot poison the per-runtime submission queue
- cover a hung recovered processing hook followed by a successful new delivery

## Root cause

Active-delivery recovery awaited the `processing` lifecycle hook while holding the global registration queue. The hook can perform Slack API writes, so one request that never settles blocks every later runtime registration. Simply detaching adoption is not sufficient because a later accepted delivery also awaited its `queued` hook behind the same hung lifecycle queue; both hook waits now remain ordered but no longer gate core delivery.

Tracked by [LET-11424](https://linear.app/letta/issue/LET-11424/cloud-slack-reconnect-wedges-gateway-on-awaited-lifecycle-io).

## Test plan

- `bun test src/channels` (1,261 passed)
- `bun run check`
- built this commit as an npm tarball and installed it into a clean `letta-cloud` worktree
- Cloud host reconnect recovery plus a later delivery completes with a permanently hung processing hook
- Cloud teleport binding plus a later delivery completes with a permanently hung processing hook
- the real Cloud Slack adapter path completes recovery and later input with `status.activate()` permanently hung
- current Cloud package `0.30.31` fails both host scenarios; this packaged change passes them
- 49 Cloud gateway host, adapter, session, and protocol tests pass against the tarball