### PR TITLE
fix(cli): avoid incorrect OpenAI outage hint for other providers

### DIFF
--- a/scripts/source-file-size-baseline.json
+++ b/scripts/source-file-size-baseline.json
@@ -9,7 +9,7 @@
   "src/cli/app/AppView.tsx": 1735,
   "src/cli/app/use-approval-flow.ts": 1163,
   "src/cli/app/use-configuration-handlers.ts": 1421,
-  "src/cli/app/use-conversation-loop.ts": 2903,
+  "src/cli/app/use-conversation-loop.ts": 2888,
   "src/cli/app/use-submit-handler.ts": 3998,
   "src/cli/components/AgentSelector.tsx": 1104,
   "src/cli/components/InputRich.tsx": 2225,

--- a/src/cli/app/AppCoordinator.tsx
+++ b/src/cli/app/AppCoordinator.tsx
@@ -3703,7 +3703,6 @@ export function App({
       );
     }
   }, [agentName, agentDescription, appendTaskNotificationEvents]);
-
   const processConversation = useConversationLoop({
     abortControllerRef,
     agentIdRef,
@@ -3722,6 +3721,7 @@ export function App({
     conversationBusyRetriesRef,
     conversationGenerationRef,
     conversationIdRef,
+    currentModelHandle,
     currentModelId,
     emptyResponseRetriesRef,
     executingToolCallIdsRef,

--- a/src/cli/app/model-config.test.ts
+++ b/src/cli/app/model-config.test.ts
@@ -3,6 +3,7 @@ import type { AgentState } from "@letta-ai/letta-client/resources/agents/agents"
 import type { LlmConfig } from "@letta-ai/letta-client/resources/models/models";
 import {
   deriveReasoningEffort,
+  getErrorHintForStopReason,
   mapHandleToLlmConfigPatch,
   providerTypeFromModelSettings,
   providerTypeFromUpdateArgs,
@@ -102,5 +103,51 @@ describe("model config helpers", () => {
         null,
       ),
     ).toBeNull();
+  });
+
+  test("does not blame OpenAI for an OpenAI-compatible Moonshot model", () => {
+    expect(
+      getErrorHintForStopReason(
+        "llm_api_error",
+        "kimi-k3",
+        "openai",
+        "moonshot/kimi-k3",
+      ),
+    ).toBe(
+      "Downstream provider is experiencing errors. Use /model to swap to a model from a different provider, or try again later.",
+    );
+  });
+
+  test("does not blame OpenAI for a Kimi Coding model", () => {
+    expect(
+      getErrorHintForStopReason(
+        "llm_api_error",
+        "kimi-for-coding",
+        "openai",
+        "moonshot_coding/kimi-for-coding",
+      ),
+    ).not.toContain("OpenAI");
+  });
+
+  test("keeps the OpenAI status hint for an OpenAI model", () => {
+    expect(
+      getErrorHintForStopReason(
+        "llm_api_error",
+        "gpt-5",
+        "openai",
+        "openai/gpt-5",
+      ),
+    ).toContain("Downstream provider (OpenAI) is experiencing errors");
+  });
+
+  test("keeps the Anthropic status hint for an Anthropic model", () => {
+    expect(
+      getErrorHintForStopReason(
+        "llm_api_error",
+        "claude-sonnet-4-6",
+        "anthropic",
+        "anthropic/claude-sonnet-4-6",
+      ),
+    ).toContain("Downstream provider (Anthropic) is experiencing errors");
   });
 });

--- a/src/cli/app/model-config.ts
+++ b/src/cli/app/model-config.ts
@@ -4,6 +4,7 @@ import type { StopReasonType } from "@letta-ai/letta-client/resources/runs/runs"
 import { getModelInfo, type ModelReasoningEffort } from "@/agent/model";
 import {
   mapModelHandleToLlmConfigPatch,
+  normalizeModelHandleForRegistry,
   resolveModelHandleFromLlmConfig,
 } from "@/agent/model-handles";
 import { ERROR_FEEDBACK_HINT, PROVIDER_STATUS_PAGES } from "./constants";
@@ -174,6 +175,7 @@ export function getErrorHintForStopReason(
   stopReason: StopReasonType | null,
   currentModelId: string | null,
   modelEndpointType?: string | null,
+  currentModelHandle?: string | null,
 ): string {
   if (stopReason !== "llm_api_error") {
     return ERROR_FEEDBACK_HINT;
@@ -184,9 +186,24 @@ export function getErrorHintForStopReason(
   // not a provider the user explicitly selected. Don't blame a specific
   // provider in that case -- the issue may be on the proxy side.
   const isAutoModel = currentModelId?.startsWith("auto") ?? false;
+  // OpenAI-compatible endpoints can be used by other providers. Prefer the
+  // canonical model handle when available so a Kimi/Moonshot 403 does not get
+  // an unrelated OpenAI outage hint merely because its wire endpoint is OpenAI
+  // compatible. Keep the endpoint fallback for older callers that lack a handle.
+  const normalizedModelHandle =
+    normalizeModelHandleForRegistry(currentModelHandle);
+  const modelProvider = normalizedModelHandle?.split("/", 1)[0];
+  const endpointStatusInfo = modelEndpointType
+    ? PROVIDER_STATUS_PAGES[modelEndpointType]
+    : undefined;
+  const isOpenAiStatus = endpointStatusInfo?.name === "OpenAI";
+  const isOpenAiModel =
+    !modelProvider ||
+    modelProvider === "openai" ||
+    modelProvider === "openai-codex";
   const statusInfo =
-    modelEndpointType && !isAutoModel
-      ? PROVIDER_STATUS_PAGES[modelEndpointType]
+    endpointStatusInfo && !isAutoModel && (!isOpenAiStatus || isOpenAiModel)
+      ? endpointStatusInfo
       : undefined;
 
   if (statusInfo) {

--- a/src/cli/app/use-conversation-loop.ts
+++ b/src/cli/app/use-conversation-loop.ts
@@ -201,6 +201,7 @@ type ConversationLoopContext = {
   conversationBusyRetriesRef: MutableRefObject<number>;
   conversationGenerationRef: MutableRefObject<number>;
   conversationIdRef: MutableRefObject<string>;
+  currentModelHandle: string | null;
   currentModelId: string | null;
   emptyResponseRetriesRef: MutableRefObject<number>;
   executingToolCallIdsRef: MutableRefObject<string[]>;
@@ -303,6 +304,7 @@ export function useConversationLoop(ctx: ConversationLoopContext) {
     conversationBusyRetriesRef,
     conversationGenerationRef,
     conversationIdRef,
+    currentModelHandle,
     currentModelId,
     emptyResponseRetriesRef,
     executingToolCallIdsRef,
@@ -2667,6 +2669,17 @@ export function useConversationLoop(ctx: ConversationLoopContext) {
             runId: lastRunId ?? undefined,
           };
 
+          const appendErrorHint = () =>
+            appendError(
+              getErrorHintForStopReason(
+                stopReasonToHandle,
+                currentModelId,
+                llmConfigRef.current?.model_endpoint_type,
+                currentModelHandle,
+              ),
+              true,
+            );
+
           // Fetch error details from the run if available (server-side errors)
           if (lastRunId) {
             try {
@@ -2713,14 +2726,7 @@ export function useConversationLoop(ctx: ConversationLoopContext) {
                   )
                 ) {
                   // Show appropriate error hint based on stop reason
-                  appendError(
-                    getErrorHintForStopReason(
-                      stopReasonToHandle,
-                      currentModelId,
-                      llmConfigRef.current?.model_endpoint_type,
-                    ),
-                    true,
-                  );
+                  appendErrorHint();
                 }
               } else {
                 // No error metadata, show generic error with run info
@@ -2733,14 +2739,7 @@ export function useConversationLoop(ctx: ConversationLoopContext) {
                 );
 
                 // Show appropriate error hint based on stop reason
-                appendError(
-                  getErrorHintForStopReason(
-                    stopReasonToHandle,
-                    currentModelId,
-                    llmConfigRef.current?.model_endpoint_type,
-                  ),
-                  true,
-                );
+                appendErrorHint();
               }
             } catch (_e) {
               // If we can't fetch error details, show generic error
@@ -2753,14 +2752,7 @@ export function useConversationLoop(ctx: ConversationLoopContext) {
               );
 
               // Show appropriate error hint based on stop reason
-              appendError(
-                getErrorHintForStopReason(
-                  stopReasonToHandle,
-                  currentModelId,
-                  llmConfigRef.current?.model_endpoint_type,
-                ),
-                true,
-              );
+              appendErrorHint();
 
               // Restore dequeued message to input on error
               if (lastDequeuedMessageRef.current) {
@@ -2787,14 +2779,7 @@ export function useConversationLoop(ctx: ConversationLoopContext) {
             );
 
             // Show appropriate error hint based on stop reason
-            appendError(
-              getErrorHintForStopReason(
-                stopReasonToHandle,
-                currentModelId,
-                llmConfigRef.current?.model_endpoint_type,
-              ),
-              true,
-            );
+            appendErrorHint();
           }
 
           // Restore dequeued message to input on error


### PR DESCRIPTION
## Summary

Fixes #4162. The TUI currently uses `llm_config.model_endpoint_type` to choose a provider status page. OpenAI-compatible Kimi/Moonshot models can therefore receive an unrelated OpenAI outage hint after a 403.

The error-hint path now also receives the canonical current model handle and suppresses the OpenAI-specific status-page hint when that handle belongs to another provider. OpenAI and other provider-specific hints remain unchanged, while the generic downstream-provider guidance is shown for unrecognized/non-OpenAI providers.

## Verification

- `bun test src/cli/app/model-config.test.ts` (12 pass)
- `bun run typecheck` (pass)
- `bun run check` (12 checks passed)

## AI Disclosure

- [ ] This pull request was written entirely by a human
- [x] This pull request was written with AI assistance and reviewed and edited by a human
- [x] I have read the [AI Policy](https://github.com/letta-ai/letta-code/blob/main/AI_POLICY.md) and agree to its terms

## AI Tool(s) Used

Hermes Agent

## Human Verification

I have reviewed and understand every change in this pull request and take responsibility for its correctness.
