### PR TITLE
fix(cli): drain TUI queue after Esc interrupt settles

### DIFF
--- a/src/cli/app/AppCoordinator.tsx
+++ b/src/cli/app/AppCoordinator.tsx
@@ -1671,12 +1671,10 @@ export function App({
     },
     [currentModelHandle, currentToolsetPreference],
   );
-  // Non-null only when the previous turn was explicitly interrupted by the user.
-  // Used to gate recovery alert injection to true user-interrupt retries.
+  // Non-null only for true user-interrupt retries (recovery alert injection).
   const pendingInterruptRecoveryConversationIdRef = useRef<string | null>(null);
 
-  // Epoch counter to force dequeue effect re-run when refs change but state doesn't
-  // Incremented when userCancelledRef is reset while messages are queued
+  // Forces dequeue effect re-run when refs change (including post-Esc cancel reset).
   const [dequeueEpoch, setDequeueEpoch] = useState(0);
   // Strict lock to ensure dequeue submit path is at-most-once while onSubmit is in flight.
   const dequeueInFlightRef = useRef(false);
@@ -4034,10 +4032,12 @@ export function App({
     setIsExecutingTool,
     setPendingApprovals,
     setRestoreQueueOnCancel,
+    setDequeueEpoch,
     setStreaming,
     streaming,
     toolAbortControllerRef,
     toolResultsInFlightRef,
+    tuiQueueRef,
     userCancelledRef,
     waitingForQueueCancelRef,
   });

