### PR TITLE
fix(app-server): persist ChatGPT OAuth reasoning effort

### DIFF
--- a/src/websocket/listener/commands/model-toolset.test.ts
+++ b/src/websocket/listener/commands/model-toolset.test.ts
@@ -53,6 +53,12 @@ class NativeCatalogBackend extends FakeHeadlessBackend {
         provider_type: "chatgpt_oauth",
         provider_category: "byok",
       },
+      {
+        handle: "openai-codex/gpt-5.6-sol",
+        display_name: "GPT-5.6 Sol",
+        provider_type: "chatgpt_oauth",
+        provider_category: "byok",
+      },
     ] as never;
   }
 }
@@ -131,6 +137,18 @@ describe("listener native model selection", () => {
         reasoning_effort: null,
       })?.updateArgs,
     ).toBeUndefined();
+  });
+
+  test("honors device reasoning effort for a ChatGPT OAuth model", () => {
+    expect(
+      resolveModelForUpdate({
+        model_id: "gpt-5.6-sol-none",
+        model_handle: "openai-codex/gpt-5.6-sol",
+        reasoning_effort: "medium",
+      })?.updateArgs,
+    ).toMatchObject({
+      reasoning_effort: "medium",
+    });
   });
 
   test("preserves ChatGPT OAuth provider identity for native Fast aliases", async () => {

--- a/src/websocket/listener/commands/model-toolset.ts
+++ b/src/websocket/listener/commands/model-toolset.ts
@@ -352,10 +352,15 @@ export function resolveModelForUpdate(
   payload: UpdateModelPayload,
 ): ResolvedModelForUpdate | null {
   const resolved = resolveModelForUpdateBase(payload);
+  const acceptsDeviceReasoningEffort =
+    resolved?.updateArgs?.[OPENAI_COMPATIBLE_PROXY_UPDATE_ARG] === true ||
+    resolved?.updateArgs?.provider_type === "chatgpt_oauth" ||
+    (resolved !== null &&
+      inferProviderTypeFromRegistryHandle(resolved.handle) === "chatgpt_oauth");
   if (
     !resolved ||
     payload.reasoning_effort === undefined ||
-    resolved.updateArgs?.[OPENAI_COMPATIBLE_PROXY_UPDATE_ARG] !== true
+    !acceptsDeviceReasoningEffort
   ) {
     return resolved;
   }


### PR DESCRIPTION
## Summary

- Preserve the Desktop-provided `reasoning_effort` for ChatGPT OAuth model updates handled by a remote App Server.
- Recognize both catalog-reported ChatGPT OAuth providers and ChatGPT OAuth model handles as accepting a device-supplied reasoning effort.
- Add a regression test for the `openai-codex/gpt-5.6-sol` update path, ensuring `medium` replaces the initial catalog value of `none`.

Fixes #4063

## Verification

- `bun test src/websocket/listener/commands/model-toolset.test.ts` — pass
- `bun test src/websocket/listen-model-update.test.ts` — pass
- `bun run check` — 12/12 checks pass

## AI Disclosure

- [ ] This pull request was written entirely by a human
- [x] This pull request was written with AI assistance and reviewed and edited by a human
- [x] I have read the [AI Policy](https://github.com/letta-ai/letta-code/blob/main/AI_POLICY.md) and agree to its terms

## AI Tool(s) Used

OpenAI Codex (investigation, implementation, and test drafting)

## Human Verification

I have reviewed and understand every change in this pull request and take responsibility for its correctness.