### PR TITLE
fix(memory): stage backups before restore

### DIFF
--- a/src/cli/subcommands/memory.test.ts
+++ b/src/cli/subcommands/memory.test.ts
@@ -1,0 +1,110 @@
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { runMemorySubcommand } from "@/cli/subcommands/memory";
+
+const AGENT_ID = "agent-restore-test";
+
+describe("letta memory restore", () => {
+  let storageDir: string;
+  let memoryDir: string;
+  let priorLocalBackend: string | undefined;
+  let priorStorageDir: string | undefined;
+
+  beforeEach(() => {
+    storageDir = mkdtempSync(join(tmpdir(), "memory-restore-"));
+    memoryDir = join(storageDir, "memfs", AGENT_ID, "memory");
+    priorLocalBackend = process.env.LETTA_LOCAL_BACKEND_EXPERIMENTAL;
+    priorStorageDir = process.env.LETTA_LOCAL_BACKEND_DIR;
+    process.env.LETTA_LOCAL_BACKEND_EXPERIMENTAL = "1";
+    process.env.LETTA_LOCAL_BACKEND_DIR = storageDir;
+    mkdirSync(memoryDir, { recursive: true });
+    writeFileSync(join(memoryDir, "MEMORY.md"), "current memory");
+  });
+
+  afterEach(() => {
+    rmSync(storageDir, { recursive: true, force: true });
+    if (priorLocalBackend === undefined) {
+      delete process.env.LETTA_LOCAL_BACKEND_EXPERIMENTAL;
+    } else {
+      process.env.LETTA_LOCAL_BACKEND_EXPERIMENTAL = priorLocalBackend;
+    }
+    if (priorStorageDir === undefined) {
+      delete process.env.LETTA_LOCAL_BACKEND_DIR;
+    } else {
+      process.env.LETTA_LOCAL_BACKEND_DIR = priorStorageDir;
+    }
+  });
+
+  test("rejects a restore source inside active memory without deleting either", async () => {
+    const sourceDir = join(memoryDir, "nested-backup");
+    mkdirSync(sourceDir);
+    writeFileSync(join(sourceDir, "MEMORY.md"), "backup memory");
+    const errorSpy = spyOn(console, "error").mockImplementation(() => {});
+
+    try {
+      const code = await runMemorySubcommand([
+        "restore",
+        "--agent",
+        AGENT_ID,
+        "--from",
+        sourceDir,
+        "--force",
+      ]);
+
+      expect(code).toBe(1);
+      expect(readFileSync(join(memoryDir, "MEMORY.md"), "utf8")).toBe(
+        "current memory",
+      );
+      expect(existsSync(join(sourceDir, "MEMORY.md"))).toBe(true);
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining("overlaps active memory"),
+      );
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+
+  test("stages a valid backup before replacing active memory", async () => {
+    const agentRoot = dirname(memoryDir);
+    const sourceDir = join(agentRoot, "memory-backup-test");
+    mkdirSync(sourceDir);
+    writeFileSync(join(sourceDir, "MEMORY.md"), "backup memory");
+    const logSpy = spyOn(console, "log").mockImplementation(() => {});
+
+    try {
+      const code = await runMemorySubcommand([
+        "restore",
+        "--agent",
+        AGENT_ID,
+        "--from",
+        sourceDir,
+        "--force",
+      ]);
+
+      expect(code).toBe(0);
+      expect(readFileSync(join(memoryDir, "MEMORY.md"), "utf8")).toBe(
+        "backup memory",
+      );
+      expect(readFileSync(join(sourceDir, "MEMORY.md"), "utf8")).toBe(
+        "backup memory",
+      );
+      expect(
+        readdirSync(agentRoot).some((name) =>
+          name.startsWith(".memory-restore-"),
+        ),
+      ).toBe(false);
+    } finally {
+      logSpy.mockRestore();
+    }
+  });
+});

--- a/src/cli/subcommands/memory.ts
+++ b/src/cli/subcommands/memory.ts
@@ -1,6 +1,15 @@
-import { cpSync, existsSync, mkdirSync, rmSync, statSync } from "node:fs";
+import {
+  cpSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  realpathSync,
+  renameSync,
+  rmSync,
+  statSync,
+} from "node:fs";
 import { readdir } from "node:fs/promises";
-import { dirname, join } from "node:path";
+import { dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
 import { parseArgs } from "node:util";
 import { getScopedMemoryFilesystemRoot } from "@/agent/memory-filesystem";
 import { getMemoryGitStatus, isGitRepo, pullMemory } from "@/agent/memory-git";
@@ -119,6 +128,86 @@ function resolveBackupPath(agentId: string, from: string): string {
     return from;
   }
   return join(getAgentRoot(agentId), from);
+}
+
+function pathContains(parent: string, child: string): boolean {
+  const pathFromParent = relative(parent, child);
+  return (
+    pathFromParent === "" ||
+    (pathFromParent !== ".." &&
+      !pathFromParent.startsWith(`..${sep}`) &&
+      !isAbsolute(pathFromParent))
+  );
+}
+
+function restoreMemoryDirectory(
+  sourcePath: string,
+  memoryRoot: string,
+): { cleanupWarning?: string } {
+  const source = realpathSync(sourcePath);
+  const target = existsSync(memoryRoot)
+    ? realpathSync(memoryRoot)
+    : resolve(memoryRoot);
+  if (pathContains(source, target) || pathContains(target, source)) {
+    throw new Error(
+      "Restore source overlaps active memory. Choose a separate backup directory.",
+    );
+  }
+
+  const transactionRoot = mkdtempSync(
+    join(dirname(memoryRoot), ".memory-restore-"),
+  );
+  const candidate = join(transactionRoot, "candidate");
+  const rollback = join(transactionRoot, "rollback");
+  let currentMoved = false;
+
+  try {
+    cpSync(source, candidate, { recursive: true });
+    if (!statSync(candidate).isDirectory()) {
+      throw new Error("Restore candidate is not a directory.");
+    }
+
+    if (existsSync(memoryRoot)) {
+      renameSync(memoryRoot, rollback);
+      currentMoved = true;
+    }
+
+    try {
+      renameSync(candidate, memoryRoot);
+      if (!statSync(memoryRoot).isDirectory()) {
+        throw new Error("Restored memory is not a directory.");
+      }
+    } catch (activationError) {
+      if (currentMoved) {
+        if (existsSync(memoryRoot)) {
+          rmSync(memoryRoot, { recursive: true, force: true });
+        }
+        try {
+          renameSync(rollback, memoryRoot);
+          currentMoved = false;
+        } catch (rollbackError) {
+          throw new Error(
+            `Memory restore failed: ${String(activationError)}. Rollback also failed: ${String(rollbackError)}. Previous memory remains at ${rollback}.`,
+          );
+        }
+      }
+      throw activationError;
+    }
+  } catch (error) {
+    if (!currentMoved) {
+      rmSync(transactionRoot, { recursive: true, force: true });
+    }
+    throw error;
+  }
+
+  try {
+    rmSync(transactionRoot, { recursive: true, force: true });
+    return {};
+  } catch (error) {
+    return {
+      cleanupWarning: `Restored memory, but could not remove the temporary rollback at ${rollback}: ${String(error)}`,
+    };
+  }
 }
 
 export async function runMemorySubcommand(argv: string[]): Promise<number> {
@@ -261,9 +350,11 @@ export async function runMemorySubcommand(argv: string[]): Promise<number> {
         return 1;
       }
       const root = getMemoryRoot(agentId);
-      rmSync(root, { recursive: true, force: true });
-      cpSync(backupPath, root, { recursive: true });
+      const result = restoreMemoryDirectory(backupPath, root);
       console.log(JSON.stringify({ restoredFrom: backupPath }, null, 2));
+      if (result.cleanupWarning) {
+        console.error(`Warning: ${result.cleanupWarning}`);
+      }
       return 0;
     }
 


### PR DESCRIPTION
## Summary

Fixes #4195.

- copy the requested backup into a complete candidate before touching active memory
- reject restore sources that overlap the active memory directory
- move the current memory to a temporary rollback, activate the candidate with a same-filesystem rename, and restore the rollback if activation fails
- leave the restore source unchanged and delete the temporary rollback only after activation succeeds

## Restore sequence

1. Resolve the real source and target paths and reject either direction of overlap.
2. Create a transaction directory next to the active memory directory.
3. Copy the source to `candidate` and verify that the copied result is a directory.
4. Rename the active memory to `rollback`, then rename `candidate` to the active memory path.
5. On an activation error, remove any failed target and rename `rollback` back.
6. After successful activation, remove the transaction directory, including the old rollback.

Keeping the transaction directory next to active memory keeps both renames on the same filesystem.

## Failure boundaries

- Candidate validation is structural only: it verifies a complete directory copy, not memory-file semantics, a manifest, or checksums.
- Synchronous copy and activation errors are handled while the restore process remains alive.
- If restoring the rollback also fails, the command reports the rollback path and leaves the previous memory there.
- If cleanup fails after activation, the restored memory remains active; the command reports a warning and leaves the temporary rollback for manual cleanup.
- This change does not add locking for concurrent memory writers.
- This change does not add restart recovery for process termination or power loss during the directory-swap window.

## Verification

- `bun test src/cli/subcommands/memory.test.ts` — 2 passed, 0 failed
- `bun run check` — 12 checks passed
- `bun run build` — passed

## AI Disclosure

- [ ] This pull request was written entirely by a human
- [x] This pull request was written with AI assistance and reviewed and edited by a human
- [x] I have read the [AI Policy](https://github.com/letta-ai/letta-code/blob/main/AI_POLICY.md) and agree to its terms

## AI Tool(s) Used

OpenAI Codex — repository research, reproduction, implementation, tests, and pull request drafting.

## Human Verification

I have reviewed and understand every change in this pull request and take responsibility for its correctness.
