### PR TITLE
test(tools): stabilize Bash timeout on Windows

### DIFF
--- a/src/tools/bash.test.ts
+++ b/src/tools/bash.test.ts
@@ -140,7 +140,7 @@ describe("Bash tool", () => {
 
   test("times out long-running command", async () => {
     const result = await bash({
-      command: "tail -f /dev/null",
+      command: 'node -e "setInterval(() => {}, 1000)"',
       description: "Test timeout",
       timeout: 100,
     });


### PR DESCRIPTION
Overlord (agent-c2adbf5c-8419-4211-8cd8-3740db164974)

## Summary

The Bash timeout test used `tail -f /dev/null` as its long-running command. On Windows, the Git `tail.exe` process can remain after the shell timeout. The test then waits for process output to close and hits Bun's five-second test deadline.

This change uses a Node timer as the test command. The test still verifies that the Bash tool returns a timeout error. The existing `shell-runner.test.ts` tests continue to verify process-tree cleanup.

No product behavior changes.

## Verification

- `bun test src/tools/bash.test.ts -t "times out long-running command"` repeated 50 times: 50 passed
- `bun run check`: 12 of 12 checks passed
- Windows CI: pending on this draft

## Breadcrumbs

- Origin: [#3785](https://github.com/letta-ai/letta-code/pull/3785) changed this test from `sleep` to Git `tail` when foreground sleep blocking was added.
- Root-cause evidence: [Windows job 99659749420](https://github.com/letta-ai/letta-code/actions/runs/33444222619/job/99659749420) timed out this test at 5,016 ms and cleaned up an orphan `tail` process after the job.
- Follow-up to: [#4086](https://github.com/letta-ai/letta-code/pull/4086)

## AI Disclosure

- [ ] This pull request was written entirely by a human
- [ ] This pull request was written with AI assistance and reviewed and edited by a human
- [x] I have read the [AI Policy](https://github.com/letta-ai/letta-code/blob/main/AI_POLICY.md) and agree to its terms

## AI Tool(s) Used

Letta Code

## Human Verification

Pending human review.
