### PR TITLE
fix(teleport): resume source after failed handoff [LET-11803]

### DIFF
--- a/src/websocket/listener/message-router.ts
+++ b/src/websocket/listener/message-router.ts
@@ -68,10 +68,10 @@ import { parseListenerReadyMessage } from "./split-stream-lifecycle";
 import {
   buildTeleportContinuationMessages,
   clearPriorReadyTeleports,
+  handleTeleportFailure,
   handleTeleportProbe,
   handleTeleportRequest,
   isRuntimeTeleportPending,
-  takeFailedTeleport,
 } from "./teleport";
 import type { ListenerTransport } from "./transport";
 import { handleIncomingMessage } from "./turn";
@@ -294,41 +294,15 @@ export function createListenerMessageHandler(
       }
 
       if (parsed.type === "teleport_failed") {
-        const pending = takeFailedTeleport({
+        handleTeleportFailure({
           listener: runtime,
-          teleportId: parsed.teleport_id,
-          agentId: parsed.runtime.agent_id,
-          conversationId: parsed.runtime.conversation_id,
+          command: parsed,
+          socket,
+          onStatusChange: opts.onStatusChange,
+          getOrCreateScopedRuntime,
+          runDetachedListenerTask,
+          processIncomingMessage,
         });
-        const approvals = pending?.continuation?.approvals;
-        if (pending && approvals && approvals.length > 0) {
-          const scopedRuntime = getOrCreateScopedRuntime(
-            runtime,
-            pending.agentId,
-            pending.conversationId,
-          );
-          runDetachedListenerTask("teleport_failed", async () => {
-            await processIncomingMessage(
-              {
-                type: "message",
-                connectionId: pending.connectionId,
-                agentId: pending.agentId,
-                conversationId: pending.conversationId,
-                messages: [
-                  {
-                    type: "approval",
-                    approvals,
-                    otid: parsed.teleport_id,
-                  },
-                ],
-              },
-              socket,
-              scopedRuntime,
-              opts.onStatusChange,
-              pending.connectionId,
-            );
-          });
-        }
         return;
       }
 

--- a/src/websocket/listener/teleport-failure-recovery.test.ts
+++ b/src/websocket/listener/teleport-failure-recovery.test.ts
@@ -1,0 +1,247 @@
+import { afterEach, expect, mock, test } from "bun:test";
+import WebSocket from "ws";
+import type { TeleportContinuation } from "@/types/protocol_v2";
+import {
+  markListenerConnectionInitialized,
+  openListenerConnection,
+  subscribeListenerConnection,
+} from "./connection";
+import { getOrCreateScopedRuntime } from "./conversation-runtime";
+import { createRuntime } from "./lifecycle";
+import { createListenerMessageHandler } from "./message-router";
+import { setActiveRuntime } from "./runtime";
+import {
+  claimPendingTeleportAtBoundary,
+  finishTeleport,
+  handleTeleportRequest,
+} from "./teleport";
+import type {
+  ConversationRuntime,
+  IncomingMessage,
+  ListenerRuntime,
+  StartListenerOptions,
+} from "./types";
+
+class MockSocket {
+  readonly bufferedAmount = 0;
+  readonly readyState = WebSocket.OPEN;
+  readonly sent: unknown[] = [];
+
+  isOpen(): boolean {
+    return true;
+  }
+
+  send(data: string): void {
+    this.sent.push(JSON.parse(data));
+  }
+}
+
+function makeOptions(): StartListenerOptions {
+  return {
+    connectionId: "source",
+    wsUrl: "ws://app-server.test",
+    deviceId: "source-device",
+    connectionName: "Source",
+    onConnected: () => {},
+    onDisconnected: () => {},
+    onError: () => {},
+  };
+}
+
+function prepareSourceTeleport(
+  listener: ListenerRuntime,
+  runtime: ConversationRuntime,
+  socket: MockSocket,
+  continuation?: TeleportContinuation,
+): void {
+  openListenerConnection({
+    runtime: listener,
+    connectionId: "source",
+    writer: socket as never,
+    options: makeOptions(),
+  });
+  subscribeListenerConnection(listener, "source", {
+    agent_id: "agent-1",
+    conversation_id: "conversation-1",
+  });
+  markListenerConnectionInitialized(listener, "source");
+  const lease = runtime.turnLifecycle.begin({
+    origin: "message",
+    workingDirectory: process.cwd(),
+  });
+  handleTeleportRequest({
+    listener,
+    connectionId: "source",
+    command: {
+      type: "teleport_request",
+      request_id: "teleport-1",
+      teleport_id: "teleport-1",
+      runtime: { agent_id: "agent-1", conversation_id: "conversation-1" },
+      target: {
+        connection_id: "target",
+        device_id: "target-device",
+        connection_name: "Target",
+      },
+    },
+  });
+  const pending = claimPendingTeleportAtBoundary({
+    listener,
+    agentId: "agent-1",
+    conversationId: "conversation-1",
+    activeTurn: true,
+    ...(continuation ? { continuation } : {}),
+  });
+  if (!pending) throw new Error("Teleport did not reach the source boundary");
+  finishTeleport(runtime, lease, pending);
+}
+
+async function deliverTeleportFailure(params: {
+  listener: ListenerRuntime;
+  runtime: ConversationRuntime;
+  socket: MockSocket;
+  processIncomingMessage: (incoming: IncomingMessage) => Promise<void>;
+  error: string;
+}): Promise<void> {
+  let detachedTask: Promise<void> | undefined;
+  const handleMessage = createListenerMessageHandler({
+    runtime: params.listener,
+    socket: params.socket as unknown as WebSocket,
+    opts: makeOptions(),
+    processQueuedTurn: async () => {},
+    fileCommandSession: { handle: () => false },
+    getParsedRuntimeScope: () => null,
+    replaySyncStateForRuntime: async () => {},
+    getOrCreateScopedRuntime: () => params.runtime,
+    handleApprovalResponseInput: async () => false,
+    handleChangeDeviceStateInput: async () => false,
+    handleAbortMessageInput: async () => false,
+    stampInboundUserMessageOtids: (incoming) => incoming,
+    safeSocketSend: () => true,
+    runDetachedListenerTask: (_name, task) => {
+      detachedTask = task();
+    },
+    trackListenerError: () => {},
+    processIncomingMessage: params.processIncomingMessage,
+  });
+
+  await handleMessage(
+    Buffer.from(
+      JSON.stringify({
+        type: "teleport_failed",
+        teleport_id: "teleport-1",
+        runtime: {
+          agent_id: "agent-1",
+          conversation_id: "conversation-1",
+        },
+        error: params.error,
+      }),
+    ),
+  );
+  await detachedTask;
+}
+
+afterEach(() => {
+  setActiveRuntime(null);
+});
+
+test("terminal teleport failure resumes the source without approvals", async () => {
+  const listener = createRuntime();
+  const runtime = getOrCreateScopedRuntime(
+    listener,
+    "agent-1",
+    "conversation-1",
+  );
+  const socket = new MockSocket();
+  const received: IncomingMessage[] = [];
+  const processIncomingMessage = mock(async (incoming: IncomingMessage) => {
+    received.push(incoming);
+  });
+  setActiveRuntime(listener);
+  prepareSourceTeleport(listener, runtime, socket);
+
+  await deliverTeleportFailure({
+    listener,
+    runtime,
+    socket,
+    processIncomingMessage,
+    error: "404 Agent <missing> & unavailable",
+  });
+
+  expect(processIncomingMessage).toHaveBeenCalledTimes(1);
+  expect(received[0]).toMatchObject({
+    type: "message",
+    connectionId: "source",
+    agentId: "agent-1",
+    conversationId: "conversation-1",
+    messages: [
+      {
+        role: "system",
+        content:
+          "<system-reminder>Teleportation failed.\n\nError: 404 Agent &lt;missing&gt; &amp; unavailable\n\nContinue the existing task from this environment now.</system-reminder>",
+        otid: "teleport-1:failed",
+      },
+    ],
+  });
+  expect(socket.sent).toContainEqual(
+    expect.objectContaining({
+      type: "stream_delta",
+      runtime: {
+        agent_id: "agent-1",
+        conversation_id: "conversation-1",
+      },
+      delta: expect.objectContaining({
+        message_type: "loop_error",
+        message: "Teleport failed: 404 Agent <missing> & unavailable",
+        stop_reason: "error",
+        is_terminal: false,
+      }),
+    }),
+  );
+  expect(listener.pendingTeleports?.has("teleport-1")).toBe(false);
+});
+
+test("terminal teleport failure preserves approval results before resuming", async () => {
+  const approvals: TeleportContinuation["approvals"] = [
+    {
+      type: "tool",
+      tool_call_id: "call-1",
+      status: "success",
+      tool_return: '{"status":"waiting_for_source"}',
+    },
+  ];
+  const listener = createRuntime();
+  const runtime = getOrCreateScopedRuntime(
+    listener,
+    "agent-1",
+    "conversation-1",
+  );
+  const socket = new MockSocket();
+  const received: IncomingMessage[] = [];
+  const processIncomingMessage = mock(async (incoming: IncomingMessage) => {
+    received.push(incoming);
+  });
+  setActiveRuntime(listener);
+  prepareSourceTeleport(listener, runtime, socket, { approvals });
+
+  await deliverTeleportFailure({
+    listener,
+    runtime,
+    socket,
+    processIncomingMessage,
+    error: "Target failed to start",
+  });
+
+  expect(received[0]?.messages).toEqual([
+    {
+      type: "approval",
+      approvals,
+      otid: "teleport-1",
+    },
+    {
+      role: "system",
+      content:
+        "<system-reminder>Teleportation failed.\n\nError: Target failed to start\n\nContinue the existing task from this environment now.</system-reminder>",
+      otid: "teleport-1:failed",
+    },
+  ]);
+});

--- a/src/websocket/listener/teleport.ts
+++ b/src/websocket/listener/teleport.ts
@@ -1,6 +1,7 @@
 import type WebSocket from "ws";
 import type {
   TeleportContinuation,
+  TeleportFailedCommand,
   TeleportProbeCommand,
   TeleportReadyMessage,
   TeleportRequestCommand,
@@ -11,8 +12,9 @@ import {
   emitProtocolV2Message,
   emitRuntimeStateUpdates,
 } from "./protocol-outbound";
+import { emitLoopErrorNotice } from "./recoverable-notices";
 import { getConversationRuntime } from "./runtime";
-import { isListenerTransportOpen } from "./transport";
+import { isListenerTransportOpen, type ListenerTransport } from "./transport";
 import type { TurnFinishTransition, TurnLease } from "./turn-lifecycle";
 import type {
   ConversationRuntime,
@@ -20,6 +22,7 @@ import type {
   ListenerConnectionId,
   ListenerRuntime,
   PendingTeleport,
+  StartListenerOptions,
 } from "./types";
 
 type SafeSocketSend = (
@@ -48,6 +51,34 @@ export function buildTeleportContinuationMessages(params: {
       otid: `${params.teleportId}:continue`,
     },
   ];
+}
+
+function escapeSystemReminderText(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
+function buildTeleportFailureMessages(params: {
+  teleportId: string;
+  error: string;
+  approvals?: NonNullable<TeleportContinuation["approvals"]>;
+}): IncomingMessage["messages"] {
+  const messages: IncomingMessage["messages"] = [];
+  if (params.approvals && params.approvals.length > 0) {
+    messages.push({
+      type: "approval",
+      approvals: params.approvals,
+      otid: params.teleportId,
+    });
+  }
+  messages.push({
+    role: "system",
+    content: `<system-reminder>Teleportation failed.\n\nError: ${escapeSystemReminderText(params.error)}\n\nContinue the existing task from this environment now.</system-reminder>`,
+    otid: `${params.teleportId}:failed`,
+  });
+  return messages;
 }
 
 function getPendingTeleports(
@@ -333,7 +364,7 @@ export function finishPendingTeleport(runtime: ConversationRuntime): void {
   if (claimed) emitClaimedTeleportReady(runtime.listener, claimed);
 }
 
-export function takeFailedTeleport(params: {
+function takeFailedTeleport(params: {
   listener: ListenerRuntime;
   teleportId: string;
   agentId: string;
@@ -349,4 +380,67 @@ export function takeFailedTeleport(params: {
   }
   params.listener.pendingTeleports?.delete(params.teleportId);
   return pending;
+}
+
+export function handleTeleportFailure(params: {
+  listener: ListenerRuntime;
+  command: TeleportFailedCommand;
+  socket: ListenerTransport;
+  onStatusChange?: StartListenerOptions["onStatusChange"];
+  getOrCreateScopedRuntime: (
+    listener: ListenerRuntime,
+    agentId?: string | null,
+    conversationId?: string | null,
+  ) => ConversationRuntime;
+  runDetachedListenerTask: (
+    commandName: string,
+    task: () => Promise<void>,
+  ) => void;
+  processIncomingMessage: (
+    msg: IncomingMessage,
+    socket: ListenerTransport,
+    runtime: ConversationRuntime,
+    onStatusChange?: StartListenerOptions["onStatusChange"],
+    connectionId?: string,
+  ) => Promise<void>;
+}): void {
+  const pending = takeFailedTeleport({
+    listener: params.listener,
+    teleportId: params.command.teleport_id,
+    agentId: params.command.runtime.agent_id,
+    conversationId: params.command.runtime.conversation_id,
+  });
+  if (!pending) return;
+
+  const runtime = params.getOrCreateScopedRuntime(
+    params.listener,
+    pending.agentId,
+    pending.conversationId,
+  );
+  emitLoopErrorNotice(params.socket, runtime, {
+    message: `Teleport failed: ${params.command.error}`,
+    stopReason: "error",
+    isTerminal: false,
+    agentId: pending.agentId,
+    conversationId: pending.conversationId,
+  });
+  params.runDetachedListenerTask("teleport_failed", async () => {
+    await params.processIncomingMessage(
+      {
+        type: "message",
+        connectionId: pending.connectionId,
+        agentId: pending.agentId,
+        conversationId: pending.conversationId,
+        messages: buildTeleportFailureMessages({
+          teleportId: params.command.teleport_id,
+          error: params.command.error,
+          approvals: pending.continuation?.approvals,
+        }),
+      },
+      params.socket,
+      runtime,
+      params.onStatusChange,
+      pending.connectionId,
+    );
+  });
 }


### PR DESCRIPTION
## Summary

When a destination reported `teleport_failed`, the source removed the pending handoff but only resumed if the interrupted turn carried approval results. Text-only turns have no approval payload, so the failure disappeared and the source conversation stayed silent.

This makes terminal handoff failure independent of approval state. The source now emits the destination error to the transcript, injects a persisted system reminder with the escaped error detail, and starts a continuation on the source. Existing approval results are still prepended when present.

## Before and after

```text
Before

teleport_failed -> remove pending handoff -> no approvals -> return silently

After

teleport_failed -> remove pending handoff -> emit visible loop_error
                -> optional approval results + failure reminder
                -> continue on the source
```

The pending handoff remains one-shot, so duplicate or stale failure frames cannot start another continuation. This does not change why a destination may fail to start; project-scoped destination lookup remains separate in LET-9091.

## Verification

- Red-first regression starts a real `teleport_request`, claims and finishes the source turn boundary, then sends the production `teleport_failed` wire shape through the parser and message router. Before the fix, the no-approval case scheduled zero source turns and the approval case omitted the failure context.
- The regression now verifies the visible `loop_error`, persisted failure reminder, source continuation, pending-handoff removal, and preservation of approval results.
- `bun test src/websocket/listener/teleport-failure-recovery.test.ts src/websocket/listener/teleport-queue.test.ts src/websocket/listener/protocol-ergonomics.test.ts src/websocket/listener/turn-lifecycle-integration.test.ts src/websocket/listener/message-router.test.ts src/websocket/listener/protocol-inbound.test.ts`, 112 passed, 0 failed.
- `bun run check`, all 12 checks passed.
- `bun run build`, published Node artifact built successfully.
- A live Cloud-to-Desktop forced-failure handoff was not run because there is not yet a safe deterministic failure trigger. This pull request remains draft for that product-path review.

## Breadcrumbs

- Requested in: LET-11803
- Letta conversation: [`conv-0ea8bf28-a961-4279-b628-1fb8ae614446`](https://chat.letta.com/chat/agent-cd664b86-4d28-49b7-8ad6-60677eaff9be?conversation=conv-0ea8bf28-a961-4279-b628-1fb8ae614446)
- Origin: #3813 introduced the `teleport_failed` source path with recovery gated on approval results; history shows no later regression.
- Related: LET-9091 tracks project-scoped destination startup separately.

## AI Disclosure

- [ ] This pull request was written entirely by a human
- [ ] This pull request was written with AI assistance and reviewed and edited by a human
- [x] I have read the [AI Policy](https://github.com/letta-ai/letta-code/blob/main/AI_POLICY.md) and agree to its terms

## AI Tool(s) Used

Letta Code (Amelia), including read-only subagents for protocol and destination-path research.

## Human Verification

Pending Caren's review. The required attestation is intentionally not made on her behalf.
