### PR TITLE
ci(sync-tools): use Amelia PR automation

### DIFF
--- a/.github/agent-prompts/sync-tools-to-cloud.md
+++ b/.github/agent-prompts/sync-tools-to-cloud.md
@@ -1,0 +1,80 @@
+You are Amelia running in your managed cloud sandbox for `letta-ai/letta-code`, dispatched by GitHub Actions.
+
+Your job is to inspect one merged `letta-ai/letta-code` pull request that changed `src/tools/` and either open one focused draft PR syncing its user-visible tool changes to `letta-ai/letta-cloud` or record that no sync is needed.
+
+## GitHub authentication
+
+Before inspecting or modifying GitHub, resolve the automation identity with `test -n "$AMELIA_GITHUB_TOKEN" && GITHUB_TOKEN= GH_TOKEN="$AMELIA_GITHUB_TOKEN" gh api user --jq .login`. It must exactly match the Expected GitHub login from the run inputs. If the secret is missing or the identities differ, stop without modifying GitHub.
+
+Use only `test -n "$AMELIA_GITHUB_TOKEN" && GITHUB_TOKEN= GH_TOKEN="$AMELIA_GITHUB_TOKEN"` for every GitHub CLI operation. Never use the agent's general `$GITHUB_TOKEN` secret or another user's credentials.
+
+## Source review
+
+Read the source PR metadata and complete diff:
+
+```bash
+test -n "$AMELIA_GITHUB_TOKEN" && GITHUB_TOKEN= GH_TOKEN="$AMELIA_GITHUB_TOKEN" gh pr view <source-pr-url> --json title,body,files,author
+test -n "$AMELIA_GITHUB_TOKEN" && GITHUB_TOKEN= GH_TOKEN="$AMELIA_GITHUB_TOKEN" gh pr diff <source-pr-url>
+```
+
+Determine whether the change has a user-visible effect in the letta-cloud FunctionCall UI. Focus on:
+
+- `libs/ui-component-library/src/lib/reusable/FunctionCall/toolNameUtils.ts`, tool variant detection and canonical naming
+- `libs/ui-component-library/src/lib/reusable/FunctionCall/FunctionCall.types.ts`, Zod literals and typed schemas
+- `libs/ui-component-library/src/lib/reusable/FunctionCall/FunctionCallPreview.tsx`, preview routing and inline summaries
+- `libs/ui-component-library/src/lib/reusable/FunctionCall/FunctionCall.tsx`, header and chat-prefix behavior
+- `libs/ui-component-library/src/lib/translations/en.json`, `fr.json`, and `cn.json`, matching labels and prefixes
+- adjacent tests
+
+Internal refactors with no schema, name, label, preview, or other user-visible UI impact do not need a cloud sync. In that case, do not create a branch, PR, GitHub comment, review request, or Slack message. Respond with exactly `NO_SYNC_NEEDED`.
+
+## Retry safety
+
+Before editing, search open and merged `letta-ai/letta-cloud` PRs for the exact Source marker from the run inputs.
+
+- If an open PR already has the marker, do not create or modify another PR. Verify its author and draft state, ensure the configured reviewers are requested, complete the Slack notification, and use that URL as the result.
+- If a merged PR already has the marker, the sync is complete. Respond with exactly `NO_SYNC_NEEDED` without a Slack message.
+- A closed, unmerged PR does not count as a completed sync. Use the unique Branch name from the run inputs for a replacement.
+
+## Implementation
+
+When a sync is needed:
+
+1. Remove any existing `/tmp/letta-cloud`, then clone `letta-ai/letta-cloud` there with the explicit Amelia credential.
+2. Create the exact Branch name from the run inputs from the repository's default branch.
+3. Make only the user-visible FunctionCall changes required by the source PR.
+4. Run focused tests for the changed components and `npm run type-check`. Fix failures introduced by the sync before proceeding.
+5. Stage only the intended files, commit, and push the branch.
+6. Open a draft PR with a Conventional Commit title. Link the source PR and include the exact Source marker from the run inputs on its own line in the body.
+
+## PR verification and reviewers
+
+Immediately after creating or recovering the PR:
+
+1. Verify that it is a draft and its author exactly matches the Expected GitHub login. If the author is wrong, close it instead of reporting success. If it is not a draft, convert it to a draft before proceeding.
+2. GET `repos/letta-ai/letta-cloud/pulls/<number>/requested_reviewers` with the explicit Amelia credential.
+3. Request every configured GitHub reviewer not already present using the REST `requested_reviewers` endpoint. Do not use `gh pr edit --add-reviewer`, which requires unavailable organization scopes.
+
+Do not merge the PR, leave GitHub comments, or review other changes.
+
+## Slack notification
+
+After the draft PR and reviewers are verified, call the native `MessageChannel` tool with `action="send"`, `channel="slack"`, and `target="C0871ER46KT"`. Do not use `curl` or another Slack API client.
+
+Use the selected Slack owner ID from the run inputs and send exactly one line:
+
+```text
+<@U079W8F9Z7G> https://github.com/letta-ai/letta-cloud/pull/1234
+```
+
+Replace the example values with the selected owner and created PR. Do not include a prefix, source PR, workflow URL, or any other text. Send no Slack message for `NO_SYNC_NEEDED`.
+
+## Final response
+
+After the PR verification, reviewer requests, and Slack notification all succeed, respond with exactly one line:
+
+```text
+PR_CREATED <url>
+```
+
+If any required step fails, do not report `PR_CREATED` or `NO_SYNC_NEEDED`. Return a concise failure so the workflow's outcome verification fails visibly.

