### PR TITLE
feat(channels): add first-party Feishu / Lark channel

### DIFF
--- a/src/channels/AGENTS.md
+++ b/src/channels/AGENTS.md
@@ -29,14 +29,19 @@ payload builders, message-action adapters with injectable transport, and
 debounce. They must stay free of node builtins and adapter imports so a browser
 or webhook host can run them.
 
+Do not add a published `./channels/<id>` subpath until Cloud (or another
+webhook host) needs those pure modules. Local-only channels such as Feishu /
+Lark keep `ingress.ts` / `outbound.ts` in-tree without a package export.
+
 Transport stays deployment-specific: the local adapters own Socket Mode
-(Slack) and grammY long polling (Telegram); Cloud supplies its own webhook
-receivers and API clients. Do not bundle an adapter and its transport into a
-shared module, and do not let a host reimplement its own copy of message,
-mention, reaction, or bot-filtering policy — separate ingress algorithms have
-already caused Cloud to silently drop events that local channels handled. When
-you change ingress or outbound policy in a subpath module, the change is a
-published API change consumed by Cloud; check the subpath exports.
+(Slack), grammY long polling (Telegram), and Feishu / Lark persistent
+connection; Cloud supplies its own webhook receivers and API clients. Do not
+bundle an adapter and its transport into a shared module, and do not let a
+host reimplement its own copy of message, mention, reaction, or bot-filtering
+policy — separate ingress algorithms have already caused Cloud to silently
+drop events that local channels handled. When you change ingress or outbound
+policy in a subpath module, the change is a published API change consumed by
+Cloud; check the subpath exports.
 
 ## Adapters are orchestration entrypoints
 

--- a/src/channels/README.md
+++ b/src/channels/README.md
@@ -1,10 +1,12 @@
 # Channel plugins
 
 Letta Code channels connect agents to external chat systems. Telegram, Slack,
-and Discord are first-party bundled plugins with custom Desktop UI. User-defined
-plugins are loaded from `~/.letta/channels/<channel-id>/` and run headlessly:
-they can receive inbound messages, participate in pairing/routing, and extend
-the shared `MessageChannel` tool, but they do not get custom Desktop screens.
+and Discord are first-party bundled plugins with custom Desktop UI. WhatsApp,
+Signal, and Feishu / Lark are first-party plugins without custom Desktop
+screens (generic `configSchema` is enough). User-defined plugins are loaded
+from `~/.letta/channels/<channel-id>/` and run headlessly: they can receive
+inbound messages, participate in pairing/routing, and extend the shared
+`MessageChannel` tool, but they do not get custom Desktop screens.
 
 ## Directory layout
 
@@ -298,6 +300,52 @@ broad message events makes mention-only delivery apply to the whole Slack app
 instead. Restart the listener after editing `accounts.json` so the running Slack
 adapter loads the new policy.
 
+## Feishu / Lark
+
+The bundled Feishu channel uses the Open Platform **persistent connection**
+(WebSocket). It is a self-built-app transport: store apps and HTTP webhooks
+are not supported in v1. Configure with `letta channels configure feishu` or
+by writing `~/.letta/channels/feishu/accounts.json`.
+
+Required Open Platform setup:
+
+1. Create a **self-built** app (Feishu at `open.feishu.cn`, or Lark at
+   `open.larksuite.com`).
+2. Enable bot capability.
+3. Subscribe to `im.message.receive_v1`.
+4. Choose **persistent connection**, not a request URL / webhook.
+5. Grant `im:message.p2p_msg:readonly`, `im:message.group_at_msg:readonly`,
+   and `im:message:send_as_bot`.
+6. Publish a version and add the bot to groups.
+
+Account fields:
+
+- `app_id` / `app_secret` — Open Platform credentials. The secret is stored
+  in the channel credential store and redacted as `has_app_secret` in
+  snapshots.
+- `domain` — `"feishu"` (default, `https://open.feishu.cn`) or `"lark"`
+  (`https://open.larksuite.com`). Using the wrong domain fails auth.
+- `group_mode` — `"mention-only"` (default) or `"open"`. Mention-only matches
+  Feishu's default group @bot event scope. `@all` / `@_all` are not treated
+  as bot mentions.
+- `agent_id` — Letta agent for group @mentions and non-pairing DMs.
+- Pairing and allowlists use Feishu `open_id` values (`ou_...`). Group chat
+  IDs are `oc_...`. Topics use `thread_id` (`omt_...`).
+
+**One running listener per App ID.** Persistent connection is cluster mode:
+if Desktop and `letta server` both connect with the same App ID, Feishu
+delivers each event to one connection at random. Starting a second adapter
+for an App ID that is already running fails.
+
+Install the Node SDK once per machine with `letta channels install feishu`
+(`@larksuiteoapi/node-sdk`). Feishu slash commands (`/status`, `/cancel`)
+are sent as **plain text** in the chat — there is no native Feishu slash
+menu in v1.
+
+Restart the listener after editing `accounts.json` so credentials, domain,
+and group-mode policy reload. Open group mode also needs the all-group-messages
+event scope on the Open Platform app; mention-only matches the default `@bot`
+scope.
 
 ## First-party vs user plugins
 

--- a/src/channels/account-config.ts
+++ b/src/channels/account-config.ts
@@ -1,5 +1,6 @@
 import { customAccountConfigAdapter } from "./custom/account-config";
 import { discordAccountConfigAdapter } from "./discord/account-config";
