### PR TITLE
fix(skills): update migrating-memory for memfs v2 root layout

### DIFF
--- a/src/skills/builtin/migrating-memory/SKILL.md
+++ b/src/skills/builtin/migrating-memory/SKILL.md
@@ -34,13 +34,21 @@ This is the recommended flow:
    ```
 
 2. **Copy the files you want into your own memfs**
-   - `system/` = attached blocks (always loaded)
-   - root = detached blocks
+   The memory layout depends on the source agent's format:
+   - **v1 (legacy):** `system/` = attached blocks (always loaded), root = detached blocks
+   - **v2 (root layout):** root-level `.md` files = core memory (always loaded), directories with `MEMORY.md` indexes = projected memory (loaded on demand)
+   - Check for `MEMORY.md` at the export root to identify v2; if absent, the export uses v1
 
-   Example:
+   Example (v1):
    ```bash
    cp -r /tmp/letta-memory-agent-abc123/system/project ~/.letta/agents/$LETTA_AGENT_ID/memory/system/
    cp /tmp/letta-memory-agent-abc123/notes.md ~/.letta/agents/$LETTA_AGENT_ID/memory/
+   ```
+
+   Example (v2):
+   ```bash
+   cp /tmp/letta-memory-agent-abc123/human.md ~/.letta/agents/$LETTA_AGENT_ID/memory/
+   cp -r /tmp/letta-memory-agent-abc123/projects ~/.letta/agents/$LETTA_AGENT_ID/memory/
    ```
 
 3. **Commit and push the memory repo**
@@ -87,6 +95,10 @@ Scenario: You're a new agent and want to inherit memory from an existing agent "
 3. **Copy the relevant files into your memfs:**
    ```bash
    cp -r /tmp/letta-memory-agent-abc123/system/project ~/.letta/agents/$LETTA_AGENT_ID/memory/system/
+   ```
+   For v2 (root layout) agents, copy root-level `.md` files and directories instead:
+   ```bash
+   cp /tmp/letta-memory-agent-abc123/project.md ~/.letta/agents/$LETTA_AGENT_ID/memory/
    ```
 
 4. **Commit and push:**


### PR DESCRIPTION
## Summary
- Updated the migrating-memory skill to account for both memfs v1 and v2 memory layouts
- v1 (legacy): `system/` = attached blocks, root = detached blocks (previous description, still accurate for v1)
- v2 (root layout): root-level `.md` files = core memory, directories with `MEMORY.md` indexes = projected memory (new format introduced in `b2c7560e`)
- Added v2-specific copy examples alongside the existing v1 examples
- Added a format detection hint: check for `MEMORY.md` at the export root to identify v2

## Stale claim and current owning source

**Stale claim:** The skill described memory structure as `system/` = attached blocks (always loaded) and root = detached blocks, which is only accurate for memfs v1.

**Current source:** `src/agent/memory-format.ts` (`detectMemoryFormat`, `isCoreMemoryPath`) introduced in commit `b2c7560e` ("feat: configurable memory layout"). In v2, `isCoreMemoryPath` returns true for root-level `.md` files (no `/` in path), not for `system/` paths.

## Focused validation performed
- `bun run check` — all 12 checks pass
- Verified `letta memory export --agent <id> --out <dir>` command syntax against `src/cli/subcommands/memory.ts`
- Verified `memory_filesystem` block detection claim against `src/agent/memory-constants.ts` and `src/agent/prompts/memory_filesystem.mdx`
- Verified `/memfs enable` command against `src/cli/app/use-submit-handler.ts`
- Verified `finding-agents` skill reference against `src/skills/builtin/finding-agents/SKILL.md`
- Verified legacy block-level CLI commands removal against current `letta memory --help` output

Builtin-skill-watch: migrating-memory@2823362103cc-7c0dde53f99d2d79