### PR TITLE
test(windows): verify headless shell calls and results

### DIFF
--- a/src/test-utils/headless-windows.test.ts
+++ b/src/test-utils/headless-windows.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, test } from "bun:test";
+import { validateWindowsScenarioOutput } from "./headless-windows";
+
+function line(value: Record<string, unknown>): string {
+  return JSON.stringify(value);
+}
+
+function validOutput(): string {
+  return [
+    line({
+      type: "message",
+      message_type: "tool_call_message",
+      tool_call: {
+        tool_call_id: "call-echo",
+        name: "Bash",
+        arguments: JSON.stringify({
+          command: "echo 'Hello from Windows'",
+        }),
+      },
+    }),
+    line({
+      type: "message",
+      message_type: "tool_return_message",
+      tool_call_id: "call-echo",
+      status: "success",
+      tool_return: "Hello from Windows",
+    }),
+    line({
+      type: "message",
+      message_type: "tool_call_message",
+      tool_call: {
+        tool_call_id: "call-multiline",
+        name: "Bash",
+        arguments: JSON.stringify({
+          command: "echo 'Line1'; echo 'Line2'",
+        }),
+      },
+    }),
+    line({
+      type: "message",
+      message_type: "tool_return_message",
+      tool_call_id: "call-multiline",
+      status: "success",
+      tool_return: [{ type: "text", text: "Line1\nLine2" }],
+    }),
+    line({
+      type: "message",
+      message_type: "tool_call_message",
+      tool_call: {
+        tool_call_id: "call-git",
+        name: "Bash",
+        arguments: JSON.stringify({ command: "git --version" }),
+      },
+    }),
+    line({
+      type: "message",
+      message_type: "tool_return_message",
+      tool_call_id: "call-git",
+      status: "success",
+      tool_return: "git version 2.51.0.windows.1",
+    }),
+    line({ type: "result", subtype: "success", result: "BANANA" }),
+  ].join("\n");
+}
+
+describe("Windows headless scenario validation", () => {
+  test("accepts executed PowerShell-compatible commands and their output", () => {
+    expect(() => validateWindowsScenarioOutput(validOutput())).not.toThrow();
+  });
+
+  test("rejects a final success marker without executed command output", () => {
+    const output = validOutput()
+      .split("\n")
+      .filter((entry) => !entry.includes("tool_return_message"))
+      .join("\n");
+
+    expect(() => validateWindowsScenarioOutput(output)).toThrow(
+      "Missing tool return",
+    );
+  });
+
+  test("rejects bash-only command syntax even when commands returned output", () => {
+    const output = validOutput().replace(
+      "echo 'Line1'; echo 'Line2'",
+      "echo 'Line1' && echo 'Line2'",
+    );
+
+    expect(() => validateWindowsScenarioOutput(output)).toThrow(
+      "forbidden bash syntax",
+    );
+  });
+
+  test("rejects failed shell execution even when output markers are present", () => {
+    const output = validOutput().replace(
+      '"tool_call_id":"call-git","status":"success"',
+      '"tool_call_id":"call-git","status":"error"',
+    );
+
+    expect(() => validateWindowsScenarioOutput(output)).toThrow(
+      "Shell tool call failed",
+    );
+  });
+
+  test("rejects output that did not come from the requested git command", () => {
+    const output = validOutput().replace("git --version", "echo 'git version'");
+
+    expect(() => validateWindowsScenarioOutput(output)).toThrow("git command");
+  });
+});

--- a/src/test-utils/headless-windows.test.ts
+++ b/src/test-utils/headless-windows.test.ts
@@ -106,4 +106,20 @@ describe("Windows headless scenario validation", () => {
 
     expect(() => validateWindowsScenarioOutput(output)).toThrow("git command");
   });
+
+  test("rejects git output substituted by another successful call", () => {
+    const output = validOutput()
+      .replace(
+        '"tool_return":"Hello from Windows"',
+        '"tool_return":"Hello from Windows\\ngit version 9"',
+      )
+      .replace(
+        '"tool_return":"git version 2.51.0.windows.1"',
+        '"tool_return":""',
+      );
+
+    expect(() => validateWindowsScenarioOutput(output)).toThrow(
+      "Missing successful git --version output",
+    );
+  });
 });