+import { feishuAccountConfigAdapter } from "./feishu/account-config";
 import type {
   ChannelAccountConfigAdapter,
   ChannelAccountPatch,
@@ -30,6 +31,8 @@ const CHANNEL_ACCOUNT_CONFIG_ADAPTERS: Record<
     whatsappAccountConfigAdapter as ChannelAccountConfigAdapter<ChannelAccount>,
   signal:
     signalAccountConfigAdapter as ChannelAccountConfigAdapter<ChannelAccount>,
+  feishu:
+    feishuAccountConfigAdapter as ChannelAccountConfigAdapter<ChannelAccount>,
 };
 
 /**

--- a/src/channels/accounts.ts
+++ b/src/channels/accounts.ts
@@ -30,6 +30,7 @@ import {
   DEFAULT_SLACK_PERMISSION_MODE,
   isCustomChannelAccount,
   isDiscordChannelAccount,
+  isFeishuChannelAccount,
   isFirstPartyChannelId,
   isSignalChannelAccount,
   isSlackChannelAccount,
@@ -49,6 +50,8 @@ const SNAKE_TO_CAMEL: Record<string, string> = {
   allowed_channels: "allowedChannels",
   allowed_groups: "allowedGroups",
   allow_bots: "allowBots",
+  app_id: "appId",
+  app_secret: "appSecret",
   group_policy: "groupPolicy",
   user_allowed_commands: "userAllowedCommands",
   auto_thread_on_mention: "autoThreadOnMention",
@@ -110,6 +113,9 @@ function getSecretFieldPaths(account: ChannelAccount): string[] {
   }
   if (isTelegramChannelAccount(account) || isDiscordChannelAccount(account)) {
     return ["token"];
+  }
+  if (isFeishuChannelAccount(account)) {
+    return ["appSecret"];
   }
   if (
     isCustomChannelAccount(account) ||
@@ -418,6 +424,16 @@ function normalizeLoadedAccount<T extends ChannelAccount>(account: T): T {
   }
   if (isTelegramChannelAccount(next)) {
     next.richPrivateChatDefault = next.richPrivateChatDefault !== false;
+  }
+  if (isFeishuChannelAccount(next)) {
+    next.appId = typeof next.appId === "string" ? next.appId : "";
+    next.appSecret = typeof next.appSecret === "string" ? next.appSecret : "";
+    next.domain = next.domain === "lark" ? "lark" : "feishu";
+    next.groupMode = next.groupMode === "open" ? "open" : "mention-only";
+    next.agentId =
+      typeof next.agentId === "string" && next.agentId.trim().length > 0
+        ? next.agentId
+        : null;
   }
   return next;
 }

--- a/src/channels/feishu/account-config.test.ts
+++ b/src/channels/feishu/account-config.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from "bun:test";
+import { feishuAccountConfigAdapter } from "@/channels/feishu/account-config";
+import type { FeishuChannelAccount } from "@/channels/types";
+
+function account(
+  overrides: Partial<FeishuChannelAccount> = {},
+): FeishuChannelAccount {
+  return {
+    channel: "feishu",
+    accountId: "acct-1",
+    enabled: true,
+    appId: "cli_app",
+    appSecret: "super-secret",
+    domain: "feishu",
+    groupMode: "mention-only",
+    agentId: "agent-1",
+    dmPolicy: "pairing",
+    allowedUsers: [],
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("feishu account config", () => {
+  test("unknown config keys are invalid", () => {
+    expect(feishuAccountConfigAdapter.isValidConfig({ webhook_url: "x" })).toBe(
+      false,
+    );
+    expect(
+      feishuAccountConfigAdapter.isValidConfig({ domain: "https://evil" }),
+    ).toBe(false);
+    expect(
+      feishuAccountConfigAdapter.isValidConfig({
+        app_id: "cli_app",
+        domain: "lark",
+      }),
+    ).toBe(true);
+  });
+
+  test("app_secret is redacted in list/get snapshots", () => {
+    const snapshot = feishuAccountConfigAdapter.toAccountConfig(account());
+    expect(snapshot.has_app_secret).toBe(true);
+    expect(snapshot.app_secret).toBeUndefined();
+    expect(JSON.stringify(snapshot)).not.toContain("super-secret");
+    expect(snapshot.app_id).toBe("cli_app");
+    expect(snapshot.domain).toBe("feishu");
+    expect(snapshot.group_mode).toBe("mention-only");
+  });
+
+  test("empty secret is reported as missing", () => {
+    const snapshot = feishuAccountConfigAdapter.toAccountConfig(
+      account({ appSecret: "  " }),
+    );
+    expect(snapshot.has_app_secret).toBe(false);
+  });
+});

--- a/src/channels/feishu/account-config.ts
+++ b/src/channels/feishu/account-config.ts
@@ -1,0 +1,91 @@
+import type { ChannelAccountConfigAdapter } from "@/channels/plugin-types";
+import type {
+  FeishuChannelAccount,
+  FeishuDomain,
+  FeishuGroupMode,
+} from "@/channels/types";
+
+const FEISHU_CONFIG_KEYS = new Set([
+  "app_id",
+  "app_secret",
+  "domain",
+  "group_mode",
+  "agent_id",
+]);
+
+function isString(value: unknown): value is string {
+  return typeof value === "string";
+}
+
+function isNullableString(value: unknown): value is string | null {
+  return value === null || typeof value === "string";
+}
+
+function isFeishuDomain(value: unknown): value is FeishuDomain {
+  return value === "feishu" || value === "lark";
+}
+
+function isFeishuGroupMode(value: unknown): value is FeishuGroupMode {
+  return value === "open" || value === "mention-only";
+}
+
+export const feishuAccountConfigAdapter: ChannelAccountConfigAdapter<FeishuChannelAccount> =
+  {
+    isValidConfig(config) {
+      for (const key of Object.keys(config)) {
+        if (!FEISHU_CONFIG_KEYS.has(key)) {
+          return false;
+        }
+      }
+      return (
+        (config.app_id === undefined || isString(config.app_id)) &&
+        (config.app_secret === undefined || isString(config.app_secret)) &&
+        (config.domain === undefined || isFeishuDomain(config.domain)) &&
+        (config.group_mode === undefined ||
+          isFeishuGroupMode(config.group_mode)) &&
+        (config.agent_id === undefined || isNullableString(config.agent_id))
+      );
+    },
+
+    toAccountPatch(config) {
+      return {
+        appId: isString(config.app_id) ? config.app_id : undefined,
+        appSecret: isString(config.app_secret) ? config.app_secret : undefined,
+        domain: isFeishuDomain(config.domain) ? config.domain : undefined,
+        groupMode: isFeishuGroupMode(config.group_mode)
+          ? config.group_mode
+          : undefined,
+        agentId: isNullableString(config.agent_id)
+          ? config.agent_id
+          : undefined,
+      };
+    },
+
+    toAccountConfig(account) {
+      return {
+        has_app_secret: account.appSecret.trim().length > 0,
+        app_id: account.appId,
+        domain: account.domain,
+        group_mode: account.groupMode,
+        agent_id: account.agentId,
+      };
+    },
+
+    toConfigSnapshotConfig(account) {
+      return {
+        has_app_secret: account.appSecret.trim().length > 0,
+        app_id: account.appId,
+        domain: account.domain,
+        group_mode: account.groupMode,
+        agent_id: account.agentId,
+      };
+    },
+
+    shouldRefreshDisplayName(patch) {
+      return (
+        patch.appId !== undefined ||
+        patch.appSecret !== undefined ||
+        patch.domain !== undefined
+      );
+    },
+  };

--- a/src/channels/feishu/account-display.ts
+++ b/src/channels/feishu/account-display.ts
@@ -1,0 +1,47 @@
+import type { FeishuDomain } from "@/channels/types";
+import { isRecord } from "@/utils/type-guards";
+import { loadFeishuModule, resolveFeishuSdkDomain } from "./runtime";
+
+function readBotName(payload: unknown): string | undefined {
+  if (!isRecord(payload)) {
+    return undefined;
+  }
+  const bot = isRecord(payload.bot) ? payload.bot : payload;
+  const name =
+    (typeof bot.app_name === "string" && bot.app_name.trim()) ||
+    (typeof bot.name === "string" && bot.name.trim()) ||
+    (isRecord(payload.data) &&
+      typeof payload.data.app_name === "string" &&
+      payload.data.app_name.trim()) ||
+    "";
+  return name || undefined;
+}
+
+export async function resolveFeishuAccountDisplayName(options: {
+  appId: string;
+  appSecret: string;
+  domain: FeishuDomain;
+}): Promise<string | undefined> {
+  if (!options.appId.trim() || !options.appSecret.trim()) {
+    return undefined;
+  }
+  try {
+    const Lark = await loadFeishuModule();
+    const client = new Lark.Client({
+      appId: options.appId.trim(),
+      appSecret: options.appSecret.trim(),
+      domain: resolveFeishuSdkDomain(options.domain, Lark),
+      ...(Lark.AppType?.SelfBuild ? { appType: Lark.AppType.SelfBuild } : {}),
+    });
+    if (typeof client.request !== "function") {
+      return undefined;
+    }
+    const result = await client.request({
+      url: "/open-apis/bot/v3/info",
+      method: "GET",
+    });
+    return readBotName(result);
+  } catch {
+    return undefined;
+  }
+}

--- a/src/channels/feishu/account-display.ts
+++ b/src/channels/feishu/account-display.ts
@@ -1,21 +1,6 @@
 import type { FeishuDomain } from "@/channels/types";
-import { isRecord } from "@/utils/type-guards";
+import { FEISHU_BOT_INFO_PATH, parseFeishuBotInfo } from "./bot-info";
 import { loadFeishuModule, resolveFeishuSdkDomain } from "./runtime";
-
-function readBotName(payload: unknown): string | undefined {
-  if (!isRecord(payload)) {
-    return undefined;
-  }
-  const bot = isRecord(payload.bot) ? payload.bot : payload;
-  const name =
-    (typeof bot.app_name === "string" && bot.app_name.trim()) ||
-    (typeof bot.name === "string" && bot.name.trim()) ||
-    (isRecord(payload.data) &&
-      typeof payload.data.app_name === "string" &&
-      payload.data.app_name.trim()) ||
-    "";
-  return name || undefined;
-}
 
 export async function resolveFeishuAccountDisplayName(options: {
   appId: string;
@@ -37,10 +22,10 @@ export async function resolveFeishuAccountDisplayName(options: {
       return undefined;
     }
     const result = await client.request({
-      url: "/open-apis/bot/v3/info",
+      url: FEISHU_BOT_INFO_PATH,
       method: "GET",
     });
-    return readBotName(result);
+    return parseFeishuBotInfo(result).name;
   } catch {
     return undefined;
   }

--- a/src/channels/feishu/adapter.test.ts
+++ b/src/channels/feishu/adapter.test.ts
@@ -1,0 +1,264 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import {
+  __testResetFeishuAppIdOwners,
+  createFeishuAdapter,
+} from "@/channels/feishu/adapter";
+import type { LarkRuntimeModuleLike } from "@/channels/feishu/internal-types";
+import { FEISHU_API_DOMAINS } from "@/channels/feishu/internal-types";
+import type {
+  FeishuChannelAccount,
+  InboundChannelMessage,
+} from "@/channels/types";
+
+class FakeEventDispatcher {
+  readonly handlers = new Map<
+    string,
+    (data: unknown) => Promise<unknown> | unknown
+  >();
+
+  register(
+    handlers: Record<string, (data: unknown) => Promise<unknown> | unknown>,
+  ): this {
+    for (const [key, handler] of Object.entries(handlers)) {
+      this.handlers.set(key, handler);
+    }
+    return this;
+  }
+}
+
+class FakeClient {
+  static instances: FakeClient[] = [];
+  readonly domain: unknown;
+  readonly create = mock(async (_request: unknown) => ({
+    data: { message_id: "om_sent" },
+  }));
+  readonly reply = mock(async (_request: unknown) => ({
+    data: { message_id: "om_reply" },
+  }));
+
+  constructor(config: { domain?: unknown }) {
+    this.domain = config.domain;
+    FakeClient.instances.push(this);
+  }
+
+  readonly im = {
+    v1: {
+      message: {
+        create: (request: unknown) => this.create(request),
+        reply: (request: unknown) => this.reply(request),
+      },
+    },
+  };
+}
+
+class FakeWSClient {
+  static instances: FakeWSClient[] = [];
+  dispatcher: FakeEventDispatcher | null = null;
+  readonly domain: unknown;
+  readonly start = mock(
+    async (options: { eventDispatcher: FakeEventDispatcher }) => {
+      this.dispatcher = options.eventDispatcher;
+    },
+  );
+  readonly close = mock(() => {});
+
+  constructor(config: { domain?: unknown }) {
+    this.domain = config.domain;
+    FakeWSClient.instances.push(this);
+  }
+
+  async emitReceive(data: unknown): Promise<void> {
+    await this.dispatcher?.handlers.get("im.message.receive_v1")?.(data);
+  }
+}
+
+function fakeRuntime(): LarkRuntimeModuleLike {
+  return {
+    Domain: {
+      Feishu: FEISHU_API_DOMAINS.feishu,
+      Lark: FEISHU_API_DOMAINS.lark,
+    },
+    Client: FakeClient as unknown as LarkRuntimeModuleLike["Client"],
+    WSClient: FakeWSClient as unknown as LarkRuntimeModuleLike["WSClient"],
+    EventDispatcher:
+      FakeEventDispatcher as unknown as LarkRuntimeModuleLike["EventDispatcher"],
+  };
+}
+
+function account(
+  overrides: Partial<FeishuChannelAccount> = {},
+): FeishuChannelAccount {
+  return {
+    channel: "feishu",
+    accountId: overrides.accountId ?? "acct-feishu",
+    enabled: true,
+    appId: "cli_app",
+    appSecret: "secret",
+    domain: "feishu",
+    groupMode: "mention-only",
+    agentId: "agent-1",
+    dmPolicy: "pairing",
+    allowedUsers: [],
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function botMentionEvent(overrides?: {
+  messageId?: string;
+  eventId?: string;
+  chatType?: string;
+}): unknown {
+  return {
+    header: {
+      event_id: overrides?.eventId ?? "evt_1",
+      event_type: "im.message.receive_v1",
+    },
+    event: {
+      sender: {
+        sender_id: { open_id: "ou_user" },
+        sender_type: "user",
+      },
+      message: {
+        message_id: overrides?.messageId ?? "om_1",
+        chat_id: "oc_group",
+        chat_type: overrides?.chatType ?? "group",
+        message_type: "text",
+        content: '{"text":"@_user_1 ping"}',
+        mentions: [
+          {
+            key: "@_user_1",
+            mentioned_type: "bot",
+            id: { open_id: "ou_bot" },
+          },
+        ],
+      },
+    },
+  };
+}
+
+async function flush(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe("feishu adapter", () => {
+  afterEach(async () => {
+    __testResetFeishuAppIdOwners();
+    FakeClient.instances = [];
+    FakeWSClient.instances = [];
+  });
+
+  test("domain lark constructs the Lark API domain", async () => {
+    const adapter = createFeishuAdapter(account({ domain: "lark" }), {
+      loadRuntimeModule: async () => fakeRuntime(),
+    });
+    await adapter.start();
+    expect(FakeClient.instances[0]?.domain).toBe(FEISHU_API_DOMAINS.lark);
+    expect(FakeWSClient.instances[0]?.domain).toBe(FEISHU_API_DOMAINS.lark);
+    await adapter.stop();
+  });
+
+  test("same message_id with different event_id is delivered once", async () => {
+    const adapter = createFeishuAdapter(account(), {
+      loadRuntimeModule: async () => fakeRuntime(),
+    });
+    const received: InboundChannelMessage[] = [];
+    adapter.onMessage = async (msg) => {
+      received.push(msg);
+    };
+    await adapter.start();
+    const ws = FakeWSClient.instances[0];
+    await ws?.emitReceive(
+      botMentionEvent({ messageId: "om_dup", eventId: "evt_a" }),
+    );
+    await flush();
+    await ws?.emitReceive(
+      botMentionEvent({ messageId: "om_dup", eventId: "evt_b" }),
+    );
+    await flush();
+    expect(received).toHaveLength(1);
+    expect(received[0]?.messageId).toBe("om_dup");
+    await adapter.stop();
+  });
+
+  test("onMessage errors do not throw back to the SDK handler", async () => {
+    const adapter = createFeishuAdapter(account(), {
+      loadRuntimeModule: async () => fakeRuntime(),
+    });
+    adapter.onMessage = async () => {
+      throw new Error("turn failed");
+    };
+    await adapter.start();
+    await expect(
+      FakeWSClient.instances[0]?.emitReceive(botMentionEvent()),
+    ).resolves.toBeUndefined();
+    await adapter.stop();
+  });
+
+  test("second start with the same App ID fails loudly", async () => {
+    const first = createFeishuAdapter(account({ accountId: "one" }), {
+      loadRuntimeModule: async () => fakeRuntime(),
+    });
+    const second = createFeishuAdapter(account({ accountId: "two" }), {
+      loadRuntimeModule: async () => fakeRuntime(),
+    });
+    await first.start();
+    await expect(second.start()).rejects.toThrow(/already connected/);
+    await first.stop();
+  });
+
+  test("sendMessage uses receive_id_type chat_id", async () => {
+    const adapter = createFeishuAdapter(account(), {
+      loadRuntimeModule: async () => fakeRuntime(),
+    });
+    await adapter.start();
+    const result = await adapter.sendMessage({
+      channel: "feishu",
+      chatId: "oc_group",
+      text: "hello",
+    });
+    expect(result.messageId).toBe("om_sent");
+    expect(FakeClient.instances[0]?.create).toHaveBeenCalledTimes(1);
+    expect(FakeClient.instances[0]?.create.mock.calls[0]?.[0]).toEqual({
+      params: { receive_id_type: "chat_id" },
+      data: {
+        receive_id: "oc_group",
+        msg_type: "text",
+        content: '{"text":"hello"}',
+      },
+    });
+    await adapter.stop();
+  });
+
+  test("lifecycle errors are sanitized before posting to the chat", async () => {
+    const adapter = createFeishuAdapter(account(), {
+      loadRuntimeModule: async () => fakeRuntime(),
+    });
+    await adapter.start();
+    await adapter.handleTurnLifecycleEvent?.({
+      type: "finished",
+      batchId: "batch-1",
+      sources: [
+        {
+          channel: "feishu",
+          chatId: "oc_group",
+          agentId: "agent-1",
+          conversationId: "conv-1",
+        },
+      ],
+      outcome: "error",
+      stopReason: "error",
+      error: "Unexpected stop reason: error",
+    });
+    const request = FakeClient.instances[0]?.create.mock.calls[0]?.[0] as {
+      data: { content: string };
+    };
+    expect(request.data.content).not.toContain("Unexpected stop reason");
+    expect(request.data.content).toContain(
+      "Something went wrong while processing that message",
+    );
+    await adapter.stop();
+  });
+});

--- a/src/channels/feishu/adapter.test.ts
+++ b/src/channels/feishu/adapter.test.ts
@@ -3,8 +3,11 @@ import {
   __testResetFeishuAppIdOwners,
   createFeishuAdapter,
 } from "@/channels/feishu/adapter";
-import type { LarkRuntimeModuleLike } from "@/channels/feishu/internal-types";
-import { FEISHU_API_DOMAINS } from "@/channels/feishu/internal-types";
+import { FEISHU_BOT_INFO_PATH } from "@/channels/feishu/bot-info";
+import {
+  FEISHU_API_DOMAINS,
+  type LarkRuntimeModuleLike,
+} from "@/channels/feishu/internal-types";
 import type {
   FeishuChannelAccount,
   InboundChannelMessage,
@@ -34,6 +37,9 @@ class FakeClient {
   }));
   readonly reply = mock(async (_request: unknown) => ({
     data: { message_id: "om_reply" },
+  }));
+  readonly request = mock(async (_config: unknown) => ({
+    bot: { open_id: "ou_bot", app_name: "Letta" },
   }));
 
   constructor(config: { domain?: unknown }) {
@@ -129,7 +135,6 @@ function botMentionEvent(overrides?: {
         mentions: [
           {
             key: "@_user_1",
-            mentioned_type: "bot",
             id: { open_id: "ou_bot" },
           },
         ],
@@ -259,6 +264,65 @@ describe("feishu adapter", () => {
     expect(request.data.content).toContain(
       "Something went wrong while processing that message",
     );
+    await adapter.stop();
+  });
+
+  test("resolves bot open_id and delivers official-shaped group @mentions", async () => {
+    const adapter = createFeishuAdapter(account(), {
+      loadRuntimeModule: async () => fakeRuntime(),
+    });
+    const received: InboundChannelMessage[] = [];
+    adapter.onMessage = async (msg) => {
+      received.push(msg);
+    };
+    await adapter.start();
+    expect(FakeClient.instances[0]?.request).toHaveBeenCalledWith({
+      url: FEISHU_BOT_INFO_PATH,
+      method: "GET",
+    });
+    await FakeWSClient.instances[0]?.emitReceive(botMentionEvent());
+    await flush();
+    expect(received).toHaveLength(1);
+    expect(received[0]?.isMention).toBe(true);
+    expect(received[0]?.routedBy).toBe("mention");
+    await adapter.stop();
+  });
+
+  test("mention-only groups drop @mentions that are not this bot", async () => {
+    const adapter = createFeishuAdapter(account(), {
+      loadRuntimeModule: async () => fakeRuntime(),
+    });
+    const received: InboundChannelMessage[] = [];
+    adapter.onMessage = async (msg) => {
+      received.push(msg);
+    };
+    await adapter.start();
+    await FakeWSClient.instances[0]?.emitReceive({
+      header: { event_id: "evt_user", event_type: "im.message.receive_v1" },
+      event: {
+        sender: {
+          sender_id: { open_id: "ou_user" },
+          sender_type: "user",
+        },
+        message: {
+          message_id: "om_user_mention",
+          chat_id: "oc_group",
+          chat_type: "group",
+          message_type: "text",
+          content: '{"text":"@_user_1 hello"}',
+          mentions: [
+            {
+              key: "@_user_1",
+              mentioned_type: "bot",
+              id: { open_id: "ou_tom" },
+              name: "Tom",
+            },
+          ],
+        },
+      },
+    });
+    await flush();
+    expect(received).toHaveLength(0);
     await adapter.stop();
   });
 });

--- a/src/channels/feishu/adapter.ts
+++ b/src/channels/feishu/adapter.ts
@@ -1,0 +1,300 @@
+import { formatChannelLifecycleErrorMessage } from "@/channels/lifecycle-error";
+import type {
+  ChannelAdapter,
+  ChannelTurnLifecycleEvent,
+  FeishuChannelAccount,
+  OutboundChannelMessage,
+} from "@/channels/types";
+import { evaluateFeishuReceiveEvent } from "./ingress";
+import type {
+  LarkClientLike,
+  LarkEventDispatcherLike,
+  LarkRuntimeModuleLike,
+  LarkWsClientLike,
+} from "./internal-types";
+import {
+  buildFeishuCreateTextMessage,
+  buildFeishuReplyTextMessage,
+} from "./outbound";
+import { loadFeishuModule, resolveFeishuSdkDomain } from "./runtime";
+
+const INGRESS_DEDUPE_TTL_MS = 7 * 60 * 60 * 1000;
+const INGRESS_DEDUPE_MAX = 10_000;
+
+const runningFeishuAppIds = new Map<string, string>();
+
+export function __testResetFeishuAppIdOwners(): void {
+  runningFeishuAppIds.clear();
+}
+
+export interface CreateFeishuAdapterOptions {
+  loadRuntimeModule?: () => Promise<LarkRuntimeModuleLike>;
+}
+
+function pruneSeenMessageIds(seen: Map<string, number>, now: number): void {
+  if (seen.size <= INGRESS_DEDUPE_MAX) {
+    for (const [id, seenAt] of seen) {
+      if (now - seenAt > INGRESS_DEDUPE_TTL_MS) {
+        seen.delete(id);
+      }
+    }
+    return;
+  }
+  const entries = [...seen.entries()].sort((left, right) => left[1] - right[1]);
+  const extra = seen.size - INGRESS_DEDUPE_MAX;
+  for (let index = 0; index < extra; index += 1) {
+    const id = entries[index]?.[0];
+    if (id) seen.delete(id);
+  }
+}
+
+function claimFeishuAppId(appId: string, accountId: string): void {
+  const owner = runningFeishuAppIds.get(appId);
+  if (owner && owner !== accountId) {
+    throw new Error(
+      `Feishu app ${appId} is already connected by account "${owner}". Only one listener can run per App ID — Feishu delivers each event to one connection in cluster mode.`,
+    );
+  }
+  runningFeishuAppIds.set(appId, accountId);
+}
+
+function releaseFeishuAppId(appId: string, accountId: string): void {
+  if (runningFeishuAppIds.get(appId) === accountId) {
+    runningFeishuAppIds.delete(appId);
+  }
+}
+
+function readCreatedMessageId(result: unknown): string {
+  if (
+    result &&
+    typeof result === "object" &&
+    "data" in result &&
+    result.data &&
+    typeof result.data === "object" &&
+    "message_id" in result.data &&
+    typeof result.data.message_id === "string" &&
+    result.data.message_id.trim()
+  ) {
+    return result.data.message_id;
+  }
+  return `feishu-${Date.now()}`;
+}
+
+export function createFeishuAdapter(
+  config: FeishuChannelAccount,
+  options?: CreateFeishuAdapterOptions,
+): ChannelAdapter {
+  let client: LarkClientLike | null = null;
+  let wsClient: LarkWsClientLike | null = null;
+  let running = false;
+  let adapter!: ChannelAdapter;
+  const seenMessageIds = new Map<string, number>();
+  const loadRuntime = options?.loadRuntimeModule ?? loadFeishuModule;
+
+  async function sendText(
+    chatId: string,
+    text: string,
+    options?: { replyToMessageId?: string; threadId?: string | null },
+  ): Promise<string> {
+    if (!client) {
+      throw new Error("Feishu not started");
+    }
+    const replyTo = options?.replyToMessageId?.trim();
+    if (replyTo && typeof client.im.v1.message.reply === "function") {
+      const request = buildFeishuReplyTextMessage({
+        messageId: replyTo,
+        text,
+        replyInThread: Boolean(options?.threadId),
+      });
+      const result = await client.im.v1.message.reply(request);
+      return readCreatedMessageId(result);
+    }
+    const request = buildFeishuCreateTextMessage({
+      receiveId: chatId,
+      receiveIdType: "chat_id",
+      text,
+    });
+    const result = await client.im.v1.message.create(request);
+    return readCreatedMessageId(result);
+  }
+
+  async function handleReceiveEvent(data: unknown): Promise<void> {
+    try {
+      const decision = evaluateFeishuReceiveEvent(data, {
+        accountId: config.accountId,
+        groupMode: config.groupMode,
+        botOpenId: null,
+      });
+      if (decision.action === "drop") {
+        return;
+      }
+      const inbound = decision.inbound;
+      const messageId = inbound.messageId?.trim();
+      if (messageId) {
+        const now = Date.now();
+        pruneSeenMessageIds(seenMessageIds, now);
+        if (seenMessageIds.has(messageId)) {
+          return;
+        }
+        seenMessageIds.set(messageId, now);
+      }
+      if (!adapter.onMessage) {
+        return;
+      }
+      void adapter.onMessage(inbound).catch((error) => {
+        console.error(
+          "[Feishu] Error handling inbound message:",
+          error instanceof Error ? error.message : error,
+        );
+      });
+    } catch (error) {
+      console.error(
+        "[Feishu] Failed to process receive event:",
+        error instanceof Error ? error.message : error,
+      );
+    }
+  }
+
+  adapter = {
+    id: `feishu:${config.accountId}`,
+    channelId: "feishu",
+    accountId: config.accountId,
+    name: "Feishu / Lark",
+
+    async start(): Promise<void> {
+      if (running) return;
+
+      const appId = config.appId.trim();
+      const appSecret = config.appSecret.trim();
+      if (!appId || !appSecret) {
+        throw new Error(
+          "Feishu account is missing an App ID or App Secret. Configure it first.",
+        );
+      }
+
+      claimFeishuAppId(appId, config.accountId);
+
+      try {
+        const Lark = await loadRuntime();
+        const domain = resolveFeishuSdkDomain(config.domain, Lark);
+        const clientConfig = {
+          appId,
+          appSecret,
+          domain,
+          ...(Lark.AppType?.SelfBuild
+            ? { appType: Lark.AppType.SelfBuild }
+            : {}),
+        };
+        client = new Lark.Client(clientConfig);
+        wsClient = new Lark.WSClient(clientConfig);
+        const dispatcher: LarkEventDispatcherLike = new Lark.EventDispatcher(
+          {},
+        ).register({
+          "im.message.receive_v1": handleReceiveEvent,
+        });
+
+        running = true;
+        const startResult = wsClient.start({ eventDispatcher: dispatcher });
+        if (startResult && typeof startResult.then === "function") {
+          void startResult.catch((error: unknown) => {
+            running = false;
+            releaseFeishuAppId(appId, config.accountId);
+            client = null;
+            wsClient = null;
+            console.error(
+              "[Feishu] WebSocket connection failed:",
+              error instanceof Error ? error.message : error,
+            );
+          });
+        }
+        console.log(
+          `[Feishu] Persistent connection started for ${appId} (${config.domain}, dm_policy: ${config.dmPolicy})`,
+        );
+      } catch (error) {
+        running = false;
+        releaseFeishuAppId(appId, config.accountId);
+        client = null;
+        wsClient = null;
+        throw error;
+      }
+    },
+
+    async stop(): Promise<void> {
+      running = false;
+      releaseFeishuAppId(config.appId.trim(), config.accountId);
+      try {
+        wsClient?.close?.();
+      } catch (error) {
+        console.warn(
+          "[Feishu] Error while closing WebSocket:",
+          error instanceof Error ? error.message : error,
+        );
+      }
+      client = null;
+      wsClient = null;
+      seenMessageIds.clear();
+      console.log("[Feishu] Bot stopped");
+    },
+
+    isRunning(): boolean {
+      return running;
+    },
+
+    async handleTurnLifecycleEvent(
+      event: ChannelTurnLifecycleEvent,
+    ): Promise<void> {
+      if (!running || event.type !== "finished" || event.outcome !== "error") {
+        return;
+      }
+      const errorText = event.error?.trim();
+      if (!errorText) return;
+      const formatted = formatChannelLifecycleErrorMessage(errorText, {
+        runId: event.runId,
+      });
+      const uniqueChats = new Map<string, string | undefined>();
+      for (const source of event.sources) {
+        if (!uniqueChats.has(source.chatId)) {
+          uniqueChats.set(source.chatId, source.messageId);
+        }
+      }
+      await Promise.all(
+        [...uniqueChats.entries()].map(async ([chatId, messageId]) => {
+          try {
+            await sendText(chatId, formatted, {
+              replyToMessageId: messageId,
+              threadId: event.sources.find((source) => source.chatId === chatId)
+                ?.threadId,
+            });
+          } catch (error) {
+            console.warn(
+              `[Feishu] Failed to post lifecycle error for ${chatId}:`,
+              error instanceof Error ? error.message : error,
+            );
+          }
+        }),
+      );
+    },
+
+    async sendMessage(
+      msg: OutboundChannelMessage,
+    ): Promise<{ messageId: string }> {
+      const messageId = await sendText(msg.chatId, msg.text, {
+        replyToMessageId: msg.replyToMessageId,
+        threadId: msg.threadId,
+      });
+      return { messageId };
+    },
+
+    async sendDirectReply(
+      chatId: string,
+      text: string,
+      options?: { replyToMessageId?: string },
+    ): Promise<void> {
+      await sendText(chatId, text, {
+        replyToMessageId: options?.replyToMessageId,
+      });
+    },
+  };
+
+  return adapter;
+}

--- a/src/channels/feishu/adapter.ts
+++ b/src/channels/feishu/adapter.ts
@@ -5,6 +5,7 @@ import type {
   FeishuChannelAccount,
   OutboundChannelMessage,
 } from "@/channels/types";
+import { FEISHU_BOT_INFO_PATH, parseFeishuBotInfo } from "./bot-info";
 import { evaluateFeishuReceiveEvent } from "./ingress";
 import type {
   LarkClientLike,
@@ -64,6 +65,25 @@ function releaseFeishuAppId(appId: string, accountId: string): void {
   }
 }
 
+async function resolveBotOpenId(api: LarkClientLike): Promise<string | null> {
+  if (typeof api.request !== "function") {
+    return null;
+  }
+  try {
+    const result = await api.request({
+      url: FEISHU_BOT_INFO_PATH,
+      method: "GET",
+    });
+    return parseFeishuBotInfo(result).openId ?? null;
+  } catch (error) {
+    console.warn(
+      "[Feishu] Could not resolve bot open_id from /open-apis/bot/v3/info:",
+      error instanceof Error ? error.message : error,
+    );
+    return null;
+  }
+}
+
 function readCreatedMessageId(result: unknown): string {
   if (
     result &&
@@ -87,6 +107,7 @@ export function createFeishuAdapter(
   let client: LarkClientLike | null = null;
   let wsClient: LarkWsClientLike | null = null;
   let running = false;
+  let botOpenId: string | null = null;
   let adapter!: ChannelAdapter;
   const seenMessageIds = new Map<string, number>();
   const loadRuntime = options?.loadRuntimeModule ?? loadFeishuModule;
@@ -123,7 +144,7 @@ export function createFeishuAdapter(
       const decision = evaluateFeishuReceiveEvent(data, {
         accountId: config.accountId,
         groupMode: config.groupMode,
-        botOpenId: null,
+        botOpenId,
       });
       if (decision.action === "drop") {
         return;
@@ -186,6 +207,12 @@ export function createFeishuAdapter(
             : {}),
         };
         client = new Lark.Client(clientConfig);
+        botOpenId = await resolveBotOpenId(client);
+        if (!botOpenId) {
+          console.warn(
+            "[Feishu] Bot open_id is unknown; mention-only groups will drop @mentions until /open-apis/bot/v3/info succeeds.",
+          );
+        }
         wsClient = new Lark.WSClient(clientConfig);
         const dispatcher: LarkEventDispatcherLike = new Lark.EventDispatcher(
           {},
@@ -201,6 +228,7 @@ export function createFeishuAdapter(
             releaseFeishuAppId(appId, config.accountId);
             client = null;
             wsClient = null;
+            botOpenId = null;
             console.error(
               "[Feishu] WebSocket connection failed:",
               error instanceof Error ? error.message : error,
@@ -215,6 +243,7 @@ export function createFeishuAdapter(
         releaseFeishuAppId(appId, config.accountId);
         client = null;
         wsClient = null;
+        botOpenId = null;
         throw error;
       }
     },
@@ -232,6 +261,7 @@ export function createFeishuAdapter(
       }
       client = null;
       wsClient = null;
+      botOpenId = null;
       seenMessageIds.clear();
       console.log("[Feishu] Bot stopped");
     },

--- a/src/channels/feishu/bot-info.test.ts
+++ b/src/channels/feishu/bot-info.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from "bun:test";
+import { parseFeishuBotInfo } from "@/channels/feishu/bot-info";
+
+describe("parseFeishuBotInfo", () => {
+  test("reads open_id and app_name from the official bot/v3/info body", () => {
+    expect(
+      parseFeishuBotInfo({
+        code: 0,
+        msg: "ok",
+        bot: {
+          activate_status: 2,
+          app_name: "Letta",
+          open_id: "ou_bot",
+        },
+      }),
+    ).toEqual({ openId: "ou_bot", name: "Letta" });
+  });
+
+  test("reads a nested data.bot payload from the SDK wrapper", () => {
+    expect(
+      parseFeishuBotInfo({
+        data: { bot: { open_id: "ou_nested", name: "Nested" } },
+      }),
+    ).toEqual({ openId: "ou_nested", name: "Nested" });
+  });
+});

--- a/src/channels/feishu/bot-info.ts
+++ b/src/channels/feishu/bot-info.ts
@@ -1,0 +1,47 @@
+import { isRecord } from "@/utils/type-guards";
+
+export const FEISHU_BOT_INFO_PATH = "/open-apis/bot/v3/info";
+
+export interface FeishuBotInfo {
+  openId?: string;
+  name?: string;
+}
+
+function asBotRecord(payload: unknown): Record<string, unknown> | null {
+  if (!isRecord(payload)) {
+    return null;
+  }
+  if (isRecord(payload.bot)) {
+    return payload.bot;
+  }
+  if (isRecord(payload.data) && isRecord(payload.data.bot)) {
+    return payload.data.bot;
+  }
+  if (isRecord(payload.data)) {
+    return payload.data;
+  }
+  return payload;
+}
+
+function readTrimmedString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+/**
+ * Parse `GET /open-apis/bot/v3/info`. Bot mentions in
+ * `im.message.receive_v1` are identified by `mentions[].id.open_id`,
+ * which is this `open_id` — not a `mentioned_type` field.
+ */
+export function parseFeishuBotInfo(payload: unknown): FeishuBotInfo {
+  const bot = asBotRecord(payload);
+  if (!bot) {
+    return {};
+  }
+  return {
+    openId: readTrimmedString(bot.open_id) ?? readTrimmedString(bot.openId),
+    name:
+      readTrimmedString(bot.app_name) ??
+      readTrimmedString(bot.appName) ??
+      readTrimmedString(bot.name),
+  };
+}

