### PR TITLE
fix(ci): make built-in skill watcher self-recovering

### DIFF
--- a/.github/agent-prompts/builtin-skills-agent-watch.md
+++ b/.github/agent-prompts/builtin-skills-agent-watch.md
@@ -2,6 +2,8 @@ You are Amelia running in your managed cloud sandbox for `letta-ai/letta-code`, 
 
 Your job is to audit one built-in skill against current Letta Code source, tests, official documentation, and any upstream contract the skill names. Either open one focused draft PR, record that the skill is current, or request human review.
 
+This is an automation run. The run inputs, credential boundaries, and final-result contract in this prompt are authoritative for this conversation even if general memory describes a different interactive workflow.
+
 ## Evidence model
 
 The selected skill is a set of trusted model instructions under `src/skills/builtin/`. A claim is current only when its command, flag, path, field, default, order, safety warning, or product behavior matches its owner.
@@ -21,9 +23,9 @@ Before running the sandbox bootstrap, resolve the watcher credential identity wi
 
 ## Sandbox setup
 
-The detector ran on a GitHub Actions runner, but your turn does not. Runner files and environment variables are unavailable in the sandbox. Run the exact `Sandbox bootstrap` block appended to this prompt. It clones the repository, checks out the exact candidate commit, installs dependencies, and rebuilds `/tmp/builtin-skills-watch-analysis.json` for the exact skill and audit timestamp.
+The detector ran on a GitHub Actions runner, but your turn does not. Runner files and environment variables are unavailable in the sandbox. Run the exact `Sandbox bootstrap` block appended to this prompt. It clones the repository, checks out the exact candidate commit, installs dependencies, and rebuilds the Analysis file for the exact skill and audit timestamp.
 
-After the block succeeds, use `SetWorkingDirectory` to select `/tmp/letta-code-builtin-skills-watch`. If that tool is unavailable, pass the absolute directory as `workdir` for every command.
+After the block succeeds, use `SetWorkingDirectory` to select the Repository checkout path from the run inputs. If that tool is unavailable, pass that absolute directory as `workdir` for every command.
 
 ## Required review behavior
 
@@ -80,7 +82,7 @@ If an exact candidate PR already exists and is open, verify it and record that U
 
 ## Review evidence
 
-Before recording a terminal outcome, write `/tmp/builtin-skill-review-evidence.json`. This file makes the audit reviewable after a mutable documentation page or upstream project changes.
+Before recording a terminal outcome, write the Evidence file path from the run inputs. This file makes the audit reviewable after a mutable documentation page or upstream project changes.
 
 Use this exact shape:
 
@@ -109,11 +111,11 @@ Use this exact shape:
 }
 ```
 
-Include at least one source. Every source needs a revision, a content digest, or both. Use exact commits or package versions when available. For mutable documentation, hash the content and preserve the relevant exact excerpt. Do not put credentials, signed URLs, browser titles, or raw secret-bearing output in this file. Keep the complete evidence object below 650 bytes by grouping related claims and omitting redundant probes. An empty probe list is valid when source inspection is sufficient.
+Include at least one source. Every source needs a revision, a content digest, or both. Use exact commits or package versions when available. For mutable documentation, hash the content and preserve the relevant exact excerpt. Do not put credentials, signed URLs, browser titles, or raw secret-bearing output in this file. Keep the complete evidence object below 16 KiB. An empty probe list is valid when source inspection is sufficient.
 
 ## Result payload
 
-After the review and any PR creation, write `/tmp/builtin-skill-watch-result.json` with this exact shape:
+After the review and any PR creation, write the Result file path from the run inputs with this exact shape:
 
 ```json
 {
@@ -133,17 +135,17 @@ After the review and any PR creation, write `/tmp/builtin-skill-watch-result.jso
 }
 ```
 
-`pr_url` must be non-null only for `pr_created`. Replace the source and probe placeholders with objects, not strings. The nested evidence must exactly match `/tmp/builtin-skill-review-evidence.json`.
+`pr_url` must be non-null only for `pr_created`. Replace the source and probe placeholders with objects, not strings. The nested evidence must exactly match the Evidence file.
 
-Encode the complete result without line breaks:
+Validate and encode the complete result with the runner's own parser. From the repository checkout, replace the placeholders with the exact Analysis file and Result file paths from the run inputs:
 
 ```bash
-base64 -w0 /tmp/builtin-skill-watch-result.json
+env -u AMELIA_GITHUB_TOKEN -u GH_TOKEN -u GITHUB_TOKEN bun scripts/builtin-skills-watch/finalize-result.ts --analysis-file <analysis-file> --result-file <result-file>
 ```
 
 ## Final response
 
-Respond with exactly one line and no Markdown fence:
+Respond with exactly the single line printed by `finalize-result.ts` and no Markdown fence:
 
 ```text
 SKILL_WATCH_RESULT <base64-result>

--- a/.github/workflows/builtin-skills-agent-watch.yml
+++ b/.github/workflows/builtin-skills-agent-watch.yml
@@ -26,6 +26,7 @@ jobs:
     permissions:
       contents: read
       issues: write
+      pull-requests: write
     outputs:
       expected_github_login: ${{ steps.github-identity.outputs.login }}
       matrix: ${{ steps.detect.outputs.matrix }}
@@ -46,10 +47,34 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      - name: Resolve Amelia GitHub identity
+        id: github-identity
+        env:
+          GH_TOKEN: ${{ secrets.AMELIA_GITHUB_TOKEN }}
+        run: |
+          login=$(gh api user --jq .login)
+          echo "login=$login" >> "$GITHUB_OUTPUT"
+          echo "Authenticated GitHub login: $login"
+
+      - name: Reconcile existing watcher PRs
+        env:
+          DRY_RUN: ${{ inputs.dry_run }}
+          GH_TOKEN: ${{ secrets.AMELIA_GITHUB_TOKEN }}
+          EXPECTED_GITHUB_LOGIN: ${{ steps.github-identity.outputs.login }}
+        run: |
+          ARGS=(
+            --tracker-issue 4065
+            --expected-github-login "$EXPECTED_GITHUB_LOGIN"
+          )
+          if [ "$DRY_RUN" = "true" ]; then
+            ARGS+=(--dry-run)
+          fi
+          bun scripts/builtin-skills-watch/reconcile-results.ts "${ARGS[@]}"
+
       - name: Prepare built-in skill audits
         id: detect
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.AMELIA_GITHUB_TOKEN }}
           REQUESTED_SKILL: ${{ inputs.skill }}
           DRY_RUN: ${{ inputs.dry_run }}
         run: |
@@ -74,16 +99,6 @@ jobs:
             ${{ runner.temp }}/builtin-skills-watch-analyses
           retention-days: 3
 
-      - name: Resolve Amelia GitHub identity
-        if: steps.detect.outputs.should_run_agent == 'true'
-        id: github-identity
-        env:
-          GH_TOKEN: ${{ secrets.AMELIA_GITHUB_TOKEN }}
-        run: |
-          login=$(gh api user --jq .login)
-          echo "login=$login" >> "$GITHUB_OUTPUT"
-          echo "Authenticated GitHub login: $login"
-
   review:
     needs: prepare
     if: needs.prepare.outputs.should_run_agent == 'true'
@@ -93,6 +108,7 @@ jobs:
       contents: read
     strategy:
       fail-fast: false
+      max-parallel: 4
       matrix: ${{ fromJSON(needs.prepare.outputs.matrix) }}
     steps:
       - name: Checkout
@@ -116,6 +132,13 @@ jobs:
           AUDIT_AT: ${{ matrix.audit_at }}
           PREVIOUS_AUDIT_BASE64: ${{ matrix.previous_audit_base64 }}
         run: |
+          WATCH_ROOT="/tmp/letta-code-builtin-skills-watch-$GITHUB_RUN_ID-$SKILL"
+          WATCH_REPO="$WATCH_ROOT/repo"
+          WATCH_ANALYSES="$WATCH_ROOT/analyses"
+          WATCH_ANALYSIS="$WATCH_ROOT/analysis.json"
+          WATCH_MANIFEST="$WATCH_ROOT/manifest.json"
+          WATCH_EVIDENCE="$WATCH_ROOT/evidence.json"
+          WATCH_RESULT="$WATCH_ROOT/result.json"
           {
             echo "prompt<<AMELIA_PROMPT_EOF"
             cat .github/agent-prompts/builtin-skills-agent-watch.md
@@ -130,6 +153,11 @@ jobs:
             echo "- Current commit: $CURRENT_SHA"
             echo "- Skill digest: $SKILL_DIGEST"
             echo "- Audit timestamp: $AUDIT_AT"
+            echo "- Sandbox workspace: $WATCH_ROOT"
+            echo "- Repository checkout: $WATCH_REPO"
+            echo "- Analysis file: $WATCH_ANALYSIS"
+            echo "- Evidence file: $WATCH_EVIDENCE"
+            echo "- Result file: $WATCH_RESULT"
             echo
             echo "## Sandbox bootstrap"
             echo
@@ -137,16 +165,17 @@ jobs:
             echo
             echo '```bash'
             echo 'set -euo pipefail'
-            echo 'rm -rf /tmp/letta-code-builtin-skills-watch /tmp/builtin-skills-watch-analyses'
+            echo "rm -rf \"$WATCH_ROOT\""
+            echo "mkdir -p \"$WATCH_ROOT\""
             # The token expands later in Amelia's sandbox.
             # shellcheck disable=SC2016
-            echo 'test -n "$AMELIA_GITHUB_TOKEN" && GITHUB_TOKEN= GH_TOKEN="$AMELIA_GITHUB_TOKEN" gh repo clone letta-ai/letta-code /tmp/letta-code-builtin-skills-watch -- --no-checkout'
-            echo 'cd /tmp/letta-code-builtin-skills-watch'
+            echo "test -n \"\$AMELIA_GITHUB_TOKEN\" && GITHUB_TOKEN= GH_TOKEN=\"\$AMELIA_GITHUB_TOKEN\" gh repo clone letta-ai/letta-code \"$WATCH_REPO\" -- --no-checkout"
+            echo "cd \"$WATCH_REPO\""
             echo "env -u AMELIA_GITHUB_TOKEN -u GH_TOKEN -u GITHUB_TOKEN git checkout \"$CURRENT_SHA\""
             echo 'env -u AMELIA_GITHUB_TOKEN -u GH_TOKEN -u GITHUB_TOKEN bun install --frozen-lockfile'
-            echo "env -u AMELIA_GITHUB_TOKEN -u GH_TOKEN -u GITHUB_TOKEN GITHUB_SERVER_URL=https://github.com GITHUB_REPOSITORY=letta-ai/letta-code GITHUB_RUN_ID=\"$GITHUB_RUN_ID\" bun scripts/builtin-skills-watch/agent-watch.ts --dry-run --skill \"$SKILL\" --current-sha \"$CURRENT_SHA\" --audit-at \"$AUDIT_AT\" --previous-audit-base64 \"$PREVIOUS_AUDIT_BASE64\" --analysis-dir /tmp/builtin-skills-watch-analyses --manifest-file /tmp/builtin-skills-watch-manifest.json > /tmp/builtin-skills-watch-analysis.log"
-            echo "cp /tmp/builtin-skills-watch-analyses/\"$SKILL\".json /tmp/builtin-skills-watch-analysis.json"
-            echo "jq -e '.candidate_id == \"$CANDIDATE_ID\" and .skill == \"$SKILL\" and .current_sha == \"$CURRENT_SHA\" and .skill_digest == \"$SKILL_DIGEST\"' /tmp/builtin-skills-watch-analysis.json > /dev/null"
+            echo "env -u AMELIA_GITHUB_TOKEN -u GH_TOKEN -u GITHUB_TOKEN GITHUB_SERVER_URL=https://github.com GITHUB_REPOSITORY=letta-ai/letta-code GITHUB_RUN_ID=\"$GITHUB_RUN_ID\" bun scripts/builtin-skills-watch/agent-watch.ts --dry-run --skill \"$SKILL\" --current-sha \"$CURRENT_SHA\" --audit-at \"$AUDIT_AT\" --previous-audit-base64 \"$PREVIOUS_AUDIT_BASE64\" --analysis-dir \"$WATCH_ANALYSES\" --manifest-file \"$WATCH_MANIFEST\" > \"$WATCH_ROOT/analysis.log\""
+            echo "cp \"$WATCH_ANALYSES/$SKILL.json\" \"$WATCH_ANALYSIS\""
+            echo "jq -e '.candidate_id == \"$CANDIDATE_ID\" and .skill == \"$SKILL\" and .current_sha == \"$CURRENT_SHA\" and .skill_digest == \"$SKILL_DIGEST\"' \"$WATCH_ANALYSIS\" > /dev/null"
             echo '```'
             echo "AMELIA_PROMPT_EOF"
           } >> "$GITHUB_OUTPUT"
