### PR TITLE
fix(updater): serialize concurrent self-updates

### DIFF
--- a/src/updater/auto-update.concurrent.test.ts
+++ b/src/updater/auto-update.concurrent.test.ts
@@ -1,0 +1,233 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { spawn } from "node:child_process";
+import {
+  chmod,
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  writeFile,
+} from "node:fs/promises";
+import { createServer, type Server } from "node:http";
+import { tmpdir } from "node:os";
+import { delimiter, join } from "node:path";
+import { pathToFileURL } from "node:url";
+import { createIsolatedCliTestEnv } from "@/test-utils/test-process-env";
+
+const LATEST_VERSION = "99.0.0";
+
+describe.skipIf(process.platform === "win32")(
+  "auto-update process coordination",
+  () => {
+    let server: Server;
+    let registryUrl: string;
+    let testDir: string;
+
+    beforeEach(async () => {
+      testDir = await mkdtemp(join(tmpdir(), "letta-update-lock-test-"));
+      server = createServer((_request, response) => {
+        response.writeHead(200, { "content-type": "application/json" });
+        response.end(JSON.stringify({ version: LATEST_VERSION }));
+      });
+      await new Promise<void>((resolve, reject) => {
+        server.once("error", reject);
+        server.listen(0, "127.0.0.1", () => resolve());
+      });
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        throw new Error("Test registry did not bind a TCP port");
+      }
+      registryUrl = `http://127.0.0.1:${address.port}`;
+    });
+
+    afterEach(async () => {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+      await rm(testDir, { recursive: true, force: true });
+    });
+
+    for (const packageManager of ["npm", "pnpm", "bun"] as const) {
+      test(`${packageManager} serializes simultaneous startup updates and rechecks the stable global install`, async () => {
+        const prefix = join(testDir, "prefix");
+        const globalRoot = join(prefix, "lib", "node_modules");
+        const packageDir = join(globalRoot, "@letta-ai", "letta-code");
+        const entrypointPackageDir =
+          packageManager === "pnpm"
+            ? join(
+                globalRoot,
+                ".pnpm",
+                "@letta-ai+letta-code@0.0.1",
+                "node_modules",
+                "@letta-ai",
+                "letta-code",
+              )
+            : packageDir;
+        const entrypoint = join(entrypointPackageDir, "letta.js");
+        const manifestPath = join(packageDir, "package.json");
+        const fakeBinDir = join(testDir, "bin");
+        const installLog = join(testDir, "install.log");
+        const activeInstallDir = join(testDir, "install-active");
+        const lockPath = join(globalRoot, ".letta-update.lock");
+        const updaterUrl = pathToFileURL(
+          join(process.cwd(), "src", "updater", "auto-update.ts"),
+        ).href;
+
+        await mkdir(packageDir, { recursive: true });
+        await mkdir(entrypointPackageDir, { recursive: true });
+        await mkdir(fakeBinDir, { recursive: true });
+        await writeFile(
+          manifestPath,
+          `${JSON.stringify({ version: "0.0.1" })}\n`,
+          "utf8",
+        );
+        await writeFile(
+          entrypoint,
+          `
+import { checkAndAutoUpdate } from ${JSON.stringify(updaterUrl)};
+import { manualUpdate } from ${JSON.stringify(updaterUrl)};
+const result = process.env.UPDATE_TEST_MODE === "manual"
+  ? await manualUpdate({ progressLog: () => {} })
+  : await checkAndAutoUpdate();
+console.log(JSON.stringify(result ?? null));
+`,
+          "utf8",
+        );
+
+        const fakePackageManagerPath = join(fakeBinDir, packageManager);
+        await writeFile(
+          fakePackageManagerPath,
+          `#!/usr/bin/env node
+const fs = require("node:fs");
+const args = process.argv.slice(2);
+if (args[0] === "prefix") {
+  process.stdout.write(process.env.FAKE_PM_PREFIX);
+  process.exit(0);
+}
+if (args[0] === "root") {
+  process.stdout.write(process.env.FAKE_PM_ROOT);
+  process.exit(0);
+}
+if (args[0] !== "install" && args[0] !== "add") process.exit(64);
+fs.appendFileSync(process.env.FAKE_PM_LOG, "start\\n");
+if (!fs.existsSync(process.env.FAKE_PM_LOCK)) {
+  fs.appendFileSync(process.env.FAKE_PM_LOG, "missing-lock\\n");
+  process.exit(74);
+}
+try {
+  fs.mkdirSync(process.env.FAKE_PM_ACTIVE);
+} catch {
+  fs.appendFileSync(process.env.FAKE_PM_LOG, "overlap\\n");
+  process.exit(73);
+}
+Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 300);
+fs.writeFileSync(
+  process.env.FAKE_PM_MANIFEST,
+  JSON.stringify({ version: process.env.FAKE_PM_VERSION }) + "\\n",
+);
+fs.rmSync(process.env.FAKE_PM_ACTIVE, { recursive: true, force: true });
+fs.appendFileSync(process.env.FAKE_PM_LOG, "end\\n");
+`,
+          "utf8",
+        );
+        await chmod(fakePackageManagerPath, 0o755);
+
+        const env = createIsolatedCliTestEnv({
+          PATH: `${fakeBinDir}${delimiter}${process.env.PATH ?? ""}`,
+          FAKE_PM_ACTIVE: activeInstallDir,
+          FAKE_PM_LOG: installLog,
+          FAKE_PM_LOCK: lockPath,
+          FAKE_PM_MANIFEST: manifestPath,
+          FAKE_PM_PREFIX: prefix,
+          FAKE_PM_ROOT: globalRoot,
+          FAKE_PM_VERSION: LATEST_VERSION,
+          DISABLE_AUTOUPDATER: "0",
+          LETTA_PACKAGE_MANAGER: packageManager,
+          LETTA_UPDATE_INSTALL_REGISTRY_URL: undefined,
+          LETTA_UPDATE_PACKAGE_NAME: "@letta-ai/letta-code",
+          LETTA_UPDATE_REGISTRY_BASE_URL: registryUrl,
+        });
+
+        const runUpdater = (mode: "auto" | "manual") =>
+          new Promise<{
+            exitCode: number | null;
+            stderr: string;
+            stdout: string;
+          }>((resolve, reject) => {
+            const child = spawn(process.execPath, [entrypoint], {
+              cwd: process.cwd(),
+              env: { ...env, UPDATE_TEST_MODE: mode },
+              stdio: ["ignore", "pipe", "pipe"],
+            });
+            let stdout = "";
+            let stderr = "";
+            child.stdout.on("data", (chunk) => {
+              stdout += String(chunk);
+            });
+            child.stderr.on("data", (chunk) => {
+              stderr += String(chunk);
+            });
+            child.once("error", reject);
+            child.once("exit", (exitCode) => {
+              resolve({ exitCode, stderr, stdout });
+            });
+          });
+
+        const results = await Promise.all([
+          runUpdater("auto"),
+          runUpdater("auto"),
+        ]);
+
+        for (const result of results) {
+          expect(result.exitCode, result.stderr).toBe(0);
+        }
+        const installEvents = (await readFile(installLog, "utf8"))
+          .trim()
+          .split("\n");
+        expect(installEvents).toEqual(["start", "end"]);
+        expect(
+          JSON.parse(await readFile(manifestPath, "utf8")) as {
+            version: string;
+          },
+        ).toEqual({ version: LATEST_VERSION });
+
+        const payloads = results.map((result) =>
+          JSON.parse(result.stdout.trim()),
+        );
+        expect(payloads).toEqual([
+          { latestVersion: LATEST_VERSION, updateApplied: true },
+          { latestVersion: LATEST_VERSION, updateApplied: true },
+        ]);
+        expect(await readFile(lockPath, "utf8").catch(() => null)).toBeNull();
+
+        await writeFile(
+          manifestPath,
+          `${JSON.stringify({ version: "0.0.1" })}\n`,
+          "utf8",
+        );
+        await writeFile(installLog, "", "utf8");
+
+        const manualResults = await Promise.all([
+          runUpdater("manual"),
+          runUpdater("manual"),
+        ]);
+        for (const result of manualResults) {
+          expect(result.exitCode, result.stderr).toBe(0);
+        }
+        expect((await readFile(installLog, "utf8")).trim().split("\n")).toEqual(
+          ["start", "end"],
+        );
+        const manualPayloads = manualResults.map((result) =>
+          JSON.parse(result.stdout.trim()),
+        ) as Array<{ message: string; success: boolean }>;
+        expect(manualPayloads.every((payload) => payload.success)).toBe(true);
+        expect(
+          manualPayloads.every((payload) =>
+            payload.message.includes("Restart Letta Code"),
+          ),
+        ).toBe(true);
+        expect(await readFile(lockPath, "utf8").catch(() => null)).toBeNull();
+      });
+    }
+  },
+);