--- a/src/channels/feishu/config-schema.ts
+++ b/src/channels/feishu/config-schema.ts
@@ -1,0 +1,68 @@
+import type { ChannelConfigSchema } from "@/channels/plugin-types";
+
+export const FEISHU_CONFIG_SCHEMA: ChannelConfigSchema = {
+  version: 1,
+  fields: [
+    {
+      type: "text",
+      key: "app_id",
+      label: "App ID",
+      required: true,
+      scope: "account",
+      placeholder: "cli_...",
+      description:
+        "Feishu / Lark Open Platform App ID. Create a self-built app; store apps cannot use persistent connection.",
+      restartRequired: true,
+    },
+    {
+      type: "secret",
+      key: "app_secret",
+      label: "App Secret",
+      required: true,
+      scope: "account",
+      placeholder: "App Secret",
+      description: "Open Platform App Secret for this self-built app.",
+      restartRequired: true,
+    },
+    {
+      type: "select",
+      key: "domain",
+      label: "Platform",
+      scope: "account",
+      default: "feishu",
+      options: [
+        { value: "feishu", label: "Feishu (open.feishu.cn)" },
+        { value: "lark", label: "Lark (open.larksuite.com)" },
+      ],
+      description:
+        "Feishu is the China console and API domain. Lark is the international console. Using the wrong domain fails authentication.",
+      restartRequired: true,
+    },
+    {
+      type: "select",
+      key: "group_mode",
+      label: "Group mode",
+      scope: "account",
+      default: "mention-only",
+      options: [
+        {
+          value: "mention-only",
+          label: "Mention only — respond when @mentioned",
+        },
+        { value: "open", label: "Open — respond to every group message" },
+      ],
+      description:
+        "Default mention-only matches Feishu's default group @bot scope. Open mode also needs the all-group-messages event scope on the app.",
+      restartRequired: true,
+    },
+    {
+      type: "text",
+      key: "agent_id",
+      label: "Agent ID",
+      scope: "account",
+      placeholder: "agent-...",
+      description:
+        "Letta agent this bot represents for DMs (when not pairing) and group @mentions.",
+    },
+  ],
+};

