### PR TITLE
fix(skills): correct built-in command override guidance in customizing-commands

### DIFF
--- a/src/skills/builtin/customizing-commands/SKILL.md
+++ b/src/skills/builtin/customizing-commands/SKILL.md
@@ -76,7 +76,7 @@ type ModCommandResult =
 
 - Command IDs omit the slash: `id: "review"`, not `"/review"`.
 - Use lowercase slugs with letters, numbers, and hyphens.
-- Do not register built-in command IDs.
+- Overriding built-in command IDs records a warning diagnostic; do this intentionally and keep `--no-mods` or `LETTA_DISABLE_MODS=1` in mind for recovery.
 - `runWhenBusy: true` commands must not return `prompt` while the main agent is busy; use scoped conversation helpers/panels and return `handled`.
 - `showInTranscript: false` commands should usually return `handled`, not `prompt`.
 - Do not import Letta Code app internals.


### PR DESCRIPTION
## Builtin-skill-watch: customizing-commands@852ca244b002-75330c920320721f

**Selected skill:** `customizing-commands`

## Stale claim

The skill's Rules section said:

> Do not register built-in command IDs.

## Current owning source

`src/mods/mod-engine.ts` (lines 1113-1126): when a mod command ID matches a built-in command ID, the engine records a diagnostic with phase `command_override` and severity `warning` (via `getModDiagnosticSeverity` in `src/mods/mod-diagnostics.ts:44`). The command still registers and shadows the built-in.

The skill's own reference file `src/skills/builtin/creating-mods/references/commands.md` says:

> Built-in commands like `/reload`, `/model`, `/statusline`, etc. can be overridden by trusted local mods. Do this intentionally and keep recovery in mind: start with `--no-mods` or `LETTA_DISABLE_MODS=1` if an override breaks command handling.

## Fix

Replaced the rule with guidance that matches the source code and the reference:

> Overriding built-in command IDs records a warning diagnostic; do this intentionally and keep `--no-mods` or `LETTA_DISABLE_MODS=1` in mind for recovery.

## Validation

- `bun run check` (12/12 checks passed)
- `bun test src/cli/mods/command-runtime.test.ts` (4 pass)
- `bun test src/mods/mod-engine.test.ts` (38 pass)