### PR TITLE
fix(skills): correct history-analyzer model and permission claims

### DIFF
--- a/src/skills/builtin/initializing-memory/SKILL.md
+++ b/src/skills/builtin/initializing-memory/SKILL.md
@@ -239,7 +239,7 @@ The goal is to extract user personality, preferences, coding patterns, and proje
 #### Prerequisites
 
 - `letta.js` must be built (`bun run build`) — subagents spawn via this binary
-- Use `subagent_type: "history-analyzer"` — cheaper model (sonnet), has `bypassPermissions`, creates its own worktree
+- Use `subagent_type: "history-analyzer"` — model: auto, runs with `--permission-mode unrestricted`, creates its own worktree
 - The `history-analyzer` subagent has the normalized trajectory format docs inlined — workers never need to know any harness's native format
 
 #### Steps


### PR DESCRIPTION
## Summary

- Fixed two stale claims in the `initializing-memory` skill about the `history-analyzer` subagent
- **Model**: changed "cheaper model (sonnet)" to "model: auto" — the actual model is `auto` which resolves to `letta/auto` (server-side auto-router), not sonnet
- **Permissions**: changed "has `bypassPermissions`" to "runs with `--permission-mode unrestricted`" — `bypassPermissions` was renamed to `unrestricted`, and this applies to all subagents, not just history-analyzer

## Evidence

- `src/agent/subagents/builtin/history-analyzer.md` frontmatter: `model: auto`
- `src/agent/model-catalog.ts`: `BUILTIN_MODEL_ALIASES` maps `"auto"` → `"letta/auto"`
- `src/agent/subagents/manager.ts` line 289: `--permission-mode unrestricted` for all subagents
- `src/permissions/mode.ts`: rename from `bypassPermissions` to `unrestricted`

Builtin-skill-watch: initializing-memory@852ca244b002-660dd5ef1db3c03e