--- a/src/channels/feishu/ingress.test.ts
+++ b/src/channels/feishu/ingress.test.ts
@@ -131,19 +131,62 @@ describe("feishu ingress", () => {
         mentions: [
           {
             key: "@_user_1",
-            mentioned_type: "bot",
             id: { open_id: "ou_bot" },
             name: "Letta",
           },
         ],
       }),
-      { accountId: "acct-1", groupMode: "mention-only" },
+      {
+        accountId: "acct-1",
+        groupMode: "mention-only",
+        botOpenId: "ou_bot",
+      },
     );
     expect(decision.action).toBe("deliver");
     if (decision.action !== "deliver") return;
     expect(decision.inbound.isMention).toBe(true);
     expect(decision.inbound.routedBy).toBe("mention");
     expect(decision.inbound.text).toBe("hello");
+  });
+
+  test("mentioned_type is ignored; bot open_id must match", () => {
+    const fakeType = evaluateFeishuReceiveEvent(
+      groupEvent({
+        content: '{"text":"@_user_1 hello"}',
+        mentions: [
+          {
+            key: "@_user_1",
+            mentioned_type: "bot",
+            id: { open_id: "ou_someone_else" },
+            name: "Tom",
+          },
+        ],
+      }),
+      { accountId: "acct-1", groupMode: "mention-only" },
+    );
+    expect(fakeType).toEqual({ action: "drop", reason: "mention_required" });
+
+    const userMention = evaluateFeishuReceiveEvent(
+      groupEvent({
+        content: '{"text":"@_user_1 hello"}',
+        mentions: [
+          {
+            key: "@_user_1",
+            id: { open_id: "ou_tom" },
+            name: "Tom",
+          },
+        ],
+      }),
+      {
+        accountId: "acct-1",
+        groupMode: "mention-only",
+        botOpenId: "ou_bot",
+      },
+    );
+    expect(userMention).toEqual({
+      action: "drop",
+      reason: "mention_required",
+    });
   });
 
   test("@all / @_all only is not a bot mention", () => {

--- a/src/channels/feishu/ingress.test.ts
+++ b/src/channels/feishu/ingress.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, test } from "bun:test";
+import { evaluateFeishuReceiveEvent } from "@/channels/feishu/ingress";
+
+/** Official `im.message.receive_v1` example from Feishu Open Platform docs. */
+const OFFICIAL_RECEIVE_EVENT = {
+  schema: "2.0",
+  header: {
+    event_id: "5e3702a84e847582be8db7fb73283c02",
+    event_type: "im.message.receive_v1",
+    create_time: "1608725989000",
+    token: "r-o6XhsDzikPVTDwsYvm3ftzkQ88QrCEY",
+    app_id: "cli_9f5343ce03454433",
+    tenant_key: "2ca1d211f64f6438",
+  },
+  event: {
+    sender: {
+      sender_id: {
+        union_id: "on_8ed6aa67826108097d9ee143816345",
+        user_id: "e33ggbyz",
+        open_id: "ou_84aad35d084aa403a838cf73ee18467",
+      },
+      sender_type: "user",
+      tenant_key: "736588c9260f175e",
+    },
+    message: {
+      message_id: "om_5ce6d572455d361153b7cb51da133945",
+      root_id: "om_5ce6d572455d361153b7cb5xxfsdfsdfsd",
+      parent_id: "om_5ce6d572455d361153b7cb5xxfsdfsdfsd",
+      create_time: "1609073151345",
+      chat_id: "oc_5ce6d572455d361153b7xx51da133945",
+      chat_type: "group",
+      message_type: "text",
+      content: '{"text":"@_user_1 hello"}',
+      mentions: [
+        {
+          key: "@_user_1",
+          id: {
+            union_id: "on_8ed6aa67826108097d9ee143816345",
+            user_id: "e33ggbyz",
+            open_id: "ou_18eac85d35abgfef9e37c2b7b8c2fce",
+          },
+          name: "Tom",
+          tenant_key: "736588c9260f175e",
+        },
+      ],
+    },
+  },
+};
+
+function groupEvent(overrides: {
+  chatType?: string;
+  content?: string;
+  mentions?: unknown[];
+  senderType?: string;
+  senderOpenId?: string;
+  messageId?: string;
+  eventId?: string;
+  messageType?: string;
+}): unknown {
+  return {
+    schema: "2.0",
+    header: {
+      event_id: overrides.eventId ?? "evt_1",
+      event_type: "im.message.receive_v1",
+      create_time: "1608725989000",
+      app_id: "cli_test",
+    },
+    event: {
+      sender: {
+        sender_id: {
+          open_id: overrides.senderOpenId ?? "ou_sender",
+        },
+        sender_type: overrides.senderType ?? "user",
+      },
+      message: {
+        message_id: overrides.messageId ?? "om_message",
+        create_time: "1609073151345",
+        chat_id: "oc_group",
+        chat_type: overrides.chatType ?? "group",
+        message_type: overrides.messageType ?? "text",
+        content: overrides.content ?? '{"text":"hello"}',
+        mentions: overrides.mentions,
+      },
+    },
+  };
+}
+
+describe("feishu ingress", () => {
+  test("official im.message.receive_v1 example parses identities", () => {
+    const decision = evaluateFeishuReceiveEvent(OFFICIAL_RECEIVE_EVENT, {
+      accountId: "acct-1",
+      groupMode: "open",
+    });
+    expect(decision.action).toBe("deliver");
+    if (decision.action !== "deliver") return;
+    expect(decision.inbound.senderId).toBe(
+      "ou_84aad35d084aa403a838cf73ee18467",
+    );
+    expect(decision.inbound.chatId).toBe("oc_5ce6d572455d361153b7xx51da133945");
+    expect(decision.inbound.messageId).toBe(
+      "om_5ce6d572455d361153b7cb51da133945",
+    );
+    expect(decision.inbound.chatType).toBe("channel");
+    expect(decision.inbound.text).toBe("hello");
+  });
+
+  test("p2p chat_type maps to direct", () => {
+    const decision = evaluateFeishuReceiveEvent(
+      groupEvent({ chatType: "p2p", content: '{"text":"hi"}' }),
+      { accountId: "acct-1" },
+    );
+    expect(decision.action).toBe("deliver");
+    if (decision.action !== "deliver") return;
+    expect(decision.inbound.chatType).toBe("direct");
+    expect(decision.inbound.routedBy).toBe("dm");
+    expect(decision.inbound.isMention).toBe(false);
+  });
+
+  test("group without bot mention is dropped in mention-only", () => {
+    const decision = evaluateFeishuReceiveEvent(
+      groupEvent({ content: '{"text":"hello"}' }),
+      { accountId: "acct-1", groupMode: "mention-only" },
+    );
+    expect(decision).toEqual({ action: "drop", reason: "mention_required" });
+  });
+
+  test("group with bot mention is delivered", () => {
+    const decision = evaluateFeishuReceiveEvent(
+      groupEvent({
+        content: '{"text":"@_user_1 hello"}',
+        mentions: [
+          {
+            key: "@_user_1",
+            mentioned_type: "bot",
+            id: { open_id: "ou_bot" },
+            name: "Letta",
+          },
+        ],
+      }),
+      { accountId: "acct-1", groupMode: "mention-only" },
+    );
+    expect(decision.action).toBe("deliver");
+    if (decision.action !== "deliver") return;
+    expect(decision.inbound.isMention).toBe(true);
+    expect(decision.inbound.routedBy).toBe("mention");
+    expect(decision.inbound.text).toBe("hello");
+  });
+
+  test("@all / @_all only is not a bot mention", () => {
+    const allKey = evaluateFeishuReceiveEvent(
+      groupEvent({
+        content: '{"text":"@_all standup"}',
+        mentions: [{ key: "@_all", name: "all" }],
+      }),
+      { accountId: "acct-1", groupMode: "mention-only" },
+    );
+    expect(allKey).toEqual({ action: "drop", reason: "broadcast_all" });
+
+    const allText = evaluateFeishuReceiveEvent(
+      groupEvent({ content: '{"text":"@all standup"}' }),
+      { accountId: "acct-1", groupMode: "mention-only" },
+    );
+    expect(allText).toEqual({ action: "drop", reason: "broadcast_all" });
+  });
+
+  test("sender_type bot is dropped", () => {
+    const decision = evaluateFeishuReceiveEvent(
+      groupEvent({ senderType: "bot", content: '{"text":"beep"}' }),
+      { accountId: "acct-1", groupMode: "open" },
+    );
+    expect(decision).toEqual({ action: "drop", reason: "bot_sender" });
+  });
+
+  test("image-only messages use a placeholder instead of crashing", () => {
+    const decision = evaluateFeishuReceiveEvent(
+      groupEvent({
+        messageType: "image",
+        content: '{"image_key":"img_123"}',
+      }),
+      { accountId: "acct-1", groupMode: "open" },
+    );
+    expect(decision.action).toBe("deliver");
+    if (decision.action !== "deliver") return;
+    expect(decision.inbound.text).toBe("[image]");
+  });
+
+  test("empty text in mention-only group without a mention is dropped", () => {
+    const decision = evaluateFeishuReceiveEvent(
+      groupEvent({ content: '{"text":""}' }),
+      { accountId: "acct-1", groupMode: "mention-only" },
+    );
+    expect(decision.action).toBe("drop");
+  });
+});

--- a/src/channels/feishu/ingress.ts
+++ b/src/channels/feishu/ingress.ts
@@ -1,0 +1,263 @@
+import type { FeishuGroupMode, InboundChannelMessage } from "@/channels/types";
+import { isRecord } from "@/utils/type-guards";
+
+export interface FeishuSenderId {
+  open_id?: string;
+  user_id?: string;
+  union_id?: string;
+}
+
+export interface FeishuMention {
+  key?: string;
+  name?: string;
+  mentioned_type?: string;
+  id?: FeishuSenderId;
+}
+
+export interface FeishuReceiveMessage {
+  message_id?: string;
+  root_id?: string;
+  parent_id?: string;
+  create_time?: string;
+  chat_id?: string;
+  chat_type?: string;
+  message_type?: string;
+  content?: string;
+  thread_id?: string;
+  mentions?: FeishuMention[];
+}
+
+export interface FeishuReceiveSender {
+  sender_id?: FeishuSenderId;
+  sender_type?: string;
+  tenant_key?: string;
+}
+
+export interface FeishuReceiveEventBody {
+  sender?: FeishuReceiveSender;
+  message?: FeishuReceiveMessage;
+}
+
+export type FeishuIngressDropReason =
+  | "malformed"
+  | "bot_sender"
+  | "self_sender"
+  | "mention_required"
+  | "broadcast_all"
+  | "empty";
+
+export type FeishuIngressDecision =
+  | { action: "drop"; reason: FeishuIngressDropReason }
+  | { action: "deliver"; inbound: InboundChannelMessage };
+
+const MENTION_KEY_RE = /@_user_\d+/g;
+const BROADCAST_ALL_TEXT_RE = /@_all\b|@all\b/i;
+const MEDIA_PLACEHOLDERS: Record<string, string> = {
+  image: "[image]",
+  file: "[file]",
+  audio: "[audio]",
+  media: "[video]",
+  sticker: "[sticker]",
+  interactive: "[card]",
+  share_chat: "[shared chat]",
+  share_user: "[shared user]",
+  merge_forward: "[forwarded messages]",
+  system: "[system]",
+};
+
+export function unwrapFeishuReceiveEvent(
+  payload: unknown,
+): FeishuReceiveEventBody | null {
+  if (!isRecord(payload)) {
+    return null;
+  }
+  if (isRecord(payload.event)) {
+    return payload.event as FeishuReceiveEventBody;
+  }
+  if (isRecord(payload.message) || isRecord(payload.sender)) {
+    return payload as FeishuReceiveEventBody;
+  }
+  return null;
+}
+
+export function stripFeishuMentionKeys(text: string): string {
+  return text
+    .replace(MENTION_KEY_RE, " ")
+    .replace(/@_all/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function isBroadcastAllMention(mention: FeishuMention): boolean {
+  const key = mention.key?.trim().toLowerCase();
+  return key === "@_all" || key === "@all";
+}
+
+export function isFeishuBroadcastAllOnly(
+  text: string,
+  mentions: FeishuMention[],
+): boolean {
+  const hasAllMention = mentions.some(isBroadcastAllMention);
+  const hasAllText = BROADCAST_ALL_TEXT_RE.test(text);
+  if (!hasAllMention && !hasAllText) {
+    return false;
+  }
+  return !mentions.some((mention) => !isBroadcastAllMention(mention));
+}
+
+export function isFeishuBotMention(
+  mentions: FeishuMention[],
+  botOpenId?: string | null,
+): boolean {
+  if (mentions.some((mention) => mention.mentioned_type === "bot")) {
+    return true;
+  }
+  const trimmedBotOpenId = botOpenId?.trim();
+  if (!trimmedBotOpenId) {
+    return false;
+  }
+  return mentions.some((mention) => mention.id?.open_id === trimmedBotOpenId);
+}
+
+function extractPostText(value: unknown): string {
+  if (!isRecord(value)) {
+    return "";
+  }
+  const localized =
+    (isRecord(value.zh_cn) ? value.zh_cn : null) ??
+    (isRecord(value.en_us) ? value.en_us : null) ??
+    value;
+  if (!isRecord(localized)) {
+    return "";
+  }
+  const title =
+    typeof localized.title === "string" ? localized.title.trim() : "";
+  const chunks: string[] = [];
+  if (Array.isArray(localized.content)) {
+    for (const row of localized.content) {
+      if (!Array.isArray(row)) continue;
+      for (const node of row) {
+        if (!isRecord(node)) continue;
+        if (typeof node.text === "string" && node.text.trim()) {
+          chunks.push(node.text);
+        }
+      }
+    }
+  }
+  const body = stripFeishuMentionKeys(chunks.join(" "));
+  if (title && body) return `${title}\n${body}`;
+  return title || body;
+}
+
+export function extractFeishuMessageText(
+  messageType: string | undefined,
+  contentRaw: string | undefined,
+): string {
+  const type = (messageType ?? "text").trim() || "text";
+  const raw = contentRaw ?? "";
+  if (!raw.trim()) {
+    return MEDIA_PLACEHOLDERS[type] ?? (type === "text" ? "" : `[${type}]`);
+  }
+
+  let parsed: unknown = raw;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return stripFeishuMentionKeys(raw) || `[${type}]`;
+  }
+
+  if (type === "text") {
+    const text =
+      isRecord(parsed) && typeof parsed.text === "string" ? parsed.text : "";
+    return stripFeishuMentionKeys(text);
+  }
+  if (type === "post") {
+    return extractPostText(parsed) || "[post]";
+  }
+  return MEDIA_PLACEHOLDERS[type] ?? `[${type}]`;
+}
+
+function parseCreateTime(value: string | undefined): number {
+  if (!value) return Date.now();
+  const numeric = Number(value);
+  if (Number.isFinite(numeric) && numeric > 0) {
+    return numeric;
+  }
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : Date.now();
+}
+
+export function evaluateFeishuReceiveEvent(
+  payload: unknown,
+  options: {
+    accountId: string;
+    groupMode?: FeishuGroupMode;
+    botOpenId?: string | null;
+  },
+): FeishuIngressDecision {
+  const event = unwrapFeishuReceiveEvent(payload);
+  const message = event?.message;
+  const sender = event?.sender;
+  const chatId = message?.chat_id?.trim();
+  const messageId = message?.message_id?.trim();
+  const senderId = sender?.sender_id?.open_id?.trim();
+  if (!event || !message || !chatId || !messageId || !senderId) {
+    return { action: "drop", reason: "malformed" };
+  }
+
+  const senderType = sender?.sender_type?.trim().toLowerCase();
+  if (senderType === "bot" || senderType === "app") {
+    return { action: "drop", reason: "bot_sender" };
+  }
+
+  const botOpenId = options.botOpenId?.trim() || null;
+  if (botOpenId && senderId === botOpenId) {
+    return { action: "drop", reason: "self_sender" };
+  }
+
+  const mentions = Array.isArray(message.mentions) ? message.mentions : [];
+  const rawContent = message.content ?? "";
+  const rawText =
+    typeof rawContent === "string" ? rawContent : JSON.stringify(rawContent);
+  const text = extractFeishuMessageText(message.message_type, rawText);
+  const chatType = message.chat_type === "p2p" ? "direct" : "channel";
+  const isBotMention = isFeishuBotMention(mentions, botOpenId);
+  const broadcastAllOnly = isFeishuBroadcastAllOnly(rawText, mentions);
+  const groupMode = options.groupMode ?? "mention-only";
+
+  if (chatType === "channel") {
+    if (broadcastAllOnly && !isBotMention) {
+      return { action: "drop", reason: "broadcast_all" };
+    }
+    if (groupMode === "mention-only" && !isBotMention) {
+      return { action: "drop", reason: "mention_required" };
+    }
+  }
+
+  if (!text && !isBotMention && chatType !== "direct") {
+    return { action: "drop", reason: "empty" };
+  }
+
+  const inbound: InboundChannelMessage = {
+    channel: "feishu",
+    accountId: options.accountId,
+    chatId,
+    senderId,
+    senderName:
+      mentions.find((mention) => mention.id?.open_id === senderId)?.name ??
+      senderId,
+    text,
+    timestamp: parseCreateTime(message.create_time),
+    messageId,
+    threadId: message.thread_id?.trim() || null,
+    chatType,
+    isMention: chatType === "direct" ? false : isBotMention,
+    routedBy:
+      chatType === "direct" ? "dm" : isBotMention ? "mention" : undefined,
+    isOpenChannel:
+      chatType === "channel" && groupMode === "open" && !isBotMention,
+    raw: payload,
+  };
+
+  return { action: "deliver", inbound };
+}

--- a/src/channels/feishu/ingress.ts
+++ b/src/channels/feishu/ingress.ts
@@ -10,7 +10,6 @@ export interface FeishuSenderId {
 export interface FeishuMention {
   key?: string;
   name?: string;
-  mentioned_type?: string;
   id?: FeishuSenderId;
 }
 
@@ -109,14 +108,17 @@ export function isFeishuBotMention(
   mentions: FeishuMention[],
   botOpenId?: string | null,
 ): boolean {
-  if (mentions.some((mention) => mention.mentioned_type === "bot")) {
-    return true;
-  }
+  // `im.message.receive_v1` mention objects carry `key`, `id.open_id`, and
+  // `name`. Do not match on `mentioned_type` — that field is absent from the
+  // live payload even though some doc tables list it.
+  // https://open.feishu.cn/document/server-docs/im-v1/message/events/receive
   const trimmedBotOpenId = botOpenId?.trim();
   if (!trimmedBotOpenId) {
     return false;
   }
-  return mentions.some((mention) => mention.id?.open_id === trimmedBotOpenId);
+  return mentions.some(
+    (mention) => mention.id?.open_id?.trim() === trimmedBotOpenId,
+  );
 }
 
 function extractPostText(value: unknown): string {

--- a/src/channels/feishu/internal-types.ts
+++ b/src/channels/feishu/internal-types.ts
@@ -1,0 +1,76 @@
+export const FEISHU_RUNTIME_PACKAGE = "@larksuiteoapi/node-sdk@1.67.0";
+export const FEISHU_RUNTIME_MODULE = "@larksuiteoapi/node-sdk";
+
+export const FEISHU_API_DOMAINS = {
+  feishu: "https://open.feishu.cn",
+  lark: "https://open.larksuite.com",
+} as const;
+
+export interface LarkClientConfigLike {
+  appId: string;
+  appSecret: string;
+  domain?: unknown;
+  appType?: unknown;
+}
+
+export interface LarkCreateMessageRequestLike {
+  params: { receive_id_type: string };
+  data: {
+    receive_id: string;
+    msg_type: string;
+    content: string;
+  };
+}
+
+export interface LarkReplyMessageRequestLike {
+  path: { message_id: string };
+  data: {
+    msg_type: string;
+    content: string;
+    reply_in_thread?: boolean;
+  };
+}
+
+export interface LarkMessageApiLike {
+  create: (
+    request: LarkCreateMessageRequestLike,
+  ) => Promise<{ data?: { message_id?: string } } | undefined>;
+  reply?: (
+    request: LarkReplyMessageRequestLike,
+  ) => Promise<{ data?: { message_id?: string } } | undefined>;
+}
+
+export interface LarkClientLike {
+  im: {
+    v1: {
+      message: LarkMessageApiLike;
+    };
+  };
+  request?: (config: { url: string; method: string }) => Promise<unknown>;
+}
+
+export interface LarkEventDispatcherLike {
+  register: (
+    handlers: Record<string, (data: unknown) => Promise<unknown> | unknown>,
+  ) => LarkEventDispatcherLike;
+}
+
+export interface LarkWsClientLike {
+  start: (options: {
+    eventDispatcher: LarkEventDispatcherLike;
+  }) => Promise<void> | void;
+  close?: () => void;
+}
+
+export interface LarkRuntimeModuleLike {
+  Domain?: {
+    Feishu?: unknown;
+    Lark?: unknown;
+  };
+  AppType?: {
+    SelfBuild?: unknown;
+  };
+  Client: new (config: LarkClientConfigLike) => LarkClientLike;
+  WSClient: new (config: LarkClientConfigLike) => LarkWsClientLike;
+  EventDispatcher: new (config?: object) => LarkEventDispatcherLike;
+}

--- a/src/channels/feishu/message-actions.ts
+++ b/src/channels/feishu/message-actions.ts
@@ -1,0 +1,44 @@
+import type {
+  ChannelMessageActionAdapter,
+  ChannelMessageActionContext,
+} from "@/channels/plugin-types";
+
+async function sendFeishuMessage(
+  ctx: ChannelMessageActionContext,
+): Promise<string> {
+  const { request, route, adapter, formatText } = ctx;
+  const text = request.message ?? "";
+
+  if (text.trim().length === 0) {
+    return "Error: Feishu send requires message.";
+  }
+
+  const formatted = formatText(text);
+  const result = await adapter.sendMessage({
+    channel: "feishu",
+    accountId: route.accountId,
+    chatId: request.chatId,
+    text: formatted.text,
+    replyToMessageId: request.replyToMessageId,
+    threadId: request.threadId ?? route.threadId ?? null,
+  });
+
+  return `Message sent to feishu (message_id: ${result.messageId})`;
+}
+
+export const feishuMessageActions: ChannelMessageActionAdapter = {
+  describeMessageTool() {
+    return {
+      actions: ["send"],
+    };
+  },
+
+  async handleAction(ctx) {
+    switch (ctx.request.action) {
+      case "send":
+        return await sendFeishuMessage(ctx);
+      default:
+        return `Error: Action "${ctx.request.action}" is not supported on feishu.`;
+    }
+  },
+};

--- a/src/channels/feishu/outbound.test.ts
+++ b/src/channels/feishu/outbound.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "bun:test";
+import {
+  buildFeishuCreateTextMessage,
+  buildFeishuReplyTextMessage,
+  buildFeishuTextContent,
+} from "@/channels/feishu/outbound";
+
+describe("feishu outbound", () => {
+  test("MessageChannel send uses receive_id_type=chat_id", () => {
+    const payload = buildFeishuCreateTextMessage({
+      receiveId: "oc_group",
+      text: "hello from letta",
+    });
+    expect(payload).toEqual({
+      params: { receive_id_type: "chat_id" },
+      data: {
+        receive_id: "oc_group",
+        msg_type: "text",
+        content: '{"text":"hello from letta"}',
+      },
+    });
+  });
+
+  test("text content is JSON-encoded", () => {
+    expect(buildFeishuTextContent('say "hi"')).toBe('{"text":"say \\"hi\\""}');
+  });
+
+  test("reply payload can target a topic thread", () => {
+    expect(
+      buildFeishuReplyTextMessage({
+        messageId: "om_parent",
+        text: "reply",
+        replyInThread: true,
+      }),
+    ).toEqual({
+      path: { message_id: "om_parent" },
+      data: {
+        msg_type: "text",
+        content: '{"text":"reply"}',
+        reply_in_thread: true,
+      },
+    });
+  });
+});

--- a/src/channels/feishu/outbound.ts
+++ b/src/channels/feishu/outbound.ts
@@ -1,0 +1,65 @@
+export type FeishuReceiveIdType =
+  | "chat_id"
+  | "open_id"
+  | "user_id"
+  | "union_id"
+  | "email";
+
+export interface FeishuCreateTextMessageRequest {
+  params: { receive_id_type: FeishuReceiveIdType };
+  data: {
+    receive_id: string;
+    msg_type: "text";
+    content: string;
+  };
+}
+
+export interface FeishuReplyTextMessageRequest {
+  path: { message_id: string };
+  data: {
+    msg_type: "text";
+    content: string;
+    reply_in_thread?: boolean;
+  };
+}
+
+export function buildFeishuTextContent(text: string): string {
+  return JSON.stringify({ text });
+}
+
+/**
+ * Build a Feishu/Lark IM create-message payload.
+ *
+ * v1 always sends `msg_type=text`. Group and p2p replies use `chat_id`
+ * (the inbound event's `chat_id`) so MessageChannel can address the same
+ * conversation the event came from.
+ */
+export function buildFeishuCreateTextMessage(options: {
+  receiveId: string;
+  receiveIdType?: FeishuReceiveIdType;
+  text: string;
+}): FeishuCreateTextMessageRequest {
+  return {
+    params: { receive_id_type: options.receiveIdType ?? "chat_id" },
+    data: {
+      receive_id: options.receiveId,
+      msg_type: "text",
+      content: buildFeishuTextContent(options.text),
+    },
+  };
+}
+
+export function buildFeishuReplyTextMessage(options: {
+  messageId: string;
+  text: string;
+  replyInThread?: boolean;
+}): FeishuReplyTextMessageRequest {
+  return {
+    path: { message_id: options.messageId },
+    data: {
+      msg_type: "text",
+      content: buildFeishuTextContent(options.text),
+      ...(options.replyInThread ? { reply_in_thread: true } : {}),
+    },
+  };
+}

--- a/src/channels/feishu/plugin.ts
+++ b/src/channels/feishu/plugin.ts
@@ -1,0 +1,39 @@
+import type { ChannelPlugin } from "@/channels/plugin-types";
+import type { ChannelAccount, FeishuChannelAccount } from "@/channels/types";
+import { resolveFeishuAccountDisplayName } from "./account-display";
+import { createFeishuAdapter } from "./adapter";
+import { FEISHU_CONFIG_SCHEMA } from "./config-schema";
+import {
+  FEISHU_RUNTIME_MODULE,
+  FEISHU_RUNTIME_PACKAGE,
+} from "./internal-types";
+import { feishuMessageActions } from "./message-actions";
+import { runFeishuSetup } from "./setup";
+
+export const feishuChannelPlugin: ChannelPlugin = {
+  metadata: {
+    id: "feishu",
+    displayName: "Feishu / Lark",
+    runtimePackages: [FEISHU_RUNTIME_PACKAGE],
+    runtimeModules: [FEISHU_RUNTIME_MODULE],
+    source: "first-party",
+    firstParty: true,
+    configSchema: FEISHU_CONFIG_SCHEMA,
+  },
+  createAdapter(account: ChannelAccount) {
+    return createFeishuAdapter(account as FeishuChannelAccount);
+  },
+  resolveAccountDisplayName(account: ChannelAccount) {
+    const feishu = account as FeishuChannelAccount;
+    if (!feishu.appId.trim() || !feishu.appSecret.trim()) return undefined;
+    return resolveFeishuAccountDisplayName({
+      appId: feishu.appId,
+      appSecret: feishu.appSecret,
+      domain: feishu.domain,
+    });
+  },
+  messageActions: feishuMessageActions,
+  runSetup() {
+    return runFeishuSetup();
+  },
+};

--- a/src/channels/feishu/runtime.ts
+++ b/src/channels/feishu/runtime.ts
@@ -1,0 +1,53 @@
+import {
+  ensureChannelRuntimeInstalled,
+  installChannelRuntime,
+  isChannelRuntimeInstalled,
+  loadChannelRuntimeModule,
+} from "@/channels/runtime-deps";
+import type { FeishuDomain } from "@/channels/types";
+import {
+  FEISHU_API_DOMAINS,
+  FEISHU_RUNTIME_MODULE,
+  type LarkRuntimeModuleLike,
+} from "./internal-types";
+
+let loadFeishuModuleOverride: (() => Promise<LarkRuntimeModuleLike>) | null =
+  null;
+
+export function __testOverrideLoadFeishuModule(
+  override: (() => Promise<LarkRuntimeModuleLike>) | null,
+): void {
+  loadFeishuModuleOverride = override;
+}
+
+export async function loadFeishuModule(): Promise<LarkRuntimeModuleLike> {
+  if (loadFeishuModuleOverride) {
+    return loadFeishuModuleOverride();
+  }
+  return loadChannelRuntimeModule<LarkRuntimeModuleLike>(
+    "feishu",
+    FEISHU_RUNTIME_MODULE,
+  );
+}
+
+export function isFeishuRuntimeInstalled(): boolean {
+  return isChannelRuntimeInstalled("feishu");
+}
+
+export async function installFeishuRuntime(): Promise<void> {
+  await installChannelRuntime("feishu");
+}
+
+export async function ensureFeishuRuntimeInstalled(): Promise<boolean> {
+  return ensureChannelRuntimeInstalled("feishu");
+}
+
+export function resolveFeishuSdkDomain(
+  domain: FeishuDomain,
+  runtime: LarkRuntimeModuleLike,
+): unknown {
+  if (domain === "lark") {
+    return runtime.Domain?.Lark ?? FEISHU_API_DOMAINS.lark;
+  }
+  return runtime.Domain?.Feishu ?? FEISHU_API_DOMAINS.feishu;
+}

--- a/src/channels/feishu/setup.ts
+++ b/src/channels/feishu/setup.ts
@@ -1,0 +1,166 @@
+/**
+ * Feishu / Lark bot setup wizard for `letta channels configure feishu`.
+ *
+ * Persistent connection (WebSocket) is self-built apps only. Store apps and
+ * webhook-only apps are out of v1.
+ */
+
+import { randomUUID } from "node:crypto";
+import { createInterface } from "node:readline/promises";
+import { upsertChannelAccountWithSecrets } from "@/channels/accounts";
+import type {
+  DmPolicy,
+  FeishuChannelAccount,
+  FeishuDomain,
+  FeishuGroupMode,
+} from "@/channels/types";
+import { ensureFeishuRuntimeInstalled } from "./runtime";
+
+export async function runFeishuSetup(): Promise<boolean> {
+  const rl = createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+
+  try {
+    console.log("\n🪶 Feishu / Lark Bot Setup\n");
+    console.log("Create a self-built app on the Open Platform. Store apps");
+    console.log("cannot use persistent connection (WebSocket).\n");
+    console.log("Required steps in the developer console:");
+    console.log("  1. Enable bot capability");
+    console.log("  2. Subscribe to event im.message.receive_v1");
+    console.log(
+      "  3. Choose persistent connection (long connection), not a webhook URL",
+    );
+    console.log("  4. Grant scopes:");
+    console.log("       im:message.p2p_msg:readonly");
+    console.log("       im:message.group_at_msg:readonly");
+    console.log("       im:message:send_as_bot");
+    console.log("  5. Publish a version and add the bot to any groups\n");
+    console.log("Only one running listener can use a given App ID. If Desktop");
+    console.log("and `letta server` both connect, Feishu delivers each event");
+    console.log("to one of them at random.\n");
+    console.log("Pairing and allowlists use Feishu open_id values (ou_...).\n");
+
+    await ensureFeishuRuntimeInstalled();
+
+    const appId = (await rl.question("Enter your App ID (cli_...): ")).trim();
+    if (!appId) {
+      console.error("No App ID provided. Setup cancelled.");
+      return false;
+    }
+
+    const appSecret = (await rl.question("Enter your App Secret: ")).trim();
+    if (!appSecret) {
+      console.error("No App Secret provided. Setup cancelled.");
+      return false;
+    }
+
+    console.log(
+      "\nPlatform — which Open Platform did you create the app on?\n",
+    );
+    console.log("  feishu — China (open.feishu.cn)  [default]");
+    console.log("  lark   — International (open.larksuite.com)\n");
+    const domainInput = await rl.question("Domain [feishu]: ");
+    const domain = (domainInput.trim() || "feishu") as FeishuDomain;
+    if (domain !== "feishu" && domain !== "lark") {
+      console.error(`Invalid domain "${domain}". Setup cancelled.`);
+      return false;
+    }
+
+    console.log("\nDM Policy — who can message this bot directly?\n");
+    console.log("  pairing   — Users must pair with a code (recommended)");
+    console.log("  allowlist — Only pre-approved open_id values");
+    console.log("  open      — Anyone can message\n");
+    const policyInput = await rl.question("DM policy [pairing]: ");
+    const policy = (policyInput.trim() || "pairing") as DmPolicy;
+    if (!["pairing", "allowlist", "open"].includes(policy)) {
+      console.error(`Invalid policy "${policy}". Setup cancelled.`);
+      return false;
+    }
+
+    let allowedUsers: string[] = [];
+    if (policy === "allowlist") {
+      const usersInput = await rl.question(
+        "Enter allowed Feishu open_id values (comma-separated, ou_...): ",
+      );
+      allowedUsers = usersInput
+        .split(",")
+        .map((entry) => entry.trim())
+        .filter(Boolean);
+    }
+
+    console.log("\nGroup behavior — when should the bot respond in groups?\n");
+    console.log(
+      "  mention-only — Respond only when @mentioned (recommended, matches default scopes)",
+    );
+    console.log(
+      "  open         — Respond to every group message (needs extra event scope)\n",
+    );
+    const groupModeInput = await rl.question("Group mode [mention-only]: ");
+    const groupMode = (groupModeInput.trim() ||
+      "mention-only") as FeishuGroupMode;
+    if (groupMode !== "open" && groupMode !== "mention-only") {
+      console.error(`Invalid group mode "${groupMode}". Setup cancelled.`);
+      return false;
+    }
+
+    const envAgentId = process.env.LETTA_AGENT_ID || "";
+    let agentId: string | null = null;
+    if (envAgentId) {
+      const useEnv = await rl.question(
+        `\nBind to agent ${envAgentId}? [Y/n]: `,
+      );
+      if (!useEnv.trim() || useEnv.trim().toLowerCase() === "y") {
+        agentId = envAgentId;
+      }
+    }
+    if (!agentId) {
+      const agentInput = await rl.question(
+        "\nAgent ID to bind this bot to (required for group @mentions and non-pairing DMs): ",
+      );
+      agentId = agentInput.trim() || null;
+    }
+    if (!agentId) {
+      console.log(
+        "\nWarning: No agent bound. DM pairing will still work, but group @mentions won't route until you bind an agent.",
+      );
+      console.log(
+        "  You can bind later: letta channels bind --channel feishu --agent <id>\n",
+      );
+    }
+
+    const now = new Date().toISOString();
+    const account: FeishuChannelAccount = {
+      channel: "feishu",
+      accountId: randomUUID(),
+      enabled: true,
+      appId,
+      appSecret,
+      domain,
+      groupMode,
+      agentId,
+      dmPolicy: policy,
+      allowedUsers,
+      createdAt: now,
+      updatedAt: now,
+    };
+
+    await upsertChannelAccountWithSecrets("feishu", account);
+    console.log("\n✓ Feishu / Lark bot configured!");
+    console.log("Config written to: ~/.letta/channels/feishu/accounts.json\n");
+    console.log("Next steps:");
+    console.log("  1. Start the listener: letta server --channels feishu");
+    console.log(
+      "  2. DM the bot (pairing) or @mention it in a group to start chatting\n",
+    );
+    return true;
+  } catch (error) {
+    console.error(
+      `Setup failed: ${error instanceof Error ? error.message : "unknown error"}`,
+    );
+    return false;
+  } finally {
+    rl.close();
+  }
+}

--- a/src/channels/message-channel-tool-definition.ts
+++ b/src/channels/message-channel-tool-definition.ts
@@ -272,8 +272,11 @@ export function buildMessageChannelDescriptionFromDiscovery(
   const signalCapabilities = discovery.activeChannels.includes("signal")
     ? '\n\nOn Signal, this tool also supports action="react" with emoji + messageId and action="upload-file" with media. Replies are sent as the linked Signal account through signal-cli-rest-api.'
     : "";
+  const feishuCapabilities = discovery.activeChannels.includes("feishu")
+    ? "\n\nOn Feishu / Lark, this tool sends plain text. Replies stay in the current chat or topic automatically. Pairing and allowlists use Feishu open_id values (ou_...)."
+    : "";
 
-  return `${description}${scopedReplyContract}${slackThreadGuidance}${telegramTopicGuidance}${slackCapabilityGuidance}${slackWorkAcknowledgement}${slackAttachmentDownload}${telegramCapabilities}${discordCapabilities}${whatsappCapabilities}${signalCapabilities}\n\nCurrently active channels: ${channelList}. Available actions across the active channels: ${actionList}. The JSON schema reflects the currently active channel plugins.`;
+  return `${description}${scopedReplyContract}${slackThreadGuidance}${telegramTopicGuidance}${slackCapabilityGuidance}${slackWorkAcknowledgement}${slackAttachmentDownload}${telegramCapabilities}${discordCapabilities}${whatsappCapabilities}${signalCapabilities}${feishuCapabilities}\n\nCurrently active channels: ${channelList}. Available actions across the active channels: ${actionList}. The JSON schema reflects the currently active channel plugins.`;
 }
 
 export function buildMessageChannelToolFromDiscovery(params: {

--- a/src/channels/pairing-types.ts
+++ b/src/channels/pairing-types.ts
@@ -1,0 +1,37 @@
+/**
+ * Account-scoped store records for pairing and discovered bind targets.
+ * Kept out of `types.ts` so that file stays under the 1,000-line ceiling.
+ */
+
+export interface PendingPairing {
+  accountId?: string;
+  code: string;
+  senderId: string;
+  senderName?: string;
+  chatId: string;
+  createdAt: string;
+  expiresAt: string;
+}
+
+export interface ApprovedUser {
+  accountId?: string;
+  senderId: string;
+  senderName?: string;
+  approvedAt: string;
+}
+
+export interface PairingStore {
+  pending: PendingPairing[];
+  approved: ApprovedUser[];
+}
+
+export interface ChannelBindableTarget {
+  accountId?: string;
+  targetId: string;
+  targetType: "channel";
+  chatId: string;
+  label: string;
+  discoveredAt: string;
+  lastSeenAt: string;
+  lastMessageId?: string;
+}

--- a/src/channels/pairing.ts
+++ b/src/channels/pairing.ts
@@ -14,7 +14,11 @@ import { randomInt } from "node:crypto";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { LEGACY_CHANNEL_ACCOUNT_ID } from "./accounts";
 import { getChannelDir, getChannelPairingPath } from "./config";
-import type { ApprovedUser, PairingStore, PendingPairing } from "./types";
+import type {
+  ApprovedUser,
+  PairingStore,
+  PendingPairing,
+} from "./pairing-types";
 
 // ── Constants ─────────────────────────────────────────────────────
 

--- a/src/channels/plugin-registry.ts
+++ b/src/channels/plugin-registry.ts
@@ -4,6 +4,7 @@ import { pathToFileURL } from "node:url";
 import { isRecord } from "@/utils/type-guards";
 import { getChannelDir, getChannelsRoot } from "./config";
 import { CUSTOM_CHANNEL_CONFIG_SCHEMA } from "./custom/plugin";
+import { FEISHU_CONFIG_SCHEMA } from "./feishu/config-schema";
 import type {
   ChannelConfigSchema,
   ChannelPlugin,
@@ -124,6 +125,21 @@ const FIRST_PARTY_CHANNEL_PLUGIN_REGISTRATIONS: Record<
     load: async () => {
       const { signalChannelPlugin } = await import("@/channels/signal/plugin");
       return signalChannelPlugin;
+    },
+  },
+  feishu: {
+    metadata: {
+      id: "feishu",
+      displayName: "Feishu / Lark",
+      runtimePackages: ["@larksuiteoapi/node-sdk@1.67.0"],
+      runtimeModules: ["@larksuiteoapi/node-sdk"],
+      source: "first-party",
+      firstParty: true,
+      configSchema: FEISHU_CONFIG_SCHEMA,
+    },
+    load: async () => {
+      const { feishuChannelPlugin } = await import("@/channels/feishu/plugin");
+      return feishuChannelPlugin;
     },
   },
 };

--- a/src/channels/plugin-types.ts
+++ b/src/channels/plugin-types.ts
@@ -7,6 +7,8 @@ import type {
   ChannelRoute,
   DiscordChannelMode,
   DmPolicy,
+  FeishuDomain,
+  FeishuGroupMode,
   OutboundChannelMessage,
   SignalGroupMode,
   SlackChannelMode,
@@ -158,8 +160,15 @@ export interface ChannelPluginAccountPatch {
   token?: string;
   botToken?: string;
   appToken?: string;
+  appId?: string;
+  appSecret?: string;
+  domain?: FeishuDomain;
   mode?: SlackChannelMode;
-  groupMode?: TelegramGroupMode | WhatsAppGroupMode | SignalGroupMode;
+  groupMode?:
+    | TelegramGroupMode
+    | WhatsAppGroupMode
+    | SignalGroupMode
+    | FeishuGroupMode;
   agentId?: string | null;
   baseUrl?: string;
   account?: string;

--- a/src/channels/registry-community-copy.test.ts
+++ b/src/channels/registry-community-copy.test.ts
@@ -67,6 +67,18 @@ describe("registry copy: first-party channels", () => {
     expect(text).not.toContain("letta channels route add");
   });
 
+  test("first-party feishu pairing uses Feishu / Lark display name", () => {
+    const text = buildPairingInstructions("feishu", "OU123", {
+      agentId: "agent-feishu",
+    });
+    expect(text).toContain("In Letta Code: open Channels > Feishu / Lark");
+    expect(text).toContain("Feishu / Lark");
+    expect(text).toContain(
+      "letta channels pair --channel feishu --code OU123 --agent agent-feishu",
+    );
+    expect(text).not.toContain("(community channel)");
+  });
+
   test("first-party copy uses 'Letta agent' consistently", () => {
     expect(buildPairingInstructions("telegram", "X")).toContain("Letta agent");
     expect(buildUnboundRouteInstructions("slack", "Y")).toContain(

--- a/src/channels/registry-inbound.ts
+++ b/src/channels/registry-inbound.ts
@@ -29,6 +29,7 @@ import type {
 } from "./types";
 import {
   isDiscordChannelAccount,
+  isFeishuChannelAccount,
   isSignalChannelAccount,
   isSlackChannelAccount,
   isTelegramChannelAccount,
@@ -340,6 +341,43 @@ export function createChannelInboundRouter(deps: {
         content: formatChannelNotification(preparedMessage),
         turnSources: [
           buildChannelTurnSource(signalResult.route, preparedMessage),
+        ],
+      });
+      return;
+    }
+
+    // Feishu groups default to mention-only (matching Feishu's default bot
+    // scope). DMs with pairing fall through; account-bound DMs auto-route.
+    if (
+      msg.channel === "feishu" &&
+      isFeishuChannelAccount(config) &&
+      (msg.chatType === "channel" || config.dmPolicy !== "pairing")
+    ) {
+      if (
+        msg.chatType === "channel" &&
+        (config.groupMode ?? "mention-only") === "mention-only" &&
+        !msg.isMention
+      ) {
+        return;
+      }
+      const feishuResult = await deps.routes.ensureFeishuRoute(
+        adapter,
+        msg,
+        config,
+      );
+      if (!feishuResult) {
+        return;
+      }
+      const preparedMessage = adapter.prepareInboundMessage
+        ? await adapter.prepareInboundMessage(msg, {
+            isFirstRouteTurn: feishuResult.isFirstRouteTurn,
+          })
+        : msg;
+      deps.deliver({
+        route: feishuResult.route,
+        content: formatChannelNotification(preparedMessage),
+        turnSources: [
+          buildChannelTurnSource(feishuResult.route, preparedMessage),
         ],
       });
       return;

--- a/src/channels/registry-presentation.ts
+++ b/src/channels/registry-presentation.ts
@@ -210,6 +210,22 @@ export function buildSignalConversationSummary(
   return `[Signal] Group${channelLabel || ` ${msg.chatId}`}`;
 }
 
+export function buildFeishuConversationSummary(
+  msg: Pick<
+    InboundChannelMessage,
+    "chatId" | "chatLabel" | "chatType" | "senderId" | "senderName" | "text"
+  >,
+): string {
+  if (msg.chatType === "direct") {
+    return `[Feishu] DM with ${msg.senderName?.trim() || msg.senderId}`;
+  }
+  const preview = truncateChannelSummaryPreview(msg.text);
+  const channelLabel =
+    msg.chatLabel && msg.chatLabel !== msg.chatId ? ` in ${msg.chatLabel}` : "";
+  if (preview) return `[Feishu] Group${channelLabel}: ${preview}`;
+  return `[Feishu] Group${channelLabel || ` ${msg.chatId}`}`;
+}
+
 export function buildChannelTurnSource(
   route: ChannelRoute,
   msg: Pick<

--- a/src/channels/registry-routes.ts
+++ b/src/channels/registry-routes.ts
@@ -5,6 +5,7 @@ import type { ChannelRegistryEvent } from "./registry-events";
 import {
   buildDirectReplyOptions,
   buildDiscordConversationSummary,
+  buildFeishuConversationSummary,
   buildSignalConversationSummary,
   buildSlackAppSetupInstructions,
   buildSlackConversationSummary,
@@ -17,6 +18,7 @@ import type {
   ChannelAdapter,
   ChannelRoute,
   DiscordChannelAccount,
+  FeishuChannelAccount,
   InboundChannelMessage,
   SignalChannelAccount,
   SlackChannelAccount,
@@ -576,6 +578,105 @@ export function createChannelRouteProvisioner(deps: {
     };
   }
 
+  async function createFeishuRoute(
+    config: FeishuChannelAccount,
+    msg: InboundChannelMessage,
+  ): Promise<ChannelRoute> {
+    if (!config.agentId) {
+      throw new Error("Feishu bot is missing an agent binding.");
+    }
+
+    const conversationId = await createConversationForAgent(
+      config.agentId,
+      buildFeishuConversationSummary(msg),
+    );
+    const now = new Date().toISOString();
+    const route: ChannelRoute = {
+      accountId: config.accountId,
+      chatId: msg.chatId,
+      chatType: msg.chatType,
+      threadId: msg.threadId ?? null,
+      agentId: config.agentId,
+      conversationId,
+      enabled: true,
+      createdAt: now,
+      updatedAt: now,
+    };
+
+    addRoute(msg.channel, route);
+    return route;
+  }
+
+  async function ensureFeishuRoute(
+    adapter: ChannelAdapter,
+    msg: InboundChannelMessage,
+    config: FeishuChannelAccount,
+  ): Promise<{
+    route: ChannelRoute;
+    isFirstRouteTurn: boolean;
+  } | null> {
+    if (!config.agentId) {
+      if (msg.chatType === "direct" || msg.isMention === true) {
+        await adapter.sendDirectReply(
+          msg.chatId,
+          "This Feishu bot isn't connected to a Letta agent yet.\n\n" +
+            "Open Channels > Feishu / Lark in Letta Code, choose which agent this bot should represent, and try again.",
+        );
+      }
+      return null;
+    }
+
+    const accountId = msg.accountId ?? LEGACY_CHANNEL_ACCOUNT_ID;
+    const routeThreadId = msg.threadId ?? null;
+    let route = getRouteFromStore(
+      msg.channel,
+      msg.chatId,
+      accountId,
+      routeThreadId,
+    );
+    if (!route) {
+      loadRoutes(msg.channel);
+      route = getRouteFromStore(
+        msg.channel,
+        msg.chatId,
+        accountId,
+        routeThreadId,
+      );
+    }
+
+    if (route) {
+      return { route, isFirstRouteTurn: false };
+    }
+
+    if (msg.chatType === "channel" && !msg.isMention && !msg.isOpenChannel) {
+      return null;
+    }
+
+    if (msg.chatType === "channel") {
+      const now = new Date().toISOString();
+      loadTargetStore(msg.channel);
+      upsertChannelTarget(msg.channel, {
+        accountId,
+        targetId: msg.chatId,
+        targetType: "channel",
+        chatId: msg.chatId,
+        label: msg.chatLabel ?? `Feishu group ${msg.chatId}`,
+        discoveredAt: now,
+        lastSeenAt: now,
+        lastMessageId: msg.messageId,
+      });
+      deps.emitEvent({
+        type: "targets_updated",
+        channelId: msg.channel,
+      });
+    }
+
+    return {
+      route: await createFeishuRoute(config, msg),
+      isFirstRouteTurn: true,
+    };
+  }
+
   return {
     createConversationForAgent,
     createSlackRoute,
@@ -584,6 +685,7 @@ export function createChannelRouteProvisioner(deps: {
     ensureDiscordRoute,
     ensureWhatsAppRoute,
     ensureSignalRoute,
+    ensureFeishuRoute,
   };
 }
 

--- a/src/channels/service-account-model.ts
+++ b/src/channels/service-account-model.ts
@@ -4,6 +4,8 @@ import { normalizeDisplayName } from "./service-shared";
 import type {
   ChannelAccount,
   CustomChannelAccount,
+  FeishuDomain,
+  FeishuGroupMode,
   SignalGroupMode,
   SupportedChannelId,
   TelegramGroupMode,
@@ -12,6 +14,7 @@ import type {
 import {
   DEFAULT_SLACK_PERMISSION_MODE,
   isDiscordChannelAccount,
+  isFeishuChannelAccount,
   isSignalChannelAccount,
   isSlackChannelAccount,
   isTelegramChannelAccount,
@@ -38,6 +41,18 @@ function normalizeSignalGroupMode(
   return value === "disabled" || value === "mention" || value === "open"
     ? value
     : undefined;
+}
+
+function normalizeFeishuGroupMode(
+  value: ChannelAccountPatch["groupMode"],
+): FeishuGroupMode | undefined {
+  return value === "open" || value === "mention-only" ? value : undefined;
+}
+
+function normalizeFeishuDomain(
+  value: ChannelAccountPatch["domain"],
+): FeishuDomain | undefined {
+  return value === "feishu" || value === "lark" ? value : undefined;
 }
 
 function normalizeOptionalConfigString(
@@ -157,6 +172,25 @@ export function createAccountFromPatch(
       transcribeVoice: normalizedPatch.transcribeVoice === true,
       downloadMedia: normalizedPatch.downloadMedia ?? true,
       mediaMaxBytes: normalizedPatch.mediaMaxBytes,
+      createdAt: now,
+      updatedAt: now,
+    };
+  }
+
+  if (channelId === "feishu") {
+    return {
+      channel: "feishu",
+      accountId,
+      displayName: normalizeDisplayName(normalizedPatch.displayName),
+      enabled: normalizedPatch.enabled ?? false,
+      appId: normalizedPatch.appId ?? "",
+      appSecret: normalizedPatch.appSecret ?? "",
+      domain: normalizeFeishuDomain(normalizedPatch.domain) ?? "feishu",
+      groupMode:
+        normalizeFeishuGroupMode(normalizedPatch.groupMode) ?? "mention-only",
+      agentId: normalizedPatch.agentId ?? null,
+      dmPolicy: normalizedPatch.dmPolicy ?? "pairing",
+      allowedUsers: normalizedPatch.allowedUsers ?? [],
       createdAt: now,
       updatedAt: now,
     };
@@ -356,6 +390,27 @@ export function mergeAccountPatch(
       downloadMedia:
         normalizedPatch.downloadMedia ?? existing.downloadMedia ?? true,
       mediaMaxBytes: normalizedPatch.mediaMaxBytes ?? existing.mediaMaxBytes,
+      updatedAt: nextUpdatedAt,
+    };
+  }
+
+  if (isFeishuChannelAccount(existing)) {
+    return {
+      ...existing,
+      displayName:
+        normalizedPatch.displayName !== undefined
+          ? normalizeDisplayName(normalizedPatch.displayName)
+          : existing.displayName,
+      enabled: normalizedPatch.enabled ?? existing.enabled,
+      appId: normalizedPatch.appId ?? existing.appId,
+      appSecret: normalizedPatch.appSecret ?? existing.appSecret,
+      domain: normalizeFeishuDomain(normalizedPatch.domain) ?? existing.domain,
+      groupMode:
+        normalizeFeishuGroupMode(normalizedPatch.groupMode) ??
+        existing.groupMode,
+      agentId: normalizedPatch.agentId ?? existing.agentId,
+      dmPolicy: normalizedPatch.dmPolicy ?? existing.dmPolicy,
+      allowedUsers: normalizedPatch.allowedUsers ?? existing.allowedUsers,
       updatedAt: nextUpdatedAt,
     };
   }

--- a/src/channels/service-accounts.ts
+++ b/src/channels/service-accounts.ts
@@ -25,6 +25,7 @@ import { loadTargetStore, removeChannelTargetsForAccount } from "./targets";
 import type { ChannelAccount } from "./types";
 import {
   isDiscordChannelAccount,
+  isFeishuChannelAccount,
   isSignalChannelAccount,
   isSlackChannelAccount,
   isTelegramChannelAccount,
@@ -90,10 +91,12 @@ export function updateChannelAccountLive(
   const shouldResetRoutes =
     (isSlackChannelAccount(existing) ||
       isDiscordChannelAccount(existing) ||
-      isSignalChannelAccount(existing)) &&
+      isSignalChannelAccount(existing) ||
+      isFeishuChannelAccount(existing)) &&
     (isSlackChannelAccount(nextAccount) ||
       isDiscordChannelAccount(nextAccount) ||
-      isSignalChannelAccount(nextAccount)) &&
+      isSignalChannelAccount(nextAccount) ||
+      isFeishuChannelAccount(nextAccount)) &&
     typeof nextAccount.agentId === "string" &&
     nextAccount.agentId !== existing.agentId;
 
@@ -147,10 +150,12 @@ export async function updateChannelAccountLiveWithSecrets(
   const shouldResetRoutes =
     (isSlackChannelAccount(existing) ||
       isDiscordChannelAccount(existing) ||
-      isSignalChannelAccount(existing)) &&
+      isSignalChannelAccount(existing) ||
+      isFeishuChannelAccount(existing)) &&
     (isSlackChannelAccount(nextAccount) ||
       isDiscordChannelAccount(nextAccount) ||
-      isSignalChannelAccount(nextAccount)) &&
+      isSignalChannelAccount(nextAccount) ||
+      isFeishuChannelAccount(nextAccount)) &&
     typeof nextAccount.agentId === "string" &&
     nextAccount.agentId !== existing.agentId;
 
@@ -243,9 +248,10 @@ export function bindChannelAccountLive(
     isSlackChannelAccount(existing) ||
     isDiscordChannelAccount(existing) ||
     isWhatsAppChannelAccount(existing) ||
-    isSignalChannelAccount(existing)
+    isSignalChannelAccount(existing) ||
+    isFeishuChannelAccount(existing)
   ) {
-    // Slack, Discord, WhatsApp, and Signal use a top-level agentId.
+    // Slack, Discord, WhatsApp, Signal, and Feishu use a top-level agentId.
     updated = upsertChannelAccount(channelId, {
       ...existing,
       agentId,
@@ -284,9 +290,10 @@ export function unbindChannelAccountLive(
     isSlackChannelAccount(existing) ||
     isDiscordChannelAccount(existing) ||
     isWhatsAppChannelAccount(existing) ||
-    isSignalChannelAccount(existing)
+    isSignalChannelAccount(existing) ||
+    isFeishuChannelAccount(existing)
   ) {
-    // Slack, Discord, WhatsApp, and Signal use a top-level agentId.
+    // Slack, Discord, WhatsApp, Signal, and Feishu use a top-level agentId.
     updated = upsertChannelAccount(channelId, {
       ...existing,
       agentId: null,
@@ -322,6 +329,11 @@ export async function startChannelAccountLive(
     if (isDiscordChannelAccount(existing)) {
       throw new Error(
         'Channel "discord" account is missing a token. Configure it first.',
+      );
+    }
+    if (isFeishuChannelAccount(existing)) {
+      throw new Error(
+        'Channel "feishu" account is missing an App ID or App Secret. Configure it first.',
       );
     }
     if (!isSlackChannelAccount(existing)) {

--- a/src/channels/service-runtime.ts
+++ b/src/channels/service-runtime.ts
@@ -25,6 +25,7 @@ import {
 import type { ChannelConfigSnapshot, ChannelSummary } from "./service-types";
 import {
   isDiscordChannelAccount,
+  isFeishuChannelAccount,
   isSlackChannelAccount,
   isTelegramChannelAccount,
 } from "./types";
@@ -48,6 +49,9 @@ export async function setChannelConfigLive(
       token: normalizedPatch.token,
       botToken: normalizedPatch.botToken,
       appToken: normalizedPatch.appToken,
+      appId: normalizedPatch.appId,
+      appSecret: normalizedPatch.appSecret,
+      domain: normalizedPatch.domain,
       mode: normalizedPatch.mode,
       defaultPermissionMode: normalizedPatch.defaultPermissionMode,
       dmPolicy: normalizedPatch.dmPolicy,
@@ -91,6 +95,9 @@ export async function setChannelConfigLive(
         token: normalizedPatch.token,
         botToken: normalizedPatch.botToken,
         appToken: normalizedPatch.appToken,
+        appId: normalizedPatch.appId,
+        appSecret: normalizedPatch.appSecret,
+        domain: normalizedPatch.domain,
         mode: normalizedPatch.mode,
         defaultPermissionMode: normalizedPatch.defaultPermissionMode,
         dmPolicy: normalizedPatch.dmPolicy,
@@ -187,6 +194,11 @@ export async function startChannelLive(
         'Channel "discord" is missing a token. Configure it first.',
       );
     }
+    if (isFeishuChannelAccount(existing)) {
+      throw new Error(
+        'Channel "feishu" is missing an App ID or App Secret. Configure it first.',
+      );
+    }
     if (!isSlackChannelAccount(existing)) {
       throw new Error(
         `Channel "${channelId}" account is not configured. Configure it first.`,
@@ -210,7 +222,10 @@ export async function startChannelLive(
     existing.accountId,
   );
   await refreshChannelAccountDisplayNameLive(channelId, existing.accountId, {
-    force: channelId === "slack" || channelId === "discord",
+    force:
+      channelId === "slack" ||
+      channelId === "discord" ||
+      channelId === "feishu",
   });
 
   const summary = listChannelSummaries().find(

--- a/src/channels/service-snapshots.ts
+++ b/src/channels/service-snapshots.ts
@@ -37,6 +37,7 @@ import type { ChannelAccount, SupportedChannelId } from "./types";
 import {
   DEFAULT_SLACK_PERMISSION_MODE,
   isDiscordChannelAccount,
+  isFeishuChannelAccount,
   isSignalChannelAccount,
   isSlackChannelAccount,
   isTelegramChannelAccount,
@@ -83,6 +84,12 @@ export function isAccountConfigured(account: ChannelAccount): boolean {
 
   if (isSignalChannelAccount(account)) {
     return account.baseUrl.trim().length > 0;
+  }
+
+  if (isFeishuChannelAccount(account)) {
+    return (
+      account.appId.trim().length > 0 && account.appSecret.trim().length > 0
+    );
   }
 
   if (!isSlackChannelAccount(account)) {
@@ -231,6 +238,26 @@ export function toAccountSnapshot(
       transcribeVoice: account.transcribeVoice === true,
       downloadMedia: account.downloadMedia === true,
       mediaMaxBytes: account.mediaMaxBytes,
+      createdAt: account.createdAt,
+      updatedAt: account.updatedAt,
+    };
+  }
+
+  if (isFeishuChannelAccount(account)) {
+    return {
+      channelId: "feishu",
+      accountId: account.accountId,
+      displayName: account.displayName,
+      enabled: account.enabled,
+      configured: isAccountConfigured(account),
+      running,
+      dmPolicy: account.dmPolicy,
+      allowedUsers: [...account.allowedUsers],
+      config: toChannelAccountProtocolConfig(account),
+      agentId: account.agentId,
+      groupMode: account.groupMode,
+      domain: account.domain,
+      hasAppSecret: account.appSecret.trim().length > 0,
       createdAt: account.createdAt,
       updatedAt: account.updatedAt,
     };
@@ -429,6 +456,22 @@ export function getChannelConfigSnapshot(
       transcribeVoice: account.transcribeVoice === true,
       downloadMedia: account.downloadMedia === true,
       mediaMaxBytes: account.mediaMaxBytes,
+    };
+  }
+
+  if (isFeishuChannelAccount(account)) {
+    return {
+      channelId: "feishu",
+      accountId: account.accountId,
+      displayName: account.displayName,
+      enabled: account.enabled,
+      dmPolicy: account.dmPolicy,
+      allowedUsers: [...account.allowedUsers],
+      config: toChannelConfigSnapshotProtocolConfig(account),
+      agentId: account.agentId,
+      groupMode: account.groupMode,
+      domain: account.domain,
+      hasAppSecret: account.appSecret.trim().length > 0,
     };
   }
 

--- a/src/channels/service-types.ts
+++ b/src/channels/service-types.ts
@@ -4,6 +4,8 @@ import type {
   ChannelDefaultPermissionMode,
   DiscordChannelMode,
   DmPolicy,
+  FeishuDomain,
+  FeishuGroupMode,
   SignalGroupMode,
   SlackChannelMode,
   TelegramGroupMode,
@@ -36,7 +38,13 @@ export interface ChannelConfigSnapshot {
   hasToken?: boolean;
   hasBotToken?: boolean;
   hasAppToken?: boolean;
-  groupMode?: TelegramGroupMode | WhatsAppGroupMode | SignalGroupMode;
+  hasAppSecret?: boolean;
+  domain?: FeishuDomain;
+  groupMode?:
+    | TelegramGroupMode
+    | WhatsAppGroupMode
+    | SignalGroupMode
+    | FeishuGroupMode;
   agentId?: string | null;
   defaultPermissionMode?: ChannelDefaultPermissionMode;
   allowedChannels?: string[] | Record<string, DiscordChannelMode>;
@@ -117,7 +125,13 @@ export interface ChannelAccountSnapshot {
   hasToken?: boolean;
   hasBotToken?: boolean;
   hasAppToken?: boolean;
-  groupMode?: TelegramGroupMode | WhatsAppGroupMode | SignalGroupMode;
+  hasAppSecret?: boolean;
+  domain?: FeishuDomain;
+  groupMode?:
+    | TelegramGroupMode
+    | WhatsAppGroupMode
+    | SignalGroupMode
+    | FeishuGroupMode;
   transcribeVoice?: boolean;
   richPrivateChatDefault?: boolean;
   richDraftStreaming?: boolean;

--- a/src/channels/types.ts
+++ b/src/channels/types.ts
@@ -69,6 +69,7 @@ export const FIRST_PARTY_CHANNEL_IDS = [
   "custom",
   "whatsapp",
   "signal",
+  "feishu",
 ] as const;
 export type FirstPartyChannelId = (typeof FIRST_PARTY_CHANNEL_IDS)[number];
 /**
@@ -519,6 +520,8 @@ export type DiscordAllowBotsMode = ChannelAllowBotsMode;
 export type TelegramGroupMode = "open" | "mention-only";
 export type WhatsAppGroupMode = "disabled" | "mention" | "open";
 export type SignalGroupMode = "disabled" | "mention" | "open";
+export type FeishuDomain = "feishu" | "lark";
+export type FeishuGroupMode = "open" | "mention-only";
 
 export interface ChannelAccountBinding {
   agentId: string | null;
@@ -871,6 +874,15 @@ export interface WhatsAppChannelAccount
   waitingBehavior?: WhatsAppWaitingBehavior;
 }
 
+export interface FeishuChannelAccount extends ChannelAccountBase {
+  channel: "feishu";
+  appId: string;
+  appSecret: string;
+  domain: FeishuDomain;
+  groupMode: FeishuGroupMode;
+  agentId: string | null;
+}
+
 export interface SignalChannelAccount extends ChannelAccountBase {
   channel: "signal";
   /** Base URL for a Signal JSON-RPC/SSE bridge, e.g. http://127.0.0.1:8080. */
@@ -905,6 +917,7 @@ export type ChannelAccount =
   | DiscordChannelAccount
   | WhatsAppChannelAccount
   | SignalChannelAccount
+  | FeishuChannelAccount
   | CustomChannelAccount;
 
 export function isFirstPartyChannelId(
@@ -949,6 +962,14 @@ export function isSignalChannelAccount(
   return account.channel === "signal" && "baseUrl" in account;
 }
 
+export function isFeishuChannelAccount(
+  account: ChannelAccount,
+): account is FeishuChannelAccount {
+  return (
+    account.channel === "feishu" && "appId" in account && "appSecret" in account
+  );
+}
+
 export function isCustomChannelAccount(
   account: ChannelAccount,
 ): account is CustomChannelAccount {
@@ -960,39 +981,9 @@ export function isCustomChannelAccount(
   return !isFirstPartyChannelId(account.channel) && "config" in account;
 }
 
-// ── Pairing ───────────────────────────────────────────────────────
-
-export interface PendingPairing {
-  accountId?: string;
-  code: string;
-  senderId: string;
-  senderName?: string;
-  chatId: string;
-  createdAt: string;
-  expiresAt: string;
-}
-
-export interface ApprovedUser {
-  accountId?: string;
-  senderId: string;
-  senderName?: string;
-  approvedAt: string;
-}
-
-export interface PairingStore {
-  pending: PendingPairing[];
-  approved: ApprovedUser[];
-}
-
-// ── Discovered bind targets ───────────────────────────────────────
-
-export interface ChannelBindableTarget {
-  accountId?: string;
-  targetId: string;
-  targetType: "channel";
-  chatId: string;
-  label: string;
-  discoveredAt: string;
-  lastSeenAt: string;
-  lastMessageId?: string;
-}
+export type {
+  ApprovedUser,
+  ChannelBindableTarget,
+  PairingStore,
+  PendingPairing,
+} from "./pairing-types";


### PR DESCRIPTION
## Summary

- Add a messenger-only first-party `feishu` channel (display name **Feishu / Lark**) over the Open Platform persistent connection (WebSocket). No webhook, cards, Drive, or custom Desktop screens.
- Pairing and allowlists use Feishu `open_id` (`ou_*`). Groups default to **mention-only** (matches the default `@bot` event scope). `@all` is not a bot mention. Bot/app senders are dropped.
- One running listener per App ID (cluster mode). `domain` selects Feishu (`open.feishu.cn`) vs Lark (`open.larksuite.com`). Text send goes through the shared `MessageChannel` tool.
- `appId` / `appSecret` / `domain` land on the existing flattened `ChannelPluginAccountPatch` (same shared create/update path as Signal), not a new discriminated patch union.

Closes #4130.

## Why

Mainland Feishu and international Lark are the same Open Platform with different consoles. A first-party plugin is what makes `letta channels configure/install/pair` work without a user-plugin manifest. Persistent connection is the local analog of Slack Socket Mode.

## Limits / non-goals

- No published `./channels/feishu` package export (Slack/Telegram subpaths shipped because Cloud needed them). Pure `ingress.ts` / `outbound.ts` stay SDK-free for a later webhook host.
- No HTTP webhook, Card Kit, docs/drive/Bitable, store apps, or `allowBots`.
- Self-built apps only. Restart the listener after editing `accounts.json`.

## Verification

- `bun run check` — 12/12
- `bun test src/channels/feishu src/channels/registry-community-copy.test.ts` — 34 passed
- Lifecycle errors go through `formatChannelLifecycleErrorMessage` (adapter test covers sanitizing before post).
- Mention-only drop, `message_id` dedup, and second App ID start are covered by tests that fail without this change.

## Live validation

No live Feishu/Lark app probe was run. Harness-only: injected SDK client, ingress/outbound unit tests, and the App ID uniqueness guard.

## AI Disclosure

- [ ] This pull request was written entirely by a human
- [x] This pull request was written with AI assistance and reviewed and edited by a human
- [x] I have read the [AI Policy](https://github.com/letta-ai/letta-code/blob/main/AI_POLICY.md) and agree to its terms

## AI Tool(s) Used

Cursor

## Human Verification

I have reviewed and understand every change in this pull request and take responsibility for its correctness.

Made with [Cursor](https://cursor.com)

Linear: https://linear.app/letta/issue/LET-11920/add-first-party-feishulark-channel-support