### PR TITLE
fix(ci): enforce Amelia authorship for agent PRs

### DIFF
--- a/.github/agent-prompts/builtin-skills-agent-watch.md
+++ b/.github/agent-prompts/builtin-skills-agent-watch.md
@@ -59,7 +59,7 @@ env -u AMELIA_GITHUB_TOKEN -u GH_TOKEN -u GITHUB_TOKEN git -c http.extraHeader="
 unset AUTH_HEADER
 ```
 
-If either push hook exists or the remote differs, do not expose the credential; return `needs_human_review` instead. Do not run any other repository or package command with the credential present.
+If either push hook exists, the remote differs, or this push fails, do not expose another credential; return `needs_human_review` instead. Never retry with plain `git push`, `CAREN_GITHUB_TOKEN`, another user's credential, or a token-bearing remote URL. Do not run any other repository or package command with the credential present.
 
 ## If the skill is stale
 

--- a/.github/agent-prompts/claude-agent-watch.md
+++ b/.github/agent-prompts/claude-agent-watch.md
@@ -20,6 +20,20 @@ For a package update, the detector compares the last audited snapshot directly t
 
 Before running the sandbox bootstrap, resolve the watcher credential identity with `test -n "$AMELIA_GITHUB_TOKEN" && GITHUB_TOKEN= GH_TOKEN="$AMELIA_GITHUB_TOKEN" gh api user --jq .login`. It must exactly match the Expected GitHub login from the run inputs. If the secret is missing or the identities differ, stop without modifying GitHub or the tracker.
 
+Plain `git push` uses the sandbox's default GitHub App credential, not `GH_TOKEN`. For the one required branch push, use exactly:
+
+```bash
+test ! -e .git/hooks/pre-push
+test ! -e .husky/pre-push
+test "$(git remote get-url origin)" = "https://github.com/letta-ai/letta-code.git"
+test -n "$AMELIA_GITHUB_TOKEN"
+AUTH_HEADER="Authorization: Basic $(printf 'x-access-token:%s' "$AMELIA_GITHUB_TOKEN" | base64 | tr -d '\n')"
+env -u AMELIA_GITHUB_TOKEN -u GH_TOKEN -u GITHUB_TOKEN git -c http.extraHeader="$AUTH_HEADER" push -u origin HEAD
+unset AUTH_HEADER
+```
+
+If either push hook exists, the remote differs, or this push fails, stop with `needs_human_review`. Never retry with plain `git push`, `CAREN_GITHUB_TOKEN`, another user's credential, or a token-bearing remote URL.
+
 ## Sandbox setup
 
 The detector ran on a GitHub Actions runner, but your turn does not. Runner files and environment variables are unavailable here. The run inputs and an exact bootstrap block are appended to this prompt.
@@ -88,6 +102,7 @@ test -n "$AMELIA_GITHUB_TOKEN" && GITHUB_TOKEN= GH_TOKEN="$AMELIA_GITHUB_TOKEN" 
   --state-commit-sha <state-commit-sha> \
   --outcome pr_created \
   --pr-url "$PR_URL" \
+  --expected-github-login <expected-login> \
   --notes "<focused local mirror change>"
 ```
 

--- a/.github/agent-prompts/codex-agent-watch.md
+++ b/.github/agent-prompts/codex-agent-watch.md
@@ -12,6 +12,20 @@ The detector already compared the tracker cursor directly to the latest stable C
 
 Before running the sandbox bootstrap, resolve the watcher credential identity with `test -n "$AMELIA_GITHUB_TOKEN" && GITHUB_TOKEN= GH_TOKEN="$AMELIA_GITHUB_TOKEN" gh api user --jq .login`. It must exactly match the Expected GitHub login from the run inputs. If the secret is missing or the identities differ, stop without modifying GitHub or the tracker.
 
+Plain `git push` uses the sandbox's default GitHub App credential, not `GH_TOKEN`. For the one required branch push, use exactly:
+
+```bash
+test ! -e .git/hooks/pre-push
+test ! -e .husky/pre-push
+test "$(git remote get-url origin)" = "https://github.com/letta-ai/letta-code.git"
+test -n "$AMELIA_GITHUB_TOKEN"
+AUTH_HEADER="Authorization: Basic $(printf 'x-access-token:%s' "$AMELIA_GITHUB_TOKEN" | base64 | tr -d '\n')"
+env -u AMELIA_GITHUB_TOKEN -u GH_TOKEN -u GITHUB_TOKEN git -c http.extraHeader="$AUTH_HEADER" push -u origin HEAD
+unset AUTH_HEADER
+```
+
+If either push hook exists, the remote differs, or this push fails, stop with `needs_human_review`. Never retry with plain `git push`, `CAREN_GITHUB_TOKEN`, another user's credential, or a token-bearing remote URL.
+
 ## Sandbox setup
 
 The detector ran on a GitHub Actions runner, but your turn does not. The runner checkout, environment variables, and analysis file path are unavailable in the sandbox. The run inputs and an exact bootstrap command are included below in this prompt.
