### PR TITLE
fix(cli): settle Esc interrupts from the turn owner so queued notifications drain

### DIFF
--- a/scripts/isolated-unit-tests.json
+++ b/scripts/isolated-unit-tests.json
@@ -1,6 +1,11 @@
 {
   "tests": [
     {
+      "path": "src/cli/tui-interrupt-queue-lifecycle.test.tsx",
+      "timeoutMs": 30000,
+      "reason": "Mounts the production TUI, which updates process-wide agent/tool context and settings; keep its proof agent out of later permission and mod tests."
+    },
+    {
       "path": "scripts/unit-test-impact.test.cjs",
       "timeoutMs": 15000,
       "reason": "Adding this test to the shared Bun batch shifted existing batch boundaries and exposed package-installer module-mock leakage; run it separately."

--- a/scripts/source-file-size-baseline.json
+++ b/scripts/source-file-size-baseline.json
@@ -9,7 +9,7 @@
   "src/cli/app/AppView.tsx": 1735,
   "src/cli/app/use-approval-flow.ts": 1163,
   "src/cli/app/use-configuration-handlers.ts": 1421,
-  "src/cli/app/use-conversation-loop.ts": 2912,
+  "src/cli/app/use-conversation-loop.ts": 2903,
   "src/cli/app/use-submit-handler.ts": 4074,
   "src/cli/components/AgentSelector.tsx": 1104,
   "src/cli/components/InputRich.tsx": 2225,

--- a/src/cli/app/AppCoordinator.tsx
+++ b/src/cli/app/AppCoordinator.tsx
@@ -1674,8 +1674,7 @@ export function App({
   // Used to gate recovery alert injection to true user-interrupt retries.
   const pendingInterruptRecoveryConversationIdRef = useRef<string | null>(null);
 
-  // Epoch counter to force dequeue effect re-run when refs change but state doesn't
-  // Incremented when userCancelledRef is reset while messages are queued
+  // Epoch counter to force dequeue effect re-run when refs change but state doesn't.
   const [dequeueEpoch, setDequeueEpoch] = useState(0);
   // Strict lock to ensure dequeue submit path is at-most-once while onSubmit is in flight.
   const dequeueInFlightRef = useRef(false);
@@ -3814,6 +3813,7 @@ export function App({
     setCurrentModelHandle,
     setCurrentModelId,
     setDequeueEpoch,
+    setInterruptRequested,
     lastStopReasonRef,
     setIsExecutingTool,
     setLlmConfig,
@@ -4030,6 +4030,7 @@ export function App({
     setApprovalResults,
     setAutoDeniedApprovals,
     setAutoHandledResults,
+    setDequeueEpoch,
     setInterruptRequested,
     setIsExecutingTool,
     setPendingApprovals,
@@ -4038,6 +4039,7 @@ export function App({
     streaming,
     toolAbortControllerRef,
     toolResultsInFlightRef,
+    tuiQueueRef,
     userCancelledRef,
     waitingForQueueCancelRef,
   });
@@ -4321,11 +4323,9 @@ export function App({
     onSubmitRef.current = onSubmit;
   }, [onSubmit]);
 
-  // Process queued messages when streaming ends.
-  // QueueRuntime is authoritative: consumeItems drives the dequeue and fires
-  // onDequeued → setQueueDisplay(prev => prev.slice(n)) to update the UI.
-  // dequeueEpoch is the sole re-trigger: bumped on every enqueue, turn
-  // completion (abortControllerRef clears), and cancel-reset.
+  // Process queued messages when streaming ends. QueueRuntime is authoritative
+  // (consumeItems fires onDequeued → setQueueDisplay). dequeueEpoch is the sole
+  // re-trigger: enqueue, turn completion, and interrupt settle (cancelling->idle).
   useEffect(() => {
     void dequeueEpoch; // explicit dep to satisfy exhaustive-deps lint
 

--- a/src/cli/app/use-conversation-loop.ts
+++ b/src/cli/app/use-conversation-loop.ts
@@ -98,6 +98,7 @@ import {
   isPatchTool,
 } from "@/cli/helpers/tool-name-mapping";
 import { alwaysRequiresUserInput } from "@/cli/helpers/tool-name-mapping.js";
+import { finishTuiTurn } from "@/cli/helpers/tui-turn-lifecycle";
 import type { LocalModAdapter } from "@/cli/mods/use-local-mod-adapter";
 import { SYSTEM_ALERT_OPEN, SYSTEM_REMINDER_OPEN } from "@/constants";
 import { runStopHooks } from "@/hooks";
@@ -246,6 +247,7 @@ type ConversationLoopContext = {
   setCurrentModelHandle: Dispatch<SetStateAction<string | null>>;
   setCurrentModelId: Dispatch<SetStateAction<string | null>>;
   setDequeueEpoch: Dispatch<SetStateAction<number>>;
+  setInterruptRequested: Dispatch<SetStateAction<boolean>>;
   lastStopReasonRef: MutableRefObject<string | null>;
   setIsExecutingTool: Dispatch<SetStateAction<boolean>>;
   setLlmConfig: Dispatch<SetStateAction<LlmConfig | null>>;
@@ -341,6 +343,7 @@ export function useConversationLoop(ctx: ConversationLoopContext) {
     setCurrentModelHandle,
     setCurrentModelId,
     setDequeueEpoch,
+    setInterruptRequested,
     lastStopReasonRef,
     setIsExecutingTool,
     setLlmConfig,
@@ -610,10 +613,9 @@ export function useConversationLoop(ctx: ConversationLoopContext) {
         chatgptExhaustedProvidersRef.current.clear();
       }
 
-      // Track last run ID for error reporting (accessible in catch block)
       let currentRunId: string | undefined;
       let preserveTranscriptStartForApproval = false;
-
+      let turnAbortController: AbortController | null = null;
       try {
         if (turnStartCancelReason) {
           const statusId = uid("status");
@@ -643,7 +645,8 @@ export function useConversationLoop(ctx: ConversationLoopContext) {
         openTrajectorySegment();
         setNetworkPhase("upload");
         setExecutionPhase("requesting");
-        abortControllerRef.current = new AbortController();
+        turnAbortController = new AbortController();
+        abortControllerRef.current = turnAbortController;
 
         if (
           await maybeStreamSyntheticNoModelResponse(
@@ -2857,30 +2860,18 @@ export function useConversationLoop(ctx: ConversationLoopContext) {
           pendingTranscriptStartLineIndexRef.current = null;
         }
 
-        // Check if this conversation was superseded by an ESC interrupt
-        const isStale = myGeneration !== conversationGenerationRef.current;
-
-        abortControllerRef.current = null;
-
-        // Decrement BEFORE bumping the epoch so that when the dequeue effect
-        // fires synchronously (Ink legacy mode), processingConversationRef.current
-        // already reflects the true count. The defer gate checks === 0 to confirm
-        // no more nested processConversation calls are outstanding.
-        if (!isStale) {
-          processingConversationRef.current = Math.max(
-            0,
-            processingConversationRef.current - 1,
-          );
-        }
-
-        // Trigger dequeue effect now that processConversation is no longer active.
-        // The dequeue effect checks abortControllerRef (a ref, not state), so it
-        // won't re-run on its own — bump dequeueEpoch to force re-evaluation.
-        // Only bump for normal completions — if stale (ESC was pressed), the user
-        // cancelled and queued messages should NOT be auto-submitted.
-        if (!isStale && (tuiQueueRef.current?.length ?? 0) > 0) {
-          setDequeueEpoch((e: number) => e + 1);
-        }
+        // Wakes dequeue on a normal completion; when superseded by an ESC
+        // interrupt, settles the interrupt (cancelling -> idle) instead.
+        finishTuiTurn({
+          isStale: myGeneration !== conversationGenerationRef.current,
+          turnAbortController,
+          abortControllerRef,
+          processingConversationRef,
+          userCancelledRef,
+          setInterruptRequested,
+          queueLength: () => tuiQueueRef.current?.length ?? 0,
+          bumpDequeueEpoch: () => setDequeueEpoch((e: number) => e + 1),
+        });
       }
     },
     [

--- a/src/cli/app/use-interrupt-handler.ts
+++ b/src/cli/app/use-interrupt-handler.ts
@@ -14,8 +14,10 @@ import { markIncompleteToolsAsCancelled } from "@/cli/helpers/accumulator";
 import { formatErrorDetails } from "@/cli/helpers/error-formatter";
 import { releaseReflectionLaunch } from "@/cli/helpers/reflection-launcher";
 import type { ApprovalRequest } from "@/cli/helpers/stream";
+import { settleTuiInterrupt } from "@/cli/helpers/tui-turn-lifecycle";
 import { INTERRUPTED_BY_USER } from "@/constants";
 import type { ApprovalContext } from "@/permissions/analyzer";
+import type { QueueRuntime } from "@/queue/queue-runtime";
 
 import { EAGER_CANCEL, INTERRUPT_MESSAGE } from "./constants";
 import { extractErrorMeta } from "./errors";
@@ -53,6 +55,7 @@ type InterruptHandlerContext = {
   setApprovalResults: Dispatch<SetStateAction<ApprovalDecision[]>>;
   setAutoDeniedApprovals: Dispatch<SetStateAction<AutoDeniedApproval[]>>;
   setAutoHandledResults: Dispatch<SetStateAction<AutoHandledToolResult[]>>;
+  setDequeueEpoch: Dispatch<SetStateAction<number>>;
   setInterruptRequested: Dispatch<SetStateAction<boolean>>;
   setIsExecutingTool: Dispatch<SetStateAction<boolean>>;
   setPendingApprovals: Dispatch<SetStateAction<ApprovalRequest[]>>;
@@ -61,6 +64,7 @@ type InterruptHandlerContext = {
   streaming: boolean;
   toolAbortControllerRef: MutableRefObject<AbortController | null>;
   toolResultsInFlightRef: MutableRefObject<boolean>;
+  tuiQueueRef: MutableRefObject<QueueRuntime | null>;
   userCancelledRef: MutableRefObject<boolean>;
   waitingForQueueCancelRef: MutableRefObject<boolean>;
 };
@@ -107,6 +111,7 @@ export function useInterruptHandler(ctx: InterruptHandlerContext) {
     setApprovalResults,
     setAutoDeniedApprovals,
     setAutoHandledResults,
+    setDequeueEpoch,
     setInterruptRequested,
     setIsExecutingTool,
     setPendingApprovals,
@@ -115,9 +120,23 @@ export function useInterruptHandler(ctx: InterruptHandlerContext) {
     streaming,
     toolAbortControllerRef,
     toolResultsInFlightRef,
+    tuiQueueRef,
     userCancelledRef,
     waitingForQueueCancelRef,
   } = ctx;
+
+  // The interrupted turn's finally block settles the interrupt once it has
+  // unwound (cancelling -> idle). If no turn is in flight there is no owner to
+  // do so, so the interrupt settles immediately.
+  const settleIfNoTurnInFlight = () => {
+    if (processingConversationRef.current > 0) return;
+    settleTuiInterrupt({
+      userCancelledRef,
+      setInterruptRequested,
+      queueLength: tuiQueueRef.current?.length ?? 0,
+      bumpDequeueEpoch: () => setDequeueEpoch((e) => e + 1),
+    });
+  };
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: refs are stable objects; .current is read dynamically when interrupt fires.
   const handleInterrupt = useCallback(async () => {
@@ -135,8 +154,9 @@ export function useInterruptHandler(ctx: InterruptHandlerContext) {
 
       // Mark any in-flight conversation as stale, consistent with EAGER_CANCEL.
       // Increment before tagging queued results so they are tied to the post-interrupt state.
+      // The stale turn keeps its processing count and abort controller until its
+      // finally block runs; that block settles the interrupt.
       conversationGenerationRef.current += 1;
-      processingConversationRef.current = 0;
 
       const autoAllowedResults = autoAllowedExecutionRef.current?.results;
       const autoAllowedMetadata = autoAllowedExecutionRef.current
@@ -182,10 +202,9 @@ export function useInterruptHandler(ctx: InterruptHandlerContext) {
         appendError(INTERRUPT_MESSAGE, true);
       }
 
-      if (abortControllerRef.current) {
-        abortControllerRef.current.abort();
-        abortControllerRef.current = null;
-      }
+      // Abort only. The turn's finally block clears the controller so nothing
+      // can dequeue a replacement turn while cancellation unwinds.
+      abortControllerRef.current?.abort();
 
       pendingInterruptRecoveryConversationIdRef.current =
         conversationIdRef.current;
@@ -214,13 +233,7 @@ export function useInterruptHandler(ctx: InterruptHandlerContext) {
           // Silently ignore - cancellation already happened client-side
         });
 
-      // Delay flag reset to ensure React has flushed state updates before dequeue can fire.
-      // Use setTimeout(50) instead of setTimeout(0) - the longer delay ensures React's
-      // batched state updates have been fully processed before we allow the dequeue effect.
-      setTimeout(() => {
-        userCancelledRef.current = false;
-      }, 50);
-
+      settleIfNoTurnInFlight();
       return;
     }
 
@@ -255,11 +268,10 @@ export function useInterruptHandler(ctx: InterruptHandlerContext) {
       // that may never fire.
       interruptSubagentsAndReleaseReflection(agentId);
 
-      // NOW abort the stream - interrupted flag is already set
-      if (abortControllerRef.current) {
-        abortControllerRef.current.abort();
-        abortControllerRef.current = null; // Clear ref so isAgentBusy() returns false
-      }
+      // NOW abort the stream - interrupted flag is already set. The controller
+      // stays set until the turn's finally block clears it: isAgentBusy() must
+      // report busy while the cancelled turn unwinds.
+      abortControllerRef.current?.abort();
 
       // Set cancellation flag to prevent processConversation from starting
       pendingInterruptRecoveryConversationIdRef.current =
@@ -267,12 +279,9 @@ export function useInterruptHandler(ctx: InterruptHandlerContext) {
       userCancelledRef.current = true;
 
       // Increment generation to mark any in-flight processConversation as stale.
-      // The stale processConversation will check this and exit quietly without
-      // decrementing the ref (since we reset it here).
+      // The stale turn keeps its processing count until its finally block runs;
+      // that block settles the interrupt (cancelling -> idle) and wakes dequeue.
       conversationGenerationRef.current += 1;
-
-      // Reset the processing guard so the next message can start a new conversation.
-      processingConversationRef.current = 0;
 
       // Stop streaming and show error message (unless tool calls were cancelled,
       // since the tool result will show "Interrupted by user")
@@ -341,15 +350,7 @@ export function useInterruptHandler(ctx: InterruptHandlerContext) {
           // Silently ignore - cancellation already happened client-side
         });
 
-      // Reset cancellation flags after cleanup is complete.
-      // Use setTimeout(50) instead of setTimeout(0) to ensure React has fully processed
-      // the streaming=false state before we allow the dequeue effect to start a new conversation.
-      // This prevents the "Maximum update depth exceeded" infinite render loop.
-      setTimeout(() => {
-        userCancelledRef.current = false;
-        setInterruptRequested(false);
-      }, 50);
-
+      settleIfNoTurnInFlight();
       return;
     } else {
       setInterruptRequested(true);
@@ -406,11 +407,13 @@ export function useInterruptHandler(ctx: InterruptHandlerContext) {
     setApprovalResults,
     setAutoDeniedApprovals,
     setAutoHandledResults,
+    setDequeueEpoch,
     setInterruptRequested,
     setIsExecutingTool,
     setPendingApprovals,
     setRestoreQueueOnCancel,
     toolResultsInFlightRef,
+    tuiQueueRef,
     userCancelledRef,
   ]);
 

--- a/src/cli/helpers/tui-turn-lifecycle.test.ts
+++ b/src/cli/helpers/tui-turn-lifecycle.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, test } from "bun:test";
+import {
+  finishTuiTurn,
+  settleTuiInterrupt,
+} from "@/cli/helpers/tui-turn-lifecycle";
+
+function harness(overrides?: {
+  processing?: number;
+  queueLength?: number;
+  controller?: AbortController | null;
+}) {
+  const controller =
+    overrides?.controller === undefined
+      ? new AbortController()
+      : overrides.controller;
+  const abortControllerRef = { current: controller };
+  const processingConversationRef = { current: overrides?.processing ?? 1 };
+  const userCancelledRef = { current: true };
+  const interruptRequested: boolean[] = [];
+  let epochBumps = 0;
+  return {
+    controller,
+    abortControllerRef,
+    processingConversationRef,
+    userCancelledRef,
+    interruptRequested,
+    bumps: () => epochBumps,
+    args: {
+      abortControllerRef,
+      processingConversationRef,
+      userCancelledRef,
+      setInterruptRequested: (value: boolean) => {
+        interruptRequested.push(value);
+      },
+      queueLength: () => overrides?.queueLength ?? 1,
+      bumpDequeueEpoch: () => {
+        epochBumps += 1;
+      },
+    },
+  };
+}
+
+describe("settleTuiInterrupt", () => {
+  test("clears the cancel guard and interrupt flag, bumps when work is queued", () => {
+    const userCancelledRef = { current: true };
+    const flags: boolean[] = [];
+    let bumps = 0;
+    settleTuiInterrupt({
+      userCancelledRef,
+      setInterruptRequested: (v) => flags.push(v),
+      queueLength: 2,
+      bumpDequeueEpoch: () => {
+        bumps += 1;
+      },
+    });
+    expect(userCancelledRef.current).toBe(false);
+    expect(flags).toEqual([false]);
+    expect(bumps).toBe(1);
+  });
+
+  test("does not bump the epoch when the queue is empty", () => {
+    const userCancelledRef = { current: true };
+    let bumps = 0;
+    settleTuiInterrupt({
+      userCancelledRef,
+      setInterruptRequested: () => {},
+      queueLength: 0,
+      bumpDequeueEpoch: () => {
+        bumps += 1;
+      },
+    });
+    expect(userCancelledRef.current).toBe(false);
+    expect(bumps).toBe(0);
+  });
+});
+
+describe("finishTuiTurn — normal completion", () => {
+  test("clears its own controller, decrements, and wakes dequeue when queued", () => {
+    const h = harness();
+    finishTuiTurn({
+      ...h.args,
+      isStale: false,
+      turnAbortController: h.controller,
+    });
+    expect(h.abortControllerRef.current).toBeNull();
+    expect(h.processingConversationRef.current).toBe(0);
+    expect(h.bumps()).toBe(1);
+    // Not an interrupt: the cancel guard is left alone.
+    expect(h.userCancelledRef.current).toBe(true);
+    expect(h.interruptRequested).toEqual([]);
+  });
+
+  test("does not bump when nothing is queued", () => {
+    const h = harness({ queueLength: 0 });
+    finishTuiTurn({
+      ...h.args,
+      isStale: false,
+      turnAbortController: h.controller,
+    });
+    expect(h.bumps()).toBe(0);
+  });
+});
+
+describe("finishTuiTurn — interrupted (stale) turn", () => {
+  test("settles the interrupt once the last in-flight call unwinds", () => {
+    const h = harness();
+    finishTuiTurn({
+      ...h.args,
+      isStale: true,
+      turnAbortController: h.controller,
+    });
+    expect(h.abortControllerRef.current).toBeNull();
+    expect(h.processingConversationRef.current).toBe(0);
+    expect(h.userCancelledRef.current).toBe(false);
+    expect(h.interruptRequested).toEqual([false]);
+    expect(h.bumps()).toBe(1);
+  });
+
+  test("a nested stale call does not settle while the outer call is in flight", () => {
+    const h = harness({ processing: 2 });
+    finishTuiTurn({
+      ...h.args,
+      isStale: true,
+      turnAbortController: h.controller,
+    });
+    expect(h.processingConversationRef.current).toBe(1);
+    expect(h.userCancelledRef.current).toBe(true);
+    expect(h.interruptRequested).toEqual([]);
+    expect(h.bumps()).toBe(0);
+  });
+
+  test("a stale turn unwinding late never clears a replacement turn's controller", () => {
+    const replacement = new AbortController();
+    const h = harness({ controller: replacement, processing: 2 });
+    const stale = new AbortController();
+    finishTuiTurn({
+      ...h.args,
+      isStale: true,
+      turnAbortController: stale,
+    });
+    expect(h.abortControllerRef.current).toBe(replacement);
+  });
+
+  test("the processing count never goes negative", () => {
+    const h = harness({ processing: 0, queueLength: 0 });
+    finishTuiTurn({
+      ...h.args,
+      isStale: true,
+      turnAbortController: h.controller,
+    });
+    expect(h.processingConversationRef.current).toBe(0);
+    expect(h.userCancelledRef.current).toBe(false);
+  });
+});

--- a/src/cli/helpers/tui-turn-lifecycle.ts
+++ b/src/cli/helpers/tui-turn-lifecycle.ts
@@ -1,0 +1,74 @@
+/**
+ * Settle a TUI interrupt: the `cancelling -> idle` boundary.
+ *
+ * The TUI mirrors the listener's turn lifecycle with refs instead of a state
+ * machine. `userCancelledRef` plays the role of the listener's `cancelling`
+ * state: it blocks the dequeue effect while an interrupted turn unwinds. The
+ * owner of that turn (the `finally` block of processConversation) calls this
+ * once the last in-flight call has finished, the same way the listener pumps
+ * its queue when a lease completes `cancelling -> idle`.
+ *
+ * Clearing a ref does not re-run the dequeue effect, so the epoch is bumped
+ * whenever work is still queued.
+ */
+export function settleTuiInterrupt(args: {
+  userCancelledRef: { current: boolean };
+  setInterruptRequested: (value: boolean) => void;
+  queueLength: number;
+  bumpDequeueEpoch: () => void;
+}): void {
+  args.userCancelledRef.current = false;
+  args.setInterruptRequested(false);
+  if (args.queueLength > 0) {
+    args.bumpDequeueEpoch();
+  }
+}
+
+export type TuiTurnFinishArgs = {
+  /** True when an ESC interrupt bumped the generation past this turn's. */
+  isStale: boolean;
+  /** The controller this turn created, or null if it never got that far. */
+  turnAbortController: AbortController | null;
+  abortControllerRef: { current: AbortController | null };
+  processingConversationRef: { current: number };
+  userCancelledRef: { current: boolean };
+  setInterruptRequested: (value: boolean) => void;
+  queueLength: () => number;
+  bumpDequeueEpoch: () => void;
+};
+
+/**
+ * Finalize one processConversation call. TUI analogue of the listener's
+ * finishListenerTurn(): clears only this turn's controller, decrements the
+ * processing count, then either wakes the dequeue effect (normal completion)
+ * or settles the interrupt (stale turn, `cancelling -> idle`) once the last
+ * nested call has unwound. A stale turn unwinding late never clears the
+ * controller of the turn that replaced it.
+ */
+export function finishTuiTurn(args: TuiTurnFinishArgs): void {
+  if (args.abortControllerRef.current === args.turnAbortController) {
+    args.abortControllerRef.current = null;
+  }
+  // Decrement BEFORE bumping the epoch: the dequeue effect can fire
+  // synchronously (Ink legacy mode) and its defer gate checks === 0.
+  args.processingConversationRef.current = Math.max(
+    0,
+    args.processingConversationRef.current - 1,
+  );
+  if (!args.isStale) {
+    // The dequeue effect gates on abortControllerRef (a ref, not state), so
+    // it needs an explicit re-trigger now that this turn is done.
+    if (args.queueLength() > 0) {
+      args.bumpDequeueEpoch();
+    }
+    return;
+  }
+  if (args.processingConversationRef.current === 0) {
+    settleTuiInterrupt({
+      userCancelledRef: args.userCancelledRef,
+      setInterruptRequested: args.setInterruptRequested,
+      queueLength: args.queueLength(),
+      bumpDequeueEpoch: args.bumpDequeueEpoch,
+    });
+  }
+}

--- a/src/cli/subcommands/teleport.test.ts
+++ b/src/cli/subcommands/teleport.test.ts
@@ -1,7 +1,12 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import type { apiRequest } from "@/backend/api/request";
 import { ApiRequestError } from "@/backend/api/request";
-import { __testOverrideLoadRoutes, loadRoutes } from "@/channels/routing";
+import { getSupportedChannelIds } from "@/channels/plugin-registry";
+import {
+  __testOverrideLoadRoutes,
+  clearAllRoutes,
+  loadRoutes,
+} from "@/channels/routing";
 import {
   formatTeleportApiError,
   resolveTeleportSession,
@@ -12,6 +17,14 @@ const CLOUD_ENV = {
   LETTA_AGENT_ID: "agent-1",
   LETTA_CONVERSATION_ID: "conv-1",
 };
+
+function resetTeleportRouteState(): void {
+  __testOverrideLoadRoutes(() => []);
+  for (const channelId of getSupportedChannelIds()) {
+    loadRoutes(channelId);
+  }
+  clearAllRoutes();
+}
 
 async function withEnvironment<T>(
   values: Record<string, string | undefined>,
@@ -59,6 +72,15 @@ function captureOutput(): {
 }
 
 describe("teleport subcommand", () => {
+  beforeEach(() => {
+    resetTeleportRouteState();
+  });
+
+  afterEach(() => {
+    resetTeleportRouteState();
+    __testOverrideLoadRoutes(null);
+  });
+
   test("prints help and returns 0", async () => {
     const out = captureOutput();
     try {

--- a/src/cli/tui-interrupt-queue-lifecycle.test.tsx
+++ b/src/cli/tui-interrupt-queue-lifecycle.test.tsx
@@ -1,0 +1,285 @@
+/**
+ * Regression tests for the TUI interrupt -> queue handoff (issue #4168).
+ *
+ * A Monitor `task_notification` queued while a turn is active must start the
+ * next turn on its own once an Esc cancellation has settled. The interrupted
+ * turn's finally block owns that `cancelling -> idle` transition and wakes the
+ * dequeue effect; no timer or later user prompt may be required.
+ *
+ * The typed-prompt case matters: a turn started from the queue bridge is woken
+ * by the dequeue effect's own completion callback, which masked the bug. A
+ * turn started by typing has no such callback.
+ */
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Readable, Writable } from "node:stream";
+import type { Stream } from "@letta-ai/letta-client/core/streaming";
+import type { LettaStreamingResponse } from "@letta-ai/letta-client/resources/agents/messages";
+import { type Instance, render } from "ink";
+import { __testSetBackend } from "@/backend";
+import {
+  type BackendMode,
+  resolveBackendMode,
+  setConfiguredBackendMode,
+} from "@/backend/backend-mode";
+import { FakeHeadlessBackend } from "@/backend/dev/fake-headless-backend";
+import {
+  createAssistantMessageStream,
+  type HeadlessTurnExecutor,
+  type HeadlessTurnExecutorInput,
+} from "@/backend/dev/headless-turn-executor";
+import { App } from "@/cli/App";
+import { settingsManager } from "@/settings-manager";
+import {
+  addToMessageQueue,
+  clearPendingMessages,
+  isQueueBridgeConnected,
+  setMessageQueueAdder,
+} from "@/utils/message-queue-bridge";
+import { formatTaskNotification } from "@/utils/task-notifications";
+
+class TuiOutputStream extends Writable {
+  columns = 100;
+  rows = 30;
+  isTTY = true;
+
+  override _write(
+    _chunk: Buffer | string,
+    _encoding: BufferEncoding,
+    callback: (error?: Error | null) => void,
+  ) {
+    callback();
+  }
+}
+
+function createInputStream(): NodeJS.ReadStream {
+  const input = new Readable({ read() {} }) as NodeJS.ReadStream;
+  input.isTTY = true;
+  input.setRawMode = () => input;
+  input.ref = () => input;
+  input.unref = () => input;
+  return input;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function waitFor(
+  predicate: () => boolean,
+  description: string,
+  timeoutMs = 5000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!predicate() && Date.now() < deadline) {
+    await sleep(10);
+  }
+  if (!predicate()) {
+    throw new Error(`Timed out waiting for ${description}`);
+  }
+}
+
+function monitorNotification(summary: string): string {
+  return formatTaskNotification({
+    taskId: "monitor-test",
+    status: "completed",
+    summary,
+    result: "done",
+    outputFile: "/tmp/monitor-test.log",
+  });
+}
+
+/**
+ * First turn: a stream that yields nothing until aborted, then ends only when
+ * the test releases it (so the test controls when cancellation settles).
+ * Every later turn: an immediate assistant reply.
+ */
+class DelayedInterruptExecutor implements HeadlessTurnExecutor {
+  readonly inputs: HeadlessTurnExecutorInput[] = [];
+  private releaseInterruptedTurn: (() => void) | null = null;
+  private readonly interruptedTurnReleased = new Promise<void>((resolve) => {
+    this.releaseInterruptedTurn = resolve;
+  });
+  private resolveAbortObserved: (() => void) | null = null;
+  readonly abortObserved = new Promise<void>((resolve) => {
+    this.resolveAbortObserved = resolve;
+  });
+
+  async execute(input: HeadlessTurnExecutorInput) {
+    this.inputs.push(input);
+    if (this.inputs.length > 1) {
+      return createAssistantMessageStream();
+    }
+
+    const controller = new AbortController();
+    const abortObserved = this.resolveAbortObserved;
+    const interruptedTurnReleased = this.interruptedTurnReleased;
+    return {
+      controller,
+      async *[Symbol.asyncIterator]() {
+        if (!controller.signal.aborted) {
+          await new Promise<void>((resolve) => {
+            controller.signal.addEventListener("abort", () => resolve(), {
+              once: true,
+            });
+          });
+        }
+        abortObserved?.();
+        await interruptedTurnReleased;
+      },
+    } as unknown as Stream<LettaStreamingResponse>;
+  }
+
+  settleInterruptedTurn(): void {
+    this.releaseInterruptedTurn?.();
+    this.releaseInterruptedTurn = null;
+  }
+}
+
+const renderedInstances = new Set<Instance>();
+let previousBackendMode: BackendMode;
+let previousHome: string | undefined;
+let tempHome: string;
+
+beforeEach(async () => {
+  previousBackendMode = resolveBackendMode();
+  setConfiguredBackendMode("local");
+  clearPendingMessages();
+  previousHome = process.env.HOME;
+  tempHome = mkdtempSync(join(tmpdir(), "letta-tui-interrupt-"));
+  process.env.HOME = tempHome;
+  await settingsManager.reset();
+  await settingsManager.initialize();
+});
+
+afterEach(async () => {
+  for (const instance of renderedInstances) {
+    instance.unmount();
+    instance.cleanup();
+  }
+  renderedInstances.clear();
+  setMessageQueueAdder(null);
+  clearPendingMessages();
+  __testSetBackend(null);
+  setConfiguredBackendMode(previousBackendMode);
+  await settingsManager.reset();
+  if (previousHome === undefined) {
+    delete process.env.HOME;
+  } else {
+    process.env.HOME = previousHome;
+  }
+  rmSync(tempHome, { recursive: true, force: true });
+});
+
+async function renderTestApp(executor: HeadlessTurnExecutor): Promise<{
+  backend: FakeHeadlessBackend;
+  stdin: NodeJS.ReadStream;
+}> {
+  const agentId = "agent-tui-interrupt-queue";
+  const backend = new FakeHeadlessBackend(agentId, executor);
+  __testSetBackend(backend);
+  const agentState = await backend.retrieveAgent(agentId);
+  const conversation = await backend.createConversation({ agent_id: agentId });
+  const stdin = createInputStream();
+  const stdout = new TuiOutputStream() as TuiOutputStream & NodeJS.WriteStream;
+  const instance = render(
+    <App
+      agentId={agentId}
+      agentState={agentState}
+      conversationId={conversation.id}
+      modsDisabled
+      systemInfoReminderEnabled={false}
+    />,
+    {
+      stdout,
+      stdin,
+      debug: true,
+      patchConsole: false,
+      exitOnCtrlC: false,
+    },
+  );
+  renderedInstances.add(instance);
+  await waitFor(isQueueBridgeConnected, "the TUI queue bridge to mount");
+  return { backend, stdin };
+}
+
+async function typePrompt(stdin: NodeJS.ReadStream, text: string) {
+  // Give the input component a moment to mount before typing.
+  await sleep(200);
+  stdin.push(text);
+  await sleep(50);
+  stdin.push("\r");
+}
+
+describe("TUI interrupt queue lifecycle", () => {
+  test("an idle Monitor notification starts an agent turn without user input", async () => {
+    const executor = new DelayedInterruptExecutor();
+    await renderTestApp(executor);
+
+    addToMessageQueue({
+      kind: "task_notification",
+      text: monitorNotification("idle monitor completion"),
+    });
+
+    await waitFor(() => executor.inputs.length === 1, "the notification turn");
+    expect(JSON.stringify(executor.inputs[0]?.body)).toContain(
+      "idle monitor completion",
+    );
+    executor.settleInterruptedTurn();
+  });
+
+  test("typed prompt, notification queued, Esc: the notification drains once cancellation settles", async () => {
+    const executor = new DelayedInterruptExecutor();
+    const { stdin } = await renderTestApp(executor);
+
+    await typePrompt(stdin, "start turn");
+    await waitFor(() => executor.inputs.length === 1, "the typed initial turn");
+
+    addToMessageQueue({
+      kind: "task_notification",
+      text: monitorNotification("queued before Esc"),
+    });
+    stdin.push("\u001b");
+    await executor.abortObserved;
+
+    // Cancellation has not settled yet: nothing may start a replacement turn.
+    await sleep(100);
+    expect(executor.inputs).toHaveLength(1);
+
+    executor.settleInterruptedTurn();
+    await waitFor(
+      () => executor.inputs.length === 2,
+      "the queued notification turn after cancellation settled",
+    );
+    expect(JSON.stringify(executor.inputs[1]?.body)).toContain(
+      "queued before Esc",
+    );
+  }, 15_000);
+
+  test("typed prompt, Esc, then a notification that arrives after cancellation settled", async () => {
+    const executor = new DelayedInterruptExecutor();
+    const { stdin } = await renderTestApp(executor);
+
+    await typePrompt(stdin, "start turn");
+    await waitFor(() => executor.inputs.length === 1, "the typed initial turn");
+
+    stdin.push("\u001b");
+    await executor.abortObserved;
+    executor.settleInterruptedTurn();
+    await sleep(200);
+
+    addToMessageQueue({
+      kind: "task_notification",
+      text: monitorNotification("arrived after Esc"),
+    });
+    await waitFor(
+      () => executor.inputs.length === 2,
+      "the notification turn after an already-settled Esc",
+    );
+    expect(JSON.stringify(executor.inputs[1]?.body)).toContain(
+      "arrived after Esc",
+    );
+  }, 15_000);
+});


### PR DESCRIPTION
## Summary

Monitor notifications queued during a TUI turn must wake the agent after an Esc interruption finishes. Previously, Esc cleared the cancellation guard in a 50 ms timer, while the interrupted turn skipped waking the queue. Notifications could remain queued until the user typed another prompt.

The interrupted turn now keeps its processing count and abort controller until its `finally` block runs. That cleanup clears only its own controller, settles the interruption once outstanding calls have unwound, and wakes the queue. If there is no turn in flight, the interrupt handler settles immediately.

This also makes queued user messages drain after Esc. The stacked follow-up [#4213](https://github.com/letta-ai/letta-code/pull/4213) adds explicit pause/resume for user messages while allowing notifications through.

## Testing

Rebased onto current main and repeated the regression in a Linux sandbox. The Ink test mounts the production TUI with a fake backend, types the first prompt, queues a Monitor notification, presses Esc, and holds cancellation open. It verifies that no replacement turn starts before cancellation settles and that the notification starts afterward without user input.

The same test fails on main at `62b0fde47efc54fde4e3f6bf4b713c335bd482b5` with `Timed out waiting for the queued notification turn after cancellation settled` and passes on this branch.

Also exercised the production TUI with an isolated local agent and OpenAI GPT-5 Mini. A real Monitor emits an event while a blocking shell command runs; Esc interrupts the shell. Before, no notification appears during the following 12 seconds. After, the Monitor notifications arrive and the agent responds without another prompt. These recordings use a dark terminal theme and make no light-theme rendering claim.

## Visual proof

Production TUI recordings, same agent/model/prompt and fresh conversations. Click either poster to play the continuous recording.

| Before | After |
| --- | --- |
| [![Before: event stays undelivered](https://chat.letta.com/artifacts/cd7791b5-ea37-48f8-89ec-5b0b1e7f93a7)](https://chat.letta.com/artifacts/236183ac-4786-406f-b25a-3fddb146362c.mp4) | [![After: queued event resumes after Esc](https://chat.letta.com/artifacts/55c763d0-e406-48fa-b3d2-70f4aa989cd5)](https://chat.letta.com/artifacts/37521cfc-72f4-45c5-ae85-ba3a02b95712.mp4) |

## Breadcrumbs

- Fixes [#4168](https://github.com/letta-ai/letta-code/issues/4168), including the original reproduction and cancellation-guard diagnosis.
- Origin: the issue documents existing Esc behavior that holds queued messages; autonomous Monitor notifications expose that behavior. No single introducing change is established here.
- Original implementation: Claude Code; [implementation session](https://claude.ai/code/session_01UAnjNvh53FXWiS6bf143Ef).
- Follow-up: [#4213](https://github.com/letta-ai/letta-code/pull/4213) separates user-message pause from notification delivery.
- Rebase and verification: [`conv-8ca6ea46-fdb4-4a09-86ac-b720362dfd2f`](https://chat.letta.com/chat/agent-b86b0d3a-c425-4c88-86b9-44171f178713?conversation=conv-8ca6ea46-fdb4-4a09-86ac-b720362dfd2f).
