### PR TITLE
fix(skills): update project skills directory path

### DIFF
--- a/src/skills/builtin/acquiring-skills/SKILL.md
+++ b/src/skills/builtin/acquiring-skills/SKILL.md
@@ -225,7 +225,7 @@ For manual installation:
 |----------|------|-------------|
 | **Agent-scoped** | `~/.letta/agents/<agent-id>/memory/skills/<skill>/` | Skills for a single agent (default) |
 | **Global** | `~/.letta/skills/<skill>/` | General-purpose skills useful across projects |
-| **Project** | `.skills/<skill>/` | Project-specific skills |
+| **Project** | `.agents/skills/<skill>/` | Project-specific skills |
 
 **Rule**: Default to **agent-scoped**. Use **project** for repo-specific skills. Use **global** only if all agents should inherit the skill.
 
@@ -242,7 +242,7 @@ rm -rf /tmp/skills-temp
 
 ## Registering New Skills
 
-After installing (via CLI or manual copy), skills are automatically discovered on the next message. Skills are discovered from `~/.letta/skills/`, `.skills/`, and agent-scoped `~/.letta/agents/<agent-id>/memory/skills/` directories.
+After installing (via CLI or manual copy), skills are automatically discovered on the next message. Skills are discovered from `.agents/skills/`, `.skills/` (legacy), `~/.letta/skills/`, and agent-scoped `~/.letta/agents/<agent-id>/memory/skills/` directories.
 
 ## Search Strategy
 


### PR DESCRIPTION
Builtin-skill-watch: acquiring-skills@852ca244b002-680a338db8f3df2e

## Summary
The acquiring-skills skill incorrectly documented `.skills/` as the project skills directory. The canonical path is `.agents/skills/` with `.skills/` as a legacy fallback for backwards compatibility.

## Stale claim
- **Claim**: Project skills are at `.skills/<skill>/`
- **Current source**: `src/agent/skills.ts` lines 179-184 show `PROJECT_SKILLS_DIR = join(".agents", "skills")` as canonical with `SKILLS_DIR = ".skills"` as legacy fallback

## Validation
- Read `src/agent/skills.ts` to verify canonical project skills path
- Read `src/cli/subcommands/skills.ts` to verify CLI commands
- Verified Hermes and ClawHub CLI commands via official documentation
- All checks pass: `bun run check`

👾 Generated with [Letta Code](https://letta.com)