### PR TITLE
fix(cli): wake queued notifications after Esc cancellation

### DIFF
--- a/src/cli/app/AppCoordinator.tsx
+++ b/src/cli/app/AppCoordinator.tsx
@@ -1680,7 +1680,6 @@ export function App({
   const [dequeueEpoch, setDequeueEpoch] = useState(0);
   // Strict lock to ensure dequeue submit path is at-most-once while onSubmit is in flight.
   const dequeueInFlightRef = useRef(false);
-
   // Queue defer mode: when 'defer', queued messages only fire on end_turn stop reason.
   // Defer mode is only meaningful in API backend mode (local backend fires end_turn
   // between each sequential tool call, making defer indistinguishable from immediate).
@@ -4030,6 +4029,7 @@ export function App({
     setApprovalResults,
     setAutoDeniedApprovals,
     setAutoHandledResults,
+    setDequeueEpoch,
     setInterruptRequested,
     setIsExecutingTool,
     setPendingApprovals,

--- a/src/cli/app/use-interrupt-handler.ts
+++ b/src/cli/app/use-interrupt-handler.ts
@@ -53,6 +53,7 @@ type InterruptHandlerContext = {
   setApprovalResults: Dispatch<SetStateAction<ApprovalDecision[]>>;
   setAutoDeniedApprovals: Dispatch<SetStateAction<AutoDeniedApproval[]>>;
   setAutoHandledResults: Dispatch<SetStateAction<AutoHandledToolResult[]>>;
+  setDequeueEpoch: Dispatch<SetStateAction<number>>;
   setInterruptRequested: Dispatch<SetStateAction<boolean>>;
   setIsExecutingTool: Dispatch<SetStateAction<boolean>>;
   setPendingApprovals: Dispatch<SetStateAction<ApprovalRequest[]>>;
@@ -107,6 +108,7 @@ export function useInterruptHandler(ctx: InterruptHandlerContext) {
     setApprovalResults,
     setAutoDeniedApprovals,
     setAutoHandledResults,
+    setDequeueEpoch,
     setInterruptRequested,
     setIsExecutingTool,
     setPendingApprovals,
@@ -219,6 +221,9 @@ export function useInterruptHandler(ctx: InterruptHandlerContext) {
       // batched state updates have been fully processed before we allow the dequeue effect.
       setTimeout(() => {
         userCancelledRef.current = false;
+        // Clearing the ref does not re-render the coordinator. Bump the epoch
+        // so queued notifications are reconsidered after cancellation settles.
+        setDequeueEpoch((epoch) => epoch + 1);
       }, 50);
 
       return;
@@ -348,6 +353,10 @@ export function useInterruptHandler(ctx: InterruptHandlerContext) {
       setTimeout(() => {
         userCancelledRef.current = false;
         setInterruptRequested(false);
+        // userCancelledRef is intentionally a ref, so resetting it alone does
+        // not wake the dequeue effect. Re-run it once the cancellation guard is
+        // cleared to deliver notifications queued before Esc.
+        setDequeueEpoch((epoch) => epoch + 1);
       }, 50);
 
       return;

--- a/src/cli/queue-ordering-wiring.test.ts
+++ b/src/cli/queue-ordering-wiring.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 import { readInteractiveAppSource } from "@/test-utils/read-interactive-app-source";
 
 function readAppSource(): string {
@@ -34,6 +36,24 @@ describe("queue ordering wiring", () => {
     expect(segment).toContain("onSubmitRef.current(concatenatedMessage)");
     expect(segment).toContain("!dequeueInFlightRef.current");
     expect(segment).toContain("queuedOverlayAction,");
+  });
+
+  test("ESC cancellation wakes queued notifications after resetting its ref guard", () => {
+    const interruptHandlerPath = fileURLToPath(
+      new URL("./app/use-interrupt-handler.ts", import.meta.url),
+    );
+    const source = readFileSync(interruptHandlerPath, "utf-8");
+
+    expect(source).toContain(
+      "setDequeueEpoch: Dispatch<SetStateAction<number>>",
+    );
+    expect(source).toContain(
+      "userCancelledRef.current = false;\n        // Clearing the ref",
+    );
+    expect(source).toContain(
+      "userCancelledRef.current = false;\n        setInterruptRequested(false);",
+    );
+    expect(source).toContain("setDequeueEpoch((epoch) => epoch + 1);");
   });
 
   test("queue display trim uses displayable-item count, not mergedCount", () => {


### PR DESCRIPTION
## Summary

- Wake the TUI dequeue effect after the cancellation guard is reset so Monitor notifications queued before Esc start automatically once the turn is idle.
- Add a source-wiring regression test covering both interrupt cleanup paths.

Fixes #4168

## Verification

- `bun test src/cli/queue-ordering-wiring.test.ts` — passed (7 tests)
- `bun run typecheck` — passed
- `bun run check` — passed (12 checks)

## AI Disclosure

- [ ] This pull request was written entirely by a human
- [x] This pull request was written with AI assistance and reviewed and edited by a human
- [x] I have read the [AI Policy](https://github.com/letta-ai/letta-code/blob/main/AI_POLICY.md) and agree to its terms

## AI Tool(s) Used

Hermes Agent (GPT-5.6 Luna) was used to inspect the issue and source, implement the fix, add the regression test, run verification, and draft this pull request. GitHub CLI was used for repository operations.

## Human Verification

I have reviewed and understand every change in this pull request and take responsibility for its correctness.
