### PR TITLE
fix(skill): add missing desktop preferences and clarify live reload

### DIFF
--- a/src/skills/builtin/editing-letta-code-desktop-preferences/SKILL.md
+++ b/src/skills/builtin/editing-letta-code-desktop-preferences/SKILL.md
@@ -15,12 +15,22 @@ The Desktop preferences file is:
 ~/.letta/desktop_preferences.json
 ```
 
-Known preference keys:
+User-editable preference keys:
 
 - `defaultWorkingDirectory`: default folder for new local sessions.
 - `theme`: `auto`, `light`, or `dark`.
 - `allowRemoteAccess`: boolean for whether remote access should be enabled in preferences.
-- `remoteEnvName`: environment name shown for remote access.
+- `runInBackground`: boolean for whether Desktop stays alive in tray/menu bar when all windows close.
+- `startAtLogin`: boolean for whether Desktop starts hidden at login.
+- `remoteEnvName`: environment name shown in the Letta Cloud environment picker for the cloud listener.
+- `localBackendDirectory`: directory containing local backend agents, conversations, and memory.
+- `allowLocalAgentsWhenSignedIn`: boolean for whether signed-in Desktop sessions can see local/offline agents.
+
+System-managed keys (do not edit directly):
+- `artifactsByAgent`: per-agent artifacts panel state, written by Desktop UI.
+- `debugPanelEnabled`: developer debug panel, controlled via app menus.
+- `remoteAppServerEnabled`: Remote App Server toggle, applied at startup.
+- `remoteAppServerUrl`: Remote App Server URL, configured via preferences UI.
 
 ## Workflow
 
@@ -29,7 +39,7 @@ Known preference keys:
 3. Merge only the requested preference updates.
 4. Write pretty JSON with a trailing newline.
 5. Do not edit token, provider, secret, agent, conversation, memory, or unrelated state files.
-6. Tell the user that the change applies live only if their Desktop build watches preference-file changes; otherwise they should reload/restart Desktop or use Preferences → General.
+6. Changes apply live within ~100ms via Desktop's file watcher; if Desktop is not running, changes take effect on next startup.
 
 ## Safe edit command
 


### PR DESCRIPTION
Builtin-skill-watch: editing-letta-code-desktop-preferences@852ca244b002-dc538832f7197f39

## Summary

The skill was missing 4 user-editable preference keys that are exposed in the Desktop Preferences UI.

## Stale claims

- Missing `runInBackground`: boolean for whether Desktop stays alive in tray/menu bar when all windows close
- Missing `startAtLogin`: boolean for whether Desktop starts hidden at login
- Missing `localBackendDirectory`: directory containing local backend agents, conversations, and memory
- Missing `allowLocalAgentsWhenSignedIn`: boolean for whether signed-in Desktop sessions can see local/offline agents

## Current owning source

DesktopPreferences interface in `letta-cloud/apps/code-desktop/electron/src/preferencesStorage.ts` at commit 90a2e445899a6d73a0f97c481b1714ecb5583ed5.

## Focused validation

- Verified DesktopPreferences interface contains all 12 preference keys
- Verified Preferences.tsx UI exposes 8 user-editable preferences
- Confirmed Desktop watches preferences file with 100ms debounce for live reload