### PR TITLE
fix(cli): wake monitor queue after interrupt

### DIFF
--- a/src/cli/app/AppCoordinator.tsx
+++ b/src/cli/app/AppCoordinator.tsx
@@ -4030,6 +4030,7 @@ export function App({
     setApprovalResults,
     setAutoDeniedApprovals,
     setAutoHandledResults,
+    setDequeueEpoch,
     setInterruptRequested,
     setIsExecutingTool,
     setPendingApprovals,
@@ -4041,7 +4042,6 @@ export function App({
     userCancelledRef,
     waitingForQueueCancelRef,
   });
-
   // Keep ref to latest processConversation to avoid circular deps in useEffect
   const processConversationRef = useRef(processConversation);
   useEffect(() => {

--- a/src/cli/app/use-interrupt-handler.ts
+++ b/src/cli/app/use-interrupt-handler.ts
@@ -53,6 +53,7 @@ type InterruptHandlerContext = {
   setApprovalResults: Dispatch<SetStateAction<ApprovalDecision[]>>;
   setAutoDeniedApprovals: Dispatch<SetStateAction<AutoDeniedApproval[]>>;
   setAutoHandledResults: Dispatch<SetStateAction<AutoHandledToolResult[]>>;
+  setDequeueEpoch: Dispatch<SetStateAction<number>>;
   setInterruptRequested: Dispatch<SetStateAction<boolean>>;
   setIsExecutingTool: Dispatch<SetStateAction<boolean>>;
   setPendingApprovals: Dispatch<SetStateAction<ApprovalRequest[]>>;
@@ -107,6 +108,7 @@ export function useInterruptHandler(ctx: InterruptHandlerContext) {
     setApprovalResults,
     setAutoDeniedApprovals,
     setAutoHandledResults,
+    setDequeueEpoch,
     setInterruptRequested,
     setIsExecutingTool,
     setPendingApprovals,
@@ -219,6 +221,7 @@ export function useInterruptHandler(ctx: InterruptHandlerContext) {
       // batched state updates have been fully processed before we allow the dequeue effect.
       setTimeout(() => {
         userCancelledRef.current = false;
+        setDequeueEpoch((epoch) => epoch + 1);
       }, 50);
 
       return;
@@ -348,6 +351,7 @@ export function useInterruptHandler(ctx: InterruptHandlerContext) {
       setTimeout(() => {
         userCancelledRef.current = false;
         setInterruptRequested(false);
+        setDequeueEpoch((epoch) => epoch + 1);
       }, 50);
 
       return;
@@ -406,6 +410,7 @@ export function useInterruptHandler(ctx: InterruptHandlerContext) {
     setApprovalResults,
     setAutoDeniedApprovals,
     setAutoHandledResults,
+    setDequeueEpoch,
     setInterruptRequested,
     setIsExecutingTool,
     setPendingApprovals,

--- a/src/cli/queue-ordering-wiring.test.ts
+++ b/src/cli/queue-ordering-wiring.test.ts
@@ -70,6 +70,23 @@ describe("queue ordering wiring", () => {
     );
   });
 
+  test("interrupt settlement wakes the queue after clearing its ref guard", () => {
+    const source = readAppSource();
+    const start = source.indexOf(
+      "// Delay flag reset to ensure React has flushed state updates before dequeue can fire.",
+    );
+    const end = source.indexOf("if (!streaming || interruptRequested)", start);
+
+    expect(start).toBeGreaterThan(-1);
+    expect(end).toBeGreaterThan(start);
+
+    const segment = source.slice(start, end);
+    const guardReset = segment.indexOf("userCancelledRef.current = false");
+    const queueWake = segment.indexOf("setDequeueEpoch((epoch) => epoch + 1)");
+    expect(guardReset).toBeGreaterThan(-1);
+    expect(queueWake).toBeGreaterThan(guardReset);
+  });
+
   test("bare exit aliases before queue classification", () => {
     const source = readAppSource();
     const start = source.indexOf("const onSubmit = useCallback(");


### PR DESCRIPTION
### Motivation

- The TUI could leave Monitor `task_notification` items queued after a user interrupt because the cancellation guard is stored in a ref (`userCancelledRef.current`) and clearing that ref did not re-trigger the dequeue effect.  
- The WebSocket listener already schedules its queue pump when cancellation settles, so the TUI needs a reactive wake-up to match the listener's behavior and automatically start queued turns after interrupt settlement.

### Description

- Added a `setDequeueEpoch` state setter to the interrupt handler context so the interrupt flow can wake the dequeue effect when the ref-guard is cleared.  
- Call `setDequeueEpoch((e) => e + 1)` immediately after `userCancelledRef.current = false` in both the non-eager and EAGER_CANCEL interrupt settlement paths so queued messages become eligible for automatic dequeue.  
- Threaded `setDequeueEpoch` through `AppCoordinator.tsx` into `useInterruptHandler` so the handler has access to the epoch bump.  
- Added a wiring regression test `queue-ordering-wiring.test.ts` that asserts the interrupt settlement code clears the ref and then performs the dequeue wake-up call.

Files changed: `src/cli/app/use-interrupt-handler.ts`, `src/cli/app/AppCoordinator.tsx`, `src/cli/queue-ordering-wiring.test.ts`.

### Testing

- Ran the focused unit test `bun test src/cli/queue-ordering-wiring.test.ts`, which passed (all test cases in the file passed).  
- Ran the project check suite `bun run check`, which completed successfully (all configured checks passed).  
- Verified `git diff --check` and local formatting/lint hooks ran as part of the development flow with no outstanding failures in the modified files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a98ca55cb808324bb1cf35ac76cd9f2)