### PR TITLE
fix(skills): correct stale validation claims and token units in creating-skills

### DIFF
--- a/src/skills/builtin/creating-skills/SKILL.md
+++ b/src/skills/builtin/creating-skills/SKILL.md
@@ -114,8 +114,8 @@ The skill should only contain the information needed for an AI agent to do the j
 
 Skills use a three-level loading system to manage context efficiently:
 
-1. **Metadata (name + description)** - Always in context (~100 words)
-2. **SKILL.md body** - When skill triggers (<5k words)
+1. **Metadata (name + description)** - Always in context (~100 tokens)
+2. **SKILL.md body** - When skill triggers (<5k tokens)
 3. **Bundled resources** - As needed by the Letta Code agent (Unlimited because scripts can be executed without reading into context window)
 
 #### Progressive Disclosure Patterns
@@ -350,9 +350,8 @@ The packaging script will:
 1. **Validate** the skill automatically, checking:
 
    - YAML frontmatter format and required fields
-   - Skill naming conventions and directory structure
-   - Description completeness and quality
-   - File organization and resource references
+   - Skill naming conventions (hyphen-case, length, matches directory name)
+   - Description presence, length, and format (no angle brackets)
 
 2. **Package** the skill if validation passes, creating a .skill file named after the skill (e.g., `my-skill.skill`) that includes all files and maintains the proper directory structure for distribution. The .skill file is a zip file with a .skill extension.
 


### PR DESCRIPTION
## Summary

- Fix progressive disclosure units from "words" to "tokens" to match the [agentskills.io specification](https://agentskills.io/specification)
- Remove stale claims about validation checks that `validate-skill.ts` does not perform: "file organization and resource references", "directory structure", and "description quality"

## Stale claims and current owning source

**Progressive disclosure units** (SKILL.md lines 117-119): Said "~100 words" and "<5k words" but the spec says "~100 tokens" and "< 5000 tokens". Words and tokens are different units.

**Packaging validation list** (SKILL.md lines 350-356): Listed four validation checks, but `validate-skill.ts` only performs:
- YAML frontmatter format and required fields (name, description)
- Skill naming conventions (hyphen-case regex, max 64 chars, no leading/trailing/double hyphens, matches directory name as warning)
- Description presence, length (max 1024 chars), and format (no angle brackets)

It does NOT check: file organization, resource references, directory structure, or description quality.

Source: `src/skills/builtin/creating-skills/scripts/validate-skill.ts` `validateSkill()` function (lines 156-287).

## Focused validation

- `bun test src/skills/skill-creator-scripts.test.ts` — 21 pass, 0 fail
- `bun run check` — 12/12 checks pass

Builtin-skill-watch: creating-skills@852ca244b002-db521788bd97d929

👾 Generated with [Letta Code](https://letta.com)

Co-Authored-By: Letta Code <noreply@letta.com>