### PR TITLE
docs(agent): clarify default conversation resumes [LET-11772]

### DIFF
--- a/src/tools/descriptions/Task.md
+++ b/src/tools/descriptions/Task.md
@@ -44,7 +44,8 @@ When deploying an existing agent, only `general-purpose` is supported: full read
   - Tool access is controlled by subagent_type
 
 - **conversation_id**: Resume from an existing conversation (e.g., "conv-xyz789")
-  - Does NOT require agent_id (conversation IDs are unique and encode the agent)
+  - Normal `conv-...` IDs are globally unique and do not require `agent_id`
+  - If a prior invocation returns the conversation ID `default`, pass both that invocation's `agent_id` and `conversation_id: "default"`; `default` is agent-scoped and cannot identify an agent by itself
   - Continues from the conversation's existing message history
   - Use this to continue context from:
     - A prior Agent tool invocation that returned a conversation_id
@@ -64,6 +65,14 @@ Agent({
 // Continue an existing conversation
 Agent({
   conversation_id: "conv-xyz789",
+  description: "Continue implementation",
+  prompt: "Now implement the fix we discussed"
+})
+
+// Continue an agent's default conversation
+Agent({
+  agent_id: "agent-abc123",
+  conversation_id: "default",
   description: "Continue implementation",
   prompt: "Now implement the fix we discussed"
 })


### PR DESCRIPTION
## Summary

The Agent tool documentation says conversation IDs identify their agent, but `default` is agent-scoped rather than globally unique. This clarifies that normal `conv-...` IDs can be resumed alone, while resuming `default` requires both the returned agent ID and `conversation_id: "default"`, and adds an example of that call.

## Verification

- `bun run check` passed through the pre-commit hook with isolated dependencies installed from the frozen lockfile.

## Breadcrumbs

- Requested in: LET-11772
- Letta conversation: [`conv-b5adec9d-d4ee-4b4c-9f93-a8427f31adce`](https://chat.letta.com/chat/agent-490d728b-861e-425b-ad93-8a61df5b3a29?conversation=conv-b5adec9d-d4ee-4b4c-9f93-a8427f31adce)

## AI Disclosure

- [ ] This pull request was written entirely by a human
- [x] This pull request was written with AI assistance and reviewed and edited by a human
- [x] I have read the [AI Policy](https://github.com/letta-ai/letta-code/blob/main/AI_POLICY.md) and agree to its terms

## AI Tool(s) Used

Letta Code
