### PR TITLE
fix(skills): correct stale claims in initializing-memory skill

### DIFF
--- a/src/skills/builtin/initializing-memory/ROOT_MEMORY.md
+++ b/src/skills/builtin/initializing-memory/ROOT_MEMORY.md
@@ -235,7 +235,7 @@ The goal is to extract user personality, preferences, coding patterns, and proje
 #### Prerequisites
 
 - `letta.js` must be built (`bun run build`) — subagents spawn via this binary
-- Use `subagent_type: "history-analyzer"` — cheaper model (sonnet), has `bypassPermissions`, creates its own worktree
+- Use `subagent_type: "history-analyzer"` — model: auto, runs with `--permission-mode unrestricted`, creates its own worktree
 - The `history-analyzer` subagent has the normalized trajectory format docs inlined — workers never need to know any harness's native format
 
 #### Steps
@@ -564,7 +564,6 @@ Launch exploration subagents in a **single message** so they run concurrently.
 Agent({
   subagent_type: "general-purpose",
   description: "Explore API layer",
-  run_in_background: true,
   prompt: `Read the implementation in src/api/.
 
 Return:
@@ -577,7 +576,6 @@ Return:
 Agent({
   subagent_type: "general-purpose",
   description: "Explore frontend layer",
-  run_in_background: true,
   prompt: `Read the implementation in src/ui/.
 
 Return:
@@ -590,7 +588,6 @@ Return:
 Agent({
   subagent_type: "general-purpose",
   description: "Explore shared systems",
-  run_in_background: true,
   prompt: `Read the implementation in src/shared/.
 
 Return:

--- a/src/skills/builtin/initializing-memory/SKILL.md
+++ b/src/skills/builtin/initializing-memory/SKILL.md
@@ -239,7 +239,7 @@ The goal is to extract user personality, preferences, coding patterns, and proje
 #### Prerequisites
 
 - `letta.js` must be built (`bun run build`) — subagents spawn via this binary
-- Use `subagent_type: "history-analyzer"` — cheaper model (sonnet), has `bypassPermissions`, creates its own worktree
+- Use `subagent_type: "history-analyzer"` — model: auto, runs with `--permission-mode unrestricted`, creates its own worktree
 - The `history-analyzer` subagent has the normalized trajectory format docs inlined — workers never need to know any harness's native format
 
 #### Steps
@@ -568,7 +568,6 @@ Launch exploration subagents in a **single message** so they run concurrently.
 Agent({
   subagent_type: "general-purpose",
   description: "Explore API layer",
-  run_in_background: true,
   prompt: `Read the implementation in src/api/.
 
 Return:
@@ -581,7 +580,6 @@ Return:
 Agent({
   subagent_type: "general-purpose",
   description: "Explore frontend layer",
-  run_in_background: true,
   prompt: `Read the implementation in src/ui/.
 
 Return:
@@ -594,7 +592,6 @@ Return:
 Agent({
   subagent_type: "general-purpose",
   description: "Explore shared systems",
-  run_in_background: true,
   prompt: `Read the implementation in src/shared/.
 
 Return:


### PR DESCRIPTION
## Summary

- Remove `run_in_background: true` from Agent tool examples (parameter removed in PR #4138, subagent launches are now always background-only)
- Fix history-analyzer model claim: "cheaper model (sonnet)" -> "model: auto" (actual frontmatter is `model: auto`, not sonnet)
- Fix permission mode claim: "has `bypassPermissions`" -> "runs with `--permission-mode unrestricted`" (renamed in `src/permissions/mode.ts`)

## Evidence

- `src/tools/schemas/Task.json`: `run_in_background` field removed (PR #4138)
- `src/agent/subagents/builtin/history-analyzer.md` frontmatter: `model: auto`
- `src/agent/subagents/manager.ts` line 293: `--permission-mode unrestricted` for all subagents

Builtin-skill-watch: initializing-memory@f61414acebd4-14a05601258ce68f

## AI Disclosure

- [ ] This pull request was written entirely by a human
- [ ] This pull request was written with AI assistance and reviewed and edited by a human
- [x] I have read the [AI Policy](https://github.com/letta-ai/letta-code/blob/main/AI_POLICY.md) and agree to its terms

## AI Tool(s) Used

Letta Code
