### PR TITLE
fix(skills): correct JSON response example in messaging-agents skill

### DIFF
--- a/src/skills/builtin/messaging-agents/SKILL.md
+++ b/src/skills/builtin/messaging-agents/SKILL.md
@@ -93,13 +93,19 @@ letta -p --from-agent $LETTA_AGENT_ID \
   "What do you know about the authentication system?"
 ```
 
-**Response:**
+**Response (with `--output-format json`):**
 ```json
 {
-  "conversation_id": "conversation-xyz789",
-  "response": "The authentication system uses JWT tokens...",
+  "type": "result",
+  "subtype": "success",
+  "is_error": false,
+  "result": "The authentication system uses JWT tokens...",
   "agent_id": "agent-abc123",
-  "agent_name": "BackendExpert"
+  "conversation_id": "conversation-xyz789",
+  "environment": { "source": "same-environment" },
+  "duration_ms": 3420,
+  "num_turns": 1,
+  "usage": { ... }
 }
 ```
 


### PR DESCRIPTION
## Summary

- The JSON response example in the `messaging-agents` skill showed a `"response"` field and `"agent_name"` field that do not exist in the actual headless JSON output
- The real output uses `"result"` for the assistant message text and does not include `"agent_name"`
- Updated the example to match the actual JSON envelope returned by headless mode (`type`, `subtype`, `is_error`, `result`, `agent_id`, `conversation_id`, `environment`, `duration_ms`, `num_turns`, `usage`)

Builtin-skill-watch: messaging-agents@c7808b069447-8bda69cb4d9e72c1

## Evidence

Verified against `src/headless.ts` lines 3385-3433 where the JSON result envelope is constructed:
- Field is `result`, not `response`
- No `agent_name` field is included in the output
- The envelope includes `type`, `subtype`, `is_error`, `duration_ms`, `duration_api_ms`, `num_turns`, `environment`, `usage`, and `run_ids`

## Test plan

- [x] Pre-commit hooks pass (biome, tsc, layer boundaries)
- [ ] Reviewer confirms the updated JSON example matches actual `letta -p --from-agent ... --output-format json` output

👾 Generated with [Letta Code](https://letta.com)