### PR TITLE
fix(teleport): support default conversations [LET-11807]

### DIFF
--- a/src/cli/subcommands/teleport.test.ts
+++ b/src/cli/subcommands/teleport.test.ts
@@ -104,8 +104,8 @@ describe("teleport subcommand", () => {
     ).toThrow("requires a Letta Cloud agent");
   });
 
-  test("rejects virtual default conversation", () => {
-    expect(() =>
+  test("accepts the virtual default conversation", () => {
+    expect(
       resolveTeleportSession(
         {
           LETTA_AGENT_ID: "agent-1",
@@ -113,7 +113,7 @@ describe("teleport subcommand", () => {
         },
         null,
       ),
-    ).toThrow("requires an active conversation");
+    ).toEqual({ agentId: "agent-1", conversationId: "default" });
   });
 
   test("rejects virtual new conversation", () => {

--- a/src/cli/subcommands/teleport.ts
+++ b/src/cli/subcommands/teleport.ts
@@ -39,7 +39,7 @@ Notes:
   - Operates on the current agent/conversation from LETTA_AGENT_ID /
     LETTA_CONVERSATION_ID (or AGENT_ID / CONVERSATION_ID), falling back to the
     last active session.
-  - Requires a Letta Cloud agent and a non-virtual conversation.
+  - Requires a Letta Cloud agent and an active conversation.
   - list: prints accessible online remote environments as JSON.
   - cloud: teleports to the agent's Cloud sandbox.
   - local: teleports to the one online Desktop environment. Desktop Remote
@@ -87,11 +87,7 @@ export function resolveTeleportSession(
   if (isLocalAgentId(session.agentId)) {
     throw new Error("Teleport requires a Letta Cloud agent");
   }
-  if (
-    !session.conversationId ||
-    session.conversationId === "default" ||
-    session.conversationId === "new"
-  ) {
+  if (!session.conversationId || session.conversationId === "new") {
     throw new Error("Teleport requires an active conversation");
   }
   return session;


### PR DESCRIPTION
## Summary

A turn running in the virtual `default` conversation is still an active conversation, and the teleport coordinator, runtime status, environment persistence, and destination listener already support that scope. The CLI rejected `default` before sending any teleport request, which made SDK-enqueued threads impossible to move between environments.

This removes that stale client-side restriction. The `new` sentinel remains rejected because it does not identify an active runtime.

## Before and after

```text
Before

1. The active turn sets LETTA_CONVERSATION_ID=default.
2. `letta teleport <environment>` resolves the current session.
3. The CLI returns `Teleport requires an active conversation`.
4. No request reaches the teleport coordinator.

After

1. The active turn sets LETTA_CONVERSATION_ID=default.
2. `letta teleport <environment>` resolves `{ agentId, conversationId: "default" }`.
3. The CLI submits the normal teleport request for that scope.
4. The existing coordinator hands the same agent conversation to the destination.
```

## Verification

- Red-first regression: the exact `{ LETTA_AGENT_ID, LETTA_CONVERSATION_ID: "default" }` input failed with `Teleport requires an active conversation` before the source change and now resolves the active session.
- `bun test src/cli/subcommands/teleport.test.ts` , 19 passed, 0 failed.
- `bun run check` , all 12 checks passed.
- No live handoff was performed because that would move a real active conversation to a second environment. The pull request remains draft for review of that product check.

## Breadcrumbs

- Requested in: LET-11807
- Letta conversation: [`conv-0ea8bf28-a961-4279-b628-1fb8ae614446`](https://chat.letta.com/chat/agent-cd664b86-4d28-49b7-8ad6-60677eaff9be?conversation=conv-0ea8bf28-a961-4279-b628-1fb8ae614446)
- Origin: #3813 introduced teleport with the `default` guard; history shows no later regression.

## AI Disclosure

- [ ] This pull request was written entirely by a human
- [ ] This pull request was written with AI assistance and reviewed and edited by a human
- [x] I have read the [AI Policy](https://github.com/letta-ai/letta-code/blob/main/AI_POLICY.md) and agree to its terms

## AI Tool(s) Used

Letta Code (Amelia), including one read-only subagent for cross-repository ownership research.

## Human Verification

Pending Caren's review. The required attestation is intentionally not made on her behalf.
