### PR TITLE
fix(skills): note letta memory tokens limitation in context-doctor ROOT_MEMORY.md

### DIFF
--- a/src/skills/builtin/context-doctor/ROOT_MEMORY.md
+++ b/src/skills/builtin/context-doctor/ROOT_MEMORY.md
@@ -24,12 +24,12 @@ Below are additional common issues with context and how they can be resolved:
 #### System prompt bloat
 Root Markdown files compiled into the system prompt should take up about 10% of the total context size (usually ~15-20K tokens). This is a soft target, not a hard requirement.
 
-Use the built-in CLI to evaluate token usage of the system prompt:
+To evaluate token usage of the system prompt, you can use:
 ```bash
 letta memory tokens --format json --quiet
 ```
 
-The command reports `total_tokens` and per-file estimates for core memory. It is only a measurement tool; decide whether to intervene based on the actual context and the guidance below.
+**Note:** This command currently scans `system/` and returns 0 tokens for root-layout agents. Until it supports root-layout memory, manually review root Markdown file sizes to assess bloat. It is only a measurement tool; decide whether to intervene based on the actual context and the guidance below.
 
 **Why detail is load-bearing (read this before cutting anything)**: In-context detail does more than carry information. It does at least four things, and byte-counting sweeps only see the first:
 1. **Information** — the literal facts stated


### PR DESCRIPTION
## Summary

The `ROOT_MEMORY.md` variant of the context-doctor skill (served to memfs-v2 root-layout agents) recommends `letta memory tokens --format json --quiet` and claims it "reports `total_tokens` and per-file estimates for core memory." However, the command only scans the `system/` directory (hardcoded in `estimateSystemPromptSize` in `system-prompt-size.ts`). For root-layout agents that have no `system/` directory, the command returns 0 tokens.

## Changes

- Add a note in `ROOT_MEMORY.md` that `letta memory tokens` currently scans `system/` and returns 0 for root-layout agents
- Suggest manually reviewing root Markdown file sizes as an alternative until the command supports root-layout memory

## Validation

- Verified `estimateSystemPromptSize` in `src/utils/system-prompt-size.ts` hardcodes `join(memoryDir, "system")` with no format detection
- Verified `letta memory tokens` tests in `memory-tokens.test.ts` all use `system/` layout, no root-layout test exists
- Verified `refreshSystemPromptDoctorState` in `system-prompt-warning.ts` has the same limitation (also calls `estimateSystemPromptTokensFromMemoryDir`)
- `SKILL.md` (served to v1 agents) is unaffected: it correctly says "per-file estimates for `system/`" and the command works for v1 agents

Builtin-skill-watch: context-doctor@c7808b069447-a4d33a7d6d5ed83f