### PR TITLE
feat(mcp): defer client-local tools to the unified CLI

### DIFF
--- a/scripts/source-file-size-baseline.json
+++ b/scripts/source-file-size-baseline.json
@@ -21,7 +21,7 @@
   "src/cli/mods/local-mod-loader.test.ts": 1043,
   "src/cli/reflection-transcript.test.ts": 1084,
   "src/cli/subcommands/skills.ts": 1264,
-  "src/headless.ts": 4994,
+  "src/headless.ts": 4986,
   "src/hooks/integration.test.ts": 1147,
   "src/index.ts": 2773,
   "src/mods/learning-harness.ts": 2434,

--- a/src/cli/app/AppCoordinator.tsx
+++ b/src/cli/app/AppCoordinator.tsx
@@ -239,7 +239,7 @@ import type {
   QueuedOverlayAction,
   StaticItem,
 } from "./types";
-import { closeMcp, useAgentMcpServers } from "./use-agent-mcp-servers";
+import { closeMcp, useMcpCleanup } from "./use-agent-mcp-servers";
 import { useApprovalFlow } from "./use-approval-flow";
 import { useBashHandlers } from "./use-bash-handlers";
 import { useConfigurationHandlers } from "./use-configuration-handlers";
@@ -2385,7 +2385,7 @@ export function App({
   useEffect(() => {
     buffersRef.current.agentId = agentState?.id;
   }, [agentState?.id]);
-  useAgentMcpServers(agentState?.id);
+  useMcpCleanup(agentState?.id);
   // Cache precomputed diffs from approval dialogs for tool return rendering
   // Key: toolCallId or "toolCallId:filePath" for Patch operations
   const precomputedDiffsRef = useRef<Map<string, AdvancedDiffSuccess>>(

--- a/src/cli/app/use-agent-mcp-servers.ts
+++ b/src/cli/app/use-agent-mcp-servers.ts
@@ -1,18 +1,17 @@
-import { useEffect } from "react";
-import { closeClientMcpServers, replaceClientMcpServers } from "@/mcp-runtime";
+import { useEffect, useRef } from "react";
+import { closeClientMcpServers } from "@/mcp-runtime";
 
 export { closeClientMcpServers as closeMcp } from "@/mcp-runtime";
 
-import { settingsManager } from "@/settings-manager";
 import { debugWarn } from "@/utils/debug";
 
-export function useAgentMcpServers(agentId: string | undefined): void {
+export function useMcpCleanup(agentId: string | undefined): void {
+  const previousAgentId = useRef(agentId);
   useEffect(() => {
-    const refresh = agentId
-      ? replaceClientMcpServers(agentId, settingsManager.getMcpServers(agentId))
-      : closeClientMcpServers();
-    void refresh.catch((error) =>
-      debugWarn("mcp", `Failed to switch agent MCP servers: ${String(error)}`),
+    if (previousAgentId.current === agentId) return;
+    previousAgentId.current = agentId;
+    void closeClientMcpServers().catch((error) =>
+      debugWarn("mcp", `Failed to close client MCP servers: ${String(error)}`),
     );
   }, [agentId]);
 }

--- a/src/cli/components/McpSelector.tsx
+++ b/src/cli/components/McpSelector.tsx
@@ -401,8 +401,8 @@ export const McpSelector = memo(function McpSelector({
           <Text dimColor>No tools discovered.</Text>
         ) : (
           viewingState.tools.map((tool) => (
-            <Box key={tool.registrationKey ?? tool.name} flexDirection="column">
-              <Text>{tool.label ?? tool.name}</Text>
+            <Box key={tool.name} flexDirection="column">
+              <Text>{tool.title ?? tool.name}</Text>
               <Text dimColor>
                 {"  "}
                 {truncateText(singleLine(tool.description), terminalWidth - 2)}

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -145,7 +145,7 @@ import {
   emitLocalToolReturns,
 } from "./headless-tool-events";
 import { computeDiffPreviews } from "./helpers/diff-preview";
-import { closeClientMcpServers, replaceClientMcpServers } from "./mcp-runtime";
+import { closeClientMcpServers } from "./mcp-runtime";
 import { disableModsForProcess, shouldDisableMods } from "./mods/disable";
 import type { ModAdapter } from "./mods/mod-adapter";
 import { getTurnStartCancel } from "./mods/turn-start-cancel";
@@ -1396,14 +1396,6 @@ export async function handleHeadlessCommand(
   markMilestone("HEADLESS_AGENT_RESOLVED");
   const publicAgentId = ephemeralFlag ? null : agent.id;
   telemetry.setCurrentAgent(publicAgentId, agent.tags);
-  if (!ephemeralFlag) {
-    await replaceClientMcpServers(
-      agent.id,
-      settingsManager.getMcpServers(agent.id),
-      { stderr: "pipe" },
-    );
-  }
-
   const isResumingAgent =
     !ephemeralFlag && !!(specifiedAgentId || (!forceNew && !fromAfFile));
   // Refresh presets before applying optional model/system-prompt overrides.

--- a/src/mcp-runtime.test.ts
+++ b/src/mcp-runtime.test.ts
@@ -19,7 +19,7 @@ afterEach(async () => {
 });
 
 describe("client-local MCP runtime", () => {
-  test("registers namespaced tools that execute through the local process", async () => {
+  test("discovers tools without registering them as model-facing tools", async () => {
     const states = await replaceClientMcpServers("agent-a", [
       {
         name: "everything",
@@ -30,21 +30,11 @@ describe("client-local MCP runtime", () => {
     ]);
 
     expect(states[0]?.status).toBe("connected");
-    const tool = getExternalToolDefinition("mcp__everything__echo");
-    if (!tool?.executor) throw new Error("MCP tool was not registered");
-    const result = await tool.executor(
-      "call-1",
-      "mcp__everything__echo",
-      { message: "local" },
-      { tool },
-    );
-    expect(result).toEqual({
-      content: [{ type: "text", text: "Echo: local" }],
-      isError: false,
-    });
+    expect(states[0]?.tools.some((tool) => tool.name === "echo")).toBe(true);
+    expect(getExternalToolDefinition("mcp__everything__echo")).toBeUndefined();
   });
 
-  test("replaces MCP tools when the selected agent changes", async () => {
+  test("replaces MCP connections when the selected agent changes", async () => {
     await replaceClientMcpServers("agent-a", [
       {
         name: "everything",
@@ -53,10 +43,9 @@ describe("client-local MCP runtime", () => {
         args: [EVERYTHING_SERVER],
       },
     ]);
-    expect(getExternalToolDefinition("mcp__everything__echo")).toBeDefined();
+    expect(getClientMcpServerStates("agent-a")).toHaveLength(1);
 
     await replaceClientMcpServers("agent-b", []);
-    expect(getExternalToolDefinition("mcp__everything__echo")).toBeUndefined();
     expect(getClientMcpServerStates("agent-a")).toHaveLength(0);
     expect(getClientMcpServerStates("agent-b")).toHaveLength(0);
   });
@@ -82,6 +71,6 @@ describe("client-local MCP runtime", () => {
     ]);
     expect(getClientMcpServerStates("agent-a")).toHaveLength(2);
     expect(getClientMcpServerStates("agent-b")).toHaveLength(0);
-    expect(getExternalToolDefinition("mcp__everything__echo")).toBeDefined();
+    expect(getExternalToolDefinition("mcp__everything__echo")).toBeUndefined();
   });
 });

--- a/src/mcp-runtime.ts
+++ b/src/mcp-runtime.ts
@@ -3,25 +3,19 @@ import {
   connectMcpServer,
   type McpOAuthConnection,
   type McpServerConfig,
-  type McpToolResult,
+  type McpToolDefinition,
 } from "@/mcp-client";
 import { createMcpOAuthSession } from "@/mcp-oauth";
-import {
-  type ExternalToolDefinition,
-  registerExternalTools,
-  unregisterExternalTools,
-} from "@/tools/manager";
 
 export interface ClientMcpServerState {
   config: McpServerConfig;
   status: "connected" | "failed";
-  tools: ExternalToolDefinition[];
+  tools: McpToolDefinition[];
   error?: string;
 }
 
 interface ActiveMcpServer {
   connection: ConnectedMcpServer;
-  tools: ExternalToolDefinition[];
 }
 
 export interface ReplaceClientMcpServersOptions {
@@ -60,7 +54,7 @@ function getRuntime(): ClientMcpRuntime {
   return runtime;
 }
 
-/** Replace all client-local MCP connections and their model-facing tools. */
+/** Replace client-local MCP connections used by the interactive MCP manager. */
 export async function replaceClientMcpServers(
   agentId: string,
   configs: readonly McpServerConfig[],
@@ -70,7 +64,6 @@ export async function replaceClientMcpServers(
   const generation = ++runtime.generation;
   await closeActiveServers(runtime);
   runtime.agentId = agentId;
-  const usedToolNames = new Set<string>();
   const states = await Promise.all(
     configs.map(async (config): Promise<ClientMcpServerState> => {
       let oauth: McpOAuthConnection | undefined;
@@ -89,26 +82,8 @@ export async function replaceClientMcpServers(
           await connection.close();
           return { config, status: "failed", tools: [], error: "Superseded" };
         }
-        const tools = connection.tools.map((tool) => {
-          const name = uniqueToolName(
-            formatClientMcpToolName(config.name, tool.name),
-            usedToolNames,
-          );
-          const definition: ExternalToolDefinition = {
-            name,
-            label: tool.title ?? tool.name,
-            description:
-              tool.description ??
-              `Tool ${tool.name} from MCP server ${config.name}`,
-            parameters: tool.inputSchema,
-            executor: async (_toolCallId, _toolName, input) =>
-              toExternalToolResult(await connection.callTool(tool.name, input)),
-          };
-          return definition;
-        });
-        registerExternalTools(tools);
-        runtime.active.set(config.name, { connection, tools });
-        return { config, status: "connected", tools };
+        runtime.active.set(config.name, { connection });
+        return { config, status: "connected", tools: connection.tools };
       } catch (error) {
         return {
           config,
@@ -158,7 +133,7 @@ export function getClientMcpServerStates(
   return runtime.agentId === agentId ? [...runtime.states] : [];
 }
 
-/** Close every local MCP connection and unregister its tools. */
+/** Close every local MCP manager connection. */
 export async function closeClientMcpServers(): Promise<void> {
   const runtime = getRuntime();
   runtime.generation++;
@@ -172,25 +147,13 @@ async function closeActiveServers(runtime: ClientMcpRuntime): Promise<void> {
   runtime.pendingOAuth.clear();
   runtime.active.clear();
   runtime.states = [];
-  for (const server of active) unregisterExternalTools(server.tools);
   await Promise.allSettled([
     ...pendingOAuth.map((oauth) => oauth.close()),
     ...active.map((server) => server.connection.close()),
   ]);
 }
 
-function uniqueToolName(base: string, used: Set<string>): string {
-  let name = base;
-  let suffix = 2;
-  while (used.has(name)) {
-    name = `${base}_${suffix}`;
-    suffix++;
-  }
-  used.add(name);
-  return name;
-}
-
-/** Return the model-facing name for a tool from a client-connected MCP server. */
+/** Return the CLI name for a tool from a client-connected MCP server. */
 export function formatClientMcpToolName(
   serverName: string,
   toolName: string,
@@ -201,49 +164,4 @@ export function formatClientMcpToolName(
 export function normalizeMcpName(value: string): string {
   const normalized = value.replace(/[^a-zA-Z0-9_-]/g, "_");
   return normalized || "tool";
-}
-
-function toExternalToolResult(result: McpToolResult): {
-  content: Array<{
-    type: string;
-    text?: string;
-    data?: string;
-    mimeType?: string;
-  }>;
-  isError: boolean;
-} {
-  return {
-    content: result.content.map((item) => normalizeContent(item)),
-    isError: result.isError === true,
-  };
-}
-
-function normalizeContent(item: unknown): {
-  type: string;
-  text?: string;
-  data?: string;
-  mimeType?: string;
-} {
-  if (isRecord(item)) {
-    if (item.type === "text" && typeof item.text === "string") {
-      return { type: "text", text: item.text };
-    }
-    if (
-      (item.type === "image" || item.type === "audio") &&
-      typeof item.data === "string"
-    ) {
-      return {
-        type: item.type,
-        data: item.data,
-        ...(typeof item.mimeType === "string"
-          ? { mimeType: item.mimeType }
-          : {}),
-      };
-    }
-  }
-  return { type: "text", text: JSON.stringify(item) };
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
 }

--- a/src/skills/builtin/using-mcp-tools/SKILL.md
+++ b/src/skills/builtin/using-mcp-tools/SKILL.md
@@ -5,7 +5,7 @@ description: Reference for the `letta mcp` CLI, which finds and invokes MCP tool
 
 # Using MCP tools
 
-`letta mcp` gives the agent one unified view of every MCP server it can reach: servers connected to the agent in Letta Cloud and servers configured locally on this machine. It works from any surface where the agent runs — cloud sandboxes (chat.letta.com), Letta Desktop, and terminals. All output is JSON.
+`letta mcp` gives the agent one unified view of every MCP server it can reach: servers connected to the agent in Letta Cloud and servers configured locally on this machine. Local MCP tools are deferred to this CLI instead of being attached directly to every model request. It works from any surface where the agent runs — cloud sandboxes (chat.letta.com), Letta Desktop, and terminals. All output is JSON.
 
 ## Commands
 

--- a/src/skills/builtin/using-mcp-tools/SKILL.md
+++ b/src/skills/builtin/using-mcp-tools/SKILL.md
@@ -5,7 +5,7 @@ description: Reference for the `letta mcp` CLI, which finds and invokes MCP tool
 
 # Using MCP tools
 
-`letta mcp` gives the agent one unified view of every MCP server it can reach: servers connected to the agent in Letta Cloud and servers configured locally on this machine. Local MCP tools are deferred to this CLI instead of being attached directly to every model request. It works from any surface where the agent runs — cloud sandboxes (chat.letta.com), Letta Desktop, and terminals. All output is JSON.
+`letta mcp` gives the agent one unified view of every MCP server it can reach: servers connected to the agent in Letta Cloud and servers configured locally on this machine. It works from any surface where the agent runs — cloud sandboxes (chat.letta.com), Letta Desktop, and terminals. All output is JSON.
 
 ## Commands
 


### PR DESCRIPTION
## Summary

MCP servers configured on the local computer should be discovered on demand through `letta mcp`, like cloud-connected MCP servers, without adding every local tool schema to each model request.

The local MCP runtime previously opened every configured server at startup and registered every returned tool as a client-side tool. The unified CLI already searches and calls those same local tools. This change stops the model-facing registration and eager startup connections; `/mcp` still connects for configuration and inspection, while `letta mcp search`, `schema`, and `call` remain the execution path.

The compatibility change is intentional: an agent can no longer call a locally configured `mcp__...` tool directly. The MCP servers system reminder points it to the unified CLI instead.

## Verification

- `bun run check` — all 12 checks passed.
- `bun test src/mcp-runtime.test.ts src/cli/subcommands/mcp.test.ts src/cli/subcommands/mcp-search.test.ts src/reminders/mcp-servers-info.test.ts` — 36 tests passed, including a real stdio MCP server call.
- `bun run build` — built the published Node artifact.
- `node letta.js mcp search "calculate the sum of two numbers" --limit 3` — returned `mcp__everything__get-sum` from the configured local server.
- `node letta.js mcp call mcp__everything__get-sum --args '{"a":19,"b":23}'` — the built artifact returned 42.

## Breadcrumbs

- Requested in: [`conv-7d04fffa-17fc-4993-97ed-5bbddaafd6dc`](https://chat.letta.com/chat/agent-57231da8-42f3-4523-b190-66c3eda21057?conversation=conv-7d04fffa-17fc-4993-97ed-5bbddaafd6dc)
- Related: Follow-up to #4167, which added unified MCP discovery and invocation.

## AI Disclosure

- [ ] This pull request was written entirely by a human
- [ ] This pull request was written with AI assistance and reviewed and edited by a human
- [x] I have read the [AI Policy](https://github.com/letta-ai/letta-code/blob/main/AI_POLICY.md) and agree to its terms

## AI Tool(s) Used

Letta Code — repository investigation, implementation, tests, build verification, and pull request drafting.

## Human Verification

Pending human review before this draft is marked ready.
