### PR TITLE
fix: upgrade pi-ai to 0.84.4 and remove temporary OpenRouter thinkingLevelMap patch

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "@letta-ai/letta-code",
       "dependencies": {
-        "@earendil-works/pi-ai": "0.84.3",
+        "@earendil-works/pi-ai": "^0.84.4",
         "@janhapke/sharp-electron": "0.35.3-electron.1",
         "@letta-ai/letta-client": "^1.10.2",
         "@letta-ai/trajectory": "0.2.0",
@@ -120,9 +120,9 @@
 
     "@discoveryjs/json-ext": ["@discoveryjs/json-ext@1.1.0", "", {}, "sha512-Xc3VhU02wqZ1HvHRJUwL09HkZSTvidqY5Ya0NXBSYOxAp+Ln9dcJr9fySI+CkONzP3PekQo9WdzCv0PGER/mOA=="],
 
-    "@earendil-works/pi-ai": ["@earendil-works/pi-ai@0.84.3", "", { "dependencies": { "@anthropic-ai/sdk": "0.91.1", "@aws-sdk/client-bedrock-runtime": "3.1048.0", "@earendil-works/pi-telemetry": "^0.84.3", "@google/genai": "1.52.0", "@smithy/node-http-handler": "4.7.3", "http-proxy-agent": "7.0.2", "https-proxy-agent": "7.0.6", "openai": "6.40.0", "partial-json": "0.1.7", "typebox": "1.3.7" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-M0YUV8vNO3y2WwWSyY8ijKJV5W4gkSUixuvk+Z00ZBjsyMfsdXfITsHEwP1UIf09YRWXT6oGn0GlCamt+P32XQ=="],
+    "@earendil-works/pi-ai": ["@earendil-works/pi-ai@0.84.4", "", { "dependencies": { "@anthropic-ai/sdk": "0.91.1", "@aws-sdk/client-bedrock-runtime": "3.1048.0", "@earendil-works/pi-telemetry": "^0.84.4", "@google/genai": "1.52.0", "@smithy/node-http-handler": "4.7.3", "http-proxy-agent": "7.0.2", "https-proxy-agent": "7.0.6", "openai": "6.40.0", "partial-json": "0.1.7", "typebox": "1.3.7" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-AClAZxf5+c4RRu44NJPS6wyQy+Nmq+Mzyyrdvm4ZVMNuixelO02RZX4G4Aq1F145Yzp43wnM5S+hLlSI7ypfVw=="],
 
-    "@earendil-works/pi-telemetry": ["@earendil-works/pi-telemetry@0.84.3", "", {}, "sha512-sgEkWoKrvSGaKn+YfLLFZmn+/A7B/w62eLwTD57nI+C9to8ITlFFVbgC2OtwvPnT3NFGHdCd53qhBEMIlptD1g=="],
+    "@earendil-works/pi-telemetry": ["@earendil-works/pi-telemetry@0.84.4", "", {}, "sha512-8e2CuxM+ht+hedQXTZmi5JVl6/xDK9RpSDL2+MbITevKYQhMZ/z6lJOTFgox3HQyGxO8mOZEtYGVeQNaD4OzqA=="],
 
     "@emnapi/runtime": ["@emnapi/runtime@1.11.3", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA=="],
 

--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@earendil-works/pi-ai": "0.84.3",
+    "@earendil-works/pi-ai": "^0.84.4",
     "@janhapke/sharp-electron": "0.35.3-electron.1",
     "@letta-ai/letta-client": "^1.10.2",
     "@letta-ai/trajectory": "0.2.0",

--- a/src/backend/dev/pi-model-factory.ts
+++ b/src/backend/dev/pi-model-factory.ts
@@ -4,7 +4,6 @@ import {
   type Model,
   type ModelThinkingLevel,
   type ThinkingLevel,
-  type ThinkingLevelMap,
 } from "@earendil-works/pi-ai";
 import type { OAuthCredentials } from "@earendil-works/pi-ai/oauth";
 import { localNamesForProviderId } from "@/backend/local/local-pi-credential-store";
@@ -102,69 +101,6 @@ function alwaysOnZaiThinking(modelId?: string): boolean {
     modelId === "glm-5-turbo" ||
     modelId === "glm-5.2-highspeed"
   );
-}
-
-/**
- * TEMPORARY PI-AI COMPATIBILITY PATCH. ADDED 2026-08-24.
- *
- * REMOVE THIS ENTIRE BLOCK after letta-code upgrades to a pi-ai release whose
- * generated OpenRouter catalog translates `reasoning.mandatory` and
- * `reasoning.supported_efforts` into `Model.thinkingLevelMap`.
- *
- * Upstream issue: https://github.com/earendil-works/pi/issues/8454
- *
- * pi-ai 0.84.2 marks these models as reasoning-capable but omits their
- * `thinkingLevelMap`. Its OpenRouter adapter therefore sends
- * `reasoning: { effort: "none" }` when Letta has no selected reasoning level,
- * and these endpoints reject the request because reasoning is mandatory.
- * `off: null` tells pi-ai to omit that field. The other nulls and strings let
- * pi-ai's own `getSupportedThinkingLevels()` and `clampThinkingLevel()` own
- * selector visibility and saved-level clamping.
- *
- * Keep this as model metadata only. Do not add OpenRouter request building,
- * effort ordering, or custom clamping here. Those behaviors belong to pi-ai.
- */
-const TEMPORARY_PI_AI_OPENROUTER_THINKING_LEVEL_MAPS: Readonly<
-  Record<string, ThinkingLevelMap>
-> = {
-  "stealth/ox-alpha": {
-    off: null,
-    minimal: null,
-    low: "low",
-    medium: null,
-    high: "high",
-    xhigh: null,
-    max: "max",
-  },
-  "google/gemini-3.7-flash": {
-    off: null,
-    minimal: null,
-    low: "low",
-    medium: "medium",
-    high: "high",
-    xhigh: null,
-    max: null,
-  },
-  "google/gemini-3.7-flash:batch": {
-    off: null,
-    minimal: null,
-    low: "low",
-    medium: "medium",
-    high: "high",
-    xhigh: null,
-    max: null,
-  },
-};
-
-export function patchTemporaryPiAiOpenRouterThinkingMap<TApi extends Api>(
-  model: Model<TApi>,
-): Model<TApi> {
-  if (model.provider !== "openrouter" || model.thinkingLevelMap) return model;
-  const thinkingLevelMap =
-    TEMPORARY_PI_AI_OPENROUTER_THINKING_LEVEL_MAPS[model.id];
-  return thinkingLevelMap
-    ? { ...model, reasoning: true, thinkingLevelMap }
-    : model;
 }
 
 // Maps Letta model settings to a pi-ai ThinkingLevel. Every pi-ai Anthropic
@@ -684,14 +620,13 @@ export async function resolvePiModelForAgent(
 
   // Mod product hook: per-credential model transformation. Deep-copied so a
   // mutating mod cannot corrupt the provider-published instance.
-  const hookedModel = patchTemporaryPiAiOpenRouterThinkingMap(
+  const hookedModel =
     oauthCredentials && registeredProvider?.config.oauth?.modifyModels
       ? (registeredProvider.config.oauth.modifyModels(
           [structuredClone(publishedModel)],
           oauthCredentials,
         )[0] ?? publishedModel)
-      : publishedModel,
-  );
+      : publishedModel;
 
   // Effective-value overrides only: with none, the turn model IS the
   // runtime-published instance — persisted selection settings that merely

--- a/src/backend/local/local-model-config.ts
+++ b/src/backend/local/local-model-config.ts
@@ -8,7 +8,6 @@ import {
   DEFAULT_PI_PROVIDER,
   isUnselectedLocalModelHandle,
   type PiProvider,
-  patchTemporaryPiAiOpenRouterThinkingMap,
   UNSELECTED_LOCAL_MODEL_HANDLE,
 } from "@/backend/dev/pi-model-factory";
 import { LocalPiModelsRuntime } from "@/backend/dev/pi-models-runtime";
@@ -71,9 +70,7 @@ interface ListLocalModelsOptions {
 function supportedThinkingLevelsForRegistration(
   model: Model<Api>,
 ): ModelThinkingLevel[] {
-  return getSupportedThinkingLevels(
-    patchTemporaryPiAiOpenRouterThinkingMap(model),
-  );
+  return getSupportedThinkingLevels(model);
 }
 
 function localProviderNamesFromRecords(
@@ -331,11 +328,7 @@ export async function listLocalModels(
     const name = options.name ?? catalogModel?.name ?? modelId;
     const reasoningLevels =
       options.reasoningLevels ??
-      (catalogModel
-        ? getSupportedThinkingLevels(
-            patchTemporaryPiAiOpenRouterThinkingMap(catalogModel),
-          )
-        : undefined);
+      (catalogModel ? getSupportedThinkingLevels(catalogModel) : undefined);
     models.push({
       display_name: name,
       handle,

--- a/src/backend/pi-model-factory.test.ts
+++ b/src/backend/pi-model-factory.test.ts
@@ -2,12 +2,10 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { getSupportedThinkingLevels, type Model } from "@earendil-works/pi-ai";
-import { streamSimple } from "@earendil-works/pi-ai/api/openai-completions";
+import { getSupportedThinkingLevels } from "@earendil-works/pi-ai";
 import { getBuiltinModels as getModels } from "@earendil-works/pi-ai/providers/all";
 import {
   applyPiEnvOverrides,
-  patchTemporaryPiAiOpenRouterThinkingMap,
   reasoningForSettings,
   resolvePiModelForAgent,
   resolveZaiConnection,
@@ -65,22 +63,17 @@ describe("pi model factory", () => {
     );
   });
 
-  test("temporarily patches pi-ai OpenRouter metadata until issue 8454 ships", () => {
-    const piModel = {
-      id: "google/gemini-3.7-flash",
-      name: "Gemini 3.7 Flash",
-      api: "openai-completions",
-      provider: "openrouter",
-      reasoning: true,
-      input: ["text"],
-      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-      contextWindow: 1_048_576,
-      maxTokens: 65_536,
-    } as Model<"openai-completions">;
-
-    const patched = patchTemporaryPiAiOpenRouterThinkingMap(piModel);
-
-    expect(patched.thinkingLevelMap).toEqual({
+  test("pi-ai 0.84.4+ generates thinkingLevelMap for OpenRouter mandatory-reasoning models", () => {
+    // pi-ai 0.84.4 fixed https://github.com/earendil-works/pi/issues/8454:
+    // the generated OpenRouter catalog now derives thinkingLevelMap from
+    // OpenRouter's reasoning metadata, so the temporary local patch is no
+    // longer needed. Verify the catalog includes the map for a model that
+    // previously required the workaround.
+    const model = getModels("openrouter").find(
+      (entry) => entry.id === "google/gemini-3.7-flash",
+    );
+    expect(model).toBeDefined();
+    expect(model?.thinkingLevelMap).toEqual({
       off: null,
       minimal: null,
       low: "low",
@@ -89,93 +82,21 @@ describe("pi model factory", () => {
       xhigh: null,
       max: null,
     });
-    expect(getSupportedThinkingLevels(patched)).toEqual([
+    expect(getSupportedThinkingLevels(model!)).toEqual([
       "low",
       "medium",
       "high",
     ]);
     expect(
-      reasoningForSettings({}, "openrouter/google/gemini-3.7-flash", patched),
+      reasoningForSettings({}, "openrouter/google/gemini-3.7-flash", model),
     ).toBeUndefined();
-    expect(
-      reasoningForSettings(
-        { reasoning_effort: "minimal" },
-        "openrouter/google/gemini-3.7-flash",
-        patched,
-      ),
-    ).toBe("low");
     expect(
       reasoningForSettings(
         { reasoning_effort: "high" },
         "openrouter/google/gemini-3.7-flash",
-        patched,
+        model,
       ),
     ).toBe("high");
-  });
-
-  test("temporary metadata makes pi-ai omit disabled OpenRouter reasoning", async () => {
-    const bodies: unknown[] = [];
-    const model = patchTemporaryPiAiOpenRouterThinkingMap({
-      id: "google/gemini-3.7-flash",
-      name: "Gemini 3.7 Flash",
-      api: "openai-completions",
-      provider: "openrouter",
-      baseUrl: "https://openrouter.test/api/v1",
-      reasoning: true,
-      input: ["text"],
-      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-      contextWindow: 1_048_576,
-      maxTokens: 65_536,
-    } as Model<"openai-completions">);
-    const fetchImpl = (async (
-      _input: Parameters<typeof fetch>[0],
-      init?: RequestInit,
-    ) => {
-      bodies.push(JSON.parse(String(init?.body)));
-      return new Response(
-        [
-          'data: {"id":"response-1","choices":[{"delta":{"content":"ok"},"finish_reason":null}]}',
-          'data: {"id":"response-1","choices":[{"delta":{},"finish_reason":"stop"}]}',
-          "data: [DONE]",
-          "",
-        ].join("\n"),
-        { headers: { "content-type": "text/event-stream" } },
-      );
-    }) as typeof fetch;
-
-    await streamSimple(
-      model,
-      { messages: [{ role: "user", content: "hello", timestamp: 0 }] },
-      { apiKey: "test-key", fetch: fetchImpl },
-    ).result();
-
-    expect(bodies).toHaveLength(1);
-    expect(bodies[0]).not.toHaveProperty("reasoning");
-  });
-
-  test("limits the temporary pi-ai patch to OpenRouter models without metadata", () => {
-    const model = {
-      id: "google/gemini-3.7-flash",
-      name: "Gemini 3.7 Flash",
-      api: "openai-completions",
-      provider: "registered-provider",
-      reasoning: true,
-      input: ["text"],
-      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-      contextWindow: 1_048_576,
-      maxTokens: 65_536,
-    } as Model<"openai-completions">;
-    const existingMap = { off: "none", high: "high" };
-    const openRouterModel = {
-      ...model,
-      provider: "openrouter",
-      thinkingLevelMap: existingMap,
-    } as Model<"openai-completions">;
-
-    expect(patchTemporaryPiAiOpenRouterThinkingMap(model)).toBe(model);
-    expect(patchTemporaryPiAiOpenRouterThinkingMap(openRouterModel)).toBe(
-      openRouterModel,
-    );
   });
 
   test("reuses a lone zAI key on the published coding-plan endpoint", async () => {


### PR DESCRIPTION
## Summary

Upgrades `@earendil-works/pi-ai` from 0.84.3 to 0.84.4. The headline fix is that the generated OpenRouter catalog now derives `thinkingLevelMap` from OpenRouter's `reasoning` metadata ([earendil-works/pi#8454](https://github.com/earendil-works/pi/issues/8454)), which means the temporary compatibility patch added 2026-08-24 is no longer needed and has been removed.

### Changes
- Bump `@earendil-works/pi-ai` from `0.84.3` to `^0.84.4`
- Remove `TEMPORARY_PI_AI_OPENROUTER_THINKING_LEVEL_MAPS` constant and `patchTemporaryPiAiOpenRouterThinkingMap` function from `pi-model-factory.ts`
- Remove all call sites in `local-model-config.ts` (2 call sites) and `pi-model-factory.ts` (1 call site)
- Remove `ThinkingLevelMap` type import (no longer used)
- Replace 3 temporary-patch tests with 1 test verifying the upstream catalog now provides `thinkingLevelMap` for `google/gemini-3.7-flash`
- Remove unused imports (`streamSimple`, `Model`) from test file

### Other fixes in 0.84.4
- Fixed OpenAI-completions `toolChoice` when no tools defined
- Fixed thinking signature serialization (buffer `streamedReasoningDetails` + `appendOpenAIReasoningDetail` merge)
- Fixed fragmented Mistral tool calls (key changed from `${callId}:${toolCall.index || 0}` to `toolCall.index ?? callId`)
- New models: `deepseek-v4-flash-vision-exp`, `meta/muse-image`, recraft variants
- Cloudflare AI Gateway catalog additions

### Verification
- `bun run check` — all 12 checks pass
- `bun test src/backend/pi-model-factory.test.ts` — 25/25 pass
- `bun test src/providers/local-pi-provider-catalog.test.ts` — 19/19 pass

Pi-ai-watch: 0.84.3...0.84.4

## Test plan
- [x] `bun run check` passes
- [x] pi-model-factory tests pass
- [x] local-pi-provider-catalog tests pass
- [ ] CI green

👾 Generated with [Letta Code](https://letta.com)

Co-Authored-By: Letta Code <noreply@letta.com>