### PR TITLE
fix(permissions): treat trailing && or || as unparseable for allow-rule matching

### DIFF
--- a/src/permissions/shell-analysis.ts
+++ b/src/permissions/shell-analysis.ts
@@ -140,6 +140,9 @@ export function splitShellSegments(input: string): string[] | null {
     }
 
     if (input.startsWith("&&", i)) {
+      if (i + 2 >= input.length || input.slice(i + 2).trim() === "") {
+        return null;
+      }
       segments.push(current);
       current = "";
       i += 2;
@@ -147,6 +150,9 @@ export function splitShellSegments(input: string): string[] | null {
     }
 
     if (input.startsWith("||", i)) {
+      if (i + 2 >= input.length || input.slice(i + 2).trim() === "") {
+        return null;
+      }
       segments.push(current);
       current = "";
       i += 2;
@@ -317,6 +323,9 @@ export function splitShellSegmentsAllowCommandSubstitution(
     }
 
     if (input.startsWith("&&", i)) {
+      if (i + 2 >= input.length || input.slice(i + 2).trim() === "") {
+        return null;
+      }
       segments.push(current);
       current = "";
       i += 2;
@@ -324,6 +333,9 @@ export function splitShellSegmentsAllowCommandSubstitution(
     }
 
     if (input.startsWith("||", i)) {
+      if (i + 2 >= input.length || input.slice(i + 2).trim() === "") {
+        return null;
+      }
       segments.push(current);
       current = "";
       i += 2;

--- a/src/permissions/shell-command-normalization.test.ts
+++ b/src/permissions/shell-command-normalization.test.ts
@@ -98,4 +98,34 @@ describe("shellAnalysis", () => {
       'curl -s -u "$EXAMPLE_API_KEY:" "https://api.stripe.com/v1/customers/cus_examplecustomer0001"',
     );
   });
+
+  test("trailing && with nothing after is unparseable", () => {
+    expect(splitShellSegments("npm test &&")).toBeNull();
+    expect(splitShellSegments("npm test && ")).toBeNull();
+    expect(splitShellSegments("npm test &&\t")).toBeNull();
+  });
+
+  test("trailing || with nothing after is unparseable", () => {
+    expect(splitShellSegments("npm test ||")).toBeNull();
+    expect(splitShellSegments("npm test || ")).toBeNull();
+  });
+
+  test("trailing && in command-substitution-aware splitter is unparseable", () => {
+    expect(
+      splitShellSegmentsAllowCommandSubstitution("npm test &&"),
+    ).toBeNull();
+    expect(
+      splitShellSegmentsAllowCommandSubstitution("npm test ||"),
+    ).toBeNull();
+  });
+
+  test("non-trailing && still splits normally", () => {
+    expect(splitShellSegments("npm test && npm run lint")).toEqual([
+      "npm test",
+      "npm run lint",
+    ]);
+    expect(
+      splitShellSegmentsAllowCommandSubstitution("npm test && npm run lint"),
+    ).toEqual(["npm test", "npm run lint"]);
+  });
 });


### PR DESCRIPTION
## Summary

- Treat commands with trailing `&&` or `||` (nothing after the operator) as unparseable so allow-rules like `Bash(npm:*)` do not auto-approve them
- Mirrors Claude Code v2.1.251 behavior documented in [permissions.md](https://code.claude.com/docs/en/permissions.md)

## Context

Claude-watch: claude@2.1.251:docs:df07fe79e9eceea35ffaff83c43677a2cc5f86649fbb5e6f9228e15f9899162c:runtime:20f0ec137fdd9e9217fd1e49221ffa37237a253ab468d092da253530f62902ca

Package: @anthropic-ai/claude-code@2.1.251
Release: https://github.com/anthropics/claude-code/releases/tag/v2.1.251

The Claude Code v2.1.251 release notes and permissions.md docs change describe a fix for Bash permission checks: when `&&` or `||` has nothing after it (e.g. `npm test &&`), the command is treated as unparseable and not split into subcommands for allow-rule matching, so a rule such as `Bash(npm *)` does not approve it.

Previously, Letta Code's `splitShellSegments` and `splitShellSegmentsAllowCommandSubstitution` silently dropped the empty trailing segment after a trailing `&&`/`||`, effectively treating `npm test &&` as just `npm test`. This meant `Bash(npm:*)` would auto-approve it.

## Changes

- `src/permissions/shell-analysis.ts`: Both `splitShellSegments` and `splitShellSegmentsAllowCommandSubstitution` now return `null` when `&&` or `||` is followed by only whitespace or end of input
- `src/permissions/shell-command-normalization.test.ts`: Added tests for trailing `&&`/`||` unparseable behavior and verified non-trailing operators still split normally

## Validation

- All 525 permission tests pass
- TypeScript typecheck passes
- Biome lint passes (pre-commit hook)

## Other evidence reviewed (no local impact)

- PreModelSwitch/PostModelSwitch hook events: Claude Code-specific, Letta Code has different hook system
- `agent_needs_input` notification expansion: Claude Code agent teams feature
- `CLAUDE_CODE_SUBAGENT_MODEL` behavior change: Claude Code-specific env var
- Sandbox filesystem `permissions.additionalDirectories` docs: Already implemented in Letta Code
- PolicyHelper failures docs: Claude Code-specific managed settings
- Arithmetic expression assignment fix (`OPTIND=1/0`, `RANDOM=2+2`): Letta Code already prompts (isSafeSegment returns false for these)
- Env-vars, headless, commands, managed-settings docs rewording: Docs clarifications only

Co-Authored-By: Letta Code <noreply@letta.com>