--- a/src/cli/app/use-conversation-loop.ts
+++ b/src/cli/app/use-conversation-loop.ts
@@ -2876,9 +2876,9 @@ export function useConversationLoop(ctx: ConversationLoopContext) {
         // Trigger dequeue effect now that processConversation is no longer active.
         // The dequeue effect checks abortControllerRef (a ref, not state), so it
         // won't re-run on its own — bump dequeueEpoch to force re-evaluation.
-        // Only bump for normal completions — if stale (ESC was pressed), the user
-        // cancelled and queued messages should NOT be auto-submitted.
-        if (!isStale && (tuiQueueRef.current?.length ?? 0) > 0) {
+        // Also bump for stale Esc completions so queued Monitor notifications
+        // drain once userCancelledRef settles (issue 4168).
+        if ((tuiQueueRef.current?.length ?? 0) > 0) {
           setDequeueEpoch((e: number) => e + 1);
         }
       }

--- a/src/cli/app/use-interrupt-handler.ts
+++ b/src/cli/app/use-interrupt-handler.ts
@@ -14,8 +14,10 @@ import { markIncompleteToolsAsCancelled } from "@/cli/helpers/accumulator";
 import { formatErrorDetails } from "@/cli/helpers/error-formatter";
 import { releaseReflectionLaunch } from "@/cli/helpers/reflection-launcher";
 import type { ApprovalRequest } from "@/cli/helpers/stream";
+import { settleTuiInterruptQueueGuard } from "@/cli/helpers/tui-queue-wake";
 import { INTERRUPTED_BY_USER } from "@/constants";
 import type { ApprovalContext } from "@/permissions/analyzer";
+import type { QueueRuntime } from "@/queue/queue-runtime";
 
 import { EAGER_CANCEL, INTERRUPT_MESSAGE } from "./constants";
 import { extractErrorMeta } from "./errors";
@@ -57,10 +59,12 @@ type InterruptHandlerContext = {
   setIsExecutingTool: Dispatch<SetStateAction<boolean>>;
   setPendingApprovals: Dispatch<SetStateAction<ApprovalRequest[]>>;
   setRestoreQueueOnCancel: Dispatch<SetStateAction<boolean>>;
+  setDequeueEpoch: Dispatch<SetStateAction<number>>;
   setStreaming: (value: boolean) => void;
   streaming: boolean;
   toolAbortControllerRef: MutableRefObject<AbortController | null>;
   toolResultsInFlightRef: MutableRefObject<boolean>;
+  tuiQueueRef: MutableRefObject<QueueRuntime | null>;
   userCancelledRef: MutableRefObject<boolean>;
   waitingForQueueCancelRef: MutableRefObject<boolean>;
 };
@@ -111,10 +115,12 @@ export function useInterruptHandler(ctx: InterruptHandlerContext) {
     setIsExecutingTool,
     setPendingApprovals,
     setRestoreQueueOnCancel,
+    setDequeueEpoch,
     setStreaming,
     streaming,
     toolAbortControllerRef,
     toolResultsInFlightRef,
+    tuiQueueRef,
     userCancelledRef,
     waitingForQueueCancelRef,
   } = ctx;
@@ -217,8 +223,14 @@ export function useInterruptHandler(ctx: InterruptHandlerContext) {
       // Delay flag reset to ensure React has flushed state updates before dequeue can fire.
       // Use setTimeout(50) instead of setTimeout(0) - the longer delay ensures React's
       // batched state updates have been fully processed before we allow the dequeue effect.
+      // Clearing the ref alone does not re-run the dequeue effect; bump the epoch so a
+      // queued Monitor notification can start once cancellation has settled.
       setTimeout(() => {
-        userCancelledRef.current = false;
+        settleTuiInterruptQueueGuard({
+          userCancelledRef,
+          queueLength: tuiQueueRef.current?.length ?? 0,
+          bumpDequeueEpoch: () => setDequeueEpoch((e) => e + 1),
+        });
       }, 50);
 
       return;
@@ -345,8 +357,14 @@ export function useInterruptHandler(ctx: InterruptHandlerContext) {
       // Use setTimeout(50) instead of setTimeout(0) to ensure React has fully processed
       // the streaming=false state before we allow the dequeue effect to start a new conversation.
       // This prevents the "Maximum update depth exceeded" infinite render loop.
+      // Clearing userCancelledRef is not a React state update, so also bump dequeueEpoch
+      // when work is queued (listener cancelling → idle then scheduleQueuePump).
       setTimeout(() => {
-        userCancelledRef.current = false;
+        settleTuiInterruptQueueGuard({
+          userCancelledRef,
+          queueLength: tuiQueueRef.current?.length ?? 0,
+          bumpDequeueEpoch: () => setDequeueEpoch((e) => e + 1),
+        });
         setInterruptRequested(false);
       }, 50);
 
@@ -410,7 +428,9 @@ export function useInterruptHandler(ctx: InterruptHandlerContext) {
     setIsExecutingTool,
     setPendingApprovals,
     setRestoreQueueOnCancel,
+    setDequeueEpoch,
     toolResultsInFlightRef,
+    tuiQueueRef,
     userCancelledRef,
   ]);
 

--- a/src/cli/helpers/tui-queue-wake.test.ts
+++ b/src/cli/helpers/tui-queue-wake.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, test } from "bun:test";
+import { getTuiBlockedReason } from "@/cli/helpers/tui-queue-adapter";
+import { settleTuiInterruptQueueGuard } from "@/cli/helpers/tui-queue-wake";
+import { QueueRuntime } from "@/queue/queue-runtime";
+
+function enqueueTaskNotification(q: QueueRuntime): void {
+  q.enqueue({
+    kind: "task_notification",
+    source: "task_notification",
+    text: "<task_notification/>",
+  } as Parameters<typeof q.enqueue>[0]);
+}
+
+describe("settleTuiInterruptQueueGuard", () => {
+  test("clears the cancel guard and bumps the epoch when work is queued", () => {
+    const userCancelledRef = { current: true };
+    let epoch = 0;
+    settleTuiInterruptQueueGuard({
+      userCancelledRef,
+      queueLength: 1,
+      bumpDequeueEpoch: () => {
+        epoch += 1;
+      },
+    });
+    expect(userCancelledRef.current).toBe(false);
+    expect(epoch).toBe(1);
+  });
+
+  test("clears the cancel guard without bumping when the queue is empty", () => {
+    const userCancelledRef = { current: true };
+    let epoch = 0;
+    settleTuiInterruptQueueGuard({
+      userCancelledRef,
+      queueLength: 0,
+      bumpDequeueEpoch: () => {
+        epoch += 1;
+      },
+    });
+    expect(userCancelledRef.current).toBe(false);
+    expect(epoch).toBe(0);
+  });
+});
+
+describe("Esc then idle drain (issue 4168)", () => {
+  test("a Monitor notification queued during interrupt drains after the guard settles", () => {
+    const q = new QueueRuntime();
+    enqueueTaskNotification(q);
+
+    const blockedWhileCancelling = getTuiBlockedReason({
+      streaming: false,
+      isExecutingTool: false,
+      commandRunning: false,
+      pendingApprovalsLen: 0,
+      queuedOverlayAction: false,
+      anySelectorOpen: false,
+      waitingForQueueCancel: false,
+      userCancelled: true,
+      abortControllerActive: false,
+    });
+    expect(blockedWhileCancelling).toBe("interrupt_in_progress");
+    q.tryDequeue(blockedWhileCancelling);
+    expect(q.length).toBe(1);
+
+    const userCancelledRef = { current: true };
+    let epoch = 0;
+    settleTuiInterruptQueueGuard({
+      userCancelledRef,
+      queueLength: q.length,
+      bumpDequeueEpoch: () => {
+        epoch += 1;
+      },
+    });
+
+    const blockedAfterSettle = getTuiBlockedReason({
+      streaming: false,
+      isExecutingTool: false,
+      commandRunning: false,
+      pendingApprovalsLen: 0,
+      queuedOverlayAction: false,
+      anySelectorOpen: false,
+      waitingForQueueCancel: false,
+      userCancelled: userCancelledRef.current,
+      abortControllerActive: false,
+    });
+    expect(blockedAfterSettle).toBeNull();
+    expect(epoch).toBe(1);
+
+    const batch = q.consumeItems(q.length);
+    expect(batch?.items).toHaveLength(1);
+    expect(batch?.items[0]?.kind).toBe("task_notification");
+    expect(q.length).toBe(0);
+  });
+});

--- a/src/cli/helpers/tui-queue-wake.ts
+++ b/src/cli/helpers/tui-queue-wake.ts
@@ -1,0 +1,19 @@
+/**
+ * TUI dequeue is a React effect keyed on `dequeueEpoch` plus busy-state.
+ * Interrupt handling mutates `userCancelledRef` — a ref change does not
+ * re-run that effect. After the cancel guard drops, bump the epoch so a
+ * queued Monitor notification (or user message) can start the next turn.
+ *
+ * This is the TUI analogue of the listener's cancelling → idle handoff,
+ * which calls scheduleQueuePump once the lifecycle is idle.
+ */
+export function settleTuiInterruptQueueGuard(args: {
+  userCancelledRef: { current: boolean };
+  queueLength: number;
+  bumpDequeueEpoch: () => void;
+}): void {
+  args.userCancelledRef.current = false;
+  if (args.queueLength > 0) {
+    args.bumpDequeueEpoch();
+  }
+}

--- a/src/cli/queue-ordering-wiring.test.ts
+++ b/src/cli/queue-ordering-wiring.test.ts
@@ -51,6 +51,38 @@ describe("queue ordering wiring", () => {
     expect(segment).toContain("prev.slice(displayConsumedCount)");
   });
 
+  test("Esc interrupt settle wakes dequeue when the queue still has work", () => {
+    const source = readAppSource();
+    const interruptStart = source.indexOf(
+      "export function useInterruptHandler(ctx: InterruptHandlerContext)",
+    );
+    const interruptEnd = source.indexOf(
+      "return {\n    handleInterrupt,\n  };",
+      interruptStart,
+    );
+    expect(interruptStart).toBeGreaterThan(-1);
+    expect(interruptEnd).toBeGreaterThan(interruptStart);
+    const interruptSegment = source.slice(interruptStart, interruptEnd);
+    expect(interruptSegment).toContain("settleTuiInterruptQueueGuard");
+    expect(interruptSegment).toContain("tuiQueueRef.current?.length ?? 0");
+    expect(interruptSegment).toContain("setDequeueEpoch((e) => e + 1)");
+
+    const finallyStart = source.indexOf(
+      "// Trigger dequeue effect now that processConversation is no longer active.",
+    );
+    const finallyEnd = source.indexOf(
+      "if ((tuiQueueRef.current?.length ?? 0) > 0)",
+      finallyStart,
+    );
+    expect(finallyStart).toBeGreaterThan(-1);
+    expect(finallyEnd).toBeGreaterThan(finallyStart);
+    const finallySegment = source.slice(finallyStart, finallyEnd + 200);
+    expect(finallySegment).toContain(
+      "if ((tuiQueueRef.current?.length ?? 0) > 0)",
+    );
+    expect(finallySegment).not.toContain("if (!isStale &&");
+  });
+
   test("onSubmit allows override-only queued submissions", () => {
     const source = readAppSource();
     const start = source.indexOf("const onSubmit = useCallback(");


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #4168.

## Summary

A Monitor `task_notification` queued while a TUI turn is active could stay stuck after Esc. Cancellation settled, but the dequeue effect never ran again until the next manual prompt.

This is TUI/listener drift, not a shared agent-loop bug. The websocket listener already treats `cancelling → idle` as a queue-pump boundary (`scheduleQueuePump`). The TUI blocked dequeue with `userCancelledRef`, then cleared that ref in a 50ms timer without bumping `dequeueEpoch`. Stale `processConversation` completions also skipped the epoch bump, so whichever of those two events happened last could leave the queue asleep.

The TUI now:

1. Clears the interrupt guard **and** bumps `dequeueEpoch` when queued work remains (`settleTuiInterruptQueueGuard`).
2. Bumps `dequeueEpoch` on turn cleanup even when the turn was made stale by Esc, so clearing `abortControllerRef` can wake dequeue after the cancel guard drops.

Idle Monitor notifications are unchanged. After Esc settles, queued notifications (and any other queued items) start the next turn without requiring another user prompt.

## Verification

- `bun run check` — 12/12 passed (cycles, boundaries, exported functions, filename casing, file size, module ownership, mock isolation, coverage, skill frontmatter, bundled skill scripts, biome, typescript)
- `bun test` focused queue files — 50 pass / 0 fail:
  - `src/cli/helpers/tui-queue-wake.test.ts`
  - `src/cli/queue-ordering-wiring.test.ts`
  - `src/cli/tui-queue-lifecycle.test.ts`
  - `src/cli/tui-queue-adapter.test.ts`
  - `src/cli/tui-queue-coalescing-parity.test.ts`

## AI Disclosure

- [x] This pull request was written with AI assistance and **reviewed and edited by a human**
- [x] I have read the [AI Policy](https://github.com/letta-ai/letta-code/blob/main/AI_POLICY.md) and agree to its terms

## AI Tool(s) Used

Cursor Grok 4.6 (Cloud Agent)

## Human Verification

I have reviewed and understand every change in this pull request and take responsibility for its correctness.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8d63dc60-86ee-4639-9fd1-35f6067d78bb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8d63dc60-86ee-4639-9fd1-35f6067d78bb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

