### PR TITLE
fix(reminders): clarify secret injection mechanism

### DIFF
--- a/src/reminders/engine.test.ts
+++ b/src/reminders/engine.test.ts
@@ -119,13 +119,17 @@ describe("secrets info reminders", () => {
     expect(text).toContain("The agent secrets were updated");
     expect(text).toContain("$PLAYGROUND_AGENT_ID");
     expect(text).toContain(
-      "the harness replaces a referenced `$NAME` with its real value",
+      "the harness loads the matching secret into the child shell's environment",
     );
-    expect(text).toContain("Secrets are not exported automatically");
+    expect(text).toContain("it does not rewrite the command text");
+    expect(text).toContain("The shell expands `$NAME` at execution time");
     expect(text).toContain('os.environ["API_KEY"]');
     expect(text).toContain("process.env.API_KEY");
     expect(text).toContain(
-      "Tool output shows `NAME=<REDACTED>`, which means the secret is set and working",
+      "Tool output shows `NAME=<REDACTED>` when a value was injected and then scrubbed",
+    );
+    expect(text).toContain(
+      "An empty direct `$NAME` expansion means that secret was not available to that invocation",
     );
     if (process.platform === "win32") {
       expect(text).toContain("$env:API_KEY = $API_KEY; python script.py");

--- a/src/reminders/engine.ts
+++ b/src/reminders/engine.ts
@@ -112,7 +112,7 @@ async function buildSecretsInfoReminder(
       process.platform === "win32"
         ? "`$env:API_KEY = $API_KEY; python script.py`\n`$env:API_KEY = $API_KEY; bun run script.ts`"
         : '`API_KEY="$API_KEY" python3 script.py`\n`API_KEY="$API_KEY" bun run script.ts`';
-    return `${SYSTEM_REMINDER_OPEN}\n${intro}\n${list}\n\nWhen running a shell command, the harness replaces a referenced \`$NAME\` with its real value. Secrets are not exported automatically, so a program you launch will not receive one unless you pass it on the launch line:\n\n${launchExamples}\n\nInside the program, read it normally with \`os.environ["API_KEY"]\` or \`process.env.API_KEY\`.\n\nYou cannot read secret values. Tool output shows \`NAME=<REDACTED>\`, which means the secret is set and working. Keep using \`$NAME\`.\n${SYSTEM_REMINDER_CLOSE}`;
+    return `${SYSTEM_REMINDER_OPEN}\n${intro}\n${list}\n\nWhen a shell command contains \`$NAME\`, the harness loads the matching secret into the child shell's environment; it does not rewrite the command text. The shell expands \`$NAME\` at execution time. If a program needs a secret but the command would not otherwise reference it, include it on the launch line so the harness can detect it:\n\n${launchExamples}\n\nInside the program, read it normally with \`os.environ["API_KEY"]\` or \`process.env.API_KEY\`.\n\nYou cannot read secret values. Tool output shows \`NAME=<REDACTED>\` when a value was injected and then scrubbed from model-visible output. An empty direct \`$NAME\` expansion means that secret was not available to that invocation; do not describe it as command-string replacement.\n${SYSTEM_REMINDER_CLOSE}`;
   } catch (error) {
     debugLog(
       "secrets",


### PR DESCRIPTION
## Summary
- explain that referenced secrets are injected into the child shell environment rather than substituted into command text
- clarify that the shell expands `$NAME` at execution time and how launched programs can request secret injection
- distinguish redacted output from an empty expansion so agents diagnose unavailable invocation secrets accurately

## Testing
- `bun test src/reminders/engine.test.ts`
- `bun run check`
- full pre-commit hook stack

Linear: [LET-11621](https://linear.app/letta/issue/LET-11621/clarify-runtime-secret-injection-in-agent-prompt)