### PR TITLE
fix(skills): remove stale `letta memory tokens` from context-doctor ROOT_MEMORY.md

### DIFF
--- a/src/skills/builtin/context-doctor/ROOT_MEMORY.md
+++ b/src/skills/builtin/context-doctor/ROOT_MEMORY.md
@@ -24,12 +24,7 @@ Below are additional common issues with context and how they can be resolved:
 #### System prompt bloat
 Root Markdown files compiled into the system prompt should take up about 10% of the total context size (usually ~15-20K tokens). This is a soft target, not a hard requirement.
 
-Use the built-in CLI to evaluate token usage of the system prompt:
-```bash
-letta memory tokens --format json --quiet
-```
-
-The command reports `total_tokens` and per-file estimates for core memory. It is only a measurement tool; decide whether to intervene based on the actual context and the guidance below.
+To estimate token usage, read your root `.md` files and divide the total byte count by 4 (the heuristic the harness uses). It is only a measurement tool; decide whether to intervene based on the actual context and the guidance below.
 
 **Why detail is load-bearing (read this before cutting anything)**: In-context detail does more than carry information. It does at least four things, and byte-counting sweeps only see the first:
 1. **Information** — the literal facts stated


### PR DESCRIPTION
Builtin-skill-watch: context-doctor@2823362103cc-be7161d9305cdf63

## Summary

- `letta memory tokens` only scans `system/` (memfs-v1 layout) and returns 0 for memfs-v2 agents with root `MEMORY.md` layout
- `ROOT_MEMORY.md` is the file loaded for memfs-v2 agents, so the command reference was stale
- Replaced with manual byte-count/4 estimation guidance (same heuristic the harness uses)

## Test plan

- [x] `bun test src/agent/prompt-assets.test.ts` — 23 pass, 0 fail
- [x] `bun test src/tools/skill-tool.test.ts` — 20 pass, 0 fail
- [x] `bun run typecheck` — 0 errors
- [x] Existing test "root-only prompt assets contain no system directory paths" still passes

👾 Generated with [Letta Code](https://letta.com)