### PR TITLE
feat(slack): expose workspace custom emoji discovery

### DIFF
--- a/src/channels/README.md
+++ b/src/channels/README.md
@@ -244,6 +244,7 @@ oauth_config:
       - channels:history
       - chat:write
       - commands
+      - emoji:read
       - files:read
       - files:write
       - groups:history

--- a/src/channels/message-channel-gateway.test.ts
+++ b/src/channels/message-channel-gateway.test.ts
@@ -13,6 +13,44 @@ function createSlackActions() {
 }
 
 describe("external MessageChannel gateway boundary", () => {
+  test("discovers Slack custom emoji through a host-owned transport", async () => {
+    const listCustomEmojis = mock(async () => ["blob_wave", "party_parrot"]);
+    const actions = createSlackMessageActionAdapter({
+      react: true,
+      listCustomEmojis: true,
+    });
+    const result = await actions.handleAction({
+      request: {
+        action: "list-custom-emojis",
+        channel: "slack",
+        chatId: "C123",
+      },
+      route: {
+        accountId: "generated-app-1",
+        chatId: "C123",
+        chatType: "channel",
+        threadId: null,
+        agentId: "agent-1",
+        conversationId: "conv-1",
+      },
+      adapter: {
+        sendMessage: async () => ({ messageId: "unused" }),
+        listCustomEmojis,
+      },
+      formatText: (text) => ({ text }),
+    });
+
+    expect(actions.describeMessageTool({}).actions).toEqual([
+      "send",
+      "react",
+      "list-custom-emojis",
+    ]);
+    expect(result).toBe(
+      "Available custom Slack emoji (2): :blob_wave:, :party_parrot:",
+    );
+    expect(listCustomEmojis).toHaveBeenCalledTimes(1);
+  });
+
   test("builds the canonical scoped tool from host-supported Slack actions", () => {
     const definition = buildMessageChannelExternalToolDefinition({
       scoped: true,

--- a/src/channels/message-channel-tool-definition.ts
+++ b/src/channels/message-channel-tool-definition.ts
@@ -250,6 +250,9 @@ export function buildMessageChannelDescriptionFromDiscovery(
   const slackCapabilities = discovery.activeChannels.includes("slack")
     ? [
         hasAction("react") ? 'action="react" with emoji + messageId' : "",
+        hasAction("list-custom-emojis")
+          ? 'action="list-custom-emojis" to discover the workspace custom emoji names available for reactions'
+          : "",
         hasAction("upload-file") ? 'action="upload-file" with media' : "",
         hasAction("download-file")
           ? 'action="download-file" with attachmentId + messageId'

--- a/src/channels/message-tool-schema.test.ts
+++ b/src/channels/message-tool-schema.test.ts
@@ -58,6 +58,7 @@ describe("buildDynamicMessageChannelSchema", () => {
     expect(properties.action?.enum).toEqual([
       "send",
       "react",
+      "list-custom-emojis",
       "upload-file",
       "download-file",
       "send-rich",
@@ -118,7 +119,7 @@ describe("buildDynamicMessageChannelSchema", () => {
       "Currently active channels: Slack, Telegram.",
     );
     expect(resolved.description).toContain(
-      "Available actions across the active channels: send, react, upload-file, download-file, send-rich.",
+      "Available actions across the active channels: send, react, list-custom-emojis, upload-file, download-file, send-rich.",
     );
     expect(resolved.description).not.toContain(
       "finish with only `Sent.` as the internal confirmation",
@@ -130,6 +131,9 @@ describe("buildDynamicMessageChannelSchema", () => {
       'On Slack, this tool also supports action="react"',
     );
     expect(resolved.description).toContain(
+      'action="list-custom-emojis" to discover the workspace custom emoji names',
+    );
+    expect(resolved.description).toContain(
       'Use action="download-file" with channel, chat_id, attachmentId, and messageId',
     );
     expect(resolved.description).toContain(
@@ -139,6 +143,7 @@ describe("buildDynamicMessageChannelSchema", () => {
     expect(properties.action?.enum).toEqual([
       "send",
       "react",
+      "list-custom-emojis",
       "upload-file",
       "download-file",
       "send-rich",
@@ -204,6 +209,7 @@ describe("buildDynamicMessageChannelSchema", () => {
     expect(properties.action?.enum).toEqual([
       "send",
       "react",
+      "list-custom-emojis",
       "upload-file",
       "download-file",
     ]);

--- a/src/channels/plugin-types.ts
+++ b/src/channels/plugin-types.ts
@@ -268,7 +268,7 @@ export interface ChannelResolvedMessageTarget {
 /** Minimal outbound surface consumed by channel-owned MessageChannel actions. */
 export type ChannelMessageActionTransport = Pick<
   ChannelAdapter,
-  "sendMessage" | "downloadAttachment"
+  "sendMessage" | "downloadAttachment" | "listCustomEmojis"
 >;
 
 /** Route identity required by MessageChannel action implementations. */

--- a/src/channels/slack/adapter-test-harness.ts
+++ b/src/channels/slack/adapter-test-harness.ts
@@ -93,6 +93,9 @@ export class FakeSlackApp {
       add: mock(async () => ({ ok: true })),
       remove: mock(async () => ({ ok: true })),
     },
+    emoji: {
+      list: mock(async () => ({ emoji: {} })),
+    },
     files: {
       getUploadURLExternal: mock(async () => ({
         ok: true,
@@ -243,6 +246,9 @@ export class FakeSlackWriteClient {
   readonly reactions = {
     add: mock(async () => ({ ok: true })),
     remove: mock(async () => ({ ok: true })),
+  };
+  readonly emoji = {
+    list: mock(async () => ({ emoji: {} })),
   };
   readonly files = {
     getUploadURLExternal: mock(async () => ({
@@ -399,6 +405,7 @@ export function installSlackAdapterTestHooks(): void {
       instance.client.conversations.replies.mockClear();
       instance.client.reactions.add.mockClear();
       instance.client.reactions.remove.mockClear();
+      instance.client.emoji.list.mockClear();
       instance.client.files.getUploadURLExternal.mockClear();
       instance.client.files.completeUploadExternal.mockClear();
       instance.init.mockClear();
@@ -415,6 +422,7 @@ export function installSlackAdapterTestHooks(): void {
       instance.assistant.threads.setStatus.mockClear();
       instance.reactions.add.mockClear();
       instance.reactions.remove.mockClear();
+      instance.emoji.list.mockClear();
       instance.files.getUploadURLExternal.mockClear();
       instance.files.completeUploadExternal.mockClear();
     }

--- a/src/channels/slack/adapter.test.ts
+++ b/src/channels/slack/adapter.test.ts
@@ -488,6 +488,34 @@ test("slack adapter can add reactions to messages", async () => {
   });
 });
 
+test("slack adapter lists sorted workspace custom emoji names", async () => {
+  const adapter = createSlackAdapter({
+    ...slackAccountDefaults,
+    channel: "slack",
+    enabled: true,
+    mode: "socket",
+    botToken: "xoxb-test-token-1234567890",
+    appToken: "xapp-test-token-1234567890",
+    dmPolicy: "pairing",
+    allowedUsers: [],
+  });
+
+  await adapter.start();
+  const writeClient = FakeSlackWriteClient.instances[0];
+  writeClient?.emoji.list.mockResolvedValueOnce({
+    emoji: {
+      party_parrot: "https://emoji.slack-edge.com/party_parrot.png",
+      blob_wave: "alias:wave",
+    },
+  });
+
+  expect(await adapter.listCustomEmojis()).toEqual([
+    "blob_wave",
+    "party_parrot",
+  ]);
+  expect(writeClient?.emoji.list).toHaveBeenCalledTimes(1);
+});
+
 test("slack adapter uploads local files through Slack's external upload flow", async () => {
   const tempDir = await mkdtemp(join(tmpdir(), "letta-slack-upload-"));
   const mediaPath = join(tempDir, "chart.png");

--- a/src/channels/slack/adapter.ts
+++ b/src/channels/slack/adapter.ts
@@ -53,6 +53,7 @@ import {
 import { createSlackWebApiClient } from "./web-api-client";
 
 export interface SlackChannelAdapter extends ChannelAdapter {
+  listCustomEmojis(): Promise<string[]>;
   downloadAttachment(params: {
     attachmentId: string;
     chatId: string;
@@ -150,6 +151,14 @@ export function createSlackAdapter(
       writeClientPromise = null;
       throw error;
     }
+  }
+
+  async function listCustomEmojis(): Promise<string[]> {
+    const client = await ensureWriteClient();
+    const response = await client.emoji.list();
+    return Object.keys(response.emoji ?? {}).sort((left, right) =>
+      left.localeCompare(right),
+    );
   }
 
   async function downloadAttachment(params: {
@@ -450,6 +459,7 @@ export function createSlackAdapter(
       );
     },
     sendMessage,
+    listCustomEmojis,
     downloadAttachment,
     sendDirectReply,
     handleControlRequestEvent,

--- a/src/channels/slack/internal-types.ts
+++ b/src/channels/slack/internal-types.ts
@@ -46,6 +46,11 @@ export type SlackWriteClient = {
       name: string;
     }) => Promise<unknown>;
   };
+  emoji: {
+    list: () => Promise<{
+      emoji?: Record<string, string>;
+    }>;
+  };
   files: {
     getUploadURLExternal: (args: {
       filename: string;

--- a/src/channels/slack/message-action-contract.ts
+++ b/src/channels/slack/message-action-contract.ts
@@ -6,6 +6,8 @@ import type {
 export interface CreateSlackMessageActionAdapterOptions {
   /** Expose reaction actions when the injected transport supports them. */
   react?: boolean;
+  /** Expose workspace custom emoji discovery when the transport supports it. */
+  listCustomEmojis?: boolean;
   /** Expose local-path uploads when the injected transport can read them. */
   uploadFile?: boolean;
   /** Host-owned proactive target resolver, when proactive sends are supported. */
@@ -73,6 +75,25 @@ async function reactInSlack(
     : `Reaction added on slack (message_id: ${result.messageId})`;
 }
 
+async function listSlackCustomEmojis(
+  context: ChannelMessageActionContext,
+): Promise<string> {
+  const listCustomEmojis = context.adapter.listCustomEmojis;
+  if (typeof listCustomEmojis !== "function") {
+    return "Error: Running Slack adapter does not support custom emoji discovery.";
+  }
+  try {
+    const names = await listCustomEmojis.call(context.adapter);
+    if (names.length === 0) {
+      return "This Slack workspace has no custom emoji available to the app.";
+    }
+    return `Available custom Slack emoji (${names.length}): ${names.map((name) => `:${name}:`).join(", ")}`;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return `Error: Could not list custom Slack emoji. ${message}`;
+  }
+}
+
 /**
  * Build canonical Slack MessageChannel actions around a host-owned transport.
  * Capabilities are explicit so remote gateways never advertise local-path or
@@ -84,6 +105,7 @@ export function createSlackMessageActionAdapter(
   const actions = [
     "send",
     ...(options.react ? ["react"] : []),
+    ...(options.listCustomEmojis ? ["list-custom-emojis"] : []),
     ...(options.uploadFile ? ["upload-file"] : []),
     ...(options.downloadFile ? ["download-file"] : []),
   ];
@@ -131,6 +153,10 @@ export function createSlackMessageActionAdapter(
           return options.react
             ? await reactInSlack(context)
             : 'Error: Action "react" is not supported on slack.';
+        case "list-custom-emojis":
+          return options.listCustomEmojis
+            ? await listSlackCustomEmojis(context)
+            : 'Error: Action "list-custom-emojis" is not supported on slack.';
         case "download-file":
           return options.downloadFile
             ? await options.downloadFile(context)

--- a/src/channels/slack/message-actions.ts
+++ b/src/channels/slack/message-actions.ts
@@ -55,6 +55,7 @@ async function downloadSlackFile(
 
 export const slackMessageActions = createSlackMessageActionAdapter({
   react: true,
+  listCustomEmojis: true,
   uploadFile: true,
   downloadFile: downloadSlackFile,
   resolveMessageTarget: async (params) =>

--- a/src/channels/slack/proactive-route.ts
+++ b/src/channels/slack/proactive-route.ts
@@ -81,7 +81,11 @@ interface CreateProactiveSlackTransportParams {
 export function createProactiveSlackTransport(
   params: CreateProactiveSlackTransportParams,
 ): ChannelMessageActionTransport {
+  const listCustomEmojis = params.adapter.listCustomEmojis?.bind(
+    params.adapter,
+  );
   return {
+    ...(listCustomEmojis ? { listCustomEmojis } : {}),
     sendMessage: async (message) => {
       const result = await params.adapter.sendMessage(message);
       const isRootChannelPost =

--- a/src/channels/slack/setup.ts
+++ b/src/channels/slack/setup.ts
@@ -40,7 +40,7 @@ export async function runSlackSetup(): Promise<boolean> {
     );
     console.log("Recommended bot token scopes:");
     console.log(
-      "  app_mentions:read, channels:history, chat:write, commands, groups:history, im:history, users:read",
+      "  app_mentions:read, channels:history, chat:write, commands, emoji:read, groups:history, im:history, users:read",
     );
     console.log("  reactions:read, reactions:write, files:read, files:write\n");
 

--- a/src/channels/types.ts
+++ b/src/channels/types.ts
@@ -279,7 +279,7 @@ export interface ChannelAdapter {
 
   /** Send a message through this channel. */
   sendMessage(msg: OutboundChannelMessage): Promise<{ messageId: string }>;
-
+  listCustomEmojis?(): Promise<string[]>;
   /**
    * Optionally materialize a platform attachment into the channel's local
    * inbound directory. MessageChannel plugins expose this only when the


### PR DESCRIPTION
## Summary

Slack agents could add reactions when they already knew an emoji name, but had no way to discover the workspace's custom emoji vocabulary. `MessageChannel` now advertises an on-demand `list-custom-emojis` action, and the Slack adapter resolves it through Slack's `emoji.list` API before the agent chooses a reaction.

The catalog is requested only when needed rather than added to every turn's context. Slack setup guidance and the example app manifest now include the required `emoji:read` bot scope.

## Verification

- `bun test src/channels/slack/proactive-route.test.ts src/channels/slack/adapter.test.ts src/channels/message-channel-gateway.test.ts src/channels/message-tool-schema.test.ts` — 35 passed
- `bun run check` — all 12 checks passed

A live Slack call was not run because this sandbox does not have a directly usable Slack bot credential with `emoji:read`. The adapter boundary is covered with the real Slack Web API response shape and the gateway action is covered through an injected host transport.

## Breadcrumbs

- Requested in: LET-11453
- Letta conversation: [`conv-cf1a3047-0ce7-4978-8339-86c34d627f2d`](https://chat.letta.com/chat/agent-19babcc0-e958-41b0-81d8-00107f71deb7?conversation=conv-cf1a3047-0ce7-4978-8339-86c34d627f2d)
- Origin: The existing Slack reaction action accepted names but exposed no custom emoji discovery path. No single regression-introducing pull request was found.

## AI Disclosure

- [ ] This pull request was written entirely by a human
- [ ] This pull request was written with AI assistance and reviewed and edited by a human
- [x] I have read the [AI Policy](https://github.com/letta-ai/letta-code/blob/main/AI_POLICY.md) and agree to its terms

## AI Tool(s) Used

Letta Code (Titan) implemented and verified the change under Charles Packer's direction.

## Human Verification

Pending maintainer review.