--- a/.github/workflows/sync-tools-to-cloud.yml
+++ b/.github/workflows/sync-tools-to-cloud.yml
@@ -115,7 +115,7 @@ jobs:
           EXPECTED_GITHUB_LOGIN: ${{ steps.github-identity.outputs.login }}
           SOURCE_MARKER: ${{ steps.prompt.outputs.source_marker }}
         run: |
-          result=$(jq -r '[.[] | select(.type == "result" and (.result | type) == "string")] | last | (.result // "" | gsub("^\\s+|\\s+$"; ""))' "$EXECUTION_FILE")
+          result=$(jq -r '[.[] | select(.type == "result" and (.result | type) == "string")] | last | (.result // "" | split("\n") | map(gsub("^\\s+|\\s+$"; "") | select(length > 0)) | last // "")' "$EXECUTION_FILE")
           if [ "$result" = "NO_SYNC_NEEDED" ]; then
             echo "No letta-cloud sync needed"
             exit 0

--- a/.github/workflows/sync-tools-to-cloud.yml
+++ b/.github/workflows/sync-tools-to-cloud.yml
@@ -13,98 +13,126 @@ on:
         required: true
         type: number
 
+concurrency:
+  group: sync-tools-to-cloud-${{ github.event.inputs.pr_number || github.event.pull_request.number }}
+  cancel-in-progress: false
+
 jobs:
   sync:
-    # Only run on merged PRs (path filter already scopes to src/tools/ changes)
-    # or on manual dispatch
     if: >
       (github.event_name == 'workflow_dispatch') ||
       (github.event.pull_request.merged == true)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
     permissions:
       contents: read
       pull-requests: read
     env:
       PR_NUMBER: ${{ github.event.inputs.pr_number || github.event.pull_request.number }}
-      PR_AUTHOR: ${{ github.event.pull_request.user.login }}
 
     steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
+      - name: Checkout
+        uses: actions/checkout@v6
 
