### PR TITLE
fix(skills): correct stale claims in generating-mod-envs skill

### DIFF
--- a/src/skills/builtin/generating-mod-envs/SKILL.md
+++ b/src/skills/builtin/generating-mod-envs/SKILL.md
@@ -46,14 +46,14 @@ Use single-line `--flag=value` commands for TUI instructions.
 Required top-level fields:
 
 - `name`: human display name.
-- `slug`: stable kebab-case run/candidate slug.
 - `objective`: one-paragraph target for the generation agent.
 - `requirements`: concrete pass/fail behavior constraints.
 - `evaluation`: either a single prompt eval or a scenario suite.
 
 Common optional fields:
 
-- `targetModName`: display metadata for the intended mod filename. The harness still chooses the candidate filename from `slug` unless `--candidate-file-name` is passed.
+- `slug`: stable kebab-case run/candidate slug. Falls back to `name` when absent.
+- `targetModName`: display metadata for the intended mod filename. The harness still chooses the candidate filename from `slug` (or `name`) unless `--candidate-file-name` is passed.
 - `candidateDiversityHints`: strategies assigned across multi-candidate runs.
 - `modApiHints`: concise API reminders that prevent bad generated code.
 - `examples`: small input/expected demos for the generation prompt.
@@ -79,9 +79,7 @@ Evaluation fields:
 - Include discrimination scenarios when paths, IDs, or sources matter. Put a tempting wrong sentinel in an irrelevant fixture and forbid it in the final answer.
 - Put load failures in `forbiddenTraceMarkers`, usually:
   - `[mods] failed to load`
-  - `[extensions] failed to load`
   - `loaded 0 mod(s)`
-  - `loaded 0 extension(s)`
 - For eval-facing tools, require `requiresApproval: false`, `parallelSafe: true`, and a strict no-argument schema when applicable.
 - Avoid over-brittle trace markers. Prefer stable substrings like the tool name plus `"message_type":"tool_return_message"`.
 - Keep requirements behavioral; put fragile implementation details in `modApiHints` only when needed.

--- a/src/skills/builtin/generating-mod-envs/assets/mod-learning-env.template.json
+++ b/src/skills/builtin/generating-mod-envs/assets/mod-learning-env.template.json
@@ -25,12 +25,7 @@
     "outputFormat": "stream-json",
     "timeoutMs": 900000,
     "maxTurns": 8,
-    "forbiddenTraceMarkers": [
-      "[mods] failed to load",
-      "[extensions] failed to load",
-      "loaded 0 mod(s)",
-      "loaded 0 extension(s)"
-    ],
+    "forbiddenTraceMarkers": ["[mods] failed to load", "loaded 0 mod(s)"],
     "scenarios": [
       {
         "name": "happy-path",


### PR DESCRIPTION
## Summary

- Move `slug` from required to optional fields in SKILL.md. The `ModLearningSpec` interface (`src/mods/learning-harness.ts:41`) marks `slug` as optional, the validator (`scripts/validate-mod-env.ts:162`) treats it as optional, and the harness falls back to `spec.slug ?? spec.name` (`learning-harness.ts:353,667`).
- Remove stale `[extensions] failed to load` and `loaded 0 extension(s)` from recommended `forbiddenTraceMarkers` in both SKILL.md and the template JSON. After the extensions-to-mods rename (PR #2798), all debug log output uses the `"mods"` prefix, so these strings never appear in trace output.

## Selected skill

`generating-mod-envs`

## Stale claims and current owning source

1. **`slug` listed as required** — `ModLearningSpec.slug` is `slug?: string` (optional) at `src/mods/learning-harness.ts:41`. The validator at `scripts/validate-mod-env.ts:162` calls `optionalString(env, "slug")`. The harness falls back via `slugify(spec.slug ?? spec.name)` at lines 353 and 667.

2. **`[extensions] failed to load` and `loaded 0 extension(s)` trace markers** — `debugLog` in `src/mods/mod-adapter.ts:198-204` always uses the `"mods"` prefix, producing `[mods] loaded N mod(s) from M source(s)` and `[mods] failed to load <path>: <error>`. No `"extensions"` prefix exists in the current codebase (confirmed via `grep -rn extensions src/ --include="*.ts" | grep debugLog`). The rename happened in PR #2798.

## Focused validation

- `bun src/skills/builtin/generating-mod-envs/scripts/validate-mod-env.ts` on template and both example envs — all pass
- `bun run check` — all 12 checks pass

Builtin-skill-watch: generating-mod-envs@852ca244b002-a3e76258693633cd