--- a/src/updater/auto-update.ts
+++ b/src/updater/auto-update.ts
@@ -3,10 +3,11 @@ import {
   execFile,
 } from "node:child_process";
 import { accessSync, constants, realpathSync } from "node:fs";
-import { readdir, rm } from "node:fs/promises";
+import { readdir, readFile, rm } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { promisify } from "node:util";
 import { trackBoundaryError } from "@/telemetry/error-reporting";
+import { withFileLock } from "@/utils/file-lock";
 import { getVersion } from "@/version";
 
 const execFileAsync = promisify(execFile);
@@ -45,8 +46,18 @@ const INSTALL_ARG_PREFIX: Record<PackageManager, string[]> = {
 
 const VALID_PACKAGE_MANAGERS = new Set<string>(Object.keys(INSTALL_ARG_PREFIX));
 const NPM_PREFIX_TIMEOUT_MS = 5000;
+const GLOBAL_ROOT_TIMEOUT_MS = 5000;
 const UPDATE_INSTALL_TIMEOUT_MS = 60_000;
+const UPDATE_LOCK_STALE_MS = 180_000;
+const UPDATE_LOCK_TIMEOUT_MS = 185_000;
+const UPDATE_LOCK_RETRY_MS = 100;
+const UPDATE_LOCK_FILENAME = ".letta-update.lock";
 type FetchImpl = typeof fetch;
+
+type UpdateInstallContext = {
+  installPath: string;
+  lockPath: string;
+};
 
 export interface SelfUpdateStatus {
   supported: boolean;
@@ -152,12 +163,127 @@ function getResolvedEntrypoint(): string {
 }
 
 function findInstalledPackagePath(resolvedPath: string): string | null {
-  const marker = `${join("node_modules", "@letta-ai", "letta-code")}`;
-  const index = resolvedPath.lastIndexOf(marker);
-  if (index === -1) {
+  const packageNames = new Set([
+    resolveUpdatePackageName(),
+    DEFAULT_UPDATE_PACKAGE_NAME,
+  ]);
+  for (const packageName of packageNames) {
+    const marker = join("node_modules", packageName);
+    const index = resolvedPath.lastIndexOf(marker);
+    if (index !== -1) {
+      return resolvedPath.slice(0, index + marker.length);
+    }
+  }
+  return null;
+}
+
+function getInstalledPackagePath(): string | null {
+  return findInstalledPackagePath(getResolvedEntrypoint());
+}
+
+async function getPackageManagerGlobalRoot(
+  packageManager: PackageManager,
+): Promise<string | null> {
+  if (packageManager === "bun") return null;
+
+  try {
+    const { stdout } = await runUpdateCommand(
+      packageManager,
+      ["root", "-g"],
+      GLOBAL_ROOT_TIMEOUT_MS,
+    );
+    const root = stdout.trim();
+    if (!root) return null;
+    try {
+      accessSync(root, constants.F_OK);
+      return root;
+    } catch {
+      debugLog(`${packageManager} global root does not exist:`, root);
+      return null;
+    }
+  } catch (error) {
+    debugLog(`Failed to resolve ${packageManager} global root:`, error);
     return null;
   }
-  return resolvedPath.slice(0, index + marker.length);
+}
+
+async function getUpdateInstallContext(): Promise<UpdateInstallContext | null> {
+  const packageManager = detectPackageManager();
+  const globalRoot = await getPackageManagerGlobalRoot(packageManager);
+  if (globalRoot) {
+    return {
+      installPath: join(globalRoot, resolveUpdatePackageName()),
+      lockPath: join(globalRoot, UPDATE_LOCK_FILENAME),
+    };
+  }
+
+  const runningInstallPath = getInstalledPackagePath();
+  if (!runningInstallPath) return null;
+  const fallbackGlobalRoot = dirname(dirname(runningInstallPath));
+
+  return {
+    installPath: join(fallbackGlobalRoot, resolveUpdatePackageName()),
+    // npm and bun installs keep their global node_modules root stable while
+    // replacing the scoped package below it.
+    lockPath: join(fallbackGlobalRoot, UPDATE_LOCK_FILENAME),
+  };
+}
+
+async function readInstalledPackageVersion(
+  installPath: string,
+): Promise<string> {
+  try {
+    const raw = await readFile(join(installPath, "package.json"), "utf8");
+    const manifest = JSON.parse(raw) as { version?: unknown };
+    if (typeof manifest.version === "string") {
+      return manifest.version;
+    }
+  } catch (error) {
+    debugLog("Failed to read installed package version:", error);
+  }
+
+  return getVersion();
+}
+
+function isLockPermissionError(error: unknown): boolean {
+  const code = (error as NodeJS.ErrnoException)?.code;
+  return code === "EACCES" || code === "EPERM" || code === "EROFS";
+}
+
+async function withUpdateLock<T>(
+  fn: (context: UpdateInstallContext | null) => Promise<T>,
+): Promise<T> {
+  const context = await getUpdateInstallContext();
+  if (!context) {
+    debugLog(
+      "Could not resolve a stable update lock path; continuing unlocked",
+    );
+    return fn(null);
+  }
+
+  let enteredCriticalSection = false;
+  try {
+    return await withFileLock(
+      context.lockPath,
+      () => {
+        enteredCriticalSection = true;
+        return fn(context);
+      },
+      {
+        staleMs: UPDATE_LOCK_STALE_MS,
+        timeoutMs: UPDATE_LOCK_TIMEOUT_MS,
+        retryMs: UPDATE_LOCK_RETRY_MS,
+      },
+    );
+  } catch (error) {
+    if (enteredCriticalSection || !isLockPermissionError(error)) throw error;
+
+    // Preserve the previous updater behavior for root-owned global installs.
+    // The package manager will produce its normal actionable permissions error;
+    // a process that cannot create this sibling lock cannot mutate the install.
+    debugLog("Update lock is not writable; continuing without it:", error);
+    return fn(context);
+  }
 }
 
 function canWritePath(path: string): boolean {
@@ -279,7 +405,23 @@ function isRunningLocally(): boolean {
 export async function checkForUpdate(
   fetchImpl: FetchImpl = fetch,
 ): Promise<UpdateCheckResult> {
-  const currentVersion = getVersion();
+  return checkForVersionUpdate(getVersion(), fetchImpl);
+}
+
+async function checkInstalledPackageForUpdate(
+  context: UpdateInstallContext | null,
+  fetchImpl: FetchImpl = fetch,
+): Promise<UpdateCheckResult> {
+  const installedVersion = context
+    ? await readInstalledPackageVersion(context.installPath)
+    : getVersion();
+  return checkForVersionUpdate(installedVersion, fetchImpl);
+}
+
+async function checkForVersionUpdate(
+  currentVersion: string,
+  fetchImpl: FetchImpl,
+): Promise<UpdateCheckResult> {
   debugLog("Current version:", currentVersion);
 
   // Skip auto-update for prerelease versions (e.g., 0.2.0-next.3)
@@ -520,20 +662,45 @@ export async function checkAndAutoUpdate(): Promise<
 
   const result = await checkForUpdate();
 
-  if (result.updateAvailable) {
+  if (!result.updateAvailable) return undefined;
+
+  return withUpdateLock(async (context) => {
+    // Another Letta process may have completed the global install while this
+    // one waited. getVersion() is bundled into the already-running process, so
+    // re-read package.json from disk before deciding to mutate the install.
+    const lockedResult = await checkInstalledPackageForUpdate(context);
+    if (!lockedResult.updateAvailable) {
+      if (
+        lockedResult.currentVersion !== getVersion() &&
+        isSignificantUpdate(getVersion(), lockedResult.currentVersion)
+      ) {
+        return {
+          updateApplied: true,
+          latestVersion: lockedResult.currentVersion,
+        };
+      }
+      return undefined;
+    }
+
     const updateResult = await performUpdate();
     if (updateResult.enotemptyFailed) {
       return { enotemptyFailed: true };
     }
     if (
       updateResult.success &&
-      result.latestVersion &&
-      isSignificantUpdate(result.currentVersion, result.latestVersion)
+      lockedResult.latestVersion &&
+      isSignificantUpdate(
+        lockedResult.currentVersion,
+        lockedResult.latestVersion,
+      )
     ) {
-      return { updateApplied: true, latestVersion: result.latestVersion };
+      return {
+        updateApplied: true,
+        latestVersion: lockedResult.latestVersion,
+      };
     }
-  }
-  return undefined;
+    return undefined;
+  });
 }
 
 export async function manualUpdate(options?: {
@@ -565,23 +732,62 @@ export async function manualUpdate(options?: {
     };
   }
 
-  const progressLog = options?.progressLog ?? console.log;
-  progressLog(
-    `Updating from ${result.currentVersion} to ${result.latestVersion}...`,
-  );
+  try {
+    return await withUpdateLock(async (context) => {
+      const lockedResult = await checkInstalledPackageForUpdate(context);
 
-  const updateResult = await performUpdate(progressLog);
+      if (lockedResult.checkFailed) {
+        return {
+          success: false,
+          message:
+            "Could not check for updates (network error). Try again later.",
+        };
+      }
 
-  if (updateResult.success) {
+      if (!lockedResult.updateAvailable) {
+        if (lockedResult.currentVersion !== getVersion()) {
+          return {
+            success: true,
+            message: `Updated to ${lockedResult.currentVersion} by another Letta process. Restart Letta Code to use the new version.`,
+          };
+        }
+        return {
+          success: true,
+          message: `Already on latest version (${lockedResult.currentVersion})`,
+        };
+      }
+
+      const progressLog = options?.progressLog ?? console.log;
+      progressLog(
+        `Updating from ${lockedResult.currentVersion} to ${lockedResult.latestVersion}...`,
+      );
+
+      const updateResult = await performUpdate(progressLog);
+
+      if (updateResult.success) {
+        return {
+          success: true,
+          message: `Updated to ${lockedResult.latestVersion}. Restart Letta Code to use the new version.`,
+        };
+      }
+
+      const installCmd = buildInstallCommand(detectPackageManager());
+      return {
+        success: false,
+        message: `Update failed: ${updateResult.error}\n\nTo update manually: ${installCmd}`,
+      };
+    });
+  } catch (error) {
+    trackBoundaryError({
+      errorType: "auto_update_coordinated_flow_failed",
+      error,
+      context: "updater_coordinated_flow",
+    });
+    const message = error instanceof Error ? error.message : String(error);
+    const installCmd = buildInstallCommand(detectPackageManager());
     return {
-      success: true,
-      message: `Updated to ${result.latestVersion}. Restart Letta Code to use the new version.`,
+      success: false,
+      message: `Update failed: ${message}\n\nTo update manually: ${installCmd}`,
     };
   }
-
-  const installCmd = buildInstallCommand(detectPackageManager());
-  return {
-    success: false,
-    message: `Update failed: ${updateResult.error}\n\nTo update manually: ${installCmd}`,
-  };
 }


### PR DESCRIPTION
Coordinate auto and manual update processes around a stable global-install lock so simultaneous startups cannot corrupt the package manager install.

👾 Generated with [Letta Code](https://letta.com)

## Summary

- Serialize automatic startup updates and manual updates across Letta processes with a file lock located beside the stable global package installation.
- Re-read the installed package's `package.json` after acquiring the lock. A process that waited for another updater can now detect the completed install, skip a duplicate package-manager invocation, and still tell the user to restart.
- Resolve stable install roots for npm and pnpm via `root -g`, with a resolved-entrypoint fallback for Bun and custom update package names.
- Cover npm, pnpm, and Bun with real concurrent child-process tests for both automatic and manual update flows.

Without this coordination, two Letta processes starting at the same time can both observe the same available version and overlap writes to one global install, producing transient missing files or a corrupted package.

The lock is considered stale after 180 seconds and callers wait up to 185 seconds. A lock timeout fails the update rather than allowing overlapping mutation. If the process cannot create the sibling lock because the global root is read-only or permission-denied, the updater preserves the previous behavior and lets the package manager produce its normal actionable permissions error.

## Verification

- Rebased onto upstream `main` at `f61414ac` with no conflicts.
- `bun test src/updater/auto-update.test.ts src/updater/auto-update.concurrent.test.ts` — 42 passed, 0 failed, 95 expectations across 2 files.
- `bun run check` — all 12 checks passed: cycles, boundaries, exported functions, filename casing, source size, module ownership, mock isolation, test coverage, skill checks, Biome, and TypeScript.
- Pre-commit hooks and `tsc --noEmit` passed when creating commit `758b5655`.

## AI Disclosure

- [ ] This pull request was written entirely by a human
- [x] This pull request was written with AI assistance and reviewed and edited by a human
- [x] I have read the [AI Policy](https://github.com/letta-ai/letta-code/blob/main/AI_POLICY.md) and agree to its terms

## AI Tool(s) Used

- Letta Code agent for investigation, implementation, testing, and PR preparation.
- Letta Code review agent using `anthropic/claude-fable-5` for adversarial reviews and re-review.

## Human Verification

I have reviewed and understand every change in this pull request and take responsibility for its correctness.