@@ -78,6 +92,7 @@ test -n "$AMELIA_GITHUB_TOKEN" && GITHUB_TOKEN= GH_TOKEN="$AMELIA_GITHUB_TOKEN" 
   --analysis-file /tmp/codex-watch-analysis.json \
   --outcome pr_created \
   --pr-url "$PR_URL" \
+  --expected-github-login <expected-login> \
   --notes "<short summary of local mirror update>"
 ```
 

--- a/.github/agent-prompts/pi-ai-agent-watch.md
+++ b/.github/agent-prompts/pi-ai-agent-watch.md
@@ -6,6 +6,20 @@ Your job is to review the cumulative stable `@earendil-works/pi-ai` changes sinc
 
 Before running the sandbox bootstrap, resolve the watcher credential identity with `test -n "$AMELIA_GITHUB_TOKEN" && GITHUB_TOKEN= GH_TOKEN="$AMELIA_GITHUB_TOKEN" gh api user --jq .login`. It must exactly match the Expected GitHub login from the run inputs. If the secret is missing or the identities differ, stop without modifying GitHub or the tracker.
 
+Plain `git push` uses the sandbox's default GitHub App credential, not `GH_TOKEN`. For the one required branch push, use exactly:
+
+```bash
+test ! -e .git/hooks/pre-push
+test ! -e .husky/pre-push
+test "$(git remote get-url origin)" = "https://github.com/letta-ai/letta-code.git"
+test -n "$AMELIA_GITHUB_TOKEN"
+AUTH_HEADER="Authorization: Basic $(printf 'x-access-token:%s' "$AMELIA_GITHUB_TOKEN" | base64 | tr -d '\n')"
+env -u AMELIA_GITHUB_TOKEN -u GH_TOKEN -u GITHUB_TOKEN git -c http.extraHeader="$AUTH_HEADER" push -u origin HEAD
+unset AUTH_HEADER
+```
+
+If either push hook exists, the remote differs, or this push fails, stop with `needs_human_review`. Never retry with plain `git push`, `CAREN_GITHUB_TOKEN`, another user's credential, or a token-bearing remote URL.
+
 ## Sandbox setup
 
 The detector ran on a GitHub Actions runner, but your turn does not. Runner files and environment variables are unavailable in the sandbox. Run the exact `Sandbox bootstrap` block appended to this prompt, then use `SetWorkingDirectory` to select `/tmp/letta-code-pi-ai-watch`. If `SetWorkingDirectory` is unavailable, pass that absolute directory as `workdir` for every command.

--- a/.github/agent-prompts/sync-tools-to-cloud.md
+++ b/.github/agent-prompts/sync-tools-to-cloud.md
@@ -8,6 +8,20 @@ Before inspecting or modifying GitHub, resolve the automation identity with `tes
 
 Use only `test -n "$AMELIA_GITHUB_TOKEN" && GITHUB_TOKEN= GH_TOKEN="$AMELIA_GITHUB_TOKEN"` for every GitHub CLI operation. Never use the agent's general `$GITHUB_TOKEN` secret or another user's credentials.
 
+Plain `git push` uses the sandbox's default GitHub App credential, not `GH_TOKEN`. For the one required branch push, use exactly:
+
+```bash
+test ! -e .git/hooks/pre-push
+test ! -e .husky/pre-push
+test "$(git remote get-url origin)" = "https://github.com/letta-ai/letta-cloud.git"
+test -n "$AMELIA_GITHUB_TOKEN"
+AUTH_HEADER="Authorization: Basic $(printf 'x-access-token:%s' "$AMELIA_GITHUB_TOKEN" | base64 | tr -d '\n')"
+env -u AMELIA_GITHUB_TOKEN -u GH_TOKEN -u GITHUB_TOKEN git -c http.extraHeader="$AUTH_HEADER" push -u origin HEAD
+unset AUTH_HEADER
+```
+
+If either push hook exists, the remote differs, or this push fails, stop without creating a PR. Never retry with plain `git push`, `CAREN_GITHUB_TOKEN`, another user's credential, or a token-bearing remote URL.
+
 ## Source review
 
 Read the source PR metadata and complete diff:

--- a/.github/workflows/builtin-skills-agent-watch.yml
+++ b/.github/workflows/builtin-skills-agent-watch.yml
@@ -98,6 +98,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.10
+
       - name: Build Amelia prompt
         id: prompt
         env:
@@ -176,6 +181,18 @@ jobs:
             --data "$(jq -nc --arg summary "$CONVERSATION_NAME" '{summary: $summary}')" \
             --output /dev/null \
             "https://api.letta.com/v1/conversations/$CONVERSATION_ID"
+
+      - name: Enforce Amelia PR identity
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.AMELIA_GITHUB_TOKEN }}
+          EXPECTED_GITHUB_LOGIN: ${{ needs.prepare.outputs.expected_github_login }}
+          PR_MARKER: "Builtin-skill-watch: ${{ matrix.candidate_id }}"
+        run: |
+          bun scripts/agent-watch/verify-pr-identity.ts \
+            --repo letta-ai/letta-code \
+            --marker "$PR_MARKER" \
+            --expected-login "$EXPECTED_GITHUB_LOGIN"
 
       - name: Extract Amelia result
         if: always()

--- a/.github/workflows/claude-agent-watch.yml
+++ b/.github/workflows/claude-agent-watch.yml
@@ -194,6 +194,18 @@ jobs:
             --output /dev/null \
             "https://api.letta.com/v1/conversations/$CONVERSATION_ID"
 
+      - name: Enforce Amelia PR identity
+        if: always() && steps.detect.outputs.should_run_agent == 'true' && steps.github-identity.outputs.login != ''
+        env:
+          GH_TOKEN: ${{ secrets.AMELIA_GITHUB_TOKEN }}
+          EXPECTED_GITHUB_LOGIN: ${{ steps.github-identity.outputs.login }}
+          PR_MARKER: "Claude-watch: ${{ steps.detect.outputs.candidate_id }}"
+        run: |
+          bun scripts/agent-watch/verify-pr-identity.ts \
+            --repo letta-ai/letta-code \
+            --marker "$PR_MARKER" \
+            --expected-login "$EXPECTED_GITHUB_LOGIN"
+
       - name: Verify terminal outcome
         if: steps.detect.outputs.should_run_agent == 'true'
         env:

--- a/.github/workflows/codex-agent-watch.yml
+++ b/.github/workflows/codex-agent-watch.yml
@@ -147,3 +147,15 @@ jobs:
             --data "$(jq -nc --arg summary "$CONVERSATION_NAME" '{summary: $summary}')" \
             --output /dev/null \
             "https://api.letta.com/v1/conversations/$CONVERSATION_ID"
+
+      - name: Enforce Amelia PR identity
+        if: always() && steps.detect.outputs.should_run_agent == 'true' && steps.github-identity.outputs.login != ''
+        env:
+          GH_TOKEN: ${{ secrets.AMELIA_GITHUB_TOKEN }}
+          EXPECTED_GITHUB_LOGIN: ${{ steps.github-identity.outputs.login }}
+          PR_MARKER: "Codex-watch: openai/codex ${{ steps.detect.outputs.current_tag }}"
+        run: |
+          bun scripts/agent-watch/verify-pr-identity.ts \
+            --repo letta-ai/letta-code \
+            --marker "$PR_MARKER" \
+            --expected-login "$EXPECTED_GITHUB_LOGIN"

--- a/.github/workflows/pi-ai-agent-watch.yml
+++ b/.github/workflows/pi-ai-agent-watch.yml
@@ -158,6 +158,18 @@ jobs:
             --output /dev/null \
             "https://api.letta.com/v1/conversations/$CONVERSATION_ID"
 
+      - name: Enforce Amelia PR identity
+        if: always() && steps.detect.outputs.should_run_agent == 'true' && steps.github-identity.outputs.login != ''
+        env:
+          GH_TOKEN: ${{ secrets.AMELIA_GITHUB_TOKEN }}
+          EXPECTED_GITHUB_LOGIN: ${{ steps.github-identity.outputs.login }}
+          PR_MARKER: "Pi-ai-watch: ${{ steps.detect.outputs.previous_version }}...${{ steps.detect.outputs.current_version }}"
+        run: |
+          bun scripts/agent-watch/verify-pr-identity.ts \
+            --repo letta-ai/letta-code \
+            --marker "$PR_MARKER" \
+            --expected-login "$EXPECTED_GITHUB_LOGIN"
+
       - name: Verify recorded outcome
         if: steps.detect.outputs.should_run_agent == 'true'
         env:

--- a/.github/workflows/sync-tools-to-cloud.yml
+++ b/.github/workflows/sync-tools-to-cloud.yml
@@ -34,6 +34,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.10
+
       - name: Resolve Amelia GitHub identity
         id: github-identity
         env:
@@ -107,6 +112,18 @@ jobs:
             --data "$(jq -nc --arg summary "$CONVERSATION_NAME" '{summary: $summary}')" \
             --output /dev/null \
             "https://api.letta.com/v1/conversations/$CONVERSATION_ID"
+
+      - name: Enforce Amelia PR identity
+        if: always() && steps.github-identity.outputs.login != ''
+        env:
+          GH_TOKEN: ${{ secrets.AMELIA_GITHUB_TOKEN }}
+          EXPECTED_GITHUB_LOGIN: ${{ steps.github-identity.outputs.login }}
+          PR_MARKER: ${{ steps.prompt.outputs.source_marker }}
+        run: |
+          bun scripts/agent-watch/verify-pr-identity.ts \
+            --repo letta-ai/letta-cloud \
+            --marker "$PR_MARKER" \
+            --expected-login "$EXPECTED_GITHUB_LOGIN"
 
       - name: Verify sync outcome
         env:

--- a/scripts/agent-watch/verify-pr-identity.test.ts
+++ b/scripts/agent-watch/verify-pr-identity.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, test } from "bun:test";
+import {
+  enforceWatcherPrIdentity,
+  parseArgs,
+  type WatcherPullRequest,
+} from "./verify-pr-identity.ts";
+
+const marker = "Pi-ai-watch: 1.0.0...1.0.1";
+
+function pullRequest(
+  overrides: Partial<WatcherPullRequest> = {},
+): WatcherPullRequest {
+  return {
+    author: { login: "amelia-letta" },
+    body: marker,
+    isDraft: true,
+    number: 123,
+    url: "https://github.com/letta-ai/letta-code/pull/123",
+    ...overrides,
+  };
+}
+
+function enforce(
+  pullRequests: WatcherPullRequest[],
+  closed: string[] = [],
+): WatcherPullRequest | null {
+  return enforceWatcherPrIdentity({
+    repo: "letta-ai/letta-code",
+    marker,
+    expectedLogin: "amelia-letta",
+    pullRequests,
+    closePullRequest: (candidate) => closed.push(candidate.url),
+  });
+}
+
+describe("enforceWatcherPrIdentity", () => {
+  test("returns the matching Amelia draft PR", () => {
+    expect(enforce([pullRequest()])?.number).toBe(123);
+  });
+
+  test("ignores unrelated open PRs", () => {
+    expect(enforce([pullRequest({ body: "unrelated" })])).toBeNull();
+  });
+
+  test("closes and rejects a PR from the wrong author", () => {
+    const closed: string[] = [];
+    expect(() =>
+      enforce([pullRequest({ author: { login: "carenthomas" } })], closed),
+    ).toThrow("author=carenthomas");
+    expect(closed).toEqual(["https://github.com/letta-ai/letta-code/pull/123"]);
+  });
+
+  test("closes and rejects a ready PR", () => {
+    const closed: string[] = [];
+    expect(() => enforce([pullRequest({ isDraft: false })], closed)).toThrow(
+      "draft=false",
+    );
+    expect(closed).toHaveLength(1);
+  });
+
+  test("rejects duplicate valid PRs", () => {
+    expect(() =>
+      enforce([
+        pullRequest(),
+        pullRequest({
+          number: 124,
+          url: "https://github.com/letta-ai/letta-code/pull/124",
+        }),
+      ]),
+    ).toThrow("Multiple open watcher PRs");
+  });
+});
+
+describe("parseArgs", () => {
+  test("requires every identity input", () => {
+    expect(() => parseArgs(["--repo", "letta-ai/letta-code"])).toThrow(
+      "--marker is required",
+    );
+  });
+
+  test("parses a complete invocation", () => {
+    expect(
+      parseArgs([
+        "--repo",
+        "letta-ai/letta-code",
+        "--marker",
+        marker,
+        "--expected-login",
+        "amelia-letta",
+      ]),
+    ).toEqual({
+      repo: "letta-ai/letta-code",
+      marker,
+      expectedLogin: "amelia-letta",
+    });
+  });
+});

--- a/scripts/agent-watch/verify-pr-identity.ts
+++ b/scripts/agent-watch/verify-pr-identity.ts
@@ -1,0 +1,119 @@
+#!/usr/bin/env bun
+
+import { spawnSync } from "node:child_process";
+
+export interface WatcherPullRequest {
+  author: { login: string } | null;
+  body: string | null;
+  isDraft: boolean;
+  number: number;
+  url: string;
+}
+
+interface Args {
+  expectedLogin: string;
+  marker: string;
+  repo: string;
+}
+
+interface EnforceOptions extends Args {
+  closePullRequest: (pullRequest: WatcherPullRequest) => void;
+  pullRequests: WatcherPullRequest[];
+}
+
+export function enforceWatcherPrIdentity(
+  options: EnforceOptions,
+): WatcherPullRequest | null {
+  const matches = options.pullRequests.filter((pullRequest) =>
+    pullRequest.body?.includes(options.marker),
+  );
+  const invalid = matches.filter(
+    (pullRequest) =>
+      pullRequest.author?.login !== options.expectedLogin ||
+      !pullRequest.isDraft,
+  );
+
+  for (const pullRequest of invalid) options.closePullRequest(pullRequest);
+
+  if (invalid.length > 0) {
+    const details = invalid
+      .map(
+        (pullRequest) =>
+          `${pullRequest.url} (author=${pullRequest.author?.login ?? "unknown"}, draft=${pullRequest.isDraft})`,
+      )
+      .join(", ");
+    throw new Error(
+      `Closed watcher PRs that did not match author=${options.expectedLogin} and draft=true: ${details}`,
+    );
+  }
+  if (matches.length > 1) {
+    throw new Error(
+      `Multiple open watcher PRs contain marker ${JSON.stringify(options.marker)}`,
+    );
+  }
+  return matches[0] ?? null;
+}
+
+export function parseArgs(argv: string[]): Args {
+  let repo = "";
+  let marker = "";
+  let expectedLogin = "";
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    if (argument === "--repo") repo = argv[++index] ?? "";
+    else if (argument === "--marker") marker = argv[++index] ?? "";
+    else if (argument === "--expected-login") {
+      expectedLogin = argv[++index] ?? "";
+    } else {
+      throw new Error(`Unknown argument: ${argument}`);
+    }
+  }
+  if (!/^[^/]+\/[^/]+$/.test(repo)) throw new Error("--repo is required");
+  if (!marker) throw new Error("--marker is required");
+  if (!expectedLogin) throw new Error("--expected-login is required");
+  return { repo, marker, expectedLogin };
+}
+
+function runGh(args: string[]): string {
+  const result = spawnSync("gh", args, {
+    encoding: "utf8",
+    maxBuffer: 50 * 1024 * 1024,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  if (result.status !== 0) {
+    throw new Error(`gh ${args.join(" ")} failed:\n${result.stderr}`);
+  }
+  return result.stdout;
+}
+
+function main(): void {
+  const args = parseArgs(process.argv.slice(2));
+  const pullRequests = JSON.parse(
+    runGh([
+      "pr",
+      "list",
+      "--repo",
+      args.repo,
+      "--state",
+      "open",
+      "--limit",
+      "1000",
+      "--json",
+      "author,body,isDraft,number,url",
+    ]),
+  ) as WatcherPullRequest[];
+  const verified = enforceWatcherPrIdentity({
+    ...args,
+    pullRequests,
+    closePullRequest: (pullRequest) => {
+      runGh(["pr", "close", pullRequest.url, "--repo", args.repo]);
+    },
+  });
+  console.log(
+    verified
+      ? `Verified Amelia draft PR: ${verified.url}`
+      : `No open PR contains marker ${JSON.stringify(args.marker)}`,
+  );
+}
+
+if (import.meta.main) main();

--- a/scripts/claude-watch/update-tracker.test.ts
+++ b/scripts/claude-watch/update-tracker.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "bun:test";
+import { parseArgs } from "./update-tracker.ts";
+
+describe("parseArgs", () => {
+  const required = [
+    "--tracker-issue",
+    "123",
+    "--analysis-file",
+    "/tmp/analysis.json",
+    "--state-commit-sha",
+    "abc123",
+    "--outcome",
+    "pr_created",
+    "--pr-url",
+    "https://github.com/letta-ai/letta-code/pull/456",
+  ];
+
+  test("requires the expected GitHub login for a PR", () => {
+    expect(() => parseArgs(required)).toThrow(
+      "--expected-github-login is required for pr_created",
+    );
+  });
+
+  test("accepts the expected GitHub login for a PR", () => {
+    expect(
+      parseArgs([...required, "--expected-github-login", "amelia-letta"])
+        .expectedGithubLogin,
+    ).toBe("amelia-letta");
+  });
+});

--- a/scripts/claude-watch/update-tracker.ts
+++ b/scripts/claude-watch/update-tracker.ts
@@ -27,6 +27,7 @@ interface Args {
   outcome: ClaudeWatchOutcome | null;
   notes: string;
   prUrl: string | null;
+  expectedGithubLogin: string | null;
   assertTerminal: boolean;
   dryRun: boolean;
 }
@@ -41,6 +42,7 @@ export function parseArgs(argv: string[]): Args {
     outcome: null,
     notes: "",
     prUrl: null,
+    expectedGithubLogin: null,
     assertTerminal: false,
     dryRun: false,
   };
@@ -59,6 +61,8 @@ export function parseArgs(argv: string[]): Args {
       args.outcome = parseOutcome(argv[++index]);
     else if (argument === "--notes") args.notes = argv[++index] ?? "";
     else if (argument === "--pr-url") args.prUrl = argv[++index] ?? null;
+    else if (argument === "--expected-github-login")
+      args.expectedGithubLogin = argv[++index] ?? null;
     else if (argument === "--assert-terminal") args.assertTerminal = true;
     else if (argument === "--dry-run") args.dryRun = true;
     else throw new Error(`Unknown argument: ${argument}`);
@@ -75,8 +79,12 @@ export function parseArgs(argv: string[]): Args {
     if (!args.outcome) throw new Error("--outcome is required");
     if (isTerminalOutcome(args.outcome) && !args.stateCommitSha)
       throw new Error("terminal outcomes require --state-commit-sha");
-    if (args.outcome === "pr_created" && !args.prUrl)
-      throw new Error("--pr-url is required for pr_created");
+    if (args.outcome === "pr_created") {
+      if (!args.prUrl) throw new Error("--pr-url is required for pr_created");
+      if (!args.expectedGithubLogin) {
+        throw new Error("--expected-github-login is required for pr_created");
+      }
+    }
   }
   return args;
 }
@@ -117,15 +125,16 @@ function verifyParityPr(
   repo: string,
   prUrl: string,
   candidateId: string,
+  expectedGithubLogin: string,
 ): void {
   const pr = ghJson<{
     isDraft: boolean;
     author: { login: string };
     body: string | null;
   }>(["pr", "view", prUrl, "--repo", repo, "--json", "isDraft,author,body"]);
-  if (!pr.isDraft || pr.author.login !== "carenthomas") {
+  if (!pr.isDraft || pr.author.login !== expectedGithubLogin) {
     throw new Error(
-      `Parity PR must be a draft authored by carenthomas (got draft=${pr.isDraft}, author=${pr.author.login})`,
+      `Parity PR must be a draft authored by ${expectedGithubLogin} (got draft=${pr.isDraft}, author=${pr.author.login})`,
     );
   }
   if (!pr.body?.includes(`Claude-watch: ${candidateId}`)) {
@@ -164,7 +173,12 @@ export function main(argv = process.argv.slice(2)): void {
     verifyStateCandidate(analysis.candidate_id, args.stateCommitSha as string);
   }
   if (args.outcome === "pr_created") {
-    verifyParityPr(args.repo, args.prUrl as string, analysis.candidate_id);
+    verifyParityPr(
+      args.repo,
+      args.prUrl as string,
+      analysis.candidate_id,
+      args.expectedGithubLogin as string,
+    );
   }
   const next = recordAnalysis(state, {
     analysis,

--- a/scripts/codex-watch/update-tracker.test.ts
+++ b/scripts/codex-watch/update-tracker.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "bun:test";
+import { parseArgs } from "./update-tracker.ts";
+
+describe("parseArgs", () => {
+  const required = [
+    "--tracker-issue",
+    "123",
+    "--analysis-file",
+    "/tmp/analysis.json",
+    "--outcome",
+    "pr_created",
+    "--pr-url",
+    "https://github.com/letta-ai/letta-code/pull/456",
+  ];
+
+  test("requires the expected GitHub login for a PR", () => {
+    expect(() => parseArgs(required)).toThrow(
+      "--expected-github-login is required for pr_created",
+    );
+  });
+
+  test("accepts the expected GitHub login for a PR", () => {
+    expect(
+      parseArgs([...required, "--expected-github-login", "amelia-letta"])
+        .expectedGithubLogin,
+    ).toBe("amelia-letta");
+  });
+});

--- a/scripts/codex-watch/update-tracker.ts
+++ b/scripts/codex-watch/update-tracker.ts
@@ -7,7 +7,7 @@
  */
 
 import { readFileSync } from "node:fs";
-import { editIssueBody, getIssueBody } from "./github.ts";
+import { editIssueBody, getIssueBody, ghJson } from "./github.ts";
 import {
   type CodexWatchAnalysis,
   DEFAULT_TARGET_REPO,
@@ -26,10 +26,11 @@ interface Args {
   outcome: TrackerOutcome | null;
   notes: string;
   prUrl: string | null;
+  expectedGithubLogin: string | null;
   dryRun: boolean;
 }
 
-function parseArgs(argv: string[]): Args {
+export function parseArgs(argv: string[]): Args {
   const args: Args = {
     repo: DEFAULT_TARGET_REPO,
     trackerIssue: null,
@@ -37,6 +38,7 @@ function parseArgs(argv: string[]): Args {
     outcome: null,
     notes: "",
     prUrl: null,
+    expectedGithubLogin: null,
     dryRun: false,
   };
 
@@ -49,10 +51,12 @@ function parseArgs(argv: string[]): Args {
     else if (a === "--outcome") args.outcome = parseOutcome(argv[++i]);
     else if (a === "--notes") args.notes = argv[++i] ?? "";
     else if (a === "--pr-url") args.prUrl = argv[++i] ?? null;
-    else if (a === "--dry-run") args.dryRun = true;
+    else if (a === "--expected-github-login") {
+      args.expectedGithubLogin = argv[++i] ?? null;
+    } else if (a === "--dry-run") args.dryRun = true;
     else if (a === "--help" || a === "-h") {
       console.log(
-        "Usage: bun scripts/codex-watch/update-tracker.ts --tracker-issue ISSUE --analysis-file FILE --outcome OUTCOME [--notes TEXT] [--pr-url URL] [--repo OWNER/REPO] [--dry-run]",
+        "Usage: bun scripts/codex-watch/update-tracker.ts --tracker-issue ISSUE --analysis-file FILE --outcome OUTCOME [--notes TEXT] [--pr-url URL --expected-github-login LOGIN] [--repo OWNER/REPO] [--dry-run]",
       );
       process.exit(0);
     } else {
@@ -65,8 +69,13 @@ function parseArgs(argv: string[]): Args {
   }
   if (!args.analysisFile) throw new Error("--analysis-file is required");
   if (!args.outcome) throw new Error("--outcome is required");
-  if (args.outcome === "pr_created" && !args.prUrl) {
-    throw new Error("--pr-url is required when --outcome pr_created");
+  if (args.outcome === "pr_created") {
+    if (!args.prUrl) {
+      throw new Error("--pr-url is required when --outcome pr_created");
+    }
+    if (!args.expectedGithubLogin) {
+      throw new Error("--expected-github-login is required for pr_created");
+    }
   }
 
   return args;
@@ -94,6 +103,14 @@ function main() {
   const analysis = readAnalysis(args.analysisFile as string);
   const body = getIssueBody(args.repo, args.trackerIssue as number);
   const state = parseTrackerState(body);
+  if (args.outcome === "pr_created") {
+    verifyParityPr(
+      args.repo,
+      args.prUrl as string,
+      args.expectedGithubLogin as string,
+      analysis.current_tag,
+    );
+  }
   const next = recordAnalysis(state, {
     analysis,
     outcome: args.outcome as TrackerOutcome,
@@ -113,6 +130,41 @@ function main() {
   );
 }
 
+function verifyParityPr(
+  repo: string,
+  prUrl: string,
+  expectedGithubLogin: string,
+  currentTag: string,
+): void {
+  const pullRequest = ghJson<{
+    author: { login: string };
+    body: string | null;
+    isDraft: boolean;
+    state: string;
+  }>([
+    "pr",
+    "view",
+    prUrl,
+    "--repo",
+    repo,
+    "--json",
+    "author,body,isDraft,state",
+  ]);
+  if (
+    pullRequest.author.login !== expectedGithubLogin ||
+    !pullRequest.isDraft ||
+    pullRequest.state !== "OPEN"
+  ) {
+    throw new Error(
+      `Codex PR must be an open draft authored by ${expectedGithubLogin} (got author=${pullRequest.author.login}, draft=${pullRequest.isDraft}, state=${pullRequest.state})`,
+    );
+  }
+  const marker = `Codex-watch: openai/codex ${currentTag}`;
+  if (!pullRequest.body?.includes(marker)) {
+    throw new Error(`Codex PR body is missing marker: ${marker}`);
+  }
+}
+
 function defaultNotes(outcome: TrackerOutcome): string {
   switch (outcome) {
     case "recorded_noop":
@@ -128,4 +180,4 @@ function defaultNotes(outcome: TrackerOutcome): string {
   }
 }
 
-main();
+if (import.meta.main) main();


### PR DESCRIPTION
## Summary

The Amelia workflows that create pull requests should always push and publish as `amelia-letta`. PR #4108 showed that setting `GH_TOKEN` for `gh` does not authenticate a plain `git push`: the sandbox used Letta Integration, the push failed, and the agent fell back to Caren's token.

This applies the fix to every PR-creating Amelia workflow:

- pi-ai, Claude, Codex, built-in skills, and tools-to-cloud prompts now use the same explicit Amelia-token Git push command and forbid credential fallback
- each Actions runner scans for the workflow's exact PR marker, accepts only an open draft from `amelia-letta`, and closes a wrong-author or non-draft PR before later success steps
- Claude tracker validation now uses the run's expected GitHub login instead of hardcoding `carenthomas`
- Codex tracker validation now checks author, draft/open state, and its exact release marker before recording `pr_created`

**Draft status:** implementation and local validation are complete; CI and human review remain.

## Review notes

**Start here:** `scripts/agent-watch/verify-pr-identity.ts`, then one `Enforce Amelia PR identity` workflow step and its matching prompt.

**Merge when:** CI passes and the reviewer confirms all five PR-creating workflows use the same Amelia-only push and runner verification path.

**Risk:** the runner guard selects PRs by exact watcher marker. A malformed or changed marker would fail closed without finding the PR, while tracker-level validation remains the second gate for watcher workflows that record PR outcomes.

## Verification

The new guard tests start from the production failure shape, an open draft whose author is `carenthomas`. GitHub listing and closure are replaced by in-memory inputs and a close callback; the tests assert that the wrong-author PR is closed and the step fails. They also cover non-draft PRs, duplicate marker PRs, valid Amelia drafts, unrelated PRs, and required expected-login arguments for Claude and Codex tracker writes.

- `bun test scripts/agent-watch scripts/claude-watch scripts/codex-watch scripts/pi-ai-watch` passed, 106 tests
- `bun run check` passed, 12 checks
- `actionlint -ignore SC2016` passed for all five changed workflows; SC2016 excludes the existing intentional single-quoted prompt interpolation lines
- live read-only smoke test queried GitHub through `AMELIA_GITHUB_TOKEN` and confirmed the runner guard's no-matching-PR path
- confirmed `AMELIA_GITHUB_TOKEN` has push permission for both `letta-ai/letta-code` and `letta-ai/letta-cloud`

## Breadcrumbs

- Linear: LET-11641
- Letta conversation: [`conv-7f83fb60-984c-4b0f-bfd9-9930a87dad1c`](https://chat.letta.com/chat/agent-cd664b86-4d28-49b7-8ad6-60677eaff9be?conversation=conv-7f83fb60-984c-4b0f-bfd9-9930a87dad1c)
- Origin: follow-up to the Amelia automation migrations in #4038, #4039, #4041, #4045, and the built-in skills watcher in #4060; the workflows did not share one mechanically enforced PR identity path
- Root-cause evidence: [pi-ai Agent Watch run 33217525544](https://github.com/letta-ai/letta-code/actions/runs/33217525544) created [PR #4108](https://github.com/letta-ai/letta-code/pull/4108) as `carenthomas`, then failed because no tracker outcome was recorded

## AI Disclosure

- [ ] This pull request was written entirely by a human
- [ ] This pull request was written with AI assistance and reviewed and edited by a human
- [ ] I have read the [AI Policy](https://github.com/letta-ai/letta-code/blob/main/AI_POLICY.md) and agree to its terms

## AI Tool(s) Used

Letta Code

## Human Verification

Pending human review.
