### PR TITLE
fix(skills): update converting-mcps-to-skills for built-in MCP client and stale --timeout option

### DIFF
--- a/src/skills/builtin/converting-mcps-to-skills/SKILL.md
+++ b/src/skills/builtin/converting-mcps-to-skills/SKILL.md
@@ -5,7 +5,7 @@ description: Connect to MCP (Model Context Protocol) servers and create skills f
 
 # Converting MCP Servers to Skills
 
-Letta Code is not itself an MCP client, but as a general computer-use agent, you can easily connect to any MCP server using the scripts in this skill.
+Letta Code has a built-in MCP client (`/mcp add`) for persistent server connections, but the scripts in this skill are useful for ad-hoc exploration, testing, and creating dedicated skills from MCP servers.
 
 ## What is MCP?
 
@@ -147,7 +147,6 @@ Actions:
 Options:
   --env "KEY=VALUE"       Set environment variable (repeatable)
   --cwd <path>            Set working directory
-  --timeout <ms>          Request timeout (default: 30000)
 ```
 
 **Examples:**


### PR DESCRIPTION
## Summary

- Update intro line to reflect that Letta Code now has a built-in MCP client (`/mcp add`), fixing the stale claim "Letta Code is not itself an MCP client"
- Remove `--timeout <ms>` option from `mcp-stdio.ts` documentation; the script does not implement this option (confirmed via `--help` output and source inspection of `parseArgs`/`ParsedArgs`)

Builtin-skill-watch: converting-mcps-to-skills@852ca244b002-1693ef41f602078b

## Selected skill

`converting-mcps-to-skills` (built-in skill at `src/skills/builtin/converting-mcps-to-skills/`)

## Stale claims and current owning source

1. **"Letta Code is not itself an MCP client"** (SKILL.md line 8)
   - Stale: Letta Code has a full built-in MCP client
   - Owning source: `src/mcp-client.ts` (connects via `@modelcontextprotocol/sdk`), `src/mcp-runtime.ts` (manages connections and tool registration), `src/cli/commands/mcp.ts` (`/mcp add` command), `src/settings-manager.ts` (`mcpServers` agent setting)
   - Official docs: https://docs.letta.com/letta-code/slash-commands/index.md lists `/mcp` as a built-in command

2. **`--timeout <ms>` option for mcp-stdio.ts** (SKILL.md line 150)
   - Stale: the script does not implement `--timeout`
   - Owning source: `src/skills/builtin/converting-mcps-to-skills/scripts/mcp-stdio.ts` — `parseArgs()` (lines 59-101) handles `--env`, `--cwd`, `--help` only; `ParsedArgs` interface has no timeout field; `printUsage()` does not list `--timeout`
   - Probe: `npx tsx mcp-stdio.ts --help` confirms no `--timeout` option exists

## Focused validation

- `bun run check` — all 12 checks pass
- `npx tsx mcp-stdio.ts --help` — confirms `--timeout` is not an available option
- `npx tsx mcp-http.ts --help` — confirms `--timeout` IS available for the HTTP script (only the stdio docs were stale)

## Test plan

- [ ] Verify SKILL.md reads correctly with the updated intro line
- [ ] Confirm `--timeout` removal from mcp-stdio.ts docs matches script behavior

👾 Generated with [Letta Code](https://letta.com)

Co-Authored-By: Letta Code <noreply@letta.com>