### PR TITLE
fix(agent): scope ChatGPT plan rotation to active turn

### DIFF
--- a/src/agent/chatgpt-plan-rotation.test.ts
+++ b/src/agent/chatgpt-plan-rotation.test.ts
@@ -1,12 +1,133 @@
 import { describe, expect, test } from "bun:test";
-import { formatPlanRotationNotice } from "@/agent/chatgpt-plan-rotation";
+import { clearAvailableModelsCache } from "@/agent/available-models";
+import {
+  formatPlanRotationNotice,
+  rotateChatGPTPlanOnQuotaLimit,
+} from "@/agent/chatgpt-plan-rotation";
 import {
   parseChatGPTUsageLimitDetail,
   selectChatGPTQuotaFailoverHandle,
 } from "@/agent/turn-recovery-policy";
+import { __testSetBackend } from "@/backend";
 
 const FULL_DETAIL =
   'ChatGPT rate limit exceeded: {"error":{"type":"usage_limit_reached","message":"You have hit your usage limit.","plan_type":"plus","resets_at":1700000000,"resets_in_seconds":3600}}';
+
+const PRIMARY_HANDLE = "chatgpt-caren/gpt-5.2";
+const SIBLING_HANDLE = "chatgpt-jin/gpt-5.2";
+
+describe("rotateChatGPTPlanOnQuotaLimit", () => {
+  test("updates only the active conversation and keeps exhausted plans turn-local", async () => {
+    const agent = { id: "agent-rotation", model: PRIMARY_HANDLE };
+    const conversations = new Map([
+      ["conv-first", { id: "conv-first", model: PRIMARY_HANDLE }],
+      ["conv-second", { id: "conv-second", model: PRIMARY_HANDLE }],
+    ]);
+    let agentUpdateCount = 0;
+    const backend = {
+      capabilities: { localModelCatalog: false },
+      async listModels() {
+        return [
+          {
+            handle: PRIMARY_HANDLE,
+            provider_type: "chatgpt_oauth",
+            provider_category: "byok",
+            max_context_window: 128_000,
+          },
+          {
+            handle: SIBLING_HANDLE,
+            provider_type: "chatgpt_oauth",
+            provider_category: "byok",
+            max_context_window: 128_000,
+          },
+        ];
+      },
+      async retrieveAgent() {
+        return agent;
+      },
+      async updateAgent(_agentId: string, update: { model?: string }) {
+        agentUpdateCount += 1;
+        Object.assign(agent, update);
+        return agent;
+      },
+      async retrieveConversation(conversationId: string) {
+        return conversations.get(conversationId);
+      },
+      async updateConversation(
+        conversationId: string,
+        update: { model?: string },
+      ) {
+        const conversation = conversations.get(conversationId);
+        if (!conversation) throw new Error("conversation not found");
+        Object.assign(conversation, update);
+        return conversation;
+      },
+    };
+    __testSetBackend(backend as never);
+    clearAvailableModelsCache();
+
+    try {
+      const firstTurnExhausted = new Set<string>();
+      const secondTurnExhausted = new Set<string>();
+
+      const firstRotation = await rotateChatGPTPlanOnQuotaLimit({
+        agentId: "agent-rotation",
+        conversationId: "conv-first",
+        currentHandle: null,
+        error: { error_code: "usage_limit_reached" },
+        exhaustedProviders: firstTurnExhausted,
+      });
+
+      expect(firstRotation?.toHandle).toBe(SIBLING_HANDLE);
+      expect(conversations.get("conv-first")?.model).toBe(SIBLING_HANDLE);
+      expect(conversations.get("conv-second")?.model).toBe(PRIMARY_HANDLE);
+      expect(agent.model).toBe(PRIMARY_HANDLE);
+      expect(agentUpdateCount).toBe(0);
+      expect(firstTurnExhausted).toEqual(new Set(["chatgpt-caren"]));
+      expect(secondTurnExhausted.size).toBe(0);
+
+      const repeatedRotation = await rotateChatGPTPlanOnQuotaLimit({
+        agentId: "agent-rotation",
+        conversationId: "conv-first",
+        // Simulate the TUI's render-time handle still naming the first plan.
+        currentHandle: PRIMARY_HANDLE,
+        error: { error_code: "usage_limit_reached" },
+        exhaustedProviders: firstTurnExhausted,
+      });
+
+      expect(repeatedRotation).toBeNull();
+      expect(firstTurnExhausted).toEqual(
+        new Set(["chatgpt-caren", "chatgpt-jin"]),
+      );
+
+      const secondRotation = await rotateChatGPTPlanOnQuotaLimit({
+        agentId: "agent-rotation",
+        conversationId: "conv-second",
+        currentHandle: null,
+        error: { error_code: "usage_limit_reached" },
+        exhaustedProviders: secondTurnExhausted,
+      });
+
+      expect(secondRotation?.toHandle).toBe(SIBLING_HANDLE);
+      expect(secondTurnExhausted).toEqual(new Set(["chatgpt-caren"]));
+
+      const defaultRotation = await rotateChatGPTPlanOnQuotaLimit({
+        agentId: "agent-rotation",
+        conversationId: "default",
+        currentHandle: null,
+        error: { error_code: "usage_limit_reached" },
+        exhaustedProviders: new Set(),
+      });
+
+      expect(defaultRotation?.toHandle).toBe(SIBLING_HANDLE);
+      expect(agent.model).toBe(SIBLING_HANDLE);
+      expect(agentUpdateCount).toBe(1);
+    } finally {
+      clearAvailableModelsCache();
+      __testSetBackend(null);
+    }
+  });
+});
 
 describe("parseChatGPTUsageLimitDetail", () => {
   test("returns null for non-strings and non-matching details", () => {

--- a/src/agent/chatgpt-plan-rotation.ts
+++ b/src/agent/chatgpt-plan-rotation.ts
@@ -1,11 +1,11 @@
 /**
- * Session-local rotation between connected ChatGPT (chatgpt_oauth BYOK)
+ * Turn-local rotation between connected ChatGPT (chatgpt_oauth BYOK)
  * plans when one hits its usage limit. Orgs register multiple ChatGPT plans
  * as separate BYOK providers (e.g. `chatgpt-caren`, `chatgpt-jin`) exposing
  * the same models; when a plan reports `usage_limit_reached` the consumers
  * (TUI / listener / headless) call `rotateChatGPTPlanOnQuotaLimit` from
- * their post-stop retry handling to swap the agent onto a sibling plan and
- * resend. No swap-back; quota errors only (no auth failover).
+ * their post-stop retry handling to swap the active conversation onto a
+ * sibling plan and resend. No swap-back; quota errors only (no auth failover).
  */
 
 import {
@@ -13,7 +13,10 @@ import {
   getCachedAvailableModels,
 } from "@/agent/available-models";
 import { resolveModelHandleFromLlmConfig } from "@/agent/model-handles";
-import { updateAgentLLMConfig } from "@/agent/modify";
+import {
+  updateAgentLLMConfig,
+  updateConversationLLMConfig,
+} from "@/agent/modify";
 import {
   parseChatGPTUsageLimitDetail,
   selectChatGPTQuotaFailoverHandle,
@@ -22,14 +25,6 @@ import { getBackend } from "@/backend";
 
 /** Maximum plan swaps per turn, enforced by each consumer. */
 export const CHATGPT_PLAN_ROTATION_MAX_SWAPS_PER_TURN = 3;
-
-// Providers whose plans hit a usage limit during this process lifetime.
-// Session-local by design: limits reset over time between sessions.
-const exhaustedProviders = new Set<string>();
-
-export function resetChatGPTPlanRotationStateForTests(): void {
-  exhaustedProviders.clear();
-}
 
 export interface ChatGPTPlanRotationResult {
   fromProvider: string;
@@ -58,10 +53,25 @@ function isChatGPTByokHandleInModels(
   );
 }
 
-async function resolveAgentModelHandle(
+async function resolveScopedModelHandle(
   agentId: string,
+  conversationId: string,
 ): Promise<string | null> {
   try {
+    if (conversationId !== "default") {
+      const conversation =
+        await getBackend().retrieveConversation(conversationId);
+      const conversationRecord = conversation as unknown as {
+        model?: unknown;
+      };
+      if (
+        typeof conversationRecord.model === "string" &&
+        conversationRecord.model.length > 0
+      ) {
+        return conversationRecord.model;
+      }
+    }
+
     const agent = await getBackend().retrieveAgent(agentId);
     const record = agent as unknown as {
       model?: unknown;
@@ -81,17 +91,21 @@ async function resolveAgentModelHandle(
 }
 
 /**
- * Attempt to rotate the agent to the same model on a sibling ChatGPT plan.
+ * Attempt to rotate the active conversation to the same model on a sibling
+ * ChatGPT plan. The default conversation still uses the agent's base model,
+ * matching the scope rules used by `/model`.
  * Returns null when the detail is not a usage-limit error, the current
  * handle is not a ChatGPT BYOK handle, no eligible sibling exists, or the
  * model update fails; callers fall through to existing error handling.
  */
 export async function rotateChatGPTPlanOnQuotaLimit(params: {
   agentId: string;
+  conversationId: string;
   currentHandle: string | null;
   error: unknown;
+  exhaustedProviders: Set<string>;
 }): Promise<ChatGPTPlanRotationResult | null> {
-  const { agentId, error } = params;
+  const { agentId, conversationId, error, exhaustedProviders } = params;
 
   const parsedDetail = parseChatGPTUsageLimitDetail(error);
   if (!parsedDetail) return null;
@@ -107,12 +121,12 @@ export async function rotateChatGPTPlanOnQuotaLimit(params: {
   }
   if (!models) return null;
 
-  // The caller-supplied handle may be a registry model id rather than the
-  // agent's BYOK handle; fall back to the agent's own model when it does not
-  // resolve to a ChatGPT BYOK entry in the models list.
-  let currentHandle = params.currentHandle;
+  // Prefer persisted scoped state because a caller's render-time model handle
+  // can be stale after an automatic swap. Fall back to the caller only when
+  // the scoped model cannot be resolved to a ChatGPT BYOK catalog entry.
+  let currentHandle = await resolveScopedModelHandle(agentId, conversationId);
   if (!currentHandle || !isChatGPTByokHandleInModels(currentHandle, models)) {
-    currentHandle = await resolveAgentModelHandle(agentId);
+    currentHandle = params.currentHandle;
   }
   if (!currentHandle || !isChatGPTByokHandleInModels(currentHandle, models)) {
     return null;
@@ -135,9 +149,15 @@ export async function rotateChatGPTPlanOnQuotaLimit(params: {
   if (!toProvider) return null;
 
   try {
-    await updateAgentLLMConfig(agentId, toHandle, {
-      provider_type: "chatgpt_oauth",
-    });
+    if (conversationId === "default") {
+      await updateAgentLLMConfig(agentId, toHandle, {
+        provider_type: "chatgpt_oauth",
+      });
+    } else {
+      await updateConversationLLMConfig(conversationId, toHandle, {
+        provider_type: "chatgpt_oauth",
+      });
+    }
   } catch {
     return null;
   }

--- a/src/cli/app/AppCoordinator.tsx
+++ b/src/cli/app/AppCoordinator.tsx
@@ -1398,9 +1398,8 @@ export function App({
   const llmApiErrorRetriesRef = useRef(0);
   const quotaAutoSwapAttemptedRef = useRef(false);
   const emptyResponseRetriesRef = useRef(0);
-  // Per-turn ChatGPT plan rotation counter (max swaps per turn)
   const chatgptPlanSwapsRef = useRef(0);
-
+  const chatgptExhaustedProvidersRef = useRef(new Set<string>());
   // Retry counter for 409 "conversation busy" errors
   const conversationBusyRetriesRef = useRef(0);
 
@@ -3767,6 +3766,7 @@ export function App({
     buffersRef,
     clearApprovalToolContext,
     chatgptPlanSwapsRef,
+    chatgptExhaustedProvidersRef,
     closeTrajectorySegment,
     consumeQueuedMessages,
     queueModeRef,

--- a/src/cli/app/use-conversation-loop.ts
+++ b/src/cli/app/use-conversation-loop.ts
@@ -196,6 +196,7 @@ type ConversationLoopContext = {
   queueModeRef: MutableRefObject<"immediate" | "defer">;
   contextTrackerRef: MutableRefObject<ContextTracker>;
   chatgptPlanSwapsRef: MutableRefObject<number>;
+  chatgptExhaustedProvidersRef: MutableRefObject<Set<string>>;
   conversationBusyRetriesRef: MutableRefObject<number>;
   conversationGenerationRef: MutableRefObject<number>;
   conversationIdRef: MutableRefObject<string>;
@@ -293,6 +294,7 @@ export function useConversationLoop(ctx: ConversationLoopContext) {
     clearApprovalToolContext,
     closeTrajectorySegment,
     chatgptPlanSwapsRef,
+    chatgptExhaustedProvidersRef,
     consumeQueuedMessages,
     queueModeRef,
     contextTrackerRef,
@@ -605,6 +607,7 @@ export function useConversationLoop(ctx: ConversationLoopContext) {
         conversationBusyRetriesRef.current = 0;
         quotaAutoSwapAttemptedRef.current = false;
         chatgptPlanSwapsRef.current = 0;
+        chatgptExhaustedProvidersRef.current.clear();
       }
 
       // Track last run ID for error reporting (accessible in catch block)
@@ -2368,18 +2371,16 @@ export function useConversationLoop(ctx: ConversationLoopContext) {
             continue;
           }
 
-          // ChatGPT plan rotation: when a chatgpt_oauth BYOK plan hits its
-          // usage limit, swap the agent to the same model on a sibling
-          // connected ChatGPT plan and resend. Takes precedence over the
-          // letta/auto quota fallback below.
           if (
             chatgptPlanSwapsRef.current <
             CHATGPT_PLAN_ROTATION_MAX_SWAPS_PER_TURN
           ) {
             const rotation = await rotateChatGPTPlanOnQuotaLimit({
               agentId: agentIdRef.current,
+              conversationId: conversationIdRef.current,
               currentHandle: currentModelId,
               error: runErrorInfo ?? detailFromRun ?? fallbackError,
+              exhaustedProviders: chatgptExhaustedProvidersRef.current,
             });
             if (rotation) {
               chatgptPlanSwapsRef.current += 1;
@@ -2397,8 +2398,7 @@ export function useConversationLoop(ctx: ConversationLoopContext) {
               buffersRef.current.interrupted = false;
               continue;
             }
-            // No sibling plan available — fall through to the letta/auto
-            // quota fallback below.
+            // No sibling plan available; try the hosted Auto fallback below.
           }
 
           // Quota-limit fallback: hosted Letta API can recover by switching to

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -2316,14 +2316,13 @@ ${SYSTEM_REMINDER_CLOSE}
     currentInput = initialTurnStartEmission.input;
   }
 
-  // Track lastRunId outside the while loop so it's available in catch block
   let llmApiErrorRetries = 0;
   let emptyResponseRetries = 0;
   let conversationBusyRetries = 0;
   let chatgptPlanSwaps = 0;
+  const chatgptExhaustedProviders = new Set<string>();
   markMilestone("HEADLESS_FIRST_STREAM_START");
   measureSinceMilestone("headless-setup-total", "HEADLESS_CLIENT_READY");
-
   // Helper to check max turns limit using server-side step count from buffers
   const checkMaxTurns = async (): Promise<void> => {
     if (maxTurns !== undefined && buffers.usage.stepCount >= maxTurns) {
@@ -2717,6 +2716,7 @@ ${SYSTEM_REMINDER_CLOSE}
         emptyResponseRetries = 0;
         conversationBusyRetries = 0;
         chatgptPlanSwaps = 0;
+        chatgptExhaustedProviders.clear();
 
         // Emit turn_end. A mod may return { continue: "..." } to append a
         // follow-up user message and run another turn. Auto-continues re-enter
@@ -2877,13 +2877,13 @@ ${SYSTEM_REMINDER_CLOSE}
       const runErrorInfo = await fetchRunErrorInfo(lastRunId),
         detailFromRun = runErrorInfo?.detail ?? runErrorInfo?.message;
 
-      // ChatGPT plan rotation: when a chatgpt_oauth BYOK plan hits its usage
-      // limit, swap to the same model on a sibling ChatGPT plan and resend.
       if (chatgptPlanSwaps < CHATGPT_PLAN_ROTATION_MAX_SWAPS_PER_TURN) {
         const rotation = await rotateChatGPTPlanOnQuotaLimit({
           agentId: agent.id,
+          conversationId,
           currentHandle: null,
           error: runErrorInfo ?? detailFromRun ?? latestErrorText,
+          exhaustedProviders: chatgptExhaustedProviders,
         });
         if (rotation) {
           chatgptPlanSwaps += 1;

--- a/src/websocket/listener/turn.ts
+++ b/src/websocket/listener/turn.ts
@@ -109,7 +109,6 @@ export async function handleIncomingMessage(
   existingTurnLease?: TurnLease,
   existingTurnCorrelation?: TurnCorrelation,
 ): Promise<void> {
-  // Notify OTID-keyed observers around the complete turn.
   notifyTurnStarted(msg);
   try {
     await handleIncomingMessageInner(
@@ -149,19 +148,18 @@ async function handleIncomingMessageInner(
     agentId,
     conversationId,
   );
-
   const turnPermissionModeState = getOrCreateConversationPermissionModeStateRef(
     runtime.listener,
     agentId,
     conversationId,
   );
-
   let postStopApprovalRecoveryRetries = 0,
     llmApiErrorRetries = 0,
     emptyResponseRetries = 0,
     chatgptPlanSwaps = 0,
     lastApprovalContinuationAccepted = false,
     activeDequeuedBatchId = dequeuedBatchId;
+  const chatgptExhaustedProviders = new Set<string>();
   const turnCorrelation =
     existingTurnCorrelation ??
     createTurnCorrelation(runtime, msg, activeDequeuedBatchId);
@@ -663,8 +661,10 @@ async function handleIncomingMessageInner(
         ) {
           const rotation = await rotateChatGPTPlanOnQuotaLimit({
             agentId,
+            conversationId,
             currentHandle: null,
             error: quotaError,
+            exhaustedProviders: chatgptExhaustedProviders,
           });
           if (rotation) {
             chatgptPlanSwaps += 1;


### PR DESCRIPTION
## Summary

ChatGPT plan rotation now follows the same model-scoping rules as `/model`: a named conversation updates only its own model override, while the virtual `default` conversation continues to update the agent model. The previous implementation always updated the agent, so a retry in a named conversation could stay on the exhausted conversation override while changing the default inherited by other conversations.

Exhausted providers now live with each frontend's per-turn retry state instead of a process-global singleton. Rotation also resolves the persisted scoped model before using a caller's cached handle, preventing a second quota failure from rotating back to a plan already exhausted during the same turn.

## Verification

- `bun test src/agent/chatgpt-plan-rotation.test.ts src/agent/turn-recovery-policy.test.ts` — 85 passed
- `bun run check` — all 12 checks passed
- `bun run build && node letta.js --version` — packaged Node build completed and reported 0.31.11
- Live Cloud headless smoke test — a fresh named conversation started on an exhausted ChatGPT OAuth plan, rotated through two quota responses, and completed successfully on a third connected plan

## Breadcrumbs

- Letta conversation: [`conv-a0fdf0fd-a65b-46e5-ad90-ff58fe67de45`](https://chat.letta.com/chat/agent-19babcc0-e958-41b0-81d8-00107f71deb7?conversation=conv-a0fdf0fd-a65b-46e5-ad90-ff58fe67de45)
- Origin: Introduced by [#3911](https://github.com/letta-ai/letta-code/pull/3911), which added automatic quota rotation using the agent-scoped model update path and process-global exhausted-provider state
- Related: Follow-up to [#3990](https://github.com/letta-ai/letta-code/pull/3990), which preserved structured quota errors for rotation

## AI Disclosure

- [ ] This pull request was written entirely by a human
- [ ] This pull request was written with AI assistance and reviewed and edited by a human
- [x] I have read the [AI Policy](https://github.com/letta-ai/letta-code/blob/main/AI_POLICY.md) and agree to its terms

## AI Tool(s) Used

Letta Code (Titan) investigated the failure, implemented the fix, and ran verification under Charles Packer's direction.

## Human Verification

Pending maintainer review.
