### PR TITLE
fix(skills): support Python 3.9 in show config

### DIFF
--- a/src/skills/builtin/self-configuration/scripts/show_config.py
+++ b/src/skills/builtin/self-configuration/scripts/show_config.py
@@ -13,6 +13,8 @@ Usage:
     python3 show_config.py --section runtime --json
 """
 
+from __future__ import annotations
+
 import argparse
 import json
 import os


### PR DESCRIPTION
## Summary

- Postpone annotation evaluation in the bundled self-configuration `show_config.py` script.
- Allow the script to start under Python 3.9 while preserving its existing type annotations and runtime behavior.

No separate issue was opened because the failure is deterministic, the compatibility fix is narrowly scoped, and no overlapping issue or pull request exists.

## Verification

- RED: `/usr/bin/python3 show_config.py --help` failed on Python 3.9.6 while evaluating `str | None`.
- GREEN: the same Python 3.9.6 command exits successfully and prints help.
- `bun test src/skills/self-configuration-show-config.test.ts` — 3 passed.
- `bun run check` — all 12 checks passed.
- `bun run build` — passed.
- The built bundled copy of `show_config.py` prints help successfully under Python 3.9.6.

## AI Disclosure

- [ ] This pull request was written entirely by a human
- [x] This pull request was written with AI assistance and reviewed and edited by a human
- [x] I have read the [AI Policy](https://github.com/letta-ai/letta-code/blob/main/AI_POLICY.md) and agree to its terms

## AI Tool(s) Used

OpenAI Codex was used to identify and reproduce the Python compatibility failure, inspect the annotation surface, implement the fix, run verification, and draft this pull request.

## Human Verification

I have reviewed and understand every change in this pull request and take responsibility for its correctness.
