### PR TITLE
fix(reflection): preserve full tool call arguments

### DIFF
--- a/scripts/source-file-size-baseline.json
+++ b/scripts/source-file-size-baseline.json
@@ -17,7 +17,7 @@
   "src/cli/components/ProviderSelector.tsx": 1692,
   "src/cli/components/ToolCallMessageRich.tsx": 1109,
   "src/cli/helpers/accumulator.ts": 1592,
-  "src/cli/helpers/reflection-transcript.ts": 1929,
+  "src/cli/helpers/reflection-transcript.ts": 1926,
   "src/cli/mods/local-mod-loader.test.ts": 1043,
   "src/cli/reflection-transcript.test.ts": 1084,
   "src/cli/subcommands/skills.ts": 1264,

--- a/src/cli/helpers/reflection-transcript.ts
+++ b/src/cli/helpers/reflection-transcript.ts
@@ -620,9 +620,6 @@ function countAssistantRows(entries: TranscriptEntry[]): number {
   return entries.filter((entry) => entry.kind === "assistant").length;
 }
 
-/** Maximum characters to keep for tool-call arguments in the reflection payload. */
-const TOOL_ARGS_TRUNCATE_LIMIT = 300;
-
 /**
  * Normalize a selected client-transcript fragment into the shared trajectory
  * record format consumed by reflection agents.
@@ -634,7 +631,7 @@ function normalizeReflectionTranscript(entries: TranscriptEntry[]): string {
     transcript,
     sourceContext: { partial: true },
     bounds: {
-      toolArguments: { maxCharacters: TOOL_ARGS_TRUNCATE_LIMIT },
+      toolArguments: { maxCharacters: null },
     },
     filters: { toolResults: "include" },
   });

--- a/src/cli/reflection-transcript.test.ts
+++ b/src/cli/reflection-transcript.test.ts
@@ -886,8 +886,8 @@ describe("reflectionTranscript helper", () => {
     expect(prompt).toContain("<parent_memory>snapshot</parent_memory>");
   });
 
-  test("reflection payload normalizes bounded tool calls and results", async () => {
-    const longArgs = JSON.stringify({ pattern: "a".repeat(500) });
+  test("reflection payload preserves tool calls and bounds results", async () => {
+    const longArgs = JSON.stringify({ pattern: "a".repeat(25_000) });
     const longResult = `BEGIN:${"x".repeat(3_000)}:END`;
     await appendTranscriptDeltaJsonl(agentId, conversationId, [
       { kind: "user", id: "u1", text: "run a search", messageId: "u1" },
@@ -925,7 +925,7 @@ describe("reflectionTranscript helper", () => {
     expect(toolMsg.tool_calls[0].id).toBe("tc1");
     expect(toolMsg.tool_calls[0].name).toBe("Grep");
     const normalizedArgs = toolMsg.tool_calls[0].args;
-    expect(Array.from(normalizedArgs).length).toBeLessThanOrEqual(300);
+    expect(normalizedArgs).toBe(longArgs);
     expect(JSON.parse(normalizedArgs)).toBeObject();
 
     const toolResult = messages.find(


### PR DESCRIPTION
## Summary
- disable tool-argument truncation when normalizing reflection payloads
- preserve arguments larger than the trajectory package’s default 20k bound
- retain the existing 2,500-character tool-result bound

## Testing
- `bun test src/cli/reflection-transcript.test.ts`
- `bun run check`