### PR TITLE
fix(skills): clarify cron runner distinction in self-configuration

### DIFF
--- a/src/skills/builtin/self-configuration/SKILL.md
+++ b/src/skills/builtin/self-configuration/SKILL.md
@@ -430,7 +430,7 @@ letta cron list
 letta cron add --name "weekly-review" --description "Weekly project review" --prompt "Ask the user for the weekly project review." --cron "0 9 * * 1" --agent "$AGENT_ID" --conversation "$CONVERSATION_ID"
 ```
 
-Scheduled tasks fire only while a Letta session/listener is running. Cron bindings can target other agents/conversations visible to the account; verify agent and conversation IDs explicitly when exact routing matters.
+Local cron tasks (`--runner local`) fire only while a Letta session/listener is running. Cloud schedules (`--runner cloud`, the default for cloud agents) are durable and fire from a cloud worker regardless of local listener state. Cron bindings can target other agents/conversations visible to the account; verify agent and conversation IDs explicitly when exact routing matters.
 
 ## CLI startup flags
 


### PR DESCRIPTION
## Summary
- Fix stale claim: "Scheduled tasks fire only while a Letta session/listener is running" was only true for local cron tasks
- Cloud schedules (`--runner cloud`, the default for cloud agents) are durable and fire from a cloud worker regardless of local listener state
- Updated line 433 in `src/skills/builtin/self-configuration/SKILL.md` to clarify the distinction

Builtin-skill-watch: self-configuration@c7808b069447-65a26aafa89a9ce4