### PR TITLE
fix(local): honor Ollama reasoning effort settings

### DIFF
--- a/src/backend/dev/pi-local-endpoint-provider.ts
+++ b/src/backend/dev/pi-local-endpoint-provider.ts
@@ -26,6 +26,8 @@ export interface LocalEndpointModelMetadata {
   contextLength?: number;
   /** Engine-specific output cap; defaults to the shared constant. */
   maxTokens?: number;
+  /** Engine-specific mapping for pi-ai thinking levels. */
+  thinkingLevelMap?: Model<"openai-completions">["thinkingLevelMap"];
   /** Engine-specific OpenAI-compat overrides merged over the defaults. */
   compat?: Model<"openai-completions">["compat"];
 }
@@ -174,6 +176,9 @@ export function createLocalEndpointPiProvider(
       cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
       contextWindow,
       maxTokens,
+      ...(metadata.thinkingLevelMap
+        ? { thinkingLevelMap: metadata.thinkingLevelMap }
+        : {}),
       compat: {
         supportsDeveloperRole: false,
         supportsReasoningEffort: false,

--- a/src/backend/dev/pi-ollama-provider.test.ts
+++ b/src/backend/dev/pi-ollama-provider.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { streamSimple } from "@earendil-works/pi-ai/api/openai-completions";
 import { testRefreshContext } from "@/test-utils/pi-refresh-context";
 import { localEndpointNativeBaseURL } from "./pi-local-endpoint-provider";
 import { resolvePiModelForAgent } from "./pi-model-factory";
@@ -171,6 +172,69 @@ describe("createOllamaPiProvider", () => {
     expect(text?.input).toEqual(["text"]);
     expect(text?.reasoning).toBe(false);
     expect(text?.contextWindow).toBe(32768);
+  });
+
+  test("publishes Ollama reasoning compatibility for thinking models", async () => {
+    const state = qwenState();
+    const provider = createOllamaPiProvider({
+      baseURL: "http://localhost:11434",
+      fetchImpl: fakeOllamaFetch(state),
+    });
+    await provider.refreshModels?.(testRefreshContext());
+
+    expect(
+      provider.getModels().find((m) => m.id === "qwen3.6:27b")?.compat,
+    ).toMatchObject({
+      supportsReasoningEffort: true,
+    });
+    expect(
+      provider.getModels().find((m) => m.id === "qwen3.6:27b")
+        ?.thinkingLevelMap,
+    ).toEqual({ off: "none" });
+  });
+
+  test("serializes configured reasoning effort for Ollama Chat Completions", async () => {
+    const state = qwenState();
+    const provider = createOllamaPiProvider({
+      baseURL: "http://localhost:11434",
+      fetchImpl: fakeOllamaFetch(state),
+    });
+    await provider.refreshModels?.(testRefreshContext());
+    const model = provider.getModels().find((m) => m.id === "qwen3.6:27b");
+    if (!model) throw new Error("Expected Qwen model");
+
+    const bodies: Record<string, unknown>[] = [];
+    const fetchImpl = (async (
+      _input: string | URL | Request,
+      init?: RequestInit,
+    ) => {
+      bodies.push(JSON.parse(String(init?.body)) as Record<string, unknown>);
+      return new Response(
+        [
+          'data: {"id":"ollama-1","choices":[{"delta":{"content":"ok"},"finish_reason":null}]}',
+          'data: {"id":"ollama-1","choices":[{"delta":{},"finish_reason":"stop"}]}',
+          "data: [DONE]",
+          "",
+        ].join("\\n"),
+        { headers: { "content-type": "text/event-stream" } },
+      );
+    }) as typeof fetch;
+
+    await streamSimple(
+      model,
+      { messages: [{ role: "user", content: "hello", timestamp: 0 }] },
+      { apiKey: "ollama", fetch: fetchImpl, reasoning: "low" },
+    ).result();
+
+    await streamSimple(
+      model,
+      { messages: [{ role: "user", content: "hello", timestamp: 0 }] },
+      { apiKey: "ollama", fetch: fetchImpl },
+    ).result();
+
+    expect(bodies).toHaveLength(2);
+    expect(bodies[0]).toHaveProperty("reasoning_effort", "low");
+    expect(bodies[1]).toHaveProperty("reasoning_effort", "none");
   });
 
   // Ollama serves OLLAMA_CONTEXT_LENGTH, not the GGUF maximum, and silently

--- a/src/backend/dev/pi-ollama-provider.ts
+++ b/src/backend/dev/pi-ollama-provider.ts
@@ -247,6 +247,19 @@ function parseOllamaShow(
     vision: capabilities.includes("vision"),
     thinking: capabilities.includes("thinking"),
     ...(contextLength !== undefined ? { contextLength } : {}),
+    // Ollama enables thinking when reasoning_effort is omitted. Map pi-ai's
+    // explicit Off level to Ollama's documented `none` value so disabling
+    // reasoning does not accidentally fall back to that default.
+    ...(capabilities.includes("thinking")
+      ? { thinkingLevelMap: { off: "none" } }
+      : {}),
+    // Ollama's OpenAI-compatible Chat Completions adapter maps
+    // `reasoning_effort` to its native `think` setting. This is deliberately
+    // an Ollama-specific override: other local OpenAI-compatible engines do
+    // not necessarily accept the field even when they report thinking.
+    ...(capabilities.includes("thinking")
+      ? { compat: { supportsReasoningEffort: true } }
+      : {}),
   };
 }
 


### PR DESCRIPTION
## Summary

- expose Ollama reasoning-effort support for models that report thinking capability
- map the disabled thinking level to Ollama's `none` value
- verify both model metadata and serialized Chat Completions requests

Closes #4081.

## Verification

- `bun test src/backend/dev/pi-ollama-provider.test.ts` (17 passed)
- `bun run check` (12/12 checks passed)
- `git diff --check`

## AI Disclosure

- [ ] This pull request was written entirely by a human
- [x] This pull request was written with AI assistance and reviewed and edited by a human
- [x] I have read the [AI Policy](https://github.com/letta-ai/letta-code/blob/main/AI_POLICY.md) and agree to its terms

## AI Tool(s) Used

Hermes Agent and OpenAI Codex were used to inspect the issue, implement the change, and run verification.

## Human Verification

Pending final human review before this draft is marked ready.