-      - uses: letta-ai/letta-code-action@daa80f29e345315623ff759f5ecf5018946bbc15
-        id: letta_sync
+      - name: Resolve Amelia GitHub identity
+        id: github-identity
+        env:
+          GH_TOKEN: ${{ secrets.AMELIA_GITHUB_TOKEN }}
+        run: |
+          login=$(gh api user --jq .login)
+          echo "login=$login" >> "$GITHUB_OUTPUT"
+          echo "Authenticated GitHub login: $login"
+
+      - name: Build Amelia prompt
+        id: prompt
+        env:
+          EXPECTED_GITHUB_LOGIN: ${{ steps.github-identity.outputs.login }}
+          OWNERS: ${{ vars.SYNC_TOOLS_OWNERS }}
+        run: |
+          jq -e '
+            type == "array" and length > 0 and
+            all(.[];
+              ((.github | type) == "string" and (.github | length) > 0) and
+              ((.slack | type) == "string" and (.slack | test("^U[A-Z0-9]+$")))
+            )
+          ' <<< "$OWNERS" > /dev/null
+          github_reviewers=$(jq -r 'map(.github) | join(",")' <<< "$OWNERS")
+          owner_count=$(jq 'length' <<< "$OWNERS")
+          slack_owner_id=$(jq -r --argjson index "$((RANDOM % owner_count))" '.[$index].slack' <<< "$OWNERS")
+          source_marker="Sync-tools-source: letta-ai/letta-code#$PR_NUMBER"
+          branch_name="sync/tools-from-letta-code-pr-$PR_NUMBER-$GITHUB_RUN_ID"
+          {
+            echo "prompt<<AMELIA_PROMPT_EOF"
+            cat .github/agent-prompts/sync-tools-to-cloud.md
+            echo
+            echo "## Run inputs"
+            echo
+            echo "- Source PR: https://github.com/letta-ai/letta-code/pull/$PR_NUMBER"
+            echo "- Workflow run: $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+            echo "- Expected GitHub login: $EXPECTED_GITHUB_LOGIN"
+            echo "- GitHub reviewers: $github_reviewers"
+            echo "- Slack owner ID: $slack_owner_id"
+            echo "- Source marker: $source_marker"
+            echo "- Branch name: $branch_name"
+            echo "AMELIA_PROMPT_EOF"
+            echo "conversation_name=$GITHUB_WORKFLOW PR #$PR_NUMBER $(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+            echo "source_marker=$source_marker"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Ask Amelia to sync tools
+        id: letta-sync
+        uses: letta-ai/letta-code-action@4b8e508a523ff576fee09be1432d6f39158c272c
         with:
           letta_api_key: ${{ secrets.AMELIA_LETTA_API_KEY }}
           github_token: ${{ secrets.AMELIA_GITHUB_TOKEN }}
           agent_id: agent-cd664b86-4d28-49b7-8ad6-60677eaff9be
+          environment: cloud
+          letta_args: --new
           track_progress: ""
           tracking_comment: "false"
           model: auto
-          prompt: |
-            A pull request that modifies `src/tools/` in letta-ai/letta-code has just been merged.
-            PR number: ${{ env.PR_NUMBER }}
+          prompt: ${{ steps.prompt.outputs.prompt }}
 
-            Your job is to sync the relevant changes to letta-ai/letta-cloud by opening a PR there.
+      - name: Name sync conversation
+        if: always() && steps.letta-sync.outputs.conversation_id != ''
+        env:
+          LETTA_API_KEY: ${{ secrets.AMELIA_LETTA_API_KEY }}
+          CONVERSATION_ID: ${{ steps.letta-sync.outputs.conversation_id }}
+          CONVERSATION_NAME: ${{ steps.prompt.outputs.conversation_name }}
+        run: |
+          curl --fail-with-body --silent --show-error \
+            --request PATCH \
+            --header "Authorization: Bearer $LETTA_API_KEY" \
+            --header "Content-Type: application/json" \
+            --data "$(jq -nc --arg summary "$CONVERSATION_NAME" '{summary: $summary}')" \
+            --output /dev/null \
+            "https://api.letta.com/v1/conversations/$CONVERSATION_ID"
 
-            ## Steps
-
-            1. Read your memory and review-knowledge.md for context on the letta-code/letta-cloud relationship.
-
-            2. Understand what changed:
-               ```bash
-               gh pr view $PR_NUMBER --repo letta-ai/letta-code --json title,body,files
-               gh pr diff $PR_NUMBER --repo letta-ai/letta-code
-               ```
-
-            3. Determine what, if anything, needs updating in letta-cloud. Follow the FunctionCall sync pattern and focus on:
-               - `libs/ui-component-library/src/lib/reusable/FunctionCall/toolNameUtils.ts` — add/adjust tool variant detection + canonical naming
-               - `libs/ui-component-library/src/lib/reusable/FunctionCall/FunctionCall.types.ts` — add/adjust Zod literals / typed schemas
-               - `libs/ui-component-library/src/lib/reusable/FunctionCall/FunctionCallPreview.tsx` — renderPreview routing, hasPrettyFunctionCallPreview, and inline summary updates
-               - `libs/ui-component-library/src/lib/reusable/FunctionCall/FunctionCall.tsx` — header/chat prefix behavior (hasCustomChatPrefix, chatPrefix, default-open behavior)
-               - `libs/ui-component-library/src/lib/translations/en.json`, `fr.json`, `cn.json` — add matching translation keys when labels/prefixes/previews change
-               - Adjacent tests for the files above
-               If the src/tools/ change has no user-visible impact in the cloud UI (for example, internal-only refactors with no schema/name/label changes), respond with exactly: `NO_SYNC_NEEDED` and stop.
-
-            4. Resolve the PR author's login. For auto-triggered runs it is already set:
-               ```bash
-               PR_AUTHOR="${{ env.PR_AUTHOR }}"
-               ```
-               If that is empty (manual dispatch), look it up:
-               ```bash
-               PR_AUTHOR=$(gh pr view $PR_NUMBER --repo letta-ai/letta-code --json author --jq '.author.login')
-               ```
-
-            5. Clone letta-cloud and make the change:
-               ```bash
-               gh repo clone letta-ai/letta-cloud /tmp/letta-cloud
-               cd /tmp/letta-cloud
-               git checkout -b sync/tools-from-letta-code-pr-$PR_NUMBER
-               ```
-               Make the necessary edits. Keep the change minimal and focused on what the letta-code PR actually changed.
-
-            6. Before committing, run the type checker to catch any type errors introduced by the edits:
-               ```bash
-               cd /tmp/letta-cloud
-               npm run type-check
-               ```
-               If type errors are reported, fix them in the same branch before proceeding. Do not push broken types.
-
-            7. Push the branch and open a PR, tagging the original author as reviewer:
-               ```bash
-               cd /tmp/letta-cloud
-               git add -A
-               git commit -m "sync(tools): reflect letta-code PR #$PR_NUMBER changes"
-               git push origin sync/tools-from-letta-code-pr-$PR_NUMBER
-               gh pr create \
-                 --repo letta-ai/letta-cloud \
-                 --title "sync(tools): reflect letta-code PR #$PR_NUMBER changes" \
-                 --body "Automated sync from letta-ai/letta-code#$PR_NUMBER.\n\nSee the source PR for context on what changed." \
-                 --reviewer "$PR_AUTHOR"
-               ```
-
-            8. Respond with exactly: `PR_CREATED <url>` where `<url>` is the letta-cloud PR URL.
-
-            ## Voice
-            You are Amelia. Work quietly and precisely. Do not leave comments or reviews — just open the PR.
+      - name: Verify sync outcome
+        env:
+          GH_TOKEN: ${{ secrets.AMELIA_GITHUB_TOKEN }}
+          EXECUTION_FILE: ${{ steps.letta-sync.outputs.execution_file }}
+          EXPECTED_GITHUB_LOGIN: ${{ steps.github-identity.outputs.login }}
+          SOURCE_MARKER: ${{ steps.prompt.outputs.source_marker }}
+        run: |
+          result=$(jq -r '[.[] | select(.type == "result" and (.result | type) == "string")] | last | (.result // "" | gsub("^\\s+|\\s+$"; ""))' "$EXECUTION_FILE")
+          if [ "$result" = "NO_SYNC_NEEDED" ]; then
+            echo "No letta-cloud sync needed"
+            exit 0
+          fi
+          if [[ ! "$result" =~ ^PR_CREATED\ https://github\.com/letta-ai/letta-cloud/pull/[0-9]+$ ]]; then
+            echo "Unexpected Amelia result: $result" >&2
+            exit 1
+          fi
+          pr_url=${result#PR_CREATED }
+          test -n "$GH_TOKEN"
+          gh pr view "$pr_url" \
+            --repo letta-ai/letta-cloud \
+            --json author,isDraft,body \
+            --jq '.' > "$RUNNER_TEMP/sync-pr.json"
+          jq -e \
+            --arg expected "$EXPECTED_GITHUB_LOGIN" \
+            --arg marker "$SOURCE_MARKER" \
+            '.author.login == $expected and .isDraft == true and (.body | contains($marker))' \
+            "$RUNNER_TEMP/sync-pr.json" > /dev/null
+          echo "Verified Amelia draft PR: $pr_url"


### PR DESCRIPTION
## Summary

- run each tools sync in a fresh named Amelia conversation with explicit GitHub identity verification
- create verified draft cloud PRs with retry-safe source markers and configured GitHub reviewers
- route created PRs to one configured owner in `#code-reviews` through native `MessageChannel`, while keeping no-sync runs silent
- verify the terminal agent result and the created PR's author, draft state, and source marker on the runner

Configured `SYNC_TOOLS_OWNERS` with the established Amelia automation owner mapping.

## Validation

- `bun run check`
- `actionlint .github/workflows/sync-tools-to-cloud.yml`
- `shellcheck` on every workflow `run` block
- prompt generation and terminal outcome contract fixtures
- live branch dispatch for source PR #4025: https://github.com/letta-ai/letta-code/actions/runs/32906004283
  - authenticated as `amelia-letta`
  - named a fresh conversation
  - verified `NO_SYNC_NEEDED`
  - created no letta-cloud PR

Linear: [LET-11433](https://linear.app/letta/issue/LET-11433/migrate-tools-sync-to-amelia-automation-workflow)
