### PR TITLE
fix(skill): correct debugPanelEnabled description in desktop preferences skill

### DIFF
--- a/src/skills/builtin/editing-letta-code-desktop-preferences/SKILL.md
+++ b/src/skills/builtin/editing-letta-code-desktop-preferences/SKILL.md
@@ -28,7 +28,7 @@ User-editable preference keys:
 
 System-managed keys (do not edit directly):
 - `artifactsByAgent`: per-agent artifacts panel state, written by Desktop UI.
-- `debugPanelEnabled`: developer debug panel, controlled via app menus.
+- `debugPanelEnabled`: developer debug panel, enables listener debug output to stderr.
 - `remoteAppServerEnabled`: Remote App Server toggle, applied at startup.
 - `remoteAppServerUrl`: Remote App Server URL, configured via preferences UI.
 


### PR DESCRIPTION
Builtin-skill-watch: editing-letta-code-desktop-preferences@c7808b069447-b7bafe6406cded8a

## Selected skill

`editing-letta-code-desktop-preferences`

## Stale claim

The skill described `debugPanelEnabled` as "controlled via app menus." No app menu in the Desktop Electron app controls this key. The preference is read by `listenerManager.ts` to set the `LETTA_DESKTOP_DEBUG_PANEL` env var for the listener child process, enabling debug output to stderr. The debug panel sidebar is opened via Cmd+J keyboard shortcut, but `debugPanelEnabled` itself has no UI toggle.

## Current owning source

- `apps/code-desktop/electron/src/preferencesStorage.ts` in `letta-ai/letta-cloud` (origin/main): defines `debugPanelEnabled` with comment "When true, the debug panel (Cmd+J) collects WebSocket message traffic and the listener mirrors debug-only lifecycle notices to stderr."
- `apps/code-desktop/electron/src/listenerManager.ts`: reads `loadPreferences().debugPanelEnabled` to set `LETTA_DESKTOP_DEBUG_PANEL` env var
- No app menu, Preferences UI toggle, or keyboard shortcut sets `debugPanelEnabled`

## Fix

Changed description from "controlled via app menus" to "enables listener debug output to stderr" to match the actual behavior.

## Validation

- `bun run check` passes (12/12 checks)
- Pre-commit hooks pass
- All other claims in the skill verified against `letta-cloud` source: file path, user-editable keys, system-managed keys, live reload timing (100ms debounce), workflow steps