### PR TITLE
fix(skills): remove stale searching-messages skill reference from finding-agents

### DIFF
--- a/src/skills/builtin/finding-agents/SKILL.md
+++ b/src/skills/builtin/finding-agents/SKILL.md
@@ -96,19 +96,17 @@ Returns the raw API response with full agent details. Key fields:
 ## Related Skills
 
 - **migrating-memory** - Once you find an agent, use this skill to copy/share memory blocks
-- **searching-messages** - Search messages across all agents to find which agent discussed a topic. Use `--all-agents` to get `agent_id` values, then use this skill to get full agent details.
 
 ### Finding Agents by Topic
 
 If you need to find which agent worked on a specific topic:
 
-1. Load both skills: `searching-messages` and `finding-agents`
-2. Search messages across all agents:
+1. Search messages across all agents:
    ```bash
    letta messages search --query "topic" --all-agents --limit 10
    ```
-3. Note the `agent_id` values from matching messages
-4. Get agent details:
+2. Note the `agent_id` values from matching messages
+3. Get agent details:
    ```bash
    letta agents list --query "partial-name"
    ```


### PR DESCRIPTION
## Summary
- Removed stale reference to non-existent `searching-messages` skill from finding-agents
- Simplified "Finding Agents by Topic" section to document CLI command directly

## Stale claim
The finding-agents skill referenced a `searching-messages` skill that does not exist in the builtin inventory. The CLI command `letta messages search` exists and works correctly, but there is no skill with that name.

## Validation
- Verified CLI command `letta messages search --query "topic" --all-agents --limit 10` exists in `src/cli/subcommands/messages.ts`
- Confirmed `searching-messages` is not in the skill inventory
- All checks pass: `bun run check`

Builtin-skill-watch: finding-agents@852ca244b002-9b67d21fdefae701