### PR TITLE
docs(skills): route agent renames through self-configuration

### DIFF
--- a/src/skills/builtin/self-configuration/SKILL.md
+++ b/src/skills/builtin/self-configuration/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: self-configuration
-description: Inspect or modify Letta Code's own memory, model, context window, system prompt, compaction, permissions, toolsets, mods, skills, channels, schedules, agent secrets, and local runtime settings. Use when the user asks how this agent or conversation is configured, or asks you to change how you behave or how the harness runs you.
+description: Inspect or modify Letta Code's own memory, model, context window, system prompt, compaction, permissions, toolsets, mods, skills, channels, schedules, agent secrets, and local runtime settings. Use when the user asks how this agent or conversation is configured, asks you to change how you behave or how the harness runs you, or renames you — the agent name is a server field, so a rename needs an agent patch, not just a memory edit.
 license: MIT
 ---
 
@@ -157,6 +157,8 @@ npx tsx <SKILL_DIR>/scripts/update-agent-settings.ts \
 ### Name and description
 
 Name and description are agent-level metadata. Do not pass them with `--target conversation`. Values must be non-empty; the helper does not clear metadata by accident.
+
+When the user renames you, this patch is the authoritative change — editing a name written in persona memory does not change the agent's actual name. Do both: patch the agent name here, then update any memory file that states your name so they agree.
 
 ```bash
 npx tsx <SKILL_DIR>/scripts/update-agent-settings.ts \

--- a/src/skills/builtin/self-configuration/SKILL.md
+++ b/src/skills/builtin/self-configuration/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: self-configuration
-description: Inspect or modify Letta Code's own memory, model, context window, system prompt, compaction, permissions, toolsets, mods, skills, channels, schedules, agent secrets, and local runtime settings. Use when the user asks how this agent or conversation is configured, asks you to change how you behave or how the harness runs you, or renames you — the agent name is a server field, so a rename needs an agent patch, not just a memory edit.
+description: Inspect or modify Letta Code's own memory, model, context window, system prompt, compaction, permissions, toolsets, mods, skills, channels, schedules, agent secrets, and local runtime settings. Use when the user asks how this agent or conversation is configured, asks you to change how you behave or how the harness runs you, or renames you.
 license: MIT
 ---
 


### PR DESCRIPTION
## Summary

When a user renames their agent, the model tends to edit the name in persona memory and stop — the server-side agent name never changes (observed on chat.letta.com with the new cloud Letta Code personality; companion PR letta-ai/letta-cloud#15345 adds the persona-side instruction).

Two additions to the bundled `self-configuration` skill:

- The skill description now names renames as a trigger, so the skill is loaded when the user says "rename yourself to X".
- The "Name and description" section states that the agent patch is the authoritative rename and that memory files stating the name should be updated to match.

## Test plan

- [x] `bun run check` (12/12 passed, including skill frontmatter validation)

👾 Generated with [Letta Code](https://letta.com)