### PR TITLE
fix(api): coalesce in-flight agent retrievals

### DIFF
--- a/src/backend/api-backend.test.ts
+++ b/src/backend/api-backend.test.ts
@@ -173,6 +173,73 @@ describe("APIBackend", () => {
     expect(getBackend().capabilities.remoteMemfs).toBe(true);
   });
 
+  test("coalesces concurrent identical agent retrievals", async () => {
+    let resolveAgent: (agent: { id: string; name: string }) => void = () => {
+      throw new Error("retrieveAgent promise was not started");
+    };
+    retrieveAgentMock.mockImplementationOnce(
+      async () =>
+        new Promise((resolve) => {
+          resolveAgent = resolve;
+        }),
+    );
+    const backend = new APIBackend({
+      getClient: getClientMock as unknown as () => Promise<APIClient>,
+      forkConversation: forkConversationMock,
+    });
+
+    const first = backend.retrieveAgent("agent-1");
+    const second = backend.retrieveAgent("agent-1");
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(retrieveAgentMock).toHaveBeenCalledTimes(1);
+
+    resolveAgent({ id: "agent-1", name: "agent" });
+    await expect(first).resolves.toMatchObject({ id: "agent-1" });
+    await expect(second).resolves.toMatchObject({ id: "agent-1" });
+  });
+
+  test("does not coalesce semantically different agent retrievals", async () => {
+    const backend = new APIBackend({
+      getClient: getClientMock as unknown as () => Promise<APIClient>,
+      forkConversation: forkConversationMock,
+    });
+
+    await Promise.all([
+      backend.retrieveAgent("agent-1"),
+      backend.retrieveAgent("agent-1", { include: ["agent.tags"] }),
+      backend.retrieveAgent("agent-2"),
+    ]);
+
+    expect(retrieveAgentMock).toHaveBeenCalledTimes(3);
+    expect(retrieveAgentMock).toHaveBeenNthCalledWith(1, "agent-1", undefined);
+    expect(retrieveAgentMock).toHaveBeenNthCalledWith(2, "agent-1", {
+      include: ["agent.tags"],
+    });
+    expect(retrieveAgentMock).toHaveBeenNthCalledWith(3, "agent-2", undefined);
+  });
+
+  test("removes failed agent retrievals from the in-flight set", async () => {
+    retrieveAgentMock
+      .mockRejectedValueOnce(new Error("network cooked"))
+      .mockResolvedValueOnce({ id: "agent-1" });
+    const backend = new APIBackend({
+      getClient: getClientMock as unknown as () => Promise<APIClient>,
+      forkConversation: forkConversationMock,
+    });
+
+    const first = backend.retrieveAgent("agent-1");
+    const second = backend.retrieveAgent("agent-1");
+    await expect(Promise.allSettled([first, second])).resolves.toEqual([
+      { status: "rejected", reason: expect.any(Error) },
+      { status: "rejected", reason: expect.any(Error) },
+    ]);
+
+    await expect(backend.retrieveAgent("agent-1")).resolves.toMatchObject({
+      id: "agent-1",
+    });
+    expect(retrieveAgentMock).toHaveBeenCalledTimes(2);
+  });
+
   test("delegates core conversation and run operations to the Letta API", async () => {
     const backend = new APIBackend({
       getClient: getClientMock as unknown as () => Promise<APIClient>,

--- a/src/backend/api-backend.test.ts
+++ b/src/backend/api-backend.test.ts
@@ -198,6 +198,63 @@ describe("APIBackend", () => {
     await expect(second).resolves.toMatchObject({ id: "agent-1" });
   });
 
+  test("does not store API client construction in the in-flight set", async () => {
+    const client = {
+      agents: { retrieve: retrieveAgentMock },
+    } as unknown as APIClient;
+    const resolveClients: Array<(client: APIClient) => void> = [];
+    const getClient = mock(
+      async () =>
+        new Promise<APIClient>((resolve) => {
+          resolveClients.push(resolve);
+        }),
+    );
+    const backend = new APIBackend({
+      getClient,
+      forkConversation: forkConversationMock,
+    });
+
+    const first = backend.retrieveAgent("agent-1");
+    const second = backend.retrieveAgent("agent-1");
+    await Promise.resolve();
+    expect(getClient).toHaveBeenCalledTimes(2);
+    expect(retrieveAgentMock).toHaveBeenCalledTimes(0);
+
+    for (const resolveClient of resolveClients) resolveClient(client);
+    await Promise.all([first, second]);
+    expect(retrieveAgentMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("removes successful agent retrievals from the in-flight set", async () => {
+    let resolveAgent: (agent: { id: string }) => void = () => {
+      throw new Error("retrieveAgent promise was not started");
+    };
+    retrieveAgentMock
+      .mockImplementationOnce(
+        async () =>
+          new Promise((resolve) => {
+            resolveAgent = resolve;
+          }),
+      )
+      .mockResolvedValueOnce({ id: "agent-1" });
+    const backend = new APIBackend({
+      getClient: getClientMock as unknown as () => Promise<APIClient>,
+      forkConversation: forkConversationMock,
+    });
+
+    const first = backend.retrieveAgent("agent-1");
+    const second = backend.retrieveAgent("agent-1");
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(retrieveAgentMock).toHaveBeenCalledTimes(1);
+
+    resolveAgent({ id: "agent-1" });
+    await Promise.all([first, second]);
+    await expect(backend.retrieveAgent("agent-1")).resolves.toMatchObject({
+      id: "agent-1",
+    });
+    expect(retrieveAgentMock).toHaveBeenCalledTimes(2);
+  });
+
   test("does not coalesce options-bearing agent retrievals", async () => {
     const backend = new APIBackend({
       getClient: getClientMock as unknown as () => Promise<APIClient>,

--- a/src/backend/api-backend.test.ts
+++ b/src/backend/api-backend.test.ts
@@ -198,7 +198,7 @@ describe("APIBackend", () => {
     await expect(second).resolves.toMatchObject({ id: "agent-1" });
   });
 
-  test("does not coalesce semantically different agent retrievals", async () => {
+  test("does not coalesce options-bearing agent retrievals", async () => {
     const backend = new APIBackend({
       getClient: getClientMock as unknown as () => Promise<APIClient>,
       forkConversation: forkConversationMock,
@@ -207,15 +207,19 @@ describe("APIBackend", () => {
     await Promise.all([
       backend.retrieveAgent("agent-1"),
       backend.retrieveAgent("agent-1", { include: ["agent.tags"] }),
+      backend.retrieveAgent("agent-1", { include: ["agent.tags"] }),
       backend.retrieveAgent("agent-2"),
     ]);
 
-    expect(retrieveAgentMock).toHaveBeenCalledTimes(3);
+    expect(retrieveAgentMock).toHaveBeenCalledTimes(4);
     expect(retrieveAgentMock).toHaveBeenNthCalledWith(1, "agent-1", undefined);
     expect(retrieveAgentMock).toHaveBeenNthCalledWith(2, "agent-1", {
       include: ["agent.tags"],
     });
-    expect(retrieveAgentMock).toHaveBeenNthCalledWith(3, "agent-2", undefined);
+    expect(retrieveAgentMock).toHaveBeenNthCalledWith(3, "agent-1", {
+      include: ["agent.tags"],
+    });
+    expect(retrieveAgentMock).toHaveBeenNthCalledWith(4, "agent-2", undefined);
   });
 
   test("removes failed agent retrievals from the in-flight set", async () => {

--- a/src/backend/backend.ts
+++ b/src/backend/backend.ts
@@ -321,6 +321,40 @@ interface APIBackendDeps {
   forkConversation?: ForkConversation;
 }
 
+function stableRetrieveAgentOptionsKey(value: unknown): string | null {
+  if (value === undefined) return "";
+  if (value === null) return "null";
+  if (typeof value !== "object") return JSON.stringify(value);
+  if (value instanceof AbortSignal) return null;
+  if (Array.isArray(value)) {
+    const entries = value.map(stableRetrieveAgentOptionsKey);
+    if (entries.some((entry) => entry === null)) return null;
+    return `[${entries.join(",")}]`;
+  }
+
+  const record = value as Record<string, unknown>;
+  if (record.signal instanceof AbortSignal) return null;
+  const entries: string[] = [];
+  for (const key of Object.keys(record).sort()) {
+    const entryValue = record[key];
+    if (typeof entryValue === "function" || typeof entryValue === "symbol") {
+      return null;
+    }
+    const serializedValue = stableRetrieveAgentOptionsKey(entryValue);
+    if (serializedValue === null) return null;
+    entries.push(`${JSON.stringify(key)}:${serializedValue}`);
+  }
+  return `{${entries.join(",")}}`;
+}
+
+function retrieveAgentInflightKey(
+  agentId: string,
+  options?: AgentRetrieveOptions,
+): string | null {
+  const optionsKey = stableRetrieveAgentOptionsKey(options);
+  return optionsKey === null ? null : `${agentId}\0${optionsKey}`;
+}
+
 export class APIBackend implements Backend {
   get capabilities(): BackendCapabilities {
     return {
@@ -340,6 +374,10 @@ export class APIBackend implements Backend {
 
   private readonly getApiClientOverride?: GetAPIClient;
   private readonly forkConversationOverride?: ForkConversation;
+  private readonly retrieveAgentInflightByKey = new Map<
+    string,
+    Promise<Awaited<ReturnType<APIClient["agents"]["retrieve"]>>>
+  >();
 
   constructor(deps: APIBackendDeps = {}) {
     this.getApiClientOverride = deps.getClient;
@@ -355,8 +393,32 @@ export class APIBackend implements Backend {
   }
 
   async retrieveAgent(agentId: string, options?: AgentRetrieveOptions) {
-    const client = await this.getClient();
-    return client.agents.retrieve(agentId, options);
+    const key = retrieveAgentInflightKey(agentId, options);
+    if (key) {
+      const inflight = this.retrieveAgentInflightByKey.get(key);
+      if (inflight) return inflight;
+    }
+
+    const request = (async () => {
+      const client = await this.getClient();
+      return client.agents.retrieve(agentId, options);
+    })();
+    if (!key) return request;
+
+    this.retrieveAgentInflightByKey.set(key, request);
+    request.then(
+      () => {
+        if (this.retrieveAgentInflightByKey.get(key) === request) {
+          this.retrieveAgentInflightByKey.delete(key);
+        }
+      },
+      () => {
+        if (this.retrieveAgentInflightByKey.get(key) === request) {
+          this.retrieveAgentInflightByKey.delete(key);
+        }
+      },
+    );
+    return request;
   }
 
   async listAgentSecrets(agentId: string): Promise<AgentSecret[]> {

--- a/src/backend/backend.ts
+++ b/src/backend/backend.ts
@@ -321,40 +321,6 @@ interface APIBackendDeps {
   forkConversation?: ForkConversation;
 }
 
-function stableRetrieveAgentOptionsKey(value: unknown): string | null {
-  if (value === undefined) return "";
-  if (value === null) return "null";
-  if (typeof value !== "object") return JSON.stringify(value);
-  if (value instanceof AbortSignal) return null;
-  if (Array.isArray(value)) {
-    const entries = value.map(stableRetrieveAgentOptionsKey);
-    if (entries.some((entry) => entry === null)) return null;
-    return `[${entries.join(",")}]`;
-  }
-
-  const record = value as Record<string, unknown>;
-  if (record.signal instanceof AbortSignal) return null;
-  const entries: string[] = [];
-  for (const key of Object.keys(record).sort()) {
-    const entryValue = record[key];
-    if (typeof entryValue === "function" || typeof entryValue === "symbol") {
-      return null;
-    }
-    const serializedValue = stableRetrieveAgentOptionsKey(entryValue);
-    if (serializedValue === null) return null;
-    entries.push(`${JSON.stringify(key)}:${serializedValue}`);
-  }
-  return `{${entries.join(",")}}`;
-}
-
-function retrieveAgentInflightKey(
-  agentId: string,
-  options?: AgentRetrieveOptions,
-): string | null {
-  const optionsKey = stableRetrieveAgentOptionsKey(options);
-  return optionsKey === null ? null : `${agentId}\0${optionsKey}`;
-}
-
 export class APIBackend implements Backend {
   get capabilities(): BackendCapabilities {
     return {
@@ -393,28 +359,28 @@ export class APIBackend implements Backend {
   }
 
   async retrieveAgent(agentId: string, options?: AgentRetrieveOptions) {
-    const key = retrieveAgentInflightKey(agentId, options);
-    if (key) {
-      const inflight = this.retrieveAgentInflightByKey.get(key);
-      if (inflight) return inflight;
+    if (options !== undefined) {
+      const client = await this.getClient();
+      return client.agents.retrieve(agentId, options);
     }
+
+    const inflight = this.retrieveAgentInflightByKey.get(agentId);
+    if (inflight) return inflight;
 
     const request = (async () => {
       const client = await this.getClient();
-      return client.agents.retrieve(agentId, options);
+      return client.agents.retrieve(agentId, undefined);
     })();
-    if (!key) return request;
-
-    this.retrieveAgentInflightByKey.set(key, request);
+    this.retrieveAgentInflightByKey.set(agentId, request);
     request.then(
       () => {
-        if (this.retrieveAgentInflightByKey.get(key) === request) {
-          this.retrieveAgentInflightByKey.delete(key);
+        if (this.retrieveAgentInflightByKey.get(agentId) === request) {
+          this.retrieveAgentInflightByKey.delete(agentId);
         }
       },
       () => {
-        if (this.retrieveAgentInflightByKey.get(key) === request) {
-          this.retrieveAgentInflightByKey.delete(key);
+        if (this.retrieveAgentInflightByKey.get(agentId) === request) {
+          this.retrieveAgentInflightByKey.delete(agentId);
         }
       },
     );

--- a/src/backend/backend.ts
+++ b/src/backend/backend.ts
@@ -359,18 +359,15 @@ export class APIBackend implements Backend {
   }
 
   async retrieveAgent(agentId: string, options?: AgentRetrieveOptions) {
+    const client = await this.getClient();
     if (options !== undefined) {
-      const client = await this.getClient();
       return client.agents.retrieve(agentId, options);
     }
 
     const inflight = this.retrieveAgentInflightByKey.get(agentId);
     if (inflight) return inflight;
 
-    const request = (async () => {
-      const client = await this.getClient();
-      return client.agents.retrieve(agentId, undefined);
-    })();
+    const request = client.agents.retrieve(agentId, undefined);
     this.retrieveAgentInflightByKey.set(agentId, request);
     request.then(
       () => {


### PR DESCRIPTION
## tl;dr

`runtime_start` and first-turn listener warmup can race into identical `GET /v1/agents/:id` requests for the same cloud-hosted agent. This keeps the API backend fresh while sharing only same-agent in-flight SDK `retrieveAgent(agentId)` requests where `options === undefined`; the entry disappears as soon as it resolves or rejects. API client construction/auth happens before the in-flight map is consulted, so a client setup hang cannot occupy or wedge the per-agent retrieve map.

## Review notes

The reproduced pair is `runtime_start` resolving `backend.retrieveAgent(agentId)` and `fetchListenerAgentMetadata` resolving `getBackend().retrieveAgent(agentId)`. The MemFS path asks for `include: ["agent.tags"]`; this PR deliberately leaves that options-bearing request independent, along with every other options shape.

Callers sharing a failed in-flight no-options request all observe the same rejection, then the next call retries normally because the entry is removed on both resolve and reject. Successful requests also clear the entry so a later call fetches fresh state. Different agents never coalesce.

## Testing

I ran the local App Server on main and on this branch, wrapped the real SDK `agents.retrieve` boundary with temporary callsite logging plus 2 seconds of artificial latency, then sent `runtime_start` and first-turn `input` back-to-back over one WebSocket for the same agent and conversation.

On main, two no-options requests overlapped: `runtime_start` began first, then `fetchListenerAgentMetadata` began 88ms later; they completed independently in 3,194ms and 3,201ms. On this branch, the same sequence produced one no-options SDK request shared by both callers. The separate options-bearing MemFS request remained independent on both runs.

## AI Disclosure

- [ ] This pull request was written entirely by a human
- [x] This pull request was written with AI assistance and reviewed and edited by a human
- [x] I have read the [AI Policy](https://github.com/letta-ai/letta-code/blob/main/AI_POLICY.md) and agree to its terms

## AI Tool(s) Used

Letta Code

## Human Verification

I have reviewed and understand every change in this pull request and take responsibility for its correctness.

## Breadcrumbs

- Letta conversation: [`conv-edc56996-21f3-4d72-bd01-6e61ed72be00`](https://chat.letta.com/chat/agent-a8cc2084-940f-4741-95c9-ace741b16c4e?conversation=conv-edc56996-21f3-4d72-bd01-6e61ed72be00)
- Linear: LET-11109
- Origin: runtime listener startup paths already performed separate uncached `retrieveAgent` calls; no single introducing PR was identified.
- Root-cause evidence: local App Server reproduction described above; internal production trace evidence remains in LET-11109.
