### PR TITLE
fix(reflection): require explicit staleness before overwriting memory facts

### DIFF
--- a/src/agent/subagents/builtin/reflection.md
+++ b/src/agent/subagents/builtin/reflection.md
@@ -54,7 +54,14 @@ Your job is to review the recent conversation payload and update the primary age
 1. a JSON message array for one conversation, or
 2. a `multi_transcript_reflection_payload` manifest. If it is a manifest, read every `payload_path` listed in `transcripts` and synthesize across all slices. Slices marked `mode: "replay"` were already reflected before and are intentionally included for another pass; use them for deduplication, contradiction resolution, and cross-session pattern extraction.
 
-When reviewing multiple transcripts, prefer patterns supported across sessions, resolve contradictions in favor of the latest evidence, and avoid recording one-off task state. Follow the phases below in order.
+## Durability and Resolutions
+
+- **Durability**: When reviewing multiple transcripts, prefer patterns supported across sessions and avoid recording one-off task state.
+- **Update**: Resolve contradictions in favor of the latest evidence only if newer evidence explicitly establishes staleness.
+- **Annotate**: If newer evidence conflicts but does not establish staleness, record it as a separate fact and leave the original unchanged (e.g., a temporary situation or a single unverified observation).
+- **Restraint**: Never weaken confirmed facts that protect against harm or irreversible actions based on a single anecdote or one-off request; keep the fact unchanged and optionally record the observation as unverified.
+
+Follow the phases below in order.
 
 ---
 


### PR DESCRIPTION
## Summary

Addresses #4029.

The sleeptime reflection prompt currently instructs the subagent to "resolve contradictions in favor of the latest evidence" unconditionally. This newest-wins rule causes destructive memory overwrites: a single unverified or anecdotal observation can replace a confirmed durable fact, including safety-critical ones (e.g., a confirmed severe allergy softened to "mild" after one anecdote about eating shellfish without reaction).

This PR replaces the inline conflict clause with a structured **Durability and Resolutions** policy: update only when newer evidence explicitly establishes staleness; otherwise record the conflicting observation as a separate fact and leave the original unchanged; never weaken confirmed safety-critical facts on anecdote.

Prompt-only change (`src/agent/subagents/builtin/reflection.md`); no code touched.

Tradeoff: memory grows slightly faster (conflicts are annotated instead of overwritten), in exchange for not destroying confirmed facts on weak evidence.

## Verification

- Measured on a 120-run eval matrix: 4 conflict cases (true update / compatible split / inferential overwrite / confidence preservation) x 10 Bedrock models (frontier + small) x 3 repeats, two-stage harness (verbatim reflection prompt, then neutral extractor, then mechanical scoring with manual adjudication of edge cases):
  - Baseline reflection.md: 90/120 correct conflict handling
  - This PR's prompt: **110/120**
  - True-update case stays 100%, so legitimate updates still go through
  - Remaining failures concentrate in the smallest models (llama3.1-8b, nova-micro)
- The exact committed text was additionally sanity-checked (N=12: 3 models x 4 cases) and behaves identically to the measured version.
- Full harness, raw run evidence, and scoring code: https://github.com/Tusharv23/letta-conflict-eval
- `bun test` on this branch: 6872 pass / 46 fail, identical counts to clean `main` on the same machine (pre-existing environment-dependent failures: telemetry auth, PTY, stream-json integration). No new failures introduced.

## AI Disclosure

- [ ] This pull request was written entirely by a human
- [x] This pull request was written with AI assistance and reviewed and edited by a human
- [x] I have read the [AI Policy](https://github.com/letta-ai/letta-code/blob/main/AI_POLICY.md) and agree to its terms

## AI Tool(s) Used

GitHub Copilot (Claude Fable 5) - used to help draft the prompt wording, plan the eval harness. All runs, changes and eval results done by me.

## Human Verification

I have reviewed and understand every change in this pull request and take responsibility for its correctness.