### PR TITLE
feat: add dart to syntax highlighted languages

### DIFF
--- a/src/cli/components/SyntaxHighlightedCommand.tsx
+++ b/src/cli/components/SyntaxHighlightedCommand.tsx
@@ -3,6 +3,7 @@ import cLang from "@shikijs/langs/c";
 import cppLang from "@shikijs/langs/cpp";
 import csharpLang from "@shikijs/langs/csharp";
 import cssLang from "@shikijs/langs/css";
+import dartLang from "@shikijs/langs/dart";
 import diffLang from "@shikijs/langs/diff";
 import dockerLang from "@shikijs/langs/docker";
 import goLang from "@shikijs/langs/go";
@@ -57,6 +58,7 @@ function getShikiHighlighter(): ReturnType<typeof createHighlighterCoreSync> {
         cppLang,
         csharpLang,
         cssLang,
+        dartLang,
         diffLang,
         dockerLang,
         goLang,
@@ -195,6 +197,7 @@ const EXT_TO_LANG: Record<string, string> = {
   graphql: "graphql",
   gql: "graphql",
   wasm: "wasm",
+  dart: "dart",
 };
 
 /** Resolve a Shiki language name from a file path, or undefined if unknown. */


### PR DESCRIPTION
## Summary

Adds Dart (`.dart`) to syntax highlighted languages

## Verification

Tested manually

## AI Disclosure

<!-- Select exactly one authorship option, then acknowledge the policy. -->

- [x] This pull request was written entirely by a human
- [ ] This pull request was written with AI assistance and reviewed and edited by a human
- [x] I have read the [AI Policy](https://github.com/letta-ai/letta-code/blob/main/AI_POLICY.md) and agree to its terms

## AI Tool(s) Used

None

## Human Verification

<!-- Copy the following phrase exactly, without the surrounding comment:
I have reviewed and understand every change in this pull request and take responsibility for its correctness.
-->
I have reviewed and understand every change in this pull request and take responsibility for its correctness.
