### PR TITLE
fix(listener): preload first-turn warm state

### DIFF
--- a/src/websocket/listener-warmup.test.ts
+++ b/src/websocket/listener-warmup.test.ts
@@ -42,7 +42,7 @@ describe("listener warmup scheduling", () => {
     fetchAgentMetadataMock.mockReset();
   });
 
-  test("sync warmup joins the first turn without duplicating agent metadata fetches", async () => {
+  test("sync warmup joins the first turn without duplicating session warmup work", async () => {
     let resolveMemfs: (() => void) | undefined;
     let resolveSecrets: (() => void) | undefined;
     let resolveMetadata: ((value: ListenerAgentMetadata) => void) | undefined;
@@ -83,8 +83,8 @@ describe("listener warmup scheduling", () => {
       conversationId: "default",
     });
 
-    expect(memfsWarmupMock).toHaveBeenCalledTimes(2);
-    expect(secretsWarmupMock).toHaveBeenCalledTimes(2);
+    expect(memfsWarmupMock).toHaveBeenCalledTimes(1);
+    expect(secretsWarmupMock).toHaveBeenCalledTimes(1);
     expect(fetchAgentMetadataMock).toHaveBeenCalledTimes(1);
 
     resolveMemfs?.();
@@ -101,9 +101,54 @@ describe("listener warmup scheduling", () => {
       lastRunAt: "2026-05-02T06:00:00.000Z",
     });
 
-    expect(memfsWarmupMock).toHaveBeenCalledTimes(2);
-    expect(secretsWarmupMock).toHaveBeenCalledTimes(2);
+    expect(memfsWarmupMock).toHaveBeenCalledTimes(1);
+    expect(secretsWarmupMock).toHaveBeenCalledTimes(1);
     expect(fetchAgentMetadataMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("sync replay starts session warmup before approval recovery settles", async () => {
+    const memfsWarmup = mock(async () => true);
+    __listenerWarmupTestUtils.setWarmupDepsForTests({
+      ensureMemfsSyncedForAgent: memfsWarmup,
+      ensureSecretsHydratedForAgent: async () => {},
+      fetchListenerAgentMetadata: async () => ({
+        name: "Warmup Agent",
+        description: null,
+        lastRunAt: null,
+      }),
+    });
+    let resolveRecovery!: () => void;
+    const listener = __listenClientTestUtils.createListenerRuntime();
+    const transport: ListenerTransport = {
+      kind: "local",
+      bufferedAmount: 0,
+      isOpen: () => true,
+      send: () => {},
+    };
+
+    const replay = replaySyncStateForRuntime(
+      listener,
+      transport as unknown as WebSocket,
+      { agent_id: "agent-warmup", conversation_id: "default" },
+      {
+        recoverApprovalStateForSync: () =>
+          new Promise<void>((resolve) => {
+            resolveRecovery = resolve;
+          }),
+        scheduleWarmupsAfterSync: () => {},
+      },
+    );
+
+    for (
+      let attempt = 0;
+      attempt < 10 && memfsWarmup.mock.calls.length === 0;
+      attempt += 1
+    ) {
+      await Bun.sleep(0);
+    }
+    expect(memfsWarmup).toHaveBeenCalledTimes(1);
+    resolveRecovery();
+    await replay;
   });
 
   test("advertises scoped mod commands after background warmup", async () => {

--- a/src/websocket/listener/lifecycle.ts
+++ b/src/websocket/listener/lifecycle.ts
@@ -101,6 +101,7 @@ import type {
 } from "./types";
 import {
   clearListenerWarmState,
+  preloadListenerWarmStateForTurn,
   scheduleListenerWarmupsAfterSync,
 } from "./warmup";
 import { stopAllWorktreeWatchers } from "./worktree-watcher";
@@ -126,7 +127,6 @@ export function safeSocketSend(
   if (socket.readyState !== WebSocket.OPEN) {
     return false;
   }
-
   try {
     const serialized =
       typeof payload === "string" ? payload : JSON.stringify(payload);
@@ -140,7 +140,6 @@ export function safeSocketSend(
     return false;
   }
 }
-
 function safeTransportSend(
   transport: ListenerTransport,
   payload: unknown,
@@ -150,7 +149,6 @@ function safeTransportSend(
   if (!isListenerTransportOpen(transport)) {
     return false;
   }
-
   try {
     const serialized =
       typeof payload === "string" ? payload : JSON.stringify(payload);
@@ -164,7 +162,6 @@ function safeTransportSend(
     return false;
   }
 }
-
 export function runDetachedListenerTask(
   commandName: string,
   task: () => Promise<void>,
@@ -179,6 +176,7 @@ export function runDetachedListenerTask(
       console.error(`[Listen] ${commandName} failed:`, error);
   });
 }
+
 export async function replaySyncStateForRuntime(
   listenerRuntime: ListenerRuntime,
   socket: WebSocket,
@@ -201,6 +199,10 @@ export async function replaySyncStateForRuntime(
     scope.agent_id,
     scope.conversation_id,
   );
+  preloadListenerWarmStateForTurn(listenerRuntime, {
+    agentId: scope.agent_id,
+    conversationId: scope.conversation_id,
+  });
   const recoverFn =
     opts?.recoverApprovalStateForSync ?? recoverApprovalStateForSync;
   if (opts?.recoverApprovals ?? true) {
@@ -217,7 +219,6 @@ export async function replaySyncStateForRuntime(
       }
     }
   }
-
   replaySubscribedConnectionState(
     listenerRuntime,
     socket,
@@ -536,7 +537,6 @@ export async function attachOpenListenerSocket(
     safeSocketSend,
     runDetachedListenerTask,
   });
-
   installExternalToolBridge(runtime);
   const transport: ListenerTransport = socket;
   const processQueuedTurn = createConnectionTurnProcessor(runtime);

--- a/src/websocket/listener/message-router.test.ts
+++ b/src/websocket/listener/message-router.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, mock, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import WebSocket from "ws";
 import {
   clearExternalTools,
@@ -12,6 +12,7 @@ import { createListenerMessageHandler } from "./message-router";
 import { scheduleQueuePump } from "./queue";
 import { setActiveRuntime } from "./runtime";
 import type { IncomingMessage, StartListenerOptions } from "./types";
+import { __listenerWarmupTestUtils } from "./warmup";
 
 class MockSocket {
   readyState = WebSocket.OPEN;
@@ -45,9 +46,22 @@ async function waitFor(predicate: () => boolean): Promise<void> {
 }
 
 describe("listener message router ownership handoff", () => {
+  beforeEach(() => {
+    __listenerWarmupTestUtils.setWarmupDepsForTests({
+      ensureMemfsSyncedForAgent: async () => true,
+      ensureSecretsHydratedForAgent: async () => {},
+      fetchListenerAgentMetadata: async () => ({
+        name: null,
+        description: null,
+        lastRunAt: null,
+      }),
+    });
+  });
+
   afterEach(() => {
     clearExternalTools();
     setActiveRuntime(null);
+    __listenerWarmupTestUtils.resetWarmupDepsForTests();
   });
 
   test("acknowledges batched external-tool registration without runtime startup", async () => {
@@ -123,6 +137,90 @@ describe("listener message router ownership handoff", () => {
     expect(prepared.clientTools.map((tool) => tool.name)).toEqual([
       "MessageChannel",
     ]);
+  });
+
+  test("starts first-turn warmup without delaying input acceptance", async () => {
+    let resolveMemfs!: () => void;
+    const memfsWarmup = mock(
+      () =>
+        new Promise<boolean>((resolve) => {
+          resolveMemfs = () => resolve(true);
+        }),
+    );
+    __listenerWarmupTestUtils.setWarmupDepsForTests({
+      ensureMemfsSyncedForAgent: memfsWarmup,
+      ensureSecretsHydratedForAgent: async () => {},
+      fetchListenerAgentMetadata: async () => ({
+        name: null,
+        description: null,
+        lastRunAt: null,
+      }),
+    });
+    const listener = createRuntime();
+    const runtime = getOrCreateScopedRuntime(listener, "agent-1", "conv-1");
+    const socket = new MockSocket();
+    const sent: unknown[] = [];
+    setActiveRuntime(listener);
+
+    const handleMessage = createListenerMessageHandler({
+      runtime: listener,
+      socket: socket as unknown as WebSocket,
+      opts: makeListenerOptions(),
+      processQueuedTurn: async () => {},
+      fileCommandSession: { handle: () => false },
+      getParsedRuntimeScope: () => null,
+      replaySyncStateForRuntime: async () => {},
+      getOrCreateScopedRuntime: () => runtime,
+      handleApprovalResponseInput: async () => false,
+      handleChangeDeviceStateInput: async () => false,
+      handleAbortMessageInput: async () => false,
+      stampInboundUserMessageOtids: (incoming) => incoming,
+      safeSocketSend: (_target, payload) => {
+        sent.push(payload);
+        return true;
+      },
+      runDetachedListenerTask: () => {},
+      trackListenerError: () => {},
+      processIncomingMessage: async () => {},
+    });
+
+    await handleMessage(
+      Buffer.from(
+        JSON.stringify({
+          type: "input",
+          request_id: "input-warmup",
+          runtime: { agent_id: "agent-1", conversation_id: "conv-1" },
+          payload: {
+            kind: "create_message",
+            messages: [
+              {
+                role: "user",
+                content: "warm me up",
+                client_message_id: "cm-input-warmup",
+              },
+            ],
+          },
+        }),
+      ),
+    );
+
+    await waitFor(() => memfsWarmup.mock.calls.length === 1);
+    await waitFor(() =>
+      sent.some((payload) => {
+        const message = payload as {
+          type?: string;
+          request_id?: string;
+          accepted?: boolean;
+        };
+        return (
+          message.type === "input_accepted" &&
+          message.request_id === "input-warmup" &&
+          message.accepted === true
+        );
+      }),
+    );
+    expect(memfsWarmup).toHaveBeenCalledTimes(1);
+    resolveMemfs();
   });
 
   test("a direct message that loses the idle race is queued and later drained", async () => {

--- a/src/websocket/listener/message-router.ts
+++ b/src/websocket/listener/message-router.ts
@@ -83,6 +83,7 @@ import type {
   ProcessQueuedTurn,
   StartListenerOptions,
 } from "./types";
+import { preloadListenerWarmStateForTurn } from "./warmup";
 
 type SafeSocketSend = (
   socket: WebSocket,
@@ -549,6 +550,10 @@ export function createListenerMessageHandler(
           incoming.agentId,
           incoming.conversationId,
         );
+        preloadListenerWarmStateForTurn(runtime, {
+          agentId: incoming.agentId ?? null,
+          conversationId: incoming.conversationId ?? "default",
+        });
 
         const processIncomingMessageDirectly = (
           directIncoming: IncomingMessage,

--- a/src/websocket/listener/warmup.ts
+++ b/src/websocket/listener/warmup.ts
@@ -53,21 +53,26 @@ const defaultWarmupDeps: ListenerWarmupDeps = {
 
 let warmupDeps: ListenerWarmupDeps = defaultWarmupDeps;
 
-/**
- * Hydrate listener-side state needed for the next turn.
- *
- * The warmup is intentionally best-effort: failures are logged and do not
- * block the user turn, mirroring the existing preflight behavior.
- */
-export async function ensureListenerWarmStateForTurn(
-  listener: ListenerRuntime,
-  scope: ListenerWarmupScope,
-): Promise<ListenerAgentMetadata | null> {
-  const { agentId } = scope;
-  if (!agentId) {
-    return null;
-  }
+const warmStateByRuntime = new WeakMap<
+  ListenerRuntime,
+  Map<string, Promise<ListenerAgentMetadata | null>>
+>();
 
+function getWarmStateMap(
+  listener: ListenerRuntime,
+): Map<string, Promise<ListenerAgentMetadata | null>> {
+  let warmStateByAgent = warmStateByRuntime.get(listener);
+  if (!warmStateByAgent) {
+    warmStateByAgent = new Map();
+    warmStateByRuntime.set(listener, warmStateByAgent);
+  }
+  return warmStateByAgent;
+}
+
+async function hydrateListenerSessionWarmState(
+  listener: ListenerRuntime,
+  agentId: string,
+): Promise<ListenerAgentMetadata | null> {
   const agentMetadataPromise =
     getAgentMetadataPromise(listener, agentId) ??
     (async () => {
@@ -95,17 +100,7 @@ export async function ensureListenerWarmStateForTurn(
       warmupDeps.ensureSecretsHydratedForAgent(listener, agentId),
       agentMetadataPromise,
     ]);
-    const agentModAdapter = await ensureListenerAgentModAdapter(
-      listener,
-      agentId,
-    );
-    const transport = listener.transport ?? listener.socket;
-    if (agentModAdapter && transport && isListenerTransportOpen(transport)) {
-      emitDeviceStatusUpdateIfChanged(transport, listener, {
-        agent_id: agentId,
-        conversation_id: scope.conversationId,
-      });
-    }
+    await ensureListenerAgentModAdapter(listener, agentId);
   } catch (error) {
     debugWarn(
       "listener-warmup",
@@ -116,6 +111,95 @@ export async function ensureListenerWarmStateForTurn(
   }
 
   return agentMetadataPromise;
+}
+
+function getOrStartListenerSessionWarmState(
+  listener: ListenerRuntime,
+  agentId: string,
+): Promise<ListenerAgentMetadata | null> {
+  const warmStateByAgent = getWarmStateMap(listener);
+  const existing = warmStateByAgent.get(agentId);
+  if (existing) {
+    return existing;
+  }
+
+  const promise = hydrateListenerSessionWarmState(listener, agentId).finally(
+    () => {
+      if (warmStateByAgent.get(agentId) === promise) {
+        warmStateByAgent.delete(agentId);
+      }
+    },
+  );
+  warmStateByAgent.set(agentId, promise);
+  return promise;
+}
+
+export function preloadListenerWarmStateForTurn(
+  listener: ListenerRuntime,
+  scope: ListenerWarmupScope,
+): void {
+  const { agentId } = scope;
+  if (!agentId) {
+    return;
+  }
+
+  void getOrStartListenerSessionWarmState(listener, agentId).catch((error) => {
+    debugWarn(
+      "listener-warmup",
+      `Background listener warmup failed for agent ${agentId}: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+  });
+}
+
+async function emitWarmStateForScope(
+  listener: ListenerRuntime,
+  scope: ListenerWarmupScope,
+  agentId: string,
+): Promise<void> {
+  const agentModAdapter = await ensureListenerAgentModAdapter(
+    listener,
+    agentId,
+  );
+  const transport = listener.transport ?? listener.socket;
+  if (agentModAdapter && transport && isListenerTransportOpen(transport)) {
+    emitDeviceStatusUpdateIfChanged(transport, listener, {
+      agent_id: agentId,
+      conversation_id: scope.conversationId,
+    });
+  }
+}
+
+/**
+ * Hydrate listener-side state needed for the next turn.
+ *
+ * The warmup is intentionally best-effort: failures are logged and do not
+ * block the user turn, mirroring the existing preflight behavior.
+ */
+export async function ensureListenerWarmStateForTurn(
+  listener: ListenerRuntime,
+  scope: ListenerWarmupScope,
+): Promise<ListenerAgentMetadata | null> {
+  const { agentId } = scope;
+  if (!agentId) {
+    return null;
+  }
+
+  const promise = getOrStartListenerSessionWarmState(listener, agentId);
+  try {
+    const metadata = await promise;
+    await emitWarmStateForScope(listener, scope, agentId);
+    return metadata;
+  } catch (error) {
+    debugWarn(
+      "listener-warmup",
+      `Listener warm state emission failed for agent ${agentId}: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+    return promise;
+  }
 }
 
 /**
@@ -149,6 +233,7 @@ export function scheduleListenerWarmupsAfterSync(
 
 export function clearListenerWarmState(listener: ListenerRuntime): void {
   listener.agentMetadataByAgent.clear();
+  warmStateByRuntime.delete(listener);
 }
 
 export const __listenerWarmupTestUtils = {


### PR DESCRIPTION
## Summary

The listener already had a warmup path for MemFS, secrets, agent metadata, and mod adapter readiness, but the first create_message turn could still be the caller that started that work after input acceptance. This PR starts the same session-stable warm state as soon as the listener sees a sync or valid create_message input, then has turn setup await the same in-flight promise instead of duplicating it.

Turn-specific work stays in turn setup: runtime-start agent fetching, tool-context construction, client-skill payload construction, approval handling, and the final Core POST are unchanged.

## Verification

- `bun test src/websocket/listener-warmup.test.ts src/websocket/listener/message-router.test.ts` — 10 pass
- `bunx --bun @biomejs/biome@2.2.5 check src/websocket/listener-warmup.test.ts src/websocket/listener/lifecycle.ts src/websocket/listener/warmup.ts src/websocket/listener/message-router.ts src/websocket/listener/message-router.test.ts` — pass
- `bun run typecheck` — pass
- `bun run check` — 12/12 pass

## Breadcrumbs

- Linear: LET-11109
- Origin: existing listener warmup path in `src/websocket/listener/warmup.ts`; no runtime-start agent-fetch changes included.

## AI Disclosure

- [ ] This pull request was written entirely by a human
- [ ] This pull request was written with AI assistance and reviewed and edited by a human
- [x] I have read the [AI Policy](https://github.com/letta-ai/letta-code/blob/main/AI_POLICY.md) and agree to its terms

## AI Tool(s) Used

Letta Code

## Human Verification

Draft pending human verification.