### PR TITLE
fix(agent): keep memoryScope on provider-not-supported subagent retry

### DIFF
--- a/src/agent/subagent-retry-parent-scope.test.ts
+++ b/src/agent/subagent-retry-parent-scope.test.ts
@@ -8,9 +8,9 @@ const managerSource = readFileSync(
 );
 
 describe("executeSubagent provider fallback wiring", () => {
-  test("forwards parentAgentIdOverride through the provider retry call", () => {
+  test("retries with a new agent, the primary model, and the original memory scope", () => {
     const retryCallMatch = managerSource.match(
-      /return executeSubagent\(\s*type,\s*config,\s*primaryModel,\s*userPrompt,\s*subagentId,\s*true,\s*\/\/ Mark as retry to prevent infinite loops\s*signal,\s*undefined,\s*\/\/ existingAgentId\s*undefined,\s*\/\/ existingConversationId\s*maxTurns,\s*parentAgentIdOverride,\s*transcriptPath,\s*undefined,\s*\/\/ memoryScope\s*undefined,\s*\/\/ systemPromptOverride\s*environment,\s*actingUserIdOverride,\s*\);/s,
+      /return executeSubagent\(\s*type,\s*config,\s*primaryModel,\s*userPrompt,\s*subagentId,\s*true,\s*\/\/ Mark as retry to prevent infinite loops\s*signal,\s*undefined,\s*\/\/ existingAgentId: new agent so --model applies\s*undefined,\s*\/\/ existingConversationId\s*maxTurns,\s*parentAgentIdOverride,\s*transcriptPath,\s*memoryScope,\s*systemPromptOverride,\s*environment,\s*actingUserIdOverride,\s*\);/s,
     );
 
     expect(retryCallMatch).toBeTruthy();

--- a/src/agent/subagents/manager.ts
+++ b/src/agent/subagents/manager.ts
@@ -599,7 +599,10 @@ async function executeSubagent(
           agentId: parentAgentIdOverride,
         });
         if (primaryModel) {
-          // Retry with the primary agent's model
+          // New agent is required: deploying an existing agent omits --model,
+          // so the retry would keep the unsupported provider. Keep memoryScope
+          // and systemPromptOverride so the replacement child uses the same
+          // writable tree and prompt the first attempt was given.
           return executeSubagent(
             type,
             config,
@@ -608,13 +611,13 @@ async function executeSubagent(
             subagentId,
             true, // Mark as retry to prevent infinite loops
             signal,
-            undefined, // existingAgentId
+            undefined, // existingAgentId: new agent so --model applies
             undefined, // existingConversationId
             maxTurns,
             parentAgentIdOverride,
             transcriptPath,
-            undefined, // memoryScope
-            undefined, // systemPromptOverride
+            memoryScope,
+            systemPromptOverride,
             environment,
             actingUserIdOverride,
           );


### PR DESCRIPTION
## Summary

When a subagent child exits because its model/provider is not supported, `executeSubagent` retries once with the parent agent's primary model. That retry correctly passes `existingAgentId` / `existingConversationId` as `undefined` so `buildSubagentArgs` creates a new agent and can pass `--model` (deploying an existing agent omits `--model` and would keep the unsupported provider).

The same retry was also passing `memoryScope` and `systemPromptOverride` as `undefined`. A reflection (or any memory-subagent) child then gets `MEMORY_DIR = inheritedPrimaryRoot` instead of `memoryScope.primaryRoot`, so the replacement process writes the parent memory repo rather than the worktree it was given.

Lost-stdout retries in the same function already forward those arguments. This change makes the provider-not-supported retry do the same for `memoryScope` and `systemPromptOverride`, and updates the source-snapshot test that previously asserted the drop.

## Verification

- `bun test src/agent/subagent-retry-parent-scope.test.ts src/agent/subagent-env-composition.test.ts src/agent/subagent-model-resolution.test.ts` — 93 pass
- `bun run check` — 12/12 pass

## AI Disclosure

- [ ] This pull request was written entirely by a human
- [x] This pull request was written with AI assistance and reviewed and edited by a human
- [x] I have read the [AI Policy](https://github.com/letta-ai/letta-code/blob/main/AI_POLICY.md) and agree to its terms

## AI Tool(s) Used

Pi coding agent (grok 4.6) for diagnosis, the code change, tests, and this PR text. A human directed the change after confirming the retry call sites in `src/agent/subagents/manager.ts`.

## Human Verification

I have reviewed and understand every change in this pull request and take responsibility for its correctness.