@@ -155,6 +184,8 @@ jobs:
       - name: Ask Amelia to audit built-in skill
         id: review
         uses: letta-ai/letta-code-action@4b8e508a523ff576fee09be1432d6f39158c272c
+        env:
+          LETTA_REQUEST_TIMEOUT_MS: "2700000"
         with:
           letta_api_key: ${{ secrets.AMELIA_LETTA_API_KEY }}
           github_token: ${{ secrets.AMELIA_GITHUB_TOKEN }}
@@ -182,6 +213,19 @@ jobs:
             --output /dev/null \
             "https://api.letta.com/v1/conversations/$CONVERSATION_ID"
 
+      - name: Cancel failed watcher turn
+        if: always() && steps.review.outcome == 'failure' && steps.review.outputs.conversation_id != ''
+        continue-on-error: true
+        env:
+          LETTA_API_KEY: ${{ secrets.AMELIA_LETTA_API_KEY }}
+          CONVERSATION_ID: ${{ steps.review.outputs.conversation_id }}
+        run: |
+          curl --fail-with-body --silent --show-error \
+            --request POST \
+            --header "Authorization: Bearer $LETTA_API_KEY" \
+            --output /dev/null \
+            "https://api.letta.com/v1/conversations/$CONVERSATION_ID/cancel"
+
       - name: Enforce Amelia PR identity
         if: always()
         env:
@@ -197,30 +241,53 @@ jobs:
       - name: Extract Amelia result
         if: always()
         env:
+          CANDIDATE_ID: ${{ matrix.candidate_id }}
+          CONVERSATION_ID: ${{ steps.review.outputs.conversation_id }}
           EXECUTION_FILE: ${{ steps.review.outputs.execution_file }}
           REVIEW_OUTCOME: ${{ steps.review.outcome }}
+          SKILL: ${{ matrix.skill }}
         run: |
+          result_dir="$RUNNER_TEMP/builtin-skill-result"
+          mkdir -p "$result_dir"
+          write_failure() {
+            jq -n \
+              --arg candidate_id "$CANDIDATE_ID" \
+              --arg skill "$SKILL" \
+              --arg kind "$1" \
+              --arg message "$2" \
+              --arg conversation_id "$CONVERSATION_ID" \
+              '{schema_version: 1, candidate_id: $candidate_id, skill: $skill, kind: $kind, message: $message, conversation_id: (if $conversation_id == "" then null else $conversation_id end)}' \
+              > "$result_dir/failure.json"
+          }
           if [ "$REVIEW_OUTCOME" != "success" ]; then
+            write_failure action_failed "Letta Code Action failed before returning a result"
             exit 0
           fi
           if [ ! -f "$EXECUTION_FILE" ]; then
-            echo "Amelia execution file is missing" >&2
-            exit 1
+            write_failure execution_file_missing "Letta Code Action returned no execution file"
+            exit 0
           fi
           result=$(jq -r '[.[] | select(.type == "result" and (.result | type) == "string")] | last | (.result // "" | split("\n") | map(gsub("^\\s+|\\s+$"; "") | select(length > 0)) | last // "")' "$EXECUTION_FILE")
-          if [ "${#result}" -gt 8192 ] || [[ ! "$result" =~ ^SKILL_WATCH_RESULT\ [A-Za-z0-9+/=]+$ ]]; then
-            echo "Unexpected Amelia result format" >&2
-            exit 1
+          if [ "${#result}" -gt 32768 ] || [[ ! "$result" =~ ^SKILL_WATCH_RESULT\ [A-Za-z0-9+/=]+$ ]]; then
+            write_failure result_marker_missing "Final response did not contain one bounded SKILL_WATCH_RESULT line"
+            exit 0
           fi
-          mkdir -p "$RUNNER_TEMP/builtin-skill-result"
-          printf '%s' "${result#SKILL_WATCH_RESULT }" | base64 --decode > "$RUNNER_TEMP/builtin-skill-result/result.json"
+          if ! printf '%s' "${result#SKILL_WATCH_RESULT }" | base64 --decode > "$result_dir/result.json"; then
+            rm -f "$result_dir/result.json"
+            write_failure result_decode_failed "SKILL_WATCH_RESULT was not valid base64"
+            exit 0
+          fi
+          if ! jq -e . "$result_dir/result.json" > /dev/null; then
+            rm -f "$result_dir/result.json"
+            write_failure result_decode_failed "SKILL_WATCH_RESULT did not decode to JSON"
+          fi
 
       - name: Upload Amelia result
         if: always()
         uses: actions/upload-artifact@v7
         with:
           name: builtin-skill-result-${{ matrix.skill }}
