### PR TITLE
fix(tools): emit tool_end for text-only structured results

### DIFF
--- a/scripts/source-file-size-baseline.json
+++ b/scripts/source-file-size-baseline.json
@@ -35,7 +35,7 @@
   "src/providers/chatgpt-usage-service.ts": 1112,
   "src/settings-manager.test.ts": 1635,
   "src/settings-manager.ts": 2102,
-  "src/tools/manager.ts": 2969,
+  "src/tools/manager.ts": 2967,
   "src/tools/tool-execution-context.test.ts": 1138,
   "src/types/protocol_v2.ts": 2666,
   "src/websocket/listen-client-concurrency.test.ts": 2686,

--- a/src/tools/manager.ts
+++ b/src/tools/manager.ts
@@ -2813,14 +2813,8 @@ async function executeToolInner(
 /**
  * Executes a tool and gives mods a chance to observe or replace the result via
  * the `tool_end` event. A handler returning `{ result: { status, output } }`
- * overrides what the agent sees (first handler wins). Only fires for string
- * results — multimodal/image results pass through unchanged. Delivery is
- * capability-gated (`events.tools`), so only enabled surfaces receive it.
- *
- * @param name - Name of the tool to execute
- * @param args - Arguments object to pass to the tool
- * @param options - Optional execution options (abort signal, tool call ID, streaming callback)
- * @returns Promise with the tool's execution result including status and optional stdout/stderr
+ * overrides what the agent sees (first handler wins). Delivery is capability-
+ * gated (`events.tools`), so only enabled surfaces receive it.
  */
 export async function executeTool(
   ...params: Parameters<typeof executeToolInner>
@@ -2836,9 +2830,13 @@ export async function executeTool(
     ? getExecutionContextById(options.toolContextId)
     : undefined;
   const modEvents = context?.modEvents;
-  if (!modEvents || typeof res.toolReturn !== "string") {
-    return res;
-  }
+  const textOutput =
+    typeof res.toolReturn === "string"
+      ? res.toolReturn
+      : res.toolReturn.every((part) => part.type === "text")
+        ? getDisplayableToolReturn(res.toolReturn)
+        : null;
+  if (!modEvents || textOutput === null) return res;
 
   const executionScope = context?.runtimeContext
     ? buildExecutionRuntimeContextSnapshot({
@@ -2865,7 +2863,7 @@ export async function executeTool(
     toolCallId: options?.toolCallId,
     toolName: name,
     status: res.status,
-    output: res.toolReturn,
+    output: textOutput,
   });
 
   return override

--- a/src/tools/tool-end-event.test.ts
+++ b/src/tools/tool-end-event.test.ts
@@ -1,0 +1,119 @@
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  test,
+} from "bun:test";
+import type { ModToolEndEvent } from "@/mods/types";
+import {
+  clearCapturedToolExecutionContexts,
+  clearExternalTools,
+  clearTools,
+  executeTool,
+  getToolNames,
+  loadSpecificTools,
+  prepareCurrentToolExecutionContext,
+  registerExternalTools,
+} from "@/tools/manager";
+
+describe("tool_end result delivery", () => {
+  let initialTools: string[] = [];
+
+  beforeAll(() => {
+    initialTools = getToolNames();
+  });
+
+  afterEach(() => {
+    clearCapturedToolExecutionContexts();
+    clearExternalTools();
+  });
+
+  afterAll(async () => {
+    if (initialTools.length > 0) {
+      await loadSpecificTools(initialTools);
+    } else {
+      clearTools();
+    }
+  });
+
+  test("emits tool_end for a Bash structured text result", async () => {
+    await loadSpecificTools(["Bash"]);
+    const endEvents: ModToolEndEvent[] = [];
+    const prepared = await prepareCurrentToolExecutionContext({
+      modEvents: {
+        async emit(name, event) {
+          if (name === "tool_end") {
+            const toolEndEvent = event as ModToolEndEvent & {
+              result?: { status: "success" | "error"; output: string };
+            };
+            endEvents.push(toolEndEvent);
+            toolEndEvent.result = {
+              status: "success",
+              output: "rewritten by mod",
+            };
+          }
+          return { diagnostics: [], handlerCount: 0, name, results: [] };
+        },
+      },
+    });
+
+    const result = await executeTool(
+      "Bash",
+      { command: "echo tool-end-repro" },
+      { toolContextId: prepared.contextId },
+    );
+
+    expect(result.status).toBe("success");
+    expect(endEvents).toHaveLength(1);
+    expect(endEvents[0]?.output).toContain("tool-end-repro");
+    expect(result.toolReturn).toBe("rewritten by mod");
+  });
+
+  test("does not emit tool_end for a result containing an image", async () => {
+    registerExternalTools([
+      {
+        name: "ScreenshotTool",
+        description: "Return a screenshot",
+        parameters: { type: "object", properties: {} },
+        executor: async () => ({
+          content: [
+            { type: "text", text: "Desktop screenshot" },
+            { type: "image", data: "aGVsbG8=", mimeType: "image/png" },
+          ],
+          isError: false,
+        }),
+      },
+    ]);
+    let endEventCount = 0;
+    const prepared = await prepareCurrentToolExecutionContext({
+      modEvents: {
+        async emit(name, _event) {
+          if (name === "tool_end") endEventCount += 1;
+          return { diagnostics: [], handlerCount: 0, name, results: [] };
+        },
+      },
+    });
+
+    const result = await executeTool(
+      "ScreenshotTool",
+      {},
+      { toolContextId: prepared.contextId },
+    );
+
+    expect(result.status).toBe("success");
+    expect(result.toolReturn).toEqual([
+      { type: "text", text: "Desktop screenshot" },
+      {
+        type: "image",
+        source: {
+          type: "base64",
+          media_type: "image/png",
+          data: "aGVsbG8=",
+        },
+      },
+    ]);
+    expect(endEventCount).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

- Emit `tool_end` for text-only structured tool returns such as Bash content parts.
- Keep multimodal results containing images unchanged and outside the string rewrite path.
- Add regression coverage for event delivery, result rewriting, and the image bypass boundary.
- Lower the pinned `manager.ts` size baseline to match the reduced file length.

The root cause was the final `executeTool` event gate: it accepted only literal string returns even though built-in tools such as Bash intentionally preserve text as structured content parts. The fix checks that every structured part is text, converts it through the existing display-text helper, and then dispatches the normal event.

This follows the behavior proposed in #3860, which its author closed voluntarily without merge. This version reuses the existing text conversion boundary and verifies both result rewriting and multimodal preservation.

Fixes #3828

## Verification

- RED before the implementation: `bun test src/tools/tool-end-event.test.ts` — 1 passed, 1 failed; the Bash result produced zero `tool_end` events.
- GREEN after the implementation: `bun test src/tools/tool-end-event.test.ts` — 2 passed, 0 failed.
- Focused and adjacent manager/shell tests — 82 passed, 0 failed.
- `bun test src/tools` — 798 passed, 1 conditional ENOSPC test skipped, 0 failed, 1993 expectations across 86 files.
- `bun run check` — all 12 repository checks passed.

The full tools run was executed outside the filesystem sandbox because the existing HEIC fixture uses macOS `sips` and Monitor tests bind a local WebSocket listener.

## Risk and scope

- No paid APIs, production credentials, or real user services were used.
- I did not manually reproduce the original Windows Desktop scenario. The regression exercises the shared production `executeTool` and real Bash path; cross-platform behavior remains subject to CI.
- The change does not make image-bearing results available to string result handlers.

## AI Disclosure

- [ ] This pull request was written entirely by a human
- [x] This pull request was written with AI assistance and reviewed and edited by a human
- [x] I have read the [AI Policy](https://github.com/letta-ai/letta-code/blob/main/AI_POLICY.md) and agree to its terms

## AI Tool(s) Used

OpenAI Codex was used for repository and issue investigation, implementation, testing, review, and PR preparation. The human submitter reviewed the complete diff and confirmed responsibility before PR creation.

## Human Verification

I have reviewed and understand every change in this pull request and take responsibility for its correctness.