### PR TITLE
feat(telemetry): measure listener first-send latency [LET-11109]

### DIFF
--- a/src/telemetry/flush-batching.test.ts
+++ b/src/telemetry/flush-batching.test.ts
@@ -38,6 +38,8 @@ describe("telemetry flush batching", () => {
     telemetryState.sessionEndTracked = false;
     telemetryState.inflightFlush = null;
     deleteEnvVarCaseInsensitive("LETTA_API_KEY");
+    deleteEnvVarCaseInsensitive("LETTA_CODE_TELEM");
+    deleteEnvVarCaseInsensitive("DO_NOT_TRACK");
     deleteEnvVarCaseInsensitive("LETTA_TELEMETRY_DISABLED");
     deleteEnvVarCaseInsensitive("LETTA_BASE_URL");
     settingsManager.getSettings = mock(() => ({
@@ -53,6 +55,61 @@ describe("telemetry flush batching", () => {
     settingsManager.getSettingsWithSecureTokens =
       originalGetSettingsWithSecureTokens;
     settingsManager.getSettings = originalGetSettings;
+  });
+
+  test("tracks listener latency completion events without payloads", () => {
+    telemetry.trackListenerRuntimeStartComplete({
+      request_id: "runtime-1",
+      connection_id: "conn-1",
+      agent_id: "agent-1",
+      conversation_id: "conv-1",
+      success: true,
+      created_agent: false,
+      created_conversation: false,
+      wait_for_replay: false,
+      duration_ms: 12,
+      validate_ms: 1,
+      resolve_agent_ms: 2,
+      resolve_conversation_ms: 3,
+      source_tags_ms: 4,
+      runtime_state_ms: 5,
+      subscribe_tools_ms: 6,
+      ack_ms: 7,
+    });
+    telemetry.trackListenerInputSendComplete({
+      connection_id: "conn-1",
+      agent_id: "agent-1",
+      conversation_id: "conv-1",
+      client_message_id: "cm-1",
+      client_message_count: 1,
+      message_count: 1,
+      includes_approval: false,
+      success: true,
+      accepted_to_core_stream_ms: 10,
+      prepare_listener_turn_ms: 4,
+      skill_content_injection_ms: 1,
+      core_stream_request_ms: 5,
+    });
+
+    expect(telemetryState.events).toHaveLength(2);
+    expect(telemetryState.events).toEqual([
+      expect.objectContaining({
+        type: "listener_runtime_start_complete",
+        data: expect.objectContaining({
+          request_id: "runtime-1",
+          connection_id: "conn-1",
+          duration_ms: 12,
+        }),
+      }),
+      expect.objectContaining({
+        type: "listener_input_send_complete",
+        data: expect.objectContaining({
+          client_message_id: "cm-1",
+          accepted_to_core_stream_ms: 10,
+        }),
+      }),
+    ]);
+    expect(JSON.stringify(telemetryState.events)).not.toContain("hello");
   });
 
   test("concurrent flush() callers share one in-flight POST", async () => {

--- a/src/telemetry/flush-batching.test.ts
+++ b/src/telemetry/flush-batching.test.ts
@@ -1,6 +1,10 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { settingsManager } from "@/settings-manager";
-import { type TelemetrySurface, telemetry } from "@/telemetry";
+import {
+  hashTelemetryCorrelationId,
+  type TelemetrySurface,
+  telemetry,
+} from "@/telemetry";
 
 type TelemetryTestState = {
   events: unknown[];
@@ -58,10 +62,11 @@ describe("telemetry flush batching", () => {
   });
 
   test("tracks listener latency completion events without payloads", () => {
+    telemetry.setCurrentAgentId("current-agent");
     telemetry.trackListenerRuntimeStartComplete({
-      request_id: "runtime-1",
-      connection_id: "conn-1",
-      agent_id: "agent-1",
+      request_id_hash: hashTelemetryCorrelationId("runtime-1"),
+      connection_id_hash: hashTelemetryCorrelationId("conn-1"),
+      agent_id: "target-agent",
       conversation_id: "conv-1",
       success: true,
       created_agent: false,
@@ -77,10 +82,10 @@ describe("telemetry flush batching", () => {
       ack_ms: 7,
     });
     telemetry.trackListenerInputSendComplete({
-      connection_id: "conn-1",
-      agent_id: "agent-1",
+      connection_id_hash: hashTelemetryCorrelationId("conn-1"),
+      agent_id: "target-agent",
       conversation_id: "conv-1",
-      client_message_id: "cm-1",
+      client_message_id_hash: hashTelemetryCorrelationId("cm-1"),
       client_message_count: 1,
       message_count: 1,
       includes_approval: false,
@@ -92,19 +97,23 @@ describe("telemetry flush batching", () => {
     });
 
     expect(telemetryState.events).toHaveLength(2);
+    telemetry.setCurrentAgent("later-current-agent", []);
+    expect(telemetryState.events).toHaveLength(2);
     expect(telemetryState.events).toEqual([
       expect.objectContaining({
         type: "listener_runtime_start_complete",
         data: expect.objectContaining({
-          request_id: "runtime-1",
-          connection_id: "conn-1",
+          request_id_hash: hashTelemetryCorrelationId("runtime-1"),
+          connection_id_hash: hashTelemetryCorrelationId("conn-1"),
+          agent_id: "target-agent",
           duration_ms: 12,
         }),
       }),
       expect.objectContaining({
         type: "listener_input_send_complete",
         data: expect.objectContaining({
-          client_message_id: "cm-1",
+          client_message_id_hash: hashTelemetryCorrelationId("cm-1"),
+          agent_id: "target-agent",
           accepted_to_core_stream_ms: 10,
         }),
       }),

--- a/src/telemetry/index.ts
+++ b/src/telemetry/index.ts
@@ -38,6 +38,8 @@ export interface TelemetryEvent {
     | "tool_usage"
     | "error"
     | "user_input"
+    | "listener_runtime_start_complete"
+    | "listener_input_send_complete"
     | "reflection_start"
     | "reflection_end"
     | "reflection_worktree_cleanup"
@@ -103,6 +105,47 @@ export interface UserInputData {
   command_name?: string;
   message_type: string;
   model_id: string;
+}
+
+export interface ListenerRuntimeStartCompleteData {
+  request_id?: string;
+  connection_id: string;
+  agent_id?: string | null;
+  conversation_id?: string | null;
+  success: boolean;
+  created_agent: boolean;
+  created_conversation: boolean;
+  wait_for_replay: boolean;
+  duration_ms: number;
+  validate_ms: number;
+  resolve_agent_ms: number;
+  resolve_conversation_ms: number;
+  source_tags_ms: number;
+  runtime_state_ms: number;
+  subscribe_tools_ms: number;
+  ack_ms: number;
+  replay_before_ack_ms?: number;
+  error_type?: string;
+  version?: string;
+  platform?: string;
+}
+
+export interface ListenerInputSendCompleteData {
+  connection_id?: string;
+  agent_id?: string | null;
+  conversation_id: string;
+  client_message_id?: string;
+  client_message_count: number;
+  message_count: number;
+  includes_approval: boolean;
+  success: boolean;
+  accepted_to_core_stream_ms: number;
+  prepare_listener_turn_ms: number;
+  skill_content_injection_ms: number;
+  core_stream_request_ms: number;
+  error_type?: string;
+  version?: string;
+  platform?: string;
 }
 
 export type ReflectionTriggerSource =
@@ -462,6 +505,8 @@ class TelemetryManager {
       | ToolUsageData
       | ErrorData
       | UserInputData
+      | ListenerRuntimeStartCompleteData
+      | ListenerInputSendCompleteData
       | ReflectionStartData
       | ReflectionEndData
       | ReflectionWorktreeCleanupData
@@ -776,6 +821,26 @@ class TelemetryManager {
       model_id: modelId,
     };
     this.track("user_input", data);
+  }
+
+  trackListenerRuntimeStartComplete(
+    options: Omit<ListenerRuntimeStartCompleteData, "version" | "platform">,
+  ) {
+    this.track("listener_runtime_start_complete", {
+      ...options,
+      version: getVersion(),
+      platform: process.platform,
+    });
+  }
+
+  trackListenerInputSendComplete(
+    options: Omit<ListenerInputSendCompleteData, "version" | "platform">,
+  ) {
+    this.track("listener_input_send_complete", {
+      ...options,
+      version: getVersion(),
+      platform: process.platform,
+    });
   }
 
   /**

--- a/src/telemetry/index.ts
+++ b/src/telemetry/index.ts
@@ -13,6 +13,12 @@ import {
   type TelemetryAgentOrigin,
 } from "./agent-origin";
 import { installFatalErrorHandlers } from "./fatal-error-handler";
+import type {
+  ListenerInputSendCompleteData,
+  ListenerRuntimeStartCompleteData,
+} from "./listener-events";
+
+export { hashTelemetryCorrelationId } from "./listener-events";
 
 export type TelemetrySurface =
   | "letta_code_tui"
@@ -107,47 +113,6 @@ export interface UserInputData {
   model_id: string;
 }
 
-export interface ListenerRuntimeStartCompleteData {
-  request_id?: string;
-  connection_id: string;
-  agent_id?: string | null;
-  conversation_id?: string | null;
-  success: boolean;
-  created_agent: boolean;
-  created_conversation: boolean;
-  wait_for_replay: boolean;
-  duration_ms: number;
-  validate_ms: number;
-  resolve_agent_ms: number;
-  resolve_conversation_ms: number;
-  source_tags_ms: number;
-  runtime_state_ms: number;
-  subscribe_tools_ms: number;
-  ack_ms: number;
-  replay_before_ack_ms?: number;
-  error_type?: string;
-  version?: string;
-  platform?: string;
-}
-
-export interface ListenerInputSendCompleteData {
-  connection_id?: string;
-  agent_id?: string | null;
-  conversation_id: string;
-  client_message_id?: string;
-  client_message_count: number;
-  message_count: number;
-  includes_approval: boolean;
-  success: boolean;
-  accepted_to_core_stream_ms: number;
-  prepare_listener_turn_ms: number;
-  skill_content_injection_ms: number;
-  core_stream_request_ms: number;
-  error_type?: string;
-  version?: string;
-  platform?: string;
-}
-
 export type ReflectionTriggerSource =
   | "manual"
   | "step-count"
@@ -219,6 +184,19 @@ export interface ReflectionArenaVoteData {
   transcript_payload_truncated: boolean;
   version?: string;
   platform?: string;
+}
+
+function hasOwnAgentId(data: Record<string, unknown>): boolean {
+  return Object.hasOwn(data, "agent_id");
+}
+
+function isListenerTargetedTelemetryEvent(
+  type: TelemetryEvent["type"],
+): boolean {
+  return (
+    type === "listener_runtime_start_complete" ||
+    type === "listener_input_send_complete"
+  );
 }
 
 export function isLettaCodeDesktopRuntime(
@@ -516,13 +494,18 @@ class TelemetryManager {
       return;
     }
 
+    const eventData = data as Record<string, unknown>;
+    const shouldPreserveAgentId =
+      isListenerTargetedTelemetryEvent(type) && hasOwnAgentId(eventData);
     const event: TelemetryEvent = {
       type,
       timestamp: new Date().toISOString(),
       data: {
         ...data,
         session_id: this.sessionId,
-        agent_id: this.currentAgentId || undefined,
+        agent_id: shouldPreserveAgentId
+          ? eventData.agent_id
+          : this.currentAgentId || undefined,
         agent_origin: this.currentAgentOrigin || undefined,
         surface: this.surface,
         backend: resolveTelemetryBackend(),
@@ -568,6 +551,12 @@ class TelemetryManager {
     }
 
     for (const event of this.events) {
+      if (
+        isListenerTargetedTelemetryEvent(event.type) &&
+        hasOwnAgentId(event.data)
+      ) {
+        continue;
+      }
       if (event.data.agent_id && event.data.agent_id !== agentId) {
         continue;
       }

--- a/src/telemetry/listener-events.ts
+++ b/src/telemetry/listener-events.ts
@@ -1,0 +1,46 @@
+import { createHash } from "node:crypto";
+
+export interface ListenerRuntimeStartCompleteData {
+  request_id_hash?: string;
+  connection_id_hash: string;
+  agent_id?: string | null;
+  conversation_id?: string | null;
+  success: boolean;
+  created_agent: boolean;
+  created_conversation: boolean;
+  wait_for_replay: boolean;
+  duration_ms: number;
+  validate_ms: number;
+  resolve_agent_ms: number;
+  resolve_conversation_ms: number;
+  source_tags_ms: number;
+  runtime_state_ms: number;
+  subscribe_tools_ms: number;
+  ack_ms: number;
+  replay_before_ack_ms?: number;
+  error_type?: string;
+  version?: string;
+  platform?: string;
+}
+
+export interface ListenerInputSendCompleteData {
+  connection_id_hash?: string;
+  agent_id?: string | null;
+  conversation_id: string;
+  client_message_id_hash?: string;
+  client_message_count: number;
+  message_count: number;
+  includes_approval: boolean;
+  success: boolean;
+  accepted_to_core_stream_ms: number;
+  prepare_listener_turn_ms: number;
+  skill_content_injection_ms: number;
+  core_stream_request_ms: number;
+  error_type?: string;
+  version?: string;
+  platform?: string;
+}
+
+export function hashTelemetryCorrelationId(value: string): string {
+  return createHash("sha256").update(value).digest("hex").slice(0, 32);
+}

--- a/src/websocket/listener/commands/runtime-start-skill-sources.test.ts
+++ b/src/websocket/listener/commands/runtime-start-skill-sources.test.ts
@@ -5,7 +5,7 @@ import { join } from "node:path";
 import type WebSocket from "ws";
 import { __testSetBackend, type AgentCreateBody } from "@/backend";
 import { LocalBackend } from "@/backend/local";
-import { telemetry } from "@/telemetry";
+import { hashTelemetryCorrelationId, telemetry } from "@/telemetry";
 import { getOrCreateScopedRuntime } from "@/websocket/listener/conversation-runtime";
 import { createRuntime } from "@/websocket/listener/lifecycle";
 import { evictConversationRuntimeIfIdle } from "@/websocket/listener/runtime";
@@ -57,8 +57,8 @@ describe("runtime_start skill sources", () => {
       expect(trackRuntimeStart).toHaveBeenCalledTimes(1);
       expect(trackRuntimeStart).toHaveBeenCalledWith(
         expect.objectContaining({
-          request_id: "runtime-telemetry",
-          connection_id: "test-connection",
+          request_id_hash: hashTelemetryCorrelationId("runtime-telemetry"),
+          connection_id_hash: hashTelemetryCorrelationId("test-connection"),
           agent_id: agent.id,
           conversation_id: "default",
           success: true,

--- a/src/websocket/listener/commands/runtime-start-skill-sources.test.ts
+++ b/src/websocket/listener/commands/runtime-start-skill-sources.test.ts
@@ -1,10 +1,11 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, mock, test } from "bun:test";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type WebSocket from "ws";
 import { __testSetBackend, type AgentCreateBody } from "@/backend";
 import { LocalBackend } from "@/backend/local";
+import { telemetry } from "@/telemetry";
 import { getOrCreateScopedRuntime } from "@/websocket/listener/conversation-runtime";
 import { createRuntime } from "@/websocket/listener/lifecycle";
 import { evictConversationRuntimeIfIdle } from "@/websocket/listener/runtime";
@@ -13,6 +14,65 @@ import { handleRuntimeStartCommand } from "./runtime-start";
 describe("runtime_start skill sources", () => {
   afterEach(() => {
     __testSetBackend(null);
+  });
+
+  test("emits one aggregate runtime_start completion telemetry event", async () => {
+    const originalTrackRuntimeStart =
+      telemetry.trackListenerRuntimeStartComplete;
+    const trackRuntimeStart = mock(() => {});
+    telemetry.trackListenerRuntimeStartComplete =
+      trackRuntimeStart as typeof telemetry.trackListenerRuntimeStartComplete;
+    const storageDir = await mkdtemp(join(tmpdir(), "runtime-telemetry-"));
+    try {
+      const backend = new LocalBackend({
+        storageDir,
+        executionMode: "deterministic",
+      });
+      __testSetBackend(backend);
+      const agent = await backend.createAgent({
+        name: "Telemetry worker",
+        model: "anthropic/claude-sonnet-4-6",
+      } as AgentCreateBody);
+      const listener = createRuntime();
+
+      await handleRuntimeStartCommand(
+        {
+          type: "runtime_start",
+          request_id: "runtime-telemetry",
+          agent_id: agent.id,
+          conversation_id: "default",
+          recover_approvals: false,
+        },
+        {
+          socket: {} as WebSocket,
+          connectionId: "test-connection",
+          runtime: listener,
+          safeSocketSend: () => true,
+          runDetachedListenerTask: () => {},
+          getOrCreateScopedRuntime,
+          replaySyncStateForRuntime: async () => {},
+        },
+      );
+
+      expect(trackRuntimeStart).toHaveBeenCalledTimes(1);
+      expect(trackRuntimeStart).toHaveBeenCalledWith(
+        expect.objectContaining({
+          request_id: "runtime-telemetry",
+          connection_id: "test-connection",
+          agent_id: agent.id,
+          conversation_id: "default",
+          success: true,
+          wait_for_replay: false,
+          duration_ms: expect.any(Number),
+          resolve_agent_ms: expect.any(Number),
+          resolve_conversation_ms: expect.any(Number),
+          ack_ms: expect.any(Number),
+        }),
+      );
+    } finally {
+      telemetry.trackListenerRuntimeStartComplete = originalTrackRuntimeStart;
+      await rm(storageDir, { recursive: true, force: true });
+    }
   });
 
   test("keeps an empty override across idle runtime eviction", async () => {

--- a/src/websocket/listener/commands/runtime-start.ts
+++ b/src/websocket/listener/commands/runtime-start.ts
@@ -18,6 +18,7 @@ import { migratePermissionMode } from "@/permissions/mode";
 import { canonicalizeRoot } from "@/permissions/sandbox-policy";
 import { resolveWorkspaceSandbox } from "@/permissions/workspace-sandbox";
 import { settingsManager } from "@/settings-manager";
+import { telemetry } from "@/telemetry";
 import type { RuntimeScope, RuntimeStartCommand } from "@/types/protocol_v2";
 import { subscribeListenerConnection } from "@/websocket/listener/connection";
 import { getBootWorkingDirectory } from "@/websocket/listener/cwd";
@@ -87,6 +88,14 @@ function getErrorMessage(error: unknown, fallback: string): string {
 
 function hasString(value: unknown): value is string {
   return typeof value === "string" && value.length > 0;
+}
+
+function elapsedMsSince(start: number): number {
+  return Math.round((performance.now() - start) * 100) / 100;
+}
+
+function errorType(error: unknown): string {
+  return error instanceof Error ? error.name : typeof error;
 }
 
 function buildRuntimeScope(
@@ -401,15 +410,32 @@ export async function handleRuntimeStartCommand(
   parsed: RuntimeStartCommand,
   context: RuntimeStartCommandContext,
 ): Promise<boolean> {
+  const telemetryStartedAt = performance.now();
   const created = { agent: false, conversation: false };
+  const timings = {
+    validateMs: 0,
+    resolveAgentMs: 0,
+    resolveConversationMs: 0,
+    sourceTagsMs: 0,
+    runtimeStateMs: 0,
+    subscribeToolsMs: 0,
+    ackMs: 0,
+    replayBeforeAckMs: undefined as number | undefined,
+  };
   let agent: AgentState | null = null;
   let conversation: Conversation | null = null;
   let runtimeScope: RuntimeStartScope | null = null;
   let shouldReplayState = false;
+  let stepStartedAt = performance.now();
 
   try {
+    stepStartedAt = performance.now();
     validateRuntimeStartShape(parsed);
+    timings.validateMs = elapsedMsSince(stepStartedAt);
+    stepStartedAt = performance.now();
     agent = await resolveRuntimeStartAgent(parsed, created);
+    timings.resolveAgentMs = elapsedMsSince(stepStartedAt);
+    stepStartedAt = performance.now();
     conversation = await resolveRuntimeStartConversation(
       parsed,
       agent,
@@ -418,10 +444,13 @@ export async function handleRuntimeStartCommand(
       context.retrieveConversation ??
         ((id) => getBackend().retrieveConversation(id)),
     );
+    timings.resolveConversationMs = elapsedMsSince(stepStartedAt);
+    stepStartedAt = performance.now();
     conversation = await applyRuntimeStartConversationSourceTags(
       parsed,
       conversation,
     );
+    timings.sourceTagsMs = elapsedMsSince(stepStartedAt);
     runtimeScope = buildRuntimeScope(agent, conversation);
     const { connectionId } = context;
     const assertConnectionOpen = () => {
@@ -440,8 +469,11 @@ export async function handleRuntimeStartCommand(
       runtimeScope.agent_id,
       runtimeScope.conversation_id,
     );
+    stepStartedAt = performance.now();
     await applyRuntimeStartState(parsed, context, runtimeScope, scopedRuntime);
+    timings.runtimeStateMs = elapsedMsSince(stepStartedAt);
     assertConnectionOpen();
+    stepStartedAt = performance.now();
     subscribeListenerConnection(context.runtime, connectionId, runtimeScope);
     registerRuntimeExternalTools(
       context.runtime,
@@ -449,8 +481,10 @@ export async function handleRuntimeStartCommand(
       runtimeScope,
       parsed.external_tools ?? [],
     );
+    timings.subscribeToolsMs = elapsedMsSince(stepStartedAt);
 
     if (parsed.wait_for_replay) {
+      stepStartedAt = performance.now();
       await context.replaySyncStateForRuntime(
         context.runtime,
         context.socket,
@@ -460,7 +494,9 @@ export async function handleRuntimeStartCommand(
           forceDeviceStatus: parsed.force_device_status !== false,
         },
       );
+      timings.replayBeforeAckMs = elapsedMsSince(stepStartedAt);
     }
+    stepStartedAt = performance.now();
     const sent = sendRuntimeStartResponse(context, parsed, {
       success: true,
       runtime: runtimeScope,
@@ -468,8 +504,31 @@ export async function handleRuntimeStartCommand(
       conversation,
       created,
     });
+    timings.ackMs = elapsedMsSince(stepStartedAt);
+    telemetry.trackListenerRuntimeStartComplete({
+      request_id: parsed.request_id,
+      connection_id: context.connectionId,
+      agent_id: runtimeScope.agent_id,
+      conversation_id: runtimeScope.conversation_id,
+      success: true,
+      created_agent: created.agent,
+      created_conversation: created.conversation,
+      wait_for_replay: parsed.wait_for_replay === true,
+      duration_ms: elapsedMsSince(telemetryStartedAt),
+      validate_ms: timings.validateMs,
+      resolve_agent_ms: timings.resolveAgentMs,
+      resolve_conversation_ms: timings.resolveConversationMs,
+      source_tags_ms: timings.sourceTagsMs,
+      runtime_state_ms: timings.runtimeStateMs,
+      subscribe_tools_ms: timings.subscribeToolsMs,
+      ack_ms: timings.ackMs,
+      ...(timings.replayBeforeAckMs !== undefined
+        ? { replay_before_ack_ms: timings.replayBeforeAckMs }
+        : {}),
+    });
     shouldReplayState = sent && !parsed.wait_for_replay;
   } catch (error) {
+    stepStartedAt = performance.now();
     sendRuntimeStartResponse(context, parsed, {
       success: false,
       runtime: null,
@@ -477,6 +536,33 @@ export async function handleRuntimeStartCommand(
       conversation,
       created,
       error: getErrorMessage(error, "Failed to start runtime"),
+    });
+    timings.ackMs = elapsedMsSince(stepStartedAt);
+    telemetry.trackListenerRuntimeStartComplete({
+      request_id: parsed.request_id,
+      connection_id: context.connectionId,
+      agent_id: runtimeScope?.agent_id ?? agent?.id ?? parsed.agent_id ?? null,
+      conversation_id:
+        runtimeScope?.conversation_id ??
+        conversation?.id ??
+        parsed.conversation_id ??
+        null,
+      success: false,
+      created_agent: created.agent,
+      created_conversation: created.conversation,
+      wait_for_replay: parsed.wait_for_replay === true,
+      duration_ms: elapsedMsSince(telemetryStartedAt),
+      validate_ms: timings.validateMs,
+      resolve_agent_ms: timings.resolveAgentMs,
+      resolve_conversation_ms: timings.resolveConversationMs,
+      source_tags_ms: timings.sourceTagsMs,
+      runtime_state_ms: timings.runtimeStateMs,
+      subscribe_tools_ms: timings.subscribeToolsMs,
+      ack_ms: timings.ackMs,
+      error_type: errorType(error),
+      ...(timings.replayBeforeAckMs !== undefined
+        ? { replay_before_ack_ms: timings.replayBeforeAckMs }
+        : {}),
     });
   }
 

--- a/src/websocket/listener/commands/runtime-start.ts
+++ b/src/websocket/listener/commands/runtime-start.ts
@@ -18,7 +18,7 @@ import { migratePermissionMode } from "@/permissions/mode";
 import { canonicalizeRoot } from "@/permissions/sandbox-policy";
 import { resolveWorkspaceSandbox } from "@/permissions/workspace-sandbox";
 import { settingsManager } from "@/settings-manager";
-import { telemetry } from "@/telemetry";
+import { hashTelemetryCorrelationId, telemetry } from "@/telemetry";
 import type { RuntimeScope, RuntimeStartCommand } from "@/types/protocol_v2";
 import { subscribeListenerConnection } from "@/websocket/listener/connection";
 import { getBootWorkingDirectory } from "@/websocket/listener/cwd";
@@ -506,8 +506,10 @@ export async function handleRuntimeStartCommand(
     });
     timings.ackMs = elapsedMsSince(stepStartedAt);
     telemetry.trackListenerRuntimeStartComplete({
-      request_id: parsed.request_id,
-      connection_id: context.connectionId,
+      ...(parsed.request_id
+        ? { request_id_hash: hashTelemetryCorrelationId(parsed.request_id) }
+        : {}),
+      connection_id_hash: hashTelemetryCorrelationId(context.connectionId),
       agent_id: runtimeScope.agent_id,
       conversation_id: runtimeScope.conversation_id,
       success: true,
@@ -539,8 +541,10 @@ export async function handleRuntimeStartCommand(
     });
     timings.ackMs = elapsedMsSince(stepStartedAt);
     telemetry.trackListenerRuntimeStartComplete({
-      request_id: parsed.request_id,
-      connection_id: context.connectionId,
+      ...(parsed.request_id
+        ? { request_id_hash: hashTelemetryCorrelationId(parsed.request_id) }
+        : {}),
+      connection_id_hash: hashTelemetryCorrelationId(context.connectionId),
       agent_id: runtimeScope?.agent_id ?? agent?.id ?? parsed.agent_id ?? null,
       conversation_id:
         runtimeScope?.conversation_id ??

--- a/src/websocket/listener/inbound-dispatch.ts
+++ b/src/websocket/listener/inbound-dispatch.ts
@@ -120,9 +120,13 @@ export function dispatchInboundMessageWhenReady(params: {
         shouldQueueInboundMessage(incoming) &&
         !shouldProcessInboundMessageDirectly(runtime, incoming)
       ) {
+        const queuedIncoming = {
+          ...incoming,
+          telemetryInputAcceptedAtMs: performance.now(),
+        };
         const accepted = enqueueInboundUserMessage(
           runtime,
-          incoming,
+          queuedIncoming,
           actingUserId,
         );
         if (accepted) {
@@ -147,10 +151,13 @@ export function dispatchInboundMessageWhenReady(params: {
       acknowledgeInput({ accepted: true, disposition: "started" });
       // Queued turns store the actor on the queue item. Direct turns skip that
       // item, so carry the actor on the message consumed by turn.ts instead.
-      const attributedIncoming =
-        actingUserId && incoming.actingUserId !== actingUserId
-          ? { ...incoming, actingUserId }
-          : incoming;
+      const attributedIncoming = {
+        ...incoming,
+        ...(actingUserId && incoming.actingUserId !== actingUserId
+          ? { actingUserId }
+          : {}),
+        telemetryInputAcceptedAtMs: performance.now(),
+      };
       await processIncomingMessage(
         attributedIncoming,
         getOrCreateProcessTransport(listener),

--- a/src/websocket/listener/inbound-dispatch.ts
+++ b/src/websocket/listener/inbound-dispatch.ts
@@ -120,9 +120,10 @@ export function dispatchInboundMessageWhenReady(params: {
         shouldQueueInboundMessage(incoming) &&
         !shouldProcessInboundMessageDirectly(runtime, incoming)
       ) {
+        const acceptedAtMs = performance.now();
         const queuedIncoming = {
           ...incoming,
-          telemetryInputAcceptedAtMs: performance.now(),
+          telemetryInputAcceptedAtMs: acceptedAtMs,
         };
         const accepted = enqueueInboundUserMessage(
           runtime,
@@ -147,6 +148,7 @@ export function dispatchInboundMessageWhenReady(params: {
         options.onStatusChange,
         options.connectionId,
       );
+      const acceptedAtMs = performance.now();
       rememberAcceptedInputDisposition(runtime, clientMessageId, "started");
       acknowledgeInput({ accepted: true, disposition: "started" });
       // Queued turns store the actor on the queue item. Direct turns skip that
@@ -156,7 +158,7 @@ export function dispatchInboundMessageWhenReady(params: {
         ...(actingUserId && incoming.actingUserId !== actingUserId
           ? { actingUserId }
           : {}),
-        telemetryInputAcceptedAtMs: performance.now(),
+        telemetryInputAcceptedAtMs: acceptedAtMs,
       };
       await processIncomingMessage(
         attributedIncoming,

--- a/src/websocket/listener/message-router.ts
+++ b/src/websocket/listener/message-router.ts
@@ -600,9 +600,13 @@ export function createListenerMessageHandler(
             return;
           }
 
+          const queuedStampedIncoming = {
+            ...stampedIncoming,
+            telemetryInputAcceptedAtMs: performance.now(),
+          };
           const enqueued = enqueueInboundUserMessage(
             scopedRuntime,
-            stampedIncoming,
+            queuedStampedIncoming,
             parsed.runtime.acting_user_id,
           );
           if (enqueued) {

--- a/src/websocket/listener/message-router.ts
+++ b/src/websocket/listener/message-router.ts
@@ -600,9 +600,10 @@ export function createListenerMessageHandler(
             return;
           }
 
+          const acceptedAtMs = performance.now();
           const queuedStampedIncoming = {
             ...stampedIncoming,
-            telemetryInputAcceptedAtMs: performance.now(),
+            telemetryInputAcceptedAtMs: acceptedAtMs,
           };
           const enqueued = enqueueInboundUserMessage(
             scopedRuntime,

--- a/src/websocket/listener/turn-finalizer.ts
+++ b/src/websocket/listener/turn-finalizer.ts
@@ -1,0 +1,56 @@
+import type { ListenerTransport } from "./transport";
+import type { TurnLease } from "./turn-lifecycle";
+import { finishListenerTurn } from "./turn-terminal";
+import type { ConversationRuntime } from "./types";
+
+type FinishTurnOptions = Parameters<typeof finishListenerTurn>[2];
+type FinishTurnTransition = ReturnType<typeof finishListenerTurn>;
+
+export function createTurnFinalizer(params: {
+  runtime: ConversationRuntime;
+  turnLease: TurnLease;
+  socket: ListenerTransport;
+  getTurnId: () => string;
+  getAgentId: () => string | null;
+  conversationId: string;
+}): {
+  noteFinalization: (transition: FinishTurnTransition) => FinishTurnTransition;
+  finishTurn: (options: FinishTurnOptions) => FinishTurnTransition;
+  finishIfInterrupted: (runId?: string | null) => boolean;
+  wasFinalized: () => boolean;
+} {
+  let finalizedByThisInvocation = false;
+  const noteFinalization = (transition: FinishTurnTransition) => {
+    finalizedByThisInvocation ||= transition.finished;
+    return transition;
+  };
+  const finishTurn = (options: FinishTurnOptions) =>
+    noteFinalization(
+      finishListenerTurn(params.runtime, params.turnLease, {
+        ...options,
+        socket: options.socket ?? params.socket,
+        turnId: params.getTurnId(),
+      }),
+    );
+  return {
+    noteFinalization,
+    finishTurn,
+    finishIfInterrupted(runId) {
+      if (
+        !params.turnLease.signal.aborted &&
+        params.runtime.turnLifecycle.isCurrent(params.turnLease)
+      ) {
+        return false;
+      }
+      finishTurn({
+        stopReason: "cancelled",
+        socket: params.socket,
+        runId,
+        agentId: params.getAgentId(),
+        conversationId: params.conversationId,
+      });
+      return true;
+    },
+    wasFinalized: () => finalizedByThisInvocation,
+  };
+}

--- a/src/websocket/listener/turn-send-telemetry.ts
+++ b/src/websocket/listener/turn-send-telemetry.ts
@@ -1,0 +1,62 @@
+import { telemetry } from "@/telemetry";
+import { getInboundClientMessageIds } from "./inbound-queue";
+import type { IncomingMessage } from "./types";
+
+export type ListenerInputSendTimings = {
+  prepareListenerTurnMs: number;
+  skillContentInjectionMs: number;
+  coreStreamRequestMs: number;
+};
+
+export function elapsedTelemetryMsSince(start: number): number {
+  return Math.round((performance.now() - start) * 100) / 100;
+}
+
+function errorType(error: unknown): string {
+  return error instanceof Error ? error.name : typeof error;
+}
+
+export function createListenerInputSendTelemetry(params: {
+  msg: IncomingMessage;
+  connectionId?: string;
+  agentId: string | null;
+  conversationId: string;
+}): {
+  timings: ListenerInputSendTimings;
+  track: (success: boolean, error?: unknown) => void;
+} {
+  const acceptedAtMs =
+    params.msg.telemetryInputAcceptedAtMs ?? performance.now();
+  const clientMessageIds = getInboundClientMessageIds(params.msg);
+  const timings: ListenerInputSendTimings = {
+    prepareListenerTurnMs: 0,
+    skillContentInjectionMs: 0,
+    coreStreamRequestMs: 0,
+  };
+  let tracked = false;
+
+  return {
+    timings,
+    track(success, error) {
+      if (tracked) return;
+      tracked = true;
+      telemetry.trackListenerInputSendComplete({
+        connection_id: params.connectionId,
+        agent_id: params.agentId,
+        conversation_id: params.conversationId,
+        client_message_id: clientMessageIds[0],
+        client_message_count: clientMessageIds.length,
+        message_count: params.msg.messages.length,
+        includes_approval: params.msg.messages.some(
+          (message) => "type" in message && message.type === "approval",
+        ),
+        success,
+        accepted_to_core_stream_ms: elapsedTelemetryMsSince(acceptedAtMs),
+        prepare_listener_turn_ms: timings.prepareListenerTurnMs,
+        skill_content_injection_ms: timings.skillContentInjectionMs,
+        core_stream_request_ms: timings.coreStreamRequestMs,
+        ...(error ? { error_type: errorType(error) } : {}),
+      });
+    },
+  };
+}

--- a/src/websocket/listener/turn-send-telemetry.ts
+++ b/src/websocket/listener/turn-send-telemetry.ts
@@ -1,4 +1,4 @@
-import { telemetry } from "@/telemetry";
+import { hashTelemetryCorrelationId, telemetry } from "@/telemetry";
 import { getInboundClientMessageIds } from "./inbound-queue";
 import type { IncomingMessage } from "./types";
 
@@ -41,10 +41,22 @@ export function createListenerInputSendTelemetry(params: {
       if (tracked) return;
       tracked = true;
       telemetry.trackListenerInputSendComplete({
-        connection_id: params.connectionId,
+        ...(params.connectionId
+          ? {
+              connection_id_hash: hashTelemetryCorrelationId(
+                params.connectionId,
+              ),
+            }
+          : {}),
         agent_id: params.agentId,
         conversation_id: params.conversationId,
-        client_message_id: clientMessageIds[0],
+        ...(clientMessageIds[0]
+          ? {
+              client_message_id_hash: hashTelemetryCorrelationId(
+                clientMessageIds[0],
+              ),
+            }
+          : {}),
         client_message_count: clientMessageIds.length,
         message_count: params.msg.messages.length,
         includes_approval: params.msg.messages.some(

--- a/src/websocket/listener/turn.ts
+++ b/src/websocket/listener/turn.ts
@@ -82,6 +82,7 @@ import {
   createTurnCorrelation,
   type TurnCorrelation,
 } from "./turn-correlation";
+import { createTurnFinalizer } from "./turn-finalizer";
 import {
   rebuildTurnInputWithFreshDenials,
   refreshTurnInputOtidsForNewRequest,
@@ -90,9 +91,12 @@ import {
 import type { TurnLease } from "./turn-lifecycle";
 import { notifyTurnFinished, notifyTurnStarted } from "./turn-observers";
 import { createTurnInputSender } from "./turn-send";
+import {
+  createListenerInputSendTelemetry,
+  elapsedTelemetryMsSince,
+} from "./turn-send-telemetry";
 import { prepareListenerTurn } from "./turn-setup";
 import { setTurnLoopStatus } from "./turn-status";
-import { finishListenerTurn } from "./turn-terminal";
 import { seedInboundUserTranscriptLines } from "./turn-transcript";
 import type { ConversationRuntime, IncomingMessage } from "./types";
 
@@ -179,37 +183,22 @@ async function handleIncomingMessageInner(
   if (!runtime.turnLifecycle.isCurrent(turnLease))
     throw new Error("Cannot continue a turn with a stale lifecycle lease");
   const turnAbortSignal = turnLease.signal;
-  let finalizedByThisInvocation = false;
-  const noteFinalization = (
-    transition: ReturnType<typeof finishListenerTurn>,
-  ) => {
-    finalizedByThisInvocation ||= transition.finished;
-    return transition;
-  };
-  const finishTurn = (options: Parameters<typeof finishListenerTurn>[2]) =>
-    noteFinalization(
-      finishListenerTurn(runtime, turnLease, {
-        ...options,
-        socket: options.socket ?? socket,
-        turnId: activeDequeuedBatchId,
-      }),
-    );
-  const finishIfInterrupted = (runId?: string | null): boolean => {
-    if (
-      !turnAbortSignal.aborted &&
-      runtime.turnLifecycle.isCurrent(turnLease)
-    ) {
-      return false;
-    }
-    finishTurn({
-      stopReason: "cancelled",
-      socket,
-      runId,
-      agentId: agentId ?? null,
-      conversationId,
-    });
-    return true;
-  };
+  const turnFinalizer = createTurnFinalizer({
+    runtime,
+    turnLease,
+    socket,
+    getTurnId: () => activeDequeuedBatchId,
+    getAgentId: () => agentId ?? null,
+    conversationId,
+  });
+  const { noteFinalization, finishTurn, finishIfInterrupted } = turnFinalizer;
+  const inputSendTelemetry = createListenerInputSendTelemetry({
+    msg,
+    connectionId,
+    agentId: agentId ?? null,
+    conversationId,
+  });
+  const sendTimings = inputSendTelemetry.timings;
   try {
     runtime.lastTerminalLoopErrorMessage = null;
     runtime.lastTerminalLoopErrorRunId = null;
@@ -227,6 +216,7 @@ async function handleIncomingMessageInner(
     });
     telemetry.setCurrentAgentId(agentId ?? null);
     let turnToolContextId: string | null = null;
+    let stepStartedAt = performance.now();
     const setup = await prepareListenerTurn({
       msg,
       runtime,
@@ -239,7 +229,9 @@ async function handleIncomingMessageInner(
       onStatusChange,
       connectionId,
     });
+    sendTimings.prepareListenerTurnMs = elapsedTelemetryMsSince(stepStartedAt);
     if (setup.kind === "interrupted") {
+      inputSendTelemetry.track(false, new Error("interrupted"));
       finishTurn({
         stopReason: "cancelled",
         socket,
@@ -249,6 +241,7 @@ async function handleIncomingMessageInner(
       return;
     }
     if (setup.kind === "cancelled") {
+      inputSendTelemetry.track(false, new Error("cancelled"));
       const transition = finishTurn({
         stopReason: "cancelled",
         agentId: agentId || null,
@@ -313,13 +306,19 @@ async function handleIncomingMessageInner(
       onTerminal: noteFinalization,
       getTurnId: () => activeDequeuedBatchId,
     });
+    stepStartedAt = performance.now();
     const currentInputWithSkillContent = injectQueuedSkillContent(
       turnInput.messages,
       { socket, runtime, agentId, conversationId },
     );
+    sendTimings.skillContentInjectionMs =
+      elapsedTelemetryMsSince(stepStartedAt);
+    stepStartedAt = performance.now();
     const initialSendResult = await turnInputSender.send(
       currentInputWithSkillContent,
     );
+    sendTimings.coreStreamRequestMs = elapsedTelemetryMsSince(stepStartedAt);
+    inputSendTelemetry.track(true);
     turnInput = updateTurnInputMessagesPreservingOtids(
       turnInput,
       currentInputWithSkillContent,
@@ -939,6 +938,7 @@ async function handleIncomingMessageInner(
       );
     }
   } catch (error) {
+    inputSendTelemetry.track(false, error);
     trackBoundaryError({
       errorType: "listener_turn_processing_failed",
       error,
@@ -1047,7 +1047,7 @@ async function handleIncomingMessageInner(
         agentId,
         normalizedAgentId: agentId,
         conversationId,
-        finalized: finalizedByThisInvocation,
+        finalized: turnFinalizer.wasFinalized(),
       });
     } finally {
       releaseListenerTurnContext({ runtime, agentId, conversationId });

--- a/src/websocket/listener/types.ts
+++ b/src/websocket/listener/types.ts
@@ -92,6 +92,7 @@ export interface IncomingMessage {
    */
   processOwnedTurn?: boolean;
   imageFailureMode?: "strict" | "drop";
+  telemetryInputAcceptedAtMs?: number;
   clientToolAllowlist?: string[];
   clientToolset?: ClientToolsetConfig;
   externalToolScopeIds?: string[];


### PR DESCRIPTION
## Summary
- Adds telemetry-only aggregate completion events for listener `runtime_start` and first send preparation through the Core message stream request.
- Preserves explicit runtime-target `agent_id` on listener latency events even when `TelemetryManager` has a different current agent, including queued telemetry events enriched later.
- Uses one accepted pre-ACK timing boundary for both direct and queued inputs; no runtime behavior, queueing, send, payload, or Core request semantics changed.

## Exact telemetry fields
- `listener_runtime_start_complete`: `request_id_hash`, `connection_id_hash`, `agent_id`, `conversation_id`, `success`, `created_agent`, `created_conversation`, `wait_for_replay`, `duration_ms`, `validate_ms`, `resolve_agent_ms`, `resolve_conversation_ms`, `source_tags_ms`, `runtime_state_ms`, `subscribe_tools_ms`, `ack_ms`, optional `replay_before_ack_ms`, optional `error_type`, plus standard `version`, `platform`, `session_id`, `surface`, `backend`.
- `listener_input_send_complete`: `connection_id_hash`, `agent_id`, `conversation_id`, `client_message_id_hash`, `client_message_count`, `message_count`, `includes_approval`, `success`, `accepted_to_core_stream_ms`, `prepare_listener_turn_ms`, `skill_content_injection_ms`, `core_stream_request_ms`, optional `error_type`, plus standard `version`, `platform`, `session_id`, `surface`, `backend`.

## Privacy / cardinality
- `request_id`, `connection_id`, and `client_message_id` are emitted only as deterministic SHA-256 prefix hashes (`*_hash`). This supports exact filtering when an operator already has the source ID, but avoids exposing raw protocol/client identifiers and keeps these fields out of grouping dimensions.
- `client_message_id` is client supplied in the inbound message path, so hashing is the safe choice over raw emission. `request_id` is also caller supplied by protocol clients. `connection_id` is an existing listener identifier, but hashed too for consistent correlation hygiene.
- No message content, tool payloads, prompts, file paths, or user text are emitted.

## Timing semantics
- `accepted_to_core_stream_ms` starts at the listener acceptance boundary immediately before ACK/disposition emission for both direct and queued paths.
- For queued inputs, the metric intentionally includes queue wait after accepted ACK until the turn opens the Core message stream.

## Validation
- `bun install --frozen-lockfile`
- `bun test src/telemetry/flush-batching.test.ts src/websocket/listener/commands/runtime-start-skill-sources.test.ts`
- `bun run check`

## Overlap risks
- Overlaps with LET-11109 listener/startup performance branches by instrumenting the same first-send path, but this PR is telemetry-only.
- The only non-telemetry-looking extraction is the existing `turn-finalizer` helper from the first commit, kept solely to avoid growing oversized `turn.ts`; review fixes did not broaden that refactor.