### PR TITLE
fix(skills): clarify which context requirements are enforced

### DIFF
--- a/src/skills/builtin/context-doctor/SKILL.md
+++ b/src/skills/builtin/context-doctor/SKILL.md
@@ -64,20 +64,16 @@ The context in the memory filesystem should have a clear structure, with a well-
 - Rewrite unclear or low-quality content
 
 #### Invalid context format
-Files in the memory filesystem must follow certain structural requirements: 
-- Must have a `system/persona.md`
-- Must NOT have overlapping file and folder names (e.g. `system/human.md` and `system/human/identity.md`) 
-- Must follow specification for skills (e.g. `skills/{skill_name}/`) with the format:
-```
-skill-name/
-├── SKILL.md          # Required: metadata + instructions
-├── scripts/          # Optional: executable code
-├── references/       # Optional: documentation
-├── assets/           # Optional: templates, resources
-└── ...               # Any additional files or directories
-```
+Files in the memory filesystem should follow certain structural conventions. Some are enforced by the system, others are recommendations:
 
-**Solution**: Reorganize files to follow the required structure
+**Enforced requirements (pre-commit hooks will reject violations)**:
+- Skills must use the directory format: `skills/{skill_name}/SKILL.md` with optional `scripts/`, `references/`, `assets/` subdirectories. Flat skill files like `skills/foo.md` are rejected.
+
+**Strongly recommended (not enforced, but best practice)**:
+- Include a `system/persona.md` to define your identity. The system handles missing persona gracefully, but identity drift is a real risk without it.
+- Avoid overlapping file and folder names (e.g. `system/human.md` AND `system/human/`). The system tolerates overlaps, but they make memory harder to navigate and can confuse agents about which path to use.
+
+**Solution**: Reorganize files to follow the recommended structure
 
 ### Poor use of progressive disclosure
 Only critical information should be in the system prompt, since it's passed on every turn. Use progressive disclosure so that context only *sometimes* needed can be dynamically retrieved.


### PR DESCRIPTION
## Summary

The context-doctor skill presented recommendations as "structural requirements" when they are actually just guidance. This could cause agents to waste time fixing issues that aren't actually problems.

## Changes

- Split "Invalid context format" section into enforced vs recommended
- Clarify that `system/persona.md` is strongly recommended but not required (system handles missing persona gracefully)
- Clarify that overlapping file/folder names should be avoided but are tolerated (no system enforcement)
- Keep skills directory format as enforced (pre-commit hook rejects violations)

## Validation

- Ran `bun run check` - all checks passed
- Verified claims against source code:
  - `src/backend/local/system-prompt-compilation.ts` - persona.md is optional (if check)
  - `src/agent/memory-git-hooks.ts` - skills directory format is enforced by pre-commit hook
  - Memory tools don't validate overlapping file/folder names

Builtin-skill-watch: context-doctor@852ca244b002-554849d11020c1f4