--- a/src/test-utils/headless-windows.test.ts
+++ b/src/test-utils/headless-windows.test.ts
@@ -107,6 +107,15 @@ describe("Windows headless scenario validation", () => {
     expect(() => validateWindowsScenarioOutput(output)).toThrow("git command");
   });
 
+  test("rejects a PowerShell comment spoof of the requested git command", () => {
+    const output = validOutput().replace(
+      "git --version",
+      "echo 'git version 9'; # git --version",
+    );
+
+    expect(() => validateWindowsScenarioOutput(output)).toThrow("git command");
+  });
+
   test("rejects git output substituted by another successful call", () => {
     const output = validOutput()
       .replace(

--- a/src/test-utils/headless-windows.ts
+++ b/src/test-utils/headless-windows.ts
@@ -10,7 +10,7 @@
  * Only runs on Windows (process.platform === 'win32')
  *
  * Usage:
- *   bun run src/tests/headless-windows.ts --model haiku
+ *   bun run src/test-utils/headless-windows.ts --model haiku
  */
 
 import { createAuthenticatedCliTestEnv } from "./test-process-env";
@@ -18,6 +18,8 @@ import { createAuthenticatedCliTestEnv } from "./test-process-env";
 type Args = {
   model: string;
 };
+
+type WireRecord = Record<string, unknown>;
 
 function parseArgs(argv: string[]): Args {
   const args: { model?: string } = {};
@@ -53,6 +55,112 @@ function windowsScenarioPrompt(): string {
   );
 }
 
+function parseWireRecords(stdout: string): WireRecord[] {
+  const records: WireRecord[] = [];
+  for (const line of stdout.split(/\r?\n/)) {
+    if (!line.trim()) continue;
+    try {
+      const value = JSON.parse(line) as unknown;
+      if (value && typeof value === "object" && !Array.isArray(value)) {
+        records.push(value as WireRecord);
+      }
+    } catch {
+      // Ignore output outside the stream-json protocol. Required protocol
+      // records are validated below.
+    }
+  }
+  return records;
+}
+
+function requireIncludes(
+  value: string,
+  expected: string,
+  description: string,
+): void {
+  if (!value.includes(expected)) {
+    throw new Error(`Missing ${description}: ${expected}`);
+  }
+}
+
+export function validateWindowsScenarioOutput(stdout: string): void {
+  const records = parseWireRecords(stdout);
+  const shellCalls = records.flatMap((record) => {
+    if (
+      record.type !== "message" ||
+      record.message_type !== "tool_call_message" ||
+      !record.tool_call ||
+      typeof record.tool_call !== "object" ||
+      Array.isArray(record.tool_call)
+    ) {
+      return [];
+    }
+    const call = record.tool_call as WireRecord;
+    return call.name === "Bash" ? [call] : [];
+  });
+  if (shellCalls.length === 0) {
+    throw new Error("No Bash tool_call_message records were emitted");
+  }
+
+  const allArguments = shellCalls
+    .map((call) => (typeof call.arguments === "string" ? call.arguments : ""))
+    .join("\n");
+  requireIncludes(allArguments, "Hello from Windows", "echo command");
+  requireIncludes(allArguments, "Line1", "multiline command first line");
+  requireIncludes(allArguments, "Line2", "multiline command second line");
+  requireIncludes(allArguments, "git --version", "git command");
+  if (allArguments.includes("<<") || allArguments.includes("&&")) {
+    throw new Error("Windows shell command used forbidden bash syntax");
+  }
+
+  const toolReturns = records.filter(
+    (record) =>
+      record.type === "message" &&
+      record.message_type === "tool_return_message",
+  );
+  const returnsByCallId = new Map(
+    toolReturns
+      .filter(
+        (record) =>
+          typeof record.tool_call_id === "string" &&
+          record.tool_call_id.length > 0,
+      )
+      .map((record) => [record.tool_call_id as string, record] as const),
+  );
+  const shellOutput: string[] = [];
+  for (const call of shellCalls) {
+    if (typeof call.tool_call_id !== "string") {
+      throw new Error("Bash tool call is missing its ID");
+    }
+    const toolReturn = returnsByCallId.get(call.tool_call_id);
+    if (!toolReturn) {
+      throw new Error("Missing tool return for Bash call");
+    }
+    if (toolReturn.status !== "success") {
+      throw new Error(`Shell tool call failed: ${call.tool_call_id}`);
+    }
+    shellOutput.push(
+      typeof toolReturn.tool_return === "string"
+        ? toolReturn.tool_return
+        : JSON.stringify(toolReturn.tool_return),
+    );
+  }
+
+  const allToolOutput = shellOutput.join("\n");
+  requireIncludes(allToolOutput, "Hello from Windows", "echo output");
+  requireIncludes(allToolOutput, "Line1", "multiline output first line");
+  requireIncludes(allToolOutput, "Line2", "multiline output second line");
+  if (!/git version \d/i.test(allToolOutput)) {
+    throw new Error("Missing successful git --version output");
+  }
+
+  const result = records.find((record) => record.type === "result");
+  if (!result || result.subtype !== "success") {
+    throw new Error("Missing successful result record");
+  }
+  const resultText = typeof result.result === "string" ? result.result : "";
+  requireIncludes(resultText, "BANANA", "final success marker");
+}
+
 async function runCLI(
   model: string,
 ): Promise<{ stdout: string; code: number }> {
@@ -67,7 +175,7 @@ async function runCLI(
     "--memfs-startup",
     "skip",
     "--output-format",
-    "text",
+    "stream-json",
     "-m",
     model,
   ];
@@ -81,7 +189,7 @@ async function runCLI(
   const err = await new Response(proc.stderr).text();
   const code = await proc.exited;
   if (code !== 0) {
-    console.error("CLI failed:", err || out);
+    console.error("CLI failed:\n", err, out);
   }
   return { stdout: out, code };
 }
@@ -97,32 +205,24 @@ async function main() {
   const { stdout, code } = await runCLI(model);
 
   if (code !== 0) {
-    console.error("CLI exited with non-zero code:", code);
-    process.exit(code);
+    throw new Error(`CLI exited with non-zero code: ${code}`);
   }
 
-  // Check for success marker
-  if (stdout.includes("BANANA")) {
-    console.log(`✅ PASS: Windows integration test succeeded with ${model}`);
-  } else {
-    console.error(`❌ FAIL: Windows integration test failed`);
+  try {
+    validateWindowsScenarioOutput(stdout);
+    console.log(`PASS: Windows integration test succeeded with ${model}`);
+  } catch (error) {
+    console.error("FAIL: Windows integration test failed");
     console.error("\n===== BEGIN STDOUT =====");
     console.error(stdout);
     console.error("===== END STDOUT =====\n");
-
-    // Check for common failure patterns
-    if (stdout.includes("heredoc") || stdout.includes("<<'EOF'")) {
-      console.error("FAILURE REASON: Agent used heredoc syntax on Windows");
-    }
-    if (stdout.includes("not recognized") || stdout.includes("not found")) {
-      console.error("FAILURE REASON: Command not found (PATH issue?)");
-    }
-
-    process.exit(1);
+    throw error;
   }
 }
 
-main().catch((e) => {
-  console.error("Fatal error:", e);
-  process.exit(1);
-});
+if (import.meta.main) {
+  main().catch((error) => {
+    console.error("Fatal error:", error);
+    process.exit(1);
+  });
+}

--- a/src/test-utils/headless-windows.ts
+++ b/src/test-utils/headless-windows.ts
@@ -88,12 +88,19 @@ type ShellExecution = {
   output: string;
 };
 
+function normalizeCommand(command: string): string {
+  return command.trim().replace(/\s+/g, " ").toLowerCase();
+}
+
 function requireExecution(
   executions: ShellExecution[],
-  matches: (command: string) => boolean,
+  expectedCommand: string,
   description: string,
 ): ShellExecution {
-  const execution = executions.find(({ command }) => matches(command));
+  const expected = normalizeCommand(expectedCommand);
+  const execution = executions.find(
+    ({ command }) => normalizeCommand(command) === expected,
+  );
   if (!execution) throw new Error(`Missing ${description} command`);
   return execution;
 }
@@ -181,19 +188,15 @@ export function validateWindowsScenarioOutput(stdout: string): void {
 
   const echo = requireExecution(
     executions,
-    (command) => command.includes("Hello from Windows"),
+    "echo 'Hello from Windows'",
     "echo",
   );
   const multiline = requireExecution(
     executions,
-    (command) => command.includes("Line1") && command.includes("Line2"),
+    "echo 'Line1'; echo 'Line2'",
     "multiline",
   );
-  const git = requireExecution(
-    executions,
-    (command) => command.includes("git --version"),
-    "git",
-  );
+  const git = requireExecution(executions, "git --version", "git");
   if (new Set([echo.id, multiline.id, git.id]).size !== 3) {
     throw new Error("Required Windows commands were not executed separately");
   }

--- a/src/test-utils/headless-windows.ts
+++ b/src/test-utils/headless-windows.ts
@@ -82,6 +82,22 @@ function requireIncludes(
   }
 }
 
+type ShellExecution = {
+  id: string;
+  command: string;
+  output: string;
+};
+
+function requireExecution(
+  executions: ShellExecution[],
+  matches: (command: string) => boolean,
+  description: string,
+): ShellExecution {
+  const execution = executions.find(({ command }) => matches(command));
+  if (!execution) throw new Error(`Missing ${description} command`);
+  return execution;
+}
+
 export function validateWindowsScenarioOutput(stdout: string): void {
   const records = parseWireRecords(stdout);
   const shellCalls = records.flatMap((record) => {
@@ -101,17 +117,6 @@ export function validateWindowsScenarioOutput(stdout: string): void {
     throw new Error("No Bash tool_call_message records were emitted");
   }
 
-  const allArguments = shellCalls
-    .map((call) => (typeof call.arguments === "string" ? call.arguments : ""))
-    .join("\n");
-  requireIncludes(allArguments, "Hello from Windows", "echo command");
-  requireIncludes(allArguments, "Line1", "multiline command first line");
-  requireIncludes(allArguments, "Line2", "multiline command second line");
-  requireIncludes(allArguments, "git --version", "git command");
-  if (allArguments.includes("<<") || allArguments.includes("&&")) {
-    throw new Error("Windows shell command used forbidden bash syntax");
-  }
-
   const toolReturns = records.filter(
     (record) =>
       record.type === "message" &&
@@ -126,7 +131,7 @@ export function validateWindowsScenarioOutput(stdout: string): void {
       )
       .map((record) => [record.tool_call_id as string, record] as const),
   );
-  const shellOutput: string[] = [];
+  const executions: ShellExecution[] = [];
   for (const call of shellCalls) {
     if (typeof call.tool_call_id !== "string") {
       throw new Error("Bash tool call is missing its ID");
@@ -138,18 +143,64 @@ export function validateWindowsScenarioOutput(stdout: string): void {
     if (toolReturn.status !== "success") {
       throw new Error(`Shell tool call failed: ${call.tool_call_id}`);
     }
-    shellOutput.push(
-      typeof toolReturn.tool_return === "string"
-        ? toolReturn.tool_return
-        : JSON.stringify(toolReturn.tool_return),
-    );
+    if (typeof call.arguments !== "string") {
+      throw new Error(
+        `Bash tool call has invalid arguments: ${call.tool_call_id}`,
+      );
+    }
+    let argumentsRecord: WireRecord;
+    try {
+      const parsed = JSON.parse(call.arguments) as unknown;
+      if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+        throw new Error("Invalid arguments object");
+      }
+      argumentsRecord = parsed as WireRecord;
+    } catch {
+      throw new Error(
+        `Bash tool call has invalid arguments: ${call.tool_call_id}`,
+      );
+    }
+    if (typeof argumentsRecord.command !== "string") {
+      throw new Error(`Bash tool call has no command: ${call.tool_call_id}`);
+    }
+    if (
+      argumentsRecord.command.includes("<<") ||
+      argumentsRecord.command.includes("&&")
+    ) {
+      throw new Error("Windows shell command used forbidden bash syntax");
+    }
+    executions.push({
+      id: call.tool_call_id,
+      command: argumentsRecord.command,
+      output:
+        typeof toolReturn.tool_return === "string"
+          ? toolReturn.tool_return
+          : JSON.stringify(toolReturn.tool_return),
+    });
   }
 
-  const allToolOutput = shellOutput.join("\n");
-  requireIncludes(allToolOutput, "Hello from Windows", "echo output");
-  requireIncludes(allToolOutput, "Line1", "multiline output first line");
-  requireIncludes(allToolOutput, "Line2", "multiline output second line");
-  if (!/git version \d/i.test(allToolOutput)) {
+  const echo = requireExecution(
+    executions,
+    (command) => command.includes("Hello from Windows"),
+    "echo",
+  );
+  const multiline = requireExecution(
+    executions,
+    (command) => command.includes("Line1") && command.includes("Line2"),
+    "multiline",
+  );
+  const git = requireExecution(
+    executions,
+    (command) => command.includes("git --version"),
+    "git",
+  );
+  if (new Set([echo.id, multiline.id, git.id]).size !== 3) {
+    throw new Error("Required Windows commands were not executed separately");
+  }
+  requireIncludes(echo.output, "Hello from Windows", "echo output");
+  requireIncludes(multiline.output, "Line1", "multiline output first line");
+  requireIncludes(multiline.output, "Line2", "multiline output second line");
+  if (!/git version \d/i.test(git.output)) {
     throw new Error("Missing successful git --version output");
   }
 


### PR DESCRIPTION
## Summary

The Windows headless lane asked the model to run three PowerShell-compatible commands, but it previously passed when the final response contained `BANANA`. That did not prove the commands ran.

This PR validates the `stream-json` records instead. It requires three separate `Bash` calls for:

1. `echo 'Hello from Windows'`
2. `echo 'Line1'; echo 'Line2'`
3. `git --version`

Each call must have its own successful `tool_return_message`, matched by `tool_call_id`; its normalized executable command must exactly equal the requested command; and its return must contain that command's expected output. Heredoc and `&&` syntax remain rejected. The final result must also be successful and contain `BANANA`.

This closes both false-pass cases from review. Output from one successful call can no longer satisfy a different command, and text inside a larger command or PowerShell comment cannot impersonate a required command. For example, `echo 'git version 9'; # git --version` is rejected because it never executes `git --version`.

The branch was rebuilt from current `main` with only the two intended commits. GitHub now displays exactly two changed files: `src/test-utils/headless-windows.ts` and its test. The focused behavior passed 7/7 locally. Current-head CI is complete: 19 successful checks, one intentional review skip, and no failures. Jibram's human verification under the repository AI policy is still required before ready.

## Verification

`bun test src/test-utils/headless-windows.test.ts` passed 7/7 focused cases. The fixtures bind each command to its own `tool_return_message` by `tool_call_id` and require exact normalized command equality. Reverting to aggregate output makes the cross-call-substitution case fail; reverting exact equality to substring matching makes the PowerShell-comment spoof case fail. The rebuilt current head passed all 19 substantive CI checks, including Windows x64, with one intentional review skip.

## Breadcrumbs

- Origin: #1632 introduced the Windows headless scenario and treated the final `BANANA` marker as sufficient proof that all three requested commands ran. History found no later PR introducing this false-pass behavior.
- Related: #4307 isolates the unrelated channel-route state that made the previous platform CI jobs fail.
- Letta conversation: [`default`](https://chat.letta.com/chat/agent-03c143ce-b161-4a7b-93e8-6a0d570cf5f4?conversation=default)

## AI Disclosure

- [ ] This pull request was written entirely by a human
- [x] This pull request was written with AI assistance and reviewed and edited by a human
- [x] I have read the [AI Policy](https://github.com/letta-ai/letta-code/blob/main/AI_POLICY.md) and agree to its terms

## AI Tool(s) Used

Letta Code was used for implementation, focused tests, mutation validation, and pull-request drafting.

## Human Verification

Pending Jibram's human verification of current head `29b61135` before this draft is marked ready. Current-head CI is all green.