-          path: ${{ runner.temp }}/builtin-skill-result/result.json
+          path: ${{ runner.temp }}/builtin-skill-result
           if-no-files-found: ignore
           retention-days: 3
 
@@ -259,6 +326,7 @@ jobs:
         with:
           pattern: builtin-skill-result-*
           path: ${{ runner.temp }}/results
+          merge-multiple: false
 
       - name: Validate and record every result
         env:

--- a/scripts/builtin-skills-watch/aggregate-results.ts
+++ b/scripts/builtin-skills-watch/aggregate-results.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env bun
 /** Validates a daily skill-review batch and updates the tracker once. */
 
-import { existsSync, readFileSync } from "node:fs";
+import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import {
   type BuiltinSkillWatchAnalysis,
@@ -9,6 +9,10 @@ import {
   DEFAULT_TARGET_REPO,
 } from "./analysis.ts";
 import { createIssueComment, editIssueBody } from "./github.ts";
+import {
+  discoverReviewArtifacts,
+  formatFailureReceipt,
+} from "./result-artifacts.ts";
 import {
   hasTerminalCandidate,
   parseTrackerState,
@@ -103,6 +107,7 @@ function main(): void {
   let state = parseTrackerState(original.body);
   let failed = false;
   const outcomes: ValidatedOutcome[] = [];
+  const artifacts = discoverReviewArtifacts(args.resultsDir as string);
 
   for (const candidate of manifest.candidates) {
     const analysisPath = join(
@@ -130,14 +135,14 @@ function main(): void {
     analysis.workflow_run_url = workflowRunUrl(pending.workflow_run_id);
     assertAnalysisIdentity(received, analysis);
 
-    const resultPath = join(
-      args.resultsDir as string,
-      `builtin-skill-result-${received.skill}`,
-      "result.json",
-    );
+    const resultPath = artifacts.results.get(received.candidate_id);
     try {
-      if (!existsSync(resultPath)) {
-        throw new Error("Amelia result artifact is missing");
+      if (!resultPath) {
+        const receipt = artifacts.failures.get(received.candidate_id);
+        if (receipt) throw new Error(formatFailureReceipt(receipt));
+        throw new Error(
+          `Amelia result artifact is missing for ${received.candidate_id}`,
+        );
       }
       const result = readReviewResult(resultPath, analysis);
       if (result.pr_url) {

--- a/scripts/builtin-skills-watch/evidence.test.ts
+++ b/scripts/builtin-skills-watch/evidence.test.ts
@@ -29,6 +29,27 @@ describe("review evidence", () => {
     expect(digestReviewEvidence(evidence)).toMatch(/^[a-f0-9]{64}$/);
   });
 
+  test("accepts RFC 3339 UTC timestamps without milliseconds", () => {
+    expect(() =>
+      parseReviewEvidence({
+        schema_version: 1,
+        candidate_id: "candidate",
+        skill: "creating-skills",
+        sources: [
+          {
+            locator: "src/skills/builtin/creating-skills/SKILL.md",
+            revision: "a".repeat(40),
+            content_digest: null,
+            retrieved_at: "2026-08-26T00:00:00Z",
+            excerpt: "current source",
+            claims: ["checked current source"],
+          },
+        ],
+        probes: [],
+      }),
+    ).not.toThrow();
+  });
+
   test("requires at least one source", () => {
     expect(() =>
       parseReviewEvidence({
@@ -38,7 +59,7 @@ describe("review evidence", () => {
         sources: [],
         probes: [],
       }),
-    ).toThrow("sources are invalid");
+    ).toThrow("between 1 and 5 sources");
   });
 
   test("rejects malformed digests and timestamps", () => {
@@ -59,28 +80,51 @@ describe("review evidence", () => {
         ],
         probes: [],
       }),
-    ).toThrow("sources are invalid");
+    ).toThrow("content_digest is invalid");
   });
 
-  test("rejects evidence too large for the tracker", () => {
+  test("accepts production-sized evidence larger than the old tracker limit", () => {
+    const evidence = parseReviewEvidence({
+      schema_version: 1,
+      candidate_id: "candidate",
+      skill: "creating-skills",
+      sources: Array.from({ length: 5 }, (_, index) => ({
+        locator: `https://docs.letta.com/source-${index}`,
+        revision: "a".repeat(40),
+        content_digest: "b".repeat(64),
+        retrieved_at: "2026-08-26T00:00:00.000Z",
+        excerpt: "q".repeat(300),
+        claims: Array.from({ length: 5 }, () => "z".repeat(300)),
+      })),
+      probes: [],
+    });
+
+    expect(Buffer.byteLength(JSON.stringify(evidence), "utf8")).toBeGreaterThan(
+      650,
+    );
+  });
+
+  test("still rejects evidence larger than an issue comment can safely hold", () => {
     expect(() =>
       parseReviewEvidence({
         schema_version: 1,
         candidate_id: "candidate",
         skill: "creating-skills",
-        sources: [
-          {
-            locator: "x".repeat(500),
-            revision: "y".repeat(300),
-            content_digest: null,
-            retrieved_at: "2026-08-26T00:00:00.000Z",
-            excerpt: "q".repeat(300),
-            claims: ["z".repeat(500)],
-          },
-        ],
-        probes: [],
+        sources: Array.from({ length: 5 }, (_, index) => ({
+          locator: `https://docs.letta.com/${"x".repeat(450)}-${index}`,
+          revision: "y".repeat(300),
+          content_digest: null,
+          retrieved_at: "2026-08-26T00:00:00.000Z",
+          excerpt: "q".repeat(300),
+          claims: Array.from({ length: 5 }, () => "z".repeat(500)),
+        })),
+        probes: Array.from({ length: 5 }, () => ({
+          command: "c".repeat(500),
+          result_digest: "d".repeat(64),
+          summary: "s".repeat(500),
+        })),
       }),
-    ).toThrow("exceeds 650 bytes");
+    ).toThrow("exceeds 16384 bytes");
   });
 
   test("requires a revision or digest and rejects unknown fields", () => {
@@ -100,7 +144,7 @@ describe("review evidence", () => {
         sources: [source],
         probes: [],
       }),
-    ).toThrow("sources are invalid");
+    ).toThrow("requires a revision or content_digest");
     expect(() =>
       parseReviewEvidence({
         schema_version: 1,
@@ -109,6 +153,6 @@ describe("review evidence", () => {
         sources: [{ ...source, content_digest: "a".repeat(64), secret: "no" }],
         probes: [],
       }),
-    ).toThrow("sources are invalid");
+    ).toThrow("unknown or missing fields");
   });
 });

--- a/scripts/builtin-skills-watch/evidence.ts
+++ b/scripts/builtin-skills-watch/evidence.ts
@@ -3,7 +3,7 @@ import { createHash } from "node:crypto";
 const MAX_SOURCES = 5;
 const MAX_PROBES = 5;
 const MAX_CLAIMS_PER_SOURCE = 5;
-const MAX_SERIALIZED_BYTES = 650;
+const MAX_SERIALIZED_BYTES = 16 * 1024;
 
 export interface EvidenceSource {
   locator: string;
@@ -51,29 +51,24 @@ export function parseReviewEvidence(value: unknown): ReviewEvidence {
   if (
     !Array.isArray(value.sources) ||
     value.sources.length === 0 ||
-    value.sources.length > MAX_SOURCES ||
-    !value.sources.every(isEvidenceSource)
+    value.sources.length > MAX_SOURCES
   ) {
-    throw new TypeError("review evidence sources are invalid");
+    throw new TypeError("review evidence must include between 1 and 5 sources");
   }
-  if (
-    !Array.isArray(value.probes) ||
-    value.probes.length > MAX_PROBES ||
-    !value.probes.every(isEvidenceProbe)
-  ) {
-    throw new TypeError("review evidence probes are invalid");
+  if (!Array.isArray(value.probes) || value.probes.length > MAX_PROBES) {
+    throw new TypeError("review evidence must include at most 5 probes");
   }
   const evidence: ReviewEvidence = {
     schema_version: 1,
     candidate_id: value.candidate_id,
     skill: value.skill,
-    sources: value.sources,
-    probes: value.probes,
+    sources: value.sources.map(parseEvidenceSource),
+    probes: value.probes.map(parseEvidenceProbe),
   };
   if (
     Buffer.byteLength(JSON.stringify(evidence), "utf8") > MAX_SERIALIZED_BYTES
   ) {
-    throw new TypeError("review evidence exceeds 650 bytes");
+    throw new TypeError("review evidence exceeds 16384 bytes");
   }
   return evidence;
 }
@@ -82,44 +77,77 @@ export function digestReviewEvidence(evidence: ReviewEvidence): string {
   return createHash("sha256").update(JSON.stringify(evidence)).digest("hex");
 }
 
-function isEvidenceSource(value: unknown): value is EvidenceSource {
-  return (
-    isRecord(value) &&
-    hasExactKeys(value, [
+function parseEvidenceSource(value: unknown, index: number): EvidenceSource {
+  const description = `review evidence source ${index + 1}`;
+  if (
+    !isRecord(value) ||
+    !hasExactKeys(value, [
       "locator",
       "revision",
       "content_digest",
       "retrieved_at",
       "excerpt",
       "claims",
-    ]) &&
-    isBoundedString(value.locator, 500) &&
-    (value.revision === null || isBoundedString(value.revision, 300)) &&
-    (value.content_digest === null || isDigest(value.content_digest)) &&
-    (value.revision !== null || value.content_digest !== null) &&
-    isIsoTimestamp(value.retrieved_at) &&
-    isBoundedString(value.excerpt, 300) &&
-    Array.isArray(value.claims) &&
-    value.claims.length > 0 &&
-    value.claims.length <= MAX_CLAIMS_PER_SOURCE &&
-    value.claims.every((claim) => isBoundedString(claim, 500))
-  );
+    ])
+  ) {
+    throw new TypeError(`${description} has unknown or missing fields`);
+  }
+  if (!isBoundedString(value.locator, 500)) {
+    throw new TypeError(`${description} locator is invalid`);
+  }
+  if (value.revision !== null && !isBoundedString(value.revision, 300)) {
+    throw new TypeError(`${description} revision is invalid`);
+  }
+  if (value.content_digest !== null && !isDigest(value.content_digest)) {
+    throw new TypeError(`${description} content_digest is invalid`);
+  }
+  if (value.revision === null && value.content_digest === null) {
+    throw new TypeError(`${description} requires a revision or content_digest`);
+  }
+  if (!isIsoTimestamp(value.retrieved_at)) {
+    throw new TypeError(`${description} retrieved_at is not an ISO timestamp`);
+  }
+  if (!isBoundedString(value.excerpt, 300)) {
+    throw new TypeError(`${description} excerpt is invalid`);
+  }
+  if (
+    !Array.isArray(value.claims) ||
+    value.claims.length === 0 ||
+    value.claims.length > MAX_CLAIMS_PER_SOURCE ||
+    !value.claims.every((claim) => isBoundedString(claim, 500))
+  ) {
+    throw new TypeError(`${description} claims are invalid`);
+  }
+  return value as unknown as EvidenceSource;
 }
 
-function isEvidenceProbe(value: unknown): value is EvidenceProbe {
-  return (
-    isRecord(value) &&
-    hasExactKeys(value, ["command", "result_digest", "summary"]) &&
-    isBoundedString(value.command, 500) &&
-    isDigest(value.result_digest) &&
-    isBoundedString(value.summary, 500)
-  );
+function parseEvidenceProbe(value: unknown, index: number): EvidenceProbe {
+  const description = `review evidence probe ${index + 1}`;
+  if (
+    !isRecord(value) ||
+    !hasExactKeys(value, ["command", "result_digest", "summary"])
+  ) {
+    throw new TypeError(`${description} has unknown or missing fields`);
+  }
+  if (!isBoundedString(value.command, 500)) {
+    throw new TypeError(`${description} command is invalid`);
+  }
+  if (!isDigest(value.result_digest)) {
+    throw new TypeError(`${description} result_digest is invalid`);
+  }
+  if (!isBoundedString(value.summary, 500)) {
+    throw new TypeError(`${description} summary is invalid`);
+  }
+  return value as unknown as EvidenceProbe;
 }
 
 function isIsoTimestamp(value: unknown): value is string {
   if (typeof value !== "string") return false;
   const parsed = new Date(value);
-  return !Number.isNaN(parsed.getTime()) && parsed.toISOString() === value;
+  return (
+    !Number.isNaN(parsed.getTime()) &&
+    /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,3})?Z$/.test(value)
+  );
 }
 
 function isDigest(value: unknown): value is string {

--- a/scripts/builtin-skills-watch/finalize-result.test.ts
+++ b/scripts/builtin-skills-watch/finalize-result.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { BuiltinSkillWatchAnalysis } from "./analysis.ts";
+
+describe("review result finalization", () => {
+  test("validates with the runner parser before encoding the result", () => {
+    const directory = mkdtempSync(join(tmpdir(), "skill-result-finalizer-"));
+    try {
+      const analysis = fakeAnalysis();
+      const analysisFile = join(directory, "analysis.json");
+      const resultFile = join(directory, "result.json");
+      writeFileSync(analysisFile, JSON.stringify(analysis));
+      writeFileSync(resultFile, JSON.stringify(fakeResult(analysis)));
+
+      const finalized = Bun.spawnSync([
+        "bun",
+        "scripts/builtin-skills-watch/finalize-result.ts",
+        "--analysis-file",
+        analysisFile,
+        "--result-file",
+        resultFile,
+      ]);
+
+      expect(finalized.exitCode).toBe(0);
+      const line = finalized.stdout.toString().trim();
+      expect(line).toStartWith("SKILL_WATCH_RESULT ");
+      expect(
+        JSON.parse(
+          Buffer.from(
+            line.slice("SKILL_WATCH_RESULT ".length),
+            "base64",
+          ).toString("utf8"),
+        ),
+      ).toEqual(fakeResult(analysis));
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  test("rejects a result for another candidate", () => {
+    const directory = mkdtempSync(join(tmpdir(), "skill-result-finalizer-"));
+    try {
+      const analysis = fakeAnalysis();
+      const analysisFile = join(directory, "analysis.json");
+      const resultFile = join(directory, "result.json");
+      writeFileSync(analysisFile, JSON.stringify(analysis));
+      writeFileSync(
+        resultFile,
+        JSON.stringify({
+          ...fakeResult(analysis),
+          candidate_id: "creating-skills@bbbbbbbbbbbb-abcdef0123456789",
+        }),
+      );
+
+      const finalized = Bun.spawnSync([
+        "bun",
+        "scripts/builtin-skills-watch/finalize-result.ts",
+        "--analysis-file",
+        analysisFile,
+        "--result-file",
+        resultFile,
+      ]);
+
+      expect(finalized.exitCode).not.toBe(0);
+      expect(finalized.stderr.toString()).toContain(
+        "does not match the pending candidate",
+      );
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+});
+
+function fakeAnalysis(): BuiltinSkillWatchAnalysis {
+  const skill = "creating-skills";
+  return {
+    schema_version: 1,
+    candidate_id: `${skill}@${"a".repeat(12)}-abcdef0123456789`,
+    skill,
+    skill_path: `src/skills/builtin/${skill}`,
+    skill_files: [`src/skills/builtin/${skill}/SKILL.md`],
+    skill_digest: "b".repeat(64),
+    current_sha: "a".repeat(40),
+    audit_at: "2026-08-26T00:00:00.000Z",
+    previous_audit: null,
+    repository_changes: {
+      previous_sha: null,
+      changed_files: [],
+      commits: [],
+      history_available: false,
+      truncated: false,
+    },
+    skill_inventory: [skill],
+    workflow_run_url: "https://github.com/letta-ai/letta-code/actions/runs/1",
+  };
+}
+
+function fakeResult(analysis: BuiltinSkillWatchAnalysis) {
+  return {
+    schema_version: 1,
+    candidate_id: analysis.candidate_id,
+    skill: analysis.skill,
+    outcome: "no_drift",
+    notes: "current source and skill agree",
+    pr_url: null,
+    evidence: {
+      schema_version: 1,
+      candidate_id: analysis.candidate_id,
+      skill: analysis.skill,
+      sources: [
+        {
+          locator: analysis.skill_path,
+          revision: analysis.current_sha,
+          content_digest: analysis.skill_digest,
+          retrieved_at: analysis.audit_at,
+          excerpt: "the current skill matches its owning source",
+          claims: ["checked current source"],
+        },
+      ],
+      probes: [],
+    },
+  } as const;
+}

--- a/scripts/builtin-skills-watch/finalize-result.ts
+++ b/scripts/builtin-skills-watch/finalize-result.ts
@@ -1,0 +1,44 @@
+#!/usr/bin/env bun
+/** Validates and encodes one agent-authored review result for the runner. */
+
+import { readAnalysis, readReviewResult } from "./update-tracker.ts";
+
+interface Args {
+  analysisFile: string | null;
+  resultFile: string | null;
+}
+
+function parseArgs(argv: string[]): Args {
+  const args: Args = { analysisFile: null, resultFile: null };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--analysis-file") {
+      args.analysisFile = argv[++index] ?? null;
+    } else if (arg === "--result-file") {
+      args.resultFile = argv[++index] ?? null;
+    } else if (arg === "--help" || arg === "-h") {
+      console.log(
+        "Usage: bun scripts/builtin-skills-watch/finalize-result.ts --analysis-file FILE --result-file FILE",
+      );
+      process.exit(0);
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+  if (!args.analysisFile || !args.resultFile) {
+    throw new Error("--analysis-file and --result-file are required");
+  }
+  return args;
+}
+
+function main(): void {
+  const args = parseArgs(process.argv.slice(2));
+  const analysis = readAnalysis(args.analysisFile as string);
+  const result = readReviewResult(args.resultFile as string, analysis);
+  const encoded = Buffer.from(JSON.stringify(result), "utf8").toString(
+    "base64",
+  );
+  console.log(`SKILL_WATCH_RESULT ${encoded}`);
+}
+
+if (import.meta.main) main();

--- a/scripts/builtin-skills-watch/reconcile-results.test.ts
+++ b/scripts/builtin-skills-watch/reconcile-results.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from "bun:test";
+import {
+  type CandidatePullRequest,
+  selectCanonicalPullRequest,
+} from "./reconcile-results.ts";
+
+describe("pending watcher PR reconciliation", () => {
+  test("prefers a merged PR and closes every open duplicate", () => {
+    const merged = pullRequest(4067, "MERGED");
+    const firstDuplicate = pullRequest(4077, "OPEN");
+    const secondDuplicate = pullRequest(4099, "OPEN");
+
+    expect(
+      selectCanonicalPullRequest([firstDuplicate, secondDuplicate, merged]),
+    ).toEqual({
+      canonical: merged,
+      duplicateOpen: [firstDuplicate, secondDuplicate],
+    });
+  });
+
+  test("uses the oldest open PR when no candidate was merged", () => {
+    const older = pullRequest(4078, "OPEN");
+    const newer = pullRequest(4098, "OPEN");
+
+    expect(selectCanonicalPullRequest([newer, older])).toEqual({
+      canonical: older,
+      duplicateOpen: [newer],
+    });
+  });
+
+  test("ignores closed unmerged PRs and rejects multiple merged PRs", () => {
+    expect(selectCanonicalPullRequest([pullRequest(1, "CLOSED")])).toEqual({
+      canonical: null,
+      duplicateOpen: [],
+    });
+    expect(() =>
+      selectCanonicalPullRequest([
+        pullRequest(1, "MERGED"),
+        pullRequest(2, "MERGED"),
+      ]),
+    ).toThrow("Multiple merged watcher PRs");
+  });
+});
+
+function pullRequest(number: number, state: string): CandidatePullRequest {
+  return {
+    number,
+    author: { login: "amelia-letta" },
+    baseRefName: "main",
+    body: "Builtin-skill-watch: creating-skills@aaaaaaaaaaaa-0000000000000001",
+    files: [{ path: "src/skills/builtin/creating-skills/SKILL.md" }],
+    headRefOid: number.toString(16).padStart(40, "0"),
+    isDraft: state === "OPEN",
+    mergedAt: state === "MERGED" ? "2026-08-27T00:00:00Z" : null,
+    state,
+    url: `https://github.com/letta-ai/letta-code/pull/${number}`,
+  };
+}

--- a/scripts/builtin-skills-watch/reconcile-results.ts
+++ b/scripts/builtin-skills-watch/reconcile-results.ts
@@ -1,0 +1,311 @@
+#!/usr/bin/env bun
+/** Reconciles pending tracker candidates against PR side effects before retries. */
+
+import {
+  type BuiltinSkillWatchAnalysis,
+  buildAnalysis,
+  DEFAULT_TARGET_REPO,
+  listBuiltinSkillsAtCommit,
+} from "./analysis.ts";
+import type { ReviewEvidence } from "./evidence.ts";
+import { createIssueComment, editIssueBody, ghJson, runGh } from "./github.ts";
+import {
+  parseTrackerState,
+  recordOutcome,
+  renderTrackerBody,
+} from "./tracker.ts";
+import {
+  getOpenTrackerIssue,
+  type PullRequestView,
+  verifyReconciledPullRequest,
+} from "./update-tracker.ts";
+
+interface Args {
+  repo: string;
+  trackerIssue: number | null;
+  expectedGithubLogin: string | null;
+  dryRun: boolean;
+}
+
+export interface CandidatePullRequest extends PullRequestView {
+  mergedAt: string | null;
+  number: number;
+}
+
+export interface PullRequestReconciliation {
+  canonical: CandidatePullRequest | null;
+  duplicateOpen: CandidatePullRequest[];
+}
+
+function parseArgs(argv: string[]): Args {
+  const args: Args = {
+    repo: DEFAULT_TARGET_REPO,
+    trackerIssue: null,
+    expectedGithubLogin: null,
+    dryRun: false,
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--repo") args.repo = argv[++index] ?? args.repo;
+    else if (arg === "--tracker-issue") {
+      args.trackerIssue = Number(argv[++index]);
+    } else if (arg === "--expected-github-login") {
+      args.expectedGithubLogin = argv[++index] ?? null;
+    } else if (arg === "--dry-run") args.dryRun = true;
+    else if (arg === "--help" || arg === "-h") {
+      console.log(
+        "Usage: bun scripts/builtin-skills-watch/reconcile-results.ts --tracker-issue ISSUE --expected-github-login LOGIN [--repo OWNER/REPO] [--dry-run]",
+      );
+      process.exit(0);
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+  if (!args.trackerIssue || Number.isNaN(args.trackerIssue)) {
+    throw new Error("--tracker-issue is required");
+  }
+  if (!args.expectedGithubLogin) {
+    throw new Error("--expected-github-login is required");
+  }
+  return args;
+}
+
+function main(): void {
+  const args = parseArgs(process.argv.slice(2));
+  assertAuthenticatedLogin(args.expectedGithubLogin as string);
+  const tracker = getOpenTrackerIssue(args.repo, args.trackerIssue as number);
+  let state = parseTrackerState(tracker.body);
+  const inventory = listBuiltinSkillsAtCommit("HEAD");
+  let reconciled = 0;
+
+  for (const skill of Object.keys(state.pending).sort()) {
+    const pending = state.pending[skill];
+    if (!pending) continue;
+    const analysis = buildAnalysis({
+      skill,
+      currentSha: pending.current_sha,
+      auditAt: pending.audit_at,
+      previousAudit: previousAudit(state, skill),
+    });
+    analysis.workflow_run_url = workflowRunUrl(pending.workflow_run_id);
+    const pullRequests = findCandidatePullRequests(
+      args.repo,
+      analysis.candidate_id,
+    );
+    const selected = selectCanonicalPullRequest(pullRequests);
+    if (!selected.canonical) continue;
+
+    verifyReconciledPullRequest(
+      args.repo,
+      selected.canonical.url,
+      analysis,
+      args.expectedGithubLogin as string,
+    );
+    for (const duplicate of selected.duplicateOpen) {
+      verifyReconciledPullRequest(
+        args.repo,
+        duplicate.url,
+        analysis,
+        args.expectedGithubLogin as string,
+      );
+    }
+
+    if (args.dryRun) {
+      console.log(
+        `${analysis.skill}: would reconcile ${selected.canonical.url}${renderDuplicatePlan(selected.duplicateOpen)}`,
+      );
+      continue;
+    }
+
+    for (const duplicate of selected.duplicateOpen) {
+      closeDuplicatePullRequest(args.repo, duplicate, selected.canonical);
+    }
+    const evidence = reconciliationEvidence(analysis, selected.canonical);
+    const evidenceUrl = createIssueComment(
+      args.repo,
+      args.trackerIssue as number,
+      renderEvidenceComment(analysis, selected.canonical, evidence),
+    );
+    state = recordOutcome(state, {
+      analysis,
+      outcome: "pr_created",
+      notes: reconciliationNotes(selected.canonical),
+      prUrl: selected.canonical.url,
+      evidence,
+      evidenceUrl,
+    });
+    reconciled += 1;
+  }
+
+  if (args.dryRun) return;
+  const latest = getOpenTrackerIssue(args.repo, args.trackerIssue as number);
+  if (latest.body !== tracker.body) {
+    throw new Error(
+      "Tracker body changed while PR side effects were reconciled",
+    );
+  }
+  if (reconciled > 0) {
+    editIssueBody(
+      args.repo,
+      args.trackerIssue as number,
+      renderTrackerBody(state, inventory),
+    );
+  }
+  console.log(`Reconciled ${reconciled} pending built-in skill candidates`);
+}
+
+export function selectCanonicalPullRequest(
+  pullRequests: CandidatePullRequest[],
+): PullRequestReconciliation {
+  const merged = pullRequests
+    .filter((pullRequest) => pullRequest.state === "MERGED")
+    .sort(byPullRequestNumber);
+  if (merged.length > 1) {
+    throw new Error(
+      `Multiple merged watcher PRs found for one candidate: ${merged.map((pullRequest) => `#${pullRequest.number}`).join(", ")}`,
+    );
+  }
+  const open = pullRequests
+    .filter((pullRequest) => pullRequest.state === "OPEN")
+    .sort(byPullRequestNumber);
+  const canonical = merged[0] ?? open[0] ?? null;
+  return {
+    canonical,
+    duplicateOpen: canonical
+      ? open.filter((pullRequest) => pullRequest.number !== canonical.number)
+      : [],
+  };
+}
+
+function findCandidatePullRequests(
+  repo: string,
+  candidateId: string,
+): CandidatePullRequest[] {
+  const marker = `Builtin-skill-watch: ${candidateId}`;
+  return ghJson<CandidatePullRequest[]>([
+    "pr",
+    "list",
+    "--repo",
+    repo,
+    "--state",
+    "all",
+    "--search",
+    `${marker} in:body`,
+    "--limit",
+    "20",
+    "--json",
+    "number,state,isDraft,mergedAt,author,baseRefName,headRefOid,body,files,url",
+  ]).filter((pullRequest) => hasExactMarker(pullRequest.body, marker));
+}
+
+function assertAuthenticatedLogin(expectedGithubLogin: string): void {
+  const authenticated = ghJson<{ login: string }>(["api", "user"]).login;
+  if (authenticated !== expectedGithubLogin) {
+    throw new Error(
+      `Authenticated GitHub login ${authenticated} does not match ${expectedGithubLogin}`,
+    );
+  }
+}
+
+function closeDuplicatePullRequest(
+  repo: string,
+  duplicate: CandidatePullRequest,
+  canonical: CandidatePullRequest,
+): void {
+  runGh([
+    "pr",
+    "close",
+    String(duplicate.number),
+    "--repo",
+    repo,
+    "--comment",
+    `Closing as a duplicate of ${canonical.url}, which has the same exact built-in skill watcher candidate.`,
+  ]);
+}
+
+function reconciliationEvidence(
+  analysis: BuiltinSkillWatchAnalysis,
+  pullRequest: CandidatePullRequest,
+): ReviewEvidence {
+  const status = pullRequest.state === "MERGED" ? "merged" : "open draft";
+  return {
+    schema_version: 1,
+    candidate_id: analysis.candidate_id,
+    skill: analysis.skill,
+    sources: [
+      {
+        locator: pullRequest.url,
+        revision: pullRequest.headRefOid,
+        content_digest: null,
+        retrieved_at: new Date().toISOString(),
+        excerpt: `The ${status} watcher PR has the exact candidate marker and a validated skill-only diff.`,
+        claims: [
+          "the watcher already created and validated a PR for this exact candidate",
+        ],
+      },
+    ],
+    probes: [],
+  };
+}
+
+function renderEvidenceComment(
+  analysis: BuiltinSkillWatchAnalysis,
+  pullRequest: CandidatePullRequest,
+  evidence: ReviewEvidence,
+): string {
+  return [
+    `## Reconciled built-in skill audit: ${analysis.skill}`,
+    "",
+    `Candidate: \`${analysis.candidate_id}\``,
+    `PR: ${pullRequest.url}`,
+    `PR state: \`${pullRequest.state.toLowerCase()}\``,
+    "",
+    "```json",
+    JSON.stringify(evidence, null, 2),
+    "```",
+  ].join("\n");
+}
+
+function reconciliationNotes(pullRequest: CandidatePullRequest): string {
+  return pullRequest.state === "MERGED"
+    ? `reconciled merged watcher PR #${pullRequest.number}`
+    : `reconciled open draft watcher PR #${pullRequest.number}`;
+}
+
+function renderDuplicatePlan(duplicates: CandidatePullRequest[]): string {
+  return duplicates.length === 0
+    ? ""
+    : ` and close duplicate ${duplicates.map((pullRequest) => `#${pullRequest.number}`).join(", ")}`;
+}
+
+function previousAudit(
+  state: ReturnType<typeof parseTrackerState>,
+  skill: string,
+): BuiltinSkillWatchAnalysis["previous_audit"] {
+  const audit = state.skills[skill];
+  return audit
+    ? {
+        candidate_id: audit.candidate_id,
+        audited_sha: audit.audited_sha,
+        skill_digest: audit.skill_digest,
+        audited_at: audit.audited_at,
+      }
+    : null;
+}
+
+function workflowRunUrl(runId: string): string {
+  return `https://github.com/letta-ai/letta-code/actions/runs/${runId}`;
+}
+
+function hasExactMarker(body: string, marker: string): boolean {
+  return body.split(/\r?\n/).some((line) => line.trim() === marker);
+}
+
+function byPullRequestNumber(
+  left: CandidatePullRequest,
+  right: CandidatePullRequest,
+): number {
+  return left.number - right.number;
+}
+
+if (import.meta.main) main();

--- a/scripts/builtin-skills-watch/result-artifacts.test.ts
+++ b/scripts/builtin-skills-watch/result-artifacts.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  discoverReviewArtifacts,
+  formatFailureReceipt,
+} from "./result-artifacts.ts";
+
+const CANDIDATE = "creating-skills@aaaaaaaaaaaa-abcdef0123456789";
+
+describe("review artifact discovery", () => {
+  test("finds both nested and root-level result artifacts", () => {
+    const directory = mkdtempSync(join(tmpdir(), "skill-artifacts-"));
+    try {
+      const nested = join(directory, "builtin-skill-result-creating-skills");
+      mkdirSync(nested);
+      writeFileSync(
+        join(nested, "result.json"),
+        JSON.stringify({ candidate_id: CANDIDATE }),
+      );
+
+      const discovered = discoverReviewArtifacts(directory);
+      expect(discovered.results.get(CANDIDATE)).toBe(
+        join(nested, "result.json"),
+      );
+
+      rmSync(nested, { recursive: true });
+      writeFileSync(
+        join(directory, "result.json"),
+        JSON.stringify({ candidate_id: CANDIDATE }),
+      );
+      expect(discoverReviewArtifacts(directory).results.get(CANDIDATE)).toBe(
+        join(directory, "result.json"),
+      );
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  test("preserves a runner-authored failure receipt", () => {
+    const directory = mkdtempSync(join(tmpdir(), "skill-artifacts-"));
+    try {
+      writeFileSync(
+        join(directory, "failure.json"),
+        JSON.stringify({
+          schema_version: 1,
+          candidate_id: CANDIDATE,
+          skill: "creating-skills",
+          kind: "action_failed",
+          message: "Letta Code Action failed before returning a result",
+          conversation_id: "conv-123",
+        }),
+      );
+
+      const receipt =
+        discoverReviewArtifacts(directory).failures.get(CANDIDATE);
+      expect(receipt).toBeDefined();
+      expect(formatFailureReceipt(receipt!)).toContain("conversation conv-123");
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  test("rejects duplicate results for one candidate", () => {
+    const directory = mkdtempSync(join(tmpdir(), "skill-artifacts-"));
+    try {
+      mkdirSync(join(directory, "first"));
+      mkdirSync(join(directory, "second"));
+      for (const subdirectory of ["first", "second"]) {
+        writeFileSync(
+          join(directory, subdirectory, "result.json"),
+          JSON.stringify({ candidate_id: CANDIDATE }),
+        );
+      }
+      expect(() => discoverReviewArtifacts(directory)).toThrow(
+        `duplicate review result for ${CANDIDATE}`,
+      );
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+});

--- a/scripts/builtin-skills-watch/result-artifacts.ts
+++ b/scripts/builtin-skills-watch/result-artifacts.ts
@@ -1,0 +1,160 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { basename, join } from "node:path";
+
+export interface ReviewFailureReceipt {
+  schema_version: 1;
+  candidate_id: string;
+  skill: string;
+  kind:
+    | "action_failed"
+    | "execution_file_missing"
+    | "result_marker_missing"
+    | "result_decode_failed";
+  message: string;
+  conversation_id: string | null;
+}
+
+export interface ReviewArtifacts {
+  results: Map<string, string>;
+  failures: Map<string, ReviewFailureReceipt>;
+}
+
+export function discoverReviewArtifacts(root: string): ReviewArtifacts {
+  const artifacts: ReviewArtifacts = {
+    results: new Map(),
+    failures: new Map(),
+  };
+  for (const path of walkFiles(root)) {
+    const name = basename(path);
+    if (name === "result.json") {
+      const candidateId = readCandidateId(path, "review result");
+      addUnique(artifacts.results, candidateId, path, "review result");
+    } else if (name === "failure.json") {
+      const receipt = parseFailureReceipt(
+        JSON.parse(readFileSync(path, "utf8")) as unknown,
+      );
+      addUnique(
+        artifacts.failures,
+        receipt.candidate_id,
+        receipt,
+        "failure receipt",
+      );
+    }
+  }
+  return artifacts;
+}
+
+export function formatFailureReceipt(receipt: ReviewFailureReceipt): string {
+  const conversation = receipt.conversation_id
+    ? ` (conversation ${receipt.conversation_id})`
+    : "";
+  return `${receipt.kind}: ${receipt.message}${conversation}`;
+}
+
+function walkFiles(root: string): string[] {
+  const files: string[] = [];
+  let entries: ReturnType<typeof readdirSync>;
+  try {
+    entries = readdirSync(root, { withFileTypes: true });
+  } catch (error) {
+    if (isMissingPath(error)) return files;
+    throw error;
+  }
+  for (const entry of entries) {
+    const path = join(root, entry.name);
+    if (entry.isDirectory()) files.push(...walkFiles(path));
+    else if (entry.isFile()) files.push(path);
+  }
+  return files.sort();
+}
+
+function readCandidateId(path: string, description: string): string {
+  const value = JSON.parse(readFileSync(path, "utf8")) as unknown;
+  if (!isRecord(value) || !isCandidateId(value.candidate_id)) {
+    throw new Error(`${description} ${path} has no valid candidate_id`);
+  }
+  return value.candidate_id;
+}
+
+function parseFailureReceipt(value: unknown): ReviewFailureReceipt {
+  if (
+    !isRecord(value) ||
+    !hasExactKeys(value, [
+      "schema_version",
+      "candidate_id",
+      "skill",
+      "kind",
+      "message",
+      "conversation_id",
+    ]) ||
+    value.schema_version !== 1 ||
+    !isCandidateId(value.candidate_id) ||
+    !isSkillName(value.skill) ||
+    !isFailureKind(value.kind) ||
+    typeof value.message !== "string" ||
+    value.message.length === 0 ||
+    value.message.length > 500 ||
+    (value.conversation_id !== null && !isConversationId(value.conversation_id))
+  ) {
+    throw new Error("Review failure receipt is invalid");
+  }
+  return value as unknown as ReviewFailureReceipt;
+}
+
+function addUnique<T>(
+  values: Map<string, T>,
+  candidateId: string,
+  value: T,
+  description: string,
+): void {
+  if (values.has(candidateId)) {
+    throw new Error(`Found duplicate ${description} for ${candidateId}`);
+  }
+  values.set(candidateId, value);
+}
+
+function isFailureKind(value: unknown): value is ReviewFailureReceipt["kind"] {
+  return (
+    value === "action_failed" ||
+    value === "execution_file_missing" ||
+    value === "result_marker_missing" ||
+    value === "result_decode_failed"
+  );
+}
+
+function isCandidateId(value: unknown): value is string {
+  return (
+    typeof value === "string" &&
+    /^[a-z0-9]+(?:-[a-z0-9]+)*@[a-f0-9]{12}-[a-f0-9]{16}$/.test(value)
+  );
+}
+
+function isSkillName(value: unknown): value is string {
+  return typeof value === "string" && /^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(value);
+}
+
+function isConversationId(value: unknown): value is string {
+  return typeof value === "string" && /^conv-[a-zA-Z0-9-]+$/.test(value);
+}
+
+function isMissingPath(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    "code" in error &&
+    (error as NodeJS.ErrnoException).code === "ENOENT"
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function hasExactKeys(
+  value: Record<string, unknown>,
+  expected: string[],
+): boolean {
+  return (
+    JSON.stringify(Object.keys(value).sort()) ===
+    JSON.stringify([...expected].sort())
+  );
+}

--- a/scripts/builtin-skills-watch/update-tracker.test.ts
+++ b/scripts/builtin-skills-watch/update-tracker.test.ts
@@ -6,6 +6,7 @@ import {
   parseReviewResult,
   type TrackerIssueView,
   validatePullRequestView,
+  validateReconciledPullRequestView,
   validateTrackerIssueView,
 } from "./update-tracker.ts";
 
@@ -79,6 +80,21 @@ describe("watcher PR validation", () => {
       ),
     ).toThrow("outside the selected skill scope");
   });
+
+  test("accepts a merged exact-candidate PR only during reconciliation", () => {
+    const merged = validPullRequest({
+      isDraft: false,
+      mergedAt: "2026-08-27T00:00:00Z",
+      state: "MERGED",
+    });
+
+    expect(() =>
+      validateReconciledPullRequestView(merged, URL, analysis(), LOGIN),
+    ).not.toThrow();
+    expect(() =>
+      validatePullRequestView(merged, URL, analysis(), LOGIN),
+    ).toThrow("open and draft");
+  });
 });
 
 describe("watcher analysis validation", () => {
@@ -135,7 +151,7 @@ describe("watcher result validation", () => {
       evidence: evidence(current),
     };
     expect(() => parseReviewResult({ ...base, secret: "no" }, current)).toThrow(
-      "does not match",
+      "unknown or missing fields",
     );
     expect(() =>
       parseReviewResult(

--- a/scripts/builtin-skills-watch/update-tracker.ts
+++ b/scripts/builtin-skills-watch/update-tracker.ts
@@ -37,6 +37,7 @@ export interface PullRequestView {
   files: Array<{ path: string }>;
   headRefOid: string;
   isDraft: boolean;
+  mergedAt?: string | null;
   state: string;
   url: string;
 }
@@ -337,19 +338,35 @@ export function parseReviewResult(
       "notes",
       "pr_url",
       "evidence",
-    ]) ||
-    value.schema_version !== 1 ||
+    ])
+  ) {
+    throw new Error("Review result has unknown or missing fields");
+  }
+  if (value.schema_version !== 1) {
+    throw new Error("Review result must use schema version 1");
+  }
+  if (
     value.candidate_id !== analysis.candidate_id ||
-    value.skill !== analysis.skill ||
-    (value.outcome !== "no_drift" &&
-      value.outcome !== "pr_created" &&
-      value.outcome !== "needs_human_review") ||
-    typeof value.notes !== "string" ||
-    value.notes.length === 0 ||
-    value.notes.length > 120 ||
-    (value.pr_url !== null && typeof value.pr_url !== "string")
+    value.skill !== analysis.skill
   ) {
     throw new Error("Review result does not match the pending candidate");
+  }
+  if (
+    value.outcome !== "no_drift" &&
+    value.outcome !== "pr_created" &&
+    value.outcome !== "needs_human_review"
+  ) {
+    throw new Error("Review result outcome is invalid");
+  }
+  if (
+    typeof value.notes !== "string" ||
+    value.notes.length === 0 ||
+    value.notes.length > 120
+  ) {
+    throw new Error("Review result notes must contain 1 to 120 characters");
+  }
+  if (value.pr_url !== null && typeof value.pr_url !== "string") {
+    throw new Error("Review result pr_url must be a string or null");
   }
   if (
     (value.outcome === "pr_created") !==
@@ -381,28 +398,61 @@ export function verifyPullRequest(
   analysis: BuiltinSkillWatchAnalysis,
   expectedGithubLogin: string,
 ): void {
+  verifyPullRequestIdentity(expectedGithubLogin);
+  const pullRequest = getPullRequest(repo, prUrl);
+  validatePullRequestView(pullRequest, prUrl, analysis, expectedGithubLogin);
+  verifyPullRequestAncestry(repo, pullRequest, analysis);
+}
+
+export function verifyReconciledPullRequest(
+  repo: string,
+  prUrl: string,
+  analysis: BuiltinSkillWatchAnalysis,
+  expectedGithubLogin: string,
+): void {
+  verifyPullRequestIdentity(expectedGithubLogin);
+  const pullRequest = getPullRequest(repo, prUrl);
+  validateReconciledPullRequestView(
+    pullRequest,
+    prUrl,
+    analysis,
+    expectedGithubLogin,
+  );
+  verifyPullRequestAncestry(repo, pullRequest, analysis);
+}
+
+function verifyPullRequestIdentity(expectedGithubLogin: string): void {
   const authenticatedLogin = ghJson<{ login: string }>(["api", "user"]).login;
   if (authenticatedLogin !== expectedGithubLogin) {
     throw new Error(
       `Authenticated GitHub login ${authenticatedLogin} does not match ${expectedGithubLogin}`,
     );
   }
+}
+
+function getPullRequest(repo: string, prUrl: string): PullRequestView {
   const match = prUrl.match(
     /^https:\/\/github\.com\/([^/]+\/[^/]+)\/pull\/(\d+)\/?$/,
   );
   if (!match || match[1] !== repo) {
     throw new Error(`PR URL must belong to https://github.com/${repo}`);
   }
-  const pullRequest = ghJson<PullRequestView>([
+  return ghJson<PullRequestView>([
     "pr",
     "view",
     match[2] as string,
     "--repo",
     repo,
     "--json",
-    "author,baseRefName,body,files,headRefOid,isDraft,state,url",
+    "author,baseRefName,body,files,headRefOid,isDraft,mergedAt,state,url",
   ]);
-  validatePullRequestView(pullRequest, prUrl, analysis, expectedGithubLogin);
+}
+
+function verifyPullRequestAncestry(
+  repo: string,
+  pullRequest: PullRequestView,
+  analysis: BuiltinSkillWatchAnalysis,
+): void {
   const comparison = ghJson<{
     status: string;
     merge_base_commit: { sha: string };
@@ -424,6 +474,33 @@ export function validatePullRequestView(
   analysis: BuiltinSkillWatchAnalysis,
   expectedGithubLogin: string,
 ): void {
+  validatePullRequestScope(pullRequest, prUrl, analysis, expectedGithubLogin);
+  if (pullRequest.state !== "OPEN" || !pullRequest.isDraft) {
+    throw new Error("Watcher PR must be open and draft");
+  }
+}
+
+export function validateReconciledPullRequestView(
+  pullRequest: PullRequestView,
+  prUrl: string,
+  analysis: BuiltinSkillWatchAnalysis,
+  expectedGithubLogin: string,
+): void {
+  validatePullRequestScope(pullRequest, prUrl, analysis, expectedGithubLogin);
+  const isOpenDraft = pullRequest.state === "OPEN" && pullRequest.isDraft;
+  const isMerged =
+    pullRequest.state === "MERGED" && typeof pullRequest.mergedAt === "string";
+  if (!isOpenDraft && !isMerged) {
+    throw new Error("Reconciled watcher PR must be an open draft or merged");
+  }
+}
+
+function validatePullRequestScope(
+  pullRequest: PullRequestView,
+  prUrl: string,
+  analysis: BuiltinSkillWatchAnalysis,
+  expectedGithubLogin: string,
+): void {
   if (pullRequest.url !== prUrl.replace(/\/$/, "")) {
     throw new Error(`PR URL mismatch: ${pullRequest.url}`);
   }
@@ -431,9 +508,6 @@ export function validatePullRequestView(
     throw new Error(
       `PR author ${pullRequest.author.login} does not match ${expectedGithubLogin}`,
     );
-  }
-  if (pullRequest.state !== "OPEN" || !pullRequest.isDraft) {
-    throw new Error("Watcher PR must be open and draft");
   }
   if (pullRequest.baseRefName !== "main") {
     throw new Error("Watcher PR must target main");


### PR DESCRIPTION
## Summary

The built-in skill watcher should review every bundled skill daily without losing results or creating duplicate PRs. Its first three scheduled runs all failed: agent turns hit the ten-minute request timeout, real evidence exceeded the 650-byte limit, and a single downloaded result used a different directory layout than the aggregator expected. The tracker stayed pending even when watcher PRs had already been opened or merged.

This keeps the schedule enabled and fixes the full retry path:

- the runner reconciles exact candidate markers against open and merged PRs before dispatch, records valid existing PRs, and closes open duplicates
- reviews run four at a time in run-and-skill-specific sandbox directories, with a 45-minute request timeout and remote cancellation after failure
- agents validate their result with the same parser the runner uses before returning it
- evidence may use up to 16 KiB, accepts RFC 3339 UTC timestamps with or without milliseconds, and reports the exact invalid source, probe, or result field
- aggregation discovers result and failure artifacts recursively by candidate ID, independent of whether `download-artifact` returns a root file or per-artifact directories
- failed review jobs upload structured receipts containing the failure stage and conversation ID

**Draft status:** implementation and local verification are complete; CI and human review remain.

## Before and after

**Before**

1. The prepare job left every candidate pending without checking existing watcher PRs.
2. The matrix started every review simultaneously, and each cloud conversation deleted and reused the same `/tmp` checkout.
3. The Letta request ended after ten minutes without cancelling the remote turn.
4. Agents manually constructed a strict result payload that most real evidence could not fit.
5. `download-artifact` nested multiple results but flattened a single result; the aggregator only checked the nested path.
6. Missing artifacts were recorded as generic errors, so the next run retried the same candidates and could create another PR.

**After**

1. `reconcile-results.ts` validates exact-marker PRs, records one merged or open draft PR, and closes open duplicates.
2. Only unresolved candidates enter a four-wide matrix, each with its own sandbox directory.
3. The action may wait up to 45 minutes; a failed action triggers `POST /v1/conversations/{id}/cancel`.
4. `finalize-result.ts` validates and encodes the agent result with the runner parser.
5. The runner uploads either `result.json` or a structured `failure.json` receipt.
6. `aggregate-results.ts` finds those files recursively by candidate ID and records exact validation failures.

## Review notes

**Merge when:** CI passes and the reviewer confirms that reconciliation fails closed for an invalid PR while valid open and merged PRs prevent another agent dispatch.

**Start here:** `.github/workflows/builtin-skills-agent-watch.yml`, then `scripts/builtin-skills-watch/reconcile-results.ts` and `scripts/builtin-skills-watch/result-artifacts.ts`.

**Risk:** reconciliation now runs before candidate preparation and can write tracker evidence or close an exact-marker duplicate. It validates author, state, base branch, changed-file scope, marker, and ancestry before either action.

## Verification

The reconciliation tests start from the observed state where one exact candidate has both a merged PR and an open duplicate. GitHub mutation is separated from the selection logic; the tests assert that the merged PR wins, all open duplicates are selected for closure, the oldest open draft wins when nothing merged, closed-unmerged PRs are ignored, and multiple merged PRs fail closed.

Artifact tests exercise both layouts returned by `actions/download-artifact`: a root `result.json` and a nested per-artifact file. They also assert candidate-ID deduplication and the structured failure receipt path. Finalizer and evidence tests exercise candidate mismatches, production-sized evidence, field-specific failures, and both accepted UTC timestamp forms.

- `bun test scripts/builtin-skills-watch` passed, 44 tests
- `bun run check` passed, 12 checks
- `actionlint -ignore SC2016 .github/workflows/builtin-skills-agent-watch.yml` passed
- live read-only reconciliation against issue #4065 identified six existing candidate PRs and #4077 as the duplicate of merged #4067
- live reconciliation recorded those six PR outcomes, reduced pending candidates from 22 to 16, and closed #4077 with the canonical PR linked in its final comment
- a downloaded result from run 33172037695 was placed at the root artifact path; recursive discovery found it, then the shared parser reported the exact invalid source field instead of “artifact missing”

## Breadcrumbs

- Linear: LET-11645
- Letta conversation: [`conv-7f83fb60-984c-4b0f-bfd9-9930a87dad1c`](https://chat.letta.com/chat/agent-cd664b86-4d28-49b7-8ad6-60677eaff9be?conversation=conv-7f83fb60-984c-4b0f-bfd9-9930a87dad1c)
- Origin: introduced by the initial built-in skill watcher in #4060; no later reliability fix landed before this change
- Related: follow-up to the PR-authorship guard in #4110, which fixed identity but not stale-skill execution or aggregation
- Root-cause evidence: [run 32951109330](https://github.com/letta-ai/letta-code/actions/runs/32951109330) failed from 2026-08-26 09:05–09:18 UTC, [run 33070917110](https://github.com/letta-ai/letta-code/actions/runs/33070917110) failed from 2026-08-27 12:14–12:26 UTC, and [run 33172037695](https://github.com/letta-ai/letta-code/actions/runs/33172037695) failed from 2026-08-28 12:40–12:52 UTC; issue #4065 retained all 22 candidates as pending while #4066–#4069 were merged and #4077, #4078, and #4098 existed as open drafts

## AI Disclosure

- [ ] This pull request was written entirely by a human
- [ ] This pull request was written with AI assistance and reviewed and edited by a human
- [ ] I have read the [AI Policy](https://github.com/letta-ai/letta-code/blob/main/AI_POLICY.md) and agree to its terms

## AI Tool(s) Used

Letta Code

## Human Verification

Pending human review.
