### PR TITLE
feat(queue): park queued user messages on interrupt and add resume_queue

### DIFF
--- a/scripts/source-file-size-baseline.json
+++ b/scripts/source-file-size-baseline.json
@@ -5,7 +5,7 @@
   "src/backend/local/local-backend.ts": 1012,
   "src/backend/local/local-store.ts": 3459,
   "src/backend/pi-stream-adapter.test.ts": 1304,
-  "src/cli/app/AppCoordinator.tsx": 5188,
+  "src/cli/app/AppCoordinator.tsx": 5141,
   "src/cli/app/AppView.tsx": 1735,
   "src/cli/app/use-approval-flow.ts": 1163,
   "src/cli/app/use-configuration-handlers.ts": 1421,

--- a/scripts/source-file-size-baseline.json
+++ b/scripts/source-file-size-baseline.json
@@ -10,7 +10,7 @@
   "src/cli/app/use-approval-flow.ts": 1163,
   "src/cli/app/use-configuration-handlers.ts": 1421,
   "src/cli/app/use-conversation-loop.ts": 2903,
-  "src/cli/app/use-submit-handler.ts": 4074,
+  "src/cli/app/use-submit-handler.ts": 4067,
   "src/cli/components/AgentSelector.tsx": 1104,
   "src/cli/components/InputRich.tsx": 2225,
   "src/cli/components/ModelSelector.tsx": 1259,

--- a/src/app-server-client.test.ts
+++ b/src/app-server-client.test.ts
@@ -391,6 +391,27 @@ describe("app-server client", () => {
     ]);
   });
 
+  test("wraps resume_queue requests", async () => {
+    const { client, control } = createFakeClient();
+    control.open();
+    const runtime = { agent_id: "agent-1", conversation_id: "conv-1" };
+
+    const resumePromise = client.resumeQueue({ runtime });
+    expect(JSON.parse(control.sent[0] ?? "{}")).toMatchObject({
+      type: "resume_queue",
+      request_id: "resume-queue-1",
+      runtime,
+    });
+    control.receive({
+      type: "resume_queue_response",
+      request_id: "resume-queue-1",
+      runtime,
+      resumed: 2,
+      success: true,
+    });
+    expect((await resumePromise).resumed).toBe(2);
+  });
+
   test("wraps conversation list requests", async () => {
     const { client, control } = createFakeClient();
     control.open();

--- a/src/app-server-client.ts
+++ b/src/app-server-client.ts
@@ -15,6 +15,8 @@ import type {
   InputCommand,
   MonitorStopCommand,
   MonitorStopResponse,
+  ResumeQueueCommand,
+  ResumeQueueResponseMessage,
   RuntimeExternalToolsUpdateCommand,
   RuntimeExternalToolsUpdateResponseMessage,
   RuntimeStartCommand,
@@ -581,6 +583,30 @@ export class AppServerClient {
         ...options,
         predicate: (message): message is AbortMessageResponseMessage =>
           message.type === "abort_message_response",
+      },
+    );
+  }
+
+  /** Release queue items parked by `abort()` without sending a new message. */
+  resumeQueue(
+    command: Omit<ResumeQueueCommand, "type" | "request_id"> & {
+      request_id?: string;
+    },
+    options: Omit<
+      AppServerRequestOptions<ResumeQueueResponseMessage>,
+      "predicate"
+    > = {},
+  ): Promise<ResumeQueueResponseMessage> {
+    return this.request(
+      {
+        type: "resume_queue",
+        request_id: command.request_id ?? this.nextRequestId("resume-queue"),
+        ...command,
+      },
+      {
+        ...options,
+        predicate: (message): message is ResumeQueueResponseMessage =>
+          message.type === "resume_queue_response",
       },
     );
   }

--- a/src/cli/app/AppCoordinator.tsx
+++ b/src/cli/app/AppCoordinator.tsx
@@ -1431,7 +1431,7 @@ export function App({
             } as Parameters<typeof tuiQueueRef.current.enqueue>[0])
           : ({
               kind: "message",
-              source: "user",
+              source: message.source ?? "user",
               content: message.text,
             } as Parameters<typeof tuiQueueRef.current.enqueue>[0]),
       );
@@ -1510,6 +1510,7 @@ export function App({
             });
             addToMessageQueue({
               kind: "user",
+              source: "cron",
               text,
               agentId: freshTask.agent_id,
               conversationId: freshTask.conversation_id,
@@ -1682,8 +1683,7 @@ export function App({
     [appendTaskNotificationEvents],
   );
 
-  // consumeItems fires onDequeued → setQueueDisplay(prev => prev.slice(n))
-  // so no direct setQueueDisplay call is needed here.
+  // Queue callbacks remove consumed display entries by item ID.
   const consumeQueuedMessages = useCallback((): QueuedMessage[] | null => {
     const len = tuiQueueRef.current?.length ?? 0;
     if (len === 0) return null;

--- a/src/cli/app/AppCoordinator.tsx
+++ b/src/cli/app/AppCoordinator.tsx
@@ -128,6 +128,7 @@ import {
 } from "@/cli/helpers/tool-name-mapping";
 import { isTaskTool } from "@/cli/helpers/tool-name-mapping.js";
 import { getTuiBlockedReason } from "@/cli/helpers/tui-queue-adapter";
+import { createTuiQueueRuntime } from "@/cli/helpers/tui-queue-runtime";
 import type { WindowTitleData } from "@/cli/helpers/window-title-config";
 import { useSyncedState } from "@/cli/hooks/use-synced-state";
 import {
@@ -161,10 +162,10 @@ import {
   isByokHandleForSelector,
   listProviders,
 } from "@/providers/byok-providers";
-import {
-  type MessageQueueItem,
+import type {
+  MessageQueueItem,
   QueueRuntime,
-  type TaskNotificationQueueItem,
+  TaskNotificationQueueItem,
 } from "@/queue/queue-runtime";
 import {
   createSharedReminderState,
@@ -1406,63 +1407,11 @@ export function App({
   // Message queue state for queueing messages during streaming
   const [queueDisplay, setQueueDisplay] = useState<QueuedMessage[]>([]);
 
-  // QueueRuntime — authoritative queue. maxItems: Infinity disables drop limits
-  // to match the previous unbounded array semantics. queueDisplay is a derived
-  // UI state maintained by the onEnqueued/onDequeued/onCleared callbacks.
-  // Lazy init pattern; typed QueueRuntime | null with ?. at all call sites.
+  // QueueRuntime — authoritative queue; queueDisplay is derived from its
+  // callbacks (see createTuiQueueRuntime). Lazy init; typed QueueRuntime | null.
   const tuiQueueRef = useRef<QueueRuntime | null>(null);
   if (!tuiQueueRef.current) {
-    tuiQueueRef.current = new QueueRuntime({
-      maxItems: Infinity,
-      callbacks: {
-        onEnqueued: (item, queueLen) => {
-          debugLog(
-            "queue-lifecycle",
-            `enqueued item_id=${item.id} kind=${item.kind} queue_len=${queueLen}`,
-          );
-          // queueDisplay is the single source for UI — updated only here.
-          if (item.kind === "message" || item.kind === "task_notification") {
-            setQueueDisplay((prev) => [...prev, toQueuedMsg(item)]);
-          }
-        },
-        onDequeued: (batch) => {
-          debugLog(
-            "queue-lifecycle",
-            `dequeued batch_id=${batch.batchId} merged_count=${batch.mergedCount} queue_len_after=${batch.queueLenAfter}`,
-          );
-          // queueDisplay only tracks displayable items. If non-display barrier
-          // kinds are ever consumed, avoid over-trimming by counting only
-          // message/task_notification entries in the batch.
-          const displayConsumedCount = batch.items.filter(
-            (item) =>
-              item.kind === "message" || item.kind === "task_notification",
-          ).length;
-          setQueueDisplay((prev) => prev.slice(displayConsumedCount));
-        },
-        onBlocked: (reason, queueLen) =>
-          debugLog(
-            "queue-lifecycle",
-            `blocked reason=${reason} queue_len=${queueLen}`,
-          ),
-        onCleared: (_reason, _clearedCount) => {
-          debugLog(
-            "queue-lifecycle",
-            `cleared reason=${_reason} cleared_count=${_clearedCount}`,
-          );
-          setQueueDisplay([]);
-        },
-        onRemoved: (item, queueLen) => {
-          debugLog(
-            "queue-lifecycle",
-            `removed item_id=${item.id} kind=${item.kind} queue_len=${queueLen}`,
-          );
-          // Remove the matching display item by queueItemId
-          setQueueDisplay((prev) =>
-            prev.filter((msg) => msg.queueItemId !== item.id),
-          );
-        },
-      },
-    });
+    tuiQueueRef.current = createTuiQueueRuntime(setQueueDisplay);
   }
 
   // Override content parts for queued submissions (to preserve part boundaries)
@@ -4329,8 +4278,12 @@ export function App({
   useEffect(() => {
     void dequeueEpoch; // explicit dep to satisfy exhaustive-deps lint
 
-    const queueLen = tuiQueueRef.current?.length ?? 0;
+    // Esc-parked user messages are skipped: only ready items count here.
+    const queueLen = tuiQueueRef.current?.readyLength ?? 0;
     const hasAnythingQueued = queueLen > 0;
+    if (!hasAnythingQueued && (tuiQueueRef.current?.length ?? 0) > 0) {
+      tuiQueueRef.current?.tryDequeue("paused_by_user");
+    }
 
     if (
       !streaming &&

--- a/src/cli/app/use-interrupt-handler.ts
+++ b/src/cli/app/use-interrupt-handler.ts
@@ -209,6 +209,7 @@ export function useInterruptHandler(ctx: InterruptHandlerContext) {
       pendingInterruptRecoveryConversationIdRef.current =
         conversationIdRef.current;
       userCancelledRef.current = true; // Prevent dequeue
+      tuiQueueRef.current?.pause(); // Park queued user messages until resume
       setStreaming(false);
       resetTrajectoryBases();
       setIsExecutingTool(false);
@@ -277,6 +278,10 @@ export function useInterruptHandler(ctx: InterruptHandlerContext) {
       pendingInterruptRecoveryConversationIdRef.current =
         conversationIdRef.current;
       userCancelledRef.current = true;
+      // Park the user's queued messages: Esc stops the turn and holds them
+      // until Enter on an empty input or the next message. System items
+      // (task notifications, cron, mod continuations) still drain on settle.
+      tuiQueueRef.current?.pause();
 
       // Increment generation to mark any in-flight processConversation as stale.
       // The stale turn keeps its processing count until its finally block runs;

--- a/src/cli/app/use-submit-handler.ts
+++ b/src/cli/app/use-submit-handler.ts
@@ -747,7 +747,15 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
         // Continue processing the new message
       }
 
-      if (!msg && !hasOverrideContent) return { submitted: false };
+      if (!msg && !hasOverrideContent) {
+        // Enter on an empty input resumes a queue parked by Esc (no new message).
+        const paused = tuiQueueRef.current?.pausedCount ?? 0;
+        if (paused === 0) return { submitted: false };
+        tuiQueueRef.current?.resume();
+        userCancelledRef.current = false;
+        setDequeueEpoch((e: number) => e + 1);
+        return { submitted: true };
+      }
 
       // If the user just cycled reasoning tiers, flush the final choice before
       // sending the next message so the upcoming run uses the selected tier.
@@ -811,32 +819,24 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
           .slice(0, 100);
       }
 
-      // Block submission if waiting for explicit user action (approvals)
-      // In this case, input is hidden anyway, so this shouldn't happen
+      // Block submission while approvals are pending (input is hidden anyway).
       if (pendingApprovals.length > 0) {
         return { submitted: false };
       }
 
-      // Queue message if agent is busy (streaming, executing tool, or running command)
-      // This allows messages to queue up while agent is working
-
-      // Reset cancellation flag before queue check - this ensures queued messages
-      // can be dequeued even if the user just cancelled. The dequeue effect checks
-      // userCancelledRef.current, so we must clear it here to prevent blocking.
+      // Queue the message if the agent is busy. Clear the cancel guard first so
+      // a stale Esc cannot block dequeue; bump the epoch (refs are not deps).
       userCancelledRef.current = false;
-
-      // If there are queued messages and agent is not busy, bump epoch to trigger
-      // dequeue effect. Without this, the effect won't re-run because refs aren't
-      // in its deps array (only state values are).
       if (!isAgentBusy() && (tuiQueueRef.current?.length ?? 0) > 0) {
-        debugLog(
-          "queue",
-          `Bumping dequeueEpoch: userCancelledRef was reset, ${tuiQueueRef.current?.length ?? 0} message(s) queued, agent not busy`,
-        );
+        debugLog("queue", "Bumping dequeueEpoch: cancel guard reset, idle");
         setDequeueEpoch((e: number) => e + 1);
       }
 
       const isSlashCommand = routedUserText.startsWith("/");
+      // A new message releases Esc-parked ones, which run first. Slash commands don't.
+      if (!isSlashCommand && !isSystemOnly) {
+        tuiQueueRef.current?.resume();
+      }
       const parsedModCommand = isSlashCommand
         ? parseModSlashCommand(routedUserText.trim())
         : null;

--- a/src/cli/app/use-submit-handler.ts
+++ b/src/cli/app/use-submit-handler.ts
@@ -824,19 +824,10 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
         return { submitted: false };
       }
 
-      // Queue the message if the agent is busy. Clear the cancel guard first so
-      // a stale Esc cannot block dequeue; bump the epoch (refs are not deps).
+      // Release cancellation, but wake dequeue only after the new input is queued.
       userCancelledRef.current = false;
-      if (!isAgentBusy() && (tuiQueueRef.current?.length ?? 0) > 0) {
-        debugLog("queue", "Bumping dequeueEpoch: cancel guard reset, idle");
-        setDequeueEpoch((e: number) => e + 1);
-      }
 
       const isSlashCommand = routedUserText.startsWith("/");
-      // A new message releases Esc-parked ones, which run first. Slash commands don't.
-      if (!isSlashCommand && !isSystemOnly) {
-        tuiQueueRef.current?.resume();
-      }
       const parsedModCommand = isSlashCommand
         ? parseModSlashCommand(routedUserText.trim())
         : null;
@@ -864,19 +855,21 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
         return { submitted: true }; // Clears input
       }
 
-      if (isAgentBusy() && !shouldBypassQueue) {
+      if (
+        !shouldBypassQueue &&
+        (isAgentBusy() ||
+          (!hasOverrideContent && (tuiQueueRef.current?.length ?? 0) > 0))
+      ) {
         // Enqueue via QueueRuntime — onEnqueued callback updates queueDisplay.
         tuiQueueRef.current?.enqueue({
           kind: "message",
           source: "user",
           content: msg,
         } as Parameters<typeof tuiQueueRef.current.enqueue>[0]);
+        if (!hasOverrideContent && !isSystemOnly) tuiQueueRef.current?.resume();
         setDequeueEpoch((e: number) => e + 1);
         return { submitted: true }; // Clears input
       }
-
-      // Note: userCancelledRef.current was already reset above before the queue check
-      // to ensure the dequeue effect isn't blocked by a stale cancellation flag.
 
       const aliasedMsg = routedUserText;
 

--- a/src/cli/components/QueuedMessages.tsx
+++ b/src/cli/components/QueuedMessages.tsx
@@ -12,8 +12,8 @@ interface QueuedMessagesProps {
 export const QueuedMessages = memo(
   ({ messages, queueMode = "immediate" }: QueuedMessagesProps) => {
     const maxDisplay = 5;
-    const displayMessages = messages
-      .filter((msg) => msg.kind === "user")
+    const userMessages = messages.filter((msg) => msg.kind === "user");
+    const displayMessages = userMessages
       .map((msg) => msg.text.trim())
       .filter((msg) => msg.length > 0);
 
@@ -21,10 +21,24 @@ export const QueuedMessages = memo(
       return null;
     }
 
+    const paused = userMessages.some((msg) => msg.paused);
     const bullet = queueMode === "defer" ? "○" : CLI_GLYPHS.prompt;
 
     return (
       <Box flexDirection="column" marginBottom={1}>
+        {paused && (
+          <Box flexDirection="row">
+            <Box width={2} flexShrink={0}>
+              <Text dimColor>{CLI_GLYPHS.bullet}</Text>
+            </Box>
+            <Box flexGrow={1}>
+              <Text dimColor>
+                Queue paused by Esc. Enter to resume, or type to send with your
+                next message.
+              </Text>
+            </Box>
+          </Box>
+        )}
         {displayMessages.slice(0, maxDisplay).map((msg, index) => (
           <Box key={`${index}-${msg.slice(0, 50)}`} flexDirection="row">
             <Box width={2} flexShrink={0}>

--- a/src/cli/helpers/queued-message-parts.ts
+++ b/src/cli/helpers/queued-message-parts.ts
@@ -60,7 +60,7 @@ export function toQueuedMsg(
   item: MessageQueueItem | TaskNotificationQueueItem,
 ): QueuedMessage {
   if (item.kind === "task_notification") {
-    return { kind: "task_notification", text: item.text };
+    return { kind: "task_notification", text: item.text, queueItemId: item.id };
   }
   const text =
     typeof item.content === "string"

--- a/src/cli/helpers/tui-queue-runtime.ts
+++ b/src/cli/helpers/tui-queue-runtime.ts
@@ -1,0 +1,88 @@
+import type { Dispatch, SetStateAction } from "react";
+import { toQueuedMsg } from "@/cli/helpers/queued-message-parts";
+import { QueueRuntime } from "@/queue/queue-runtime";
+import { debugLog } from "@/utils/debug";
+import type { QueuedMessage } from "@/utils/message-queue-bridge";
+
+/**
+ * The TUI's authoritative queue. `queueDisplay` is derived UI state kept in
+ * sync only through these callbacks: enqueue appends, dequeue/remove drop by
+ * queue item id, clear empties, and pause/resume re-project the paused flags.
+ *
+ * maxItems: Infinity disables drop limits to match the earlier unbounded
+ * array semantics.
+ */
+export function createTuiQueueRuntime(
+  setQueueDisplay: Dispatch<SetStateAction<QueuedMessage[]>>,
+): QueueRuntime {
+  const queue: QueueRuntime = new QueueRuntime({
+    maxItems: Infinity,
+    callbacks: {
+      onEnqueued: (item, queueLen) => {
+        debugLog(
+          "queue-lifecycle",
+          `enqueued item_id=${item.id} kind=${item.kind} queue_len=${queueLen}`,
+        );
+        if (item.kind === "message" || item.kind === "task_notification") {
+          setQueueDisplay((prev) => [...prev, toQueuedMsg(item)]);
+        }
+      },
+      onDequeued: (batch) => {
+        debugLog(
+          "queue-lifecycle",
+          `dequeued batch_id=${batch.batchId} merged_count=${batch.mergedCount} queue_len_after=${batch.queueLenAfter}`,
+        );
+        // Drop by id, not by head count: a dequeue may skip Esc-parked user
+        // messages sitting ahead of the items it consumed.
+        const consumed = new Set(batch.items.map((item) => item.id));
+        setQueueDisplay((prev) =>
+          prev.filter(
+            (msg) =>
+              msg.queueItemId === undefined || !consumed.has(msg.queueItemId),
+          ),
+        );
+      },
+      onBlocked: (reason, queueLen) =>
+        debugLog(
+          "queue-lifecycle",
+          `blocked reason=${reason} queue_len=${queueLen}`,
+        ),
+      onCleared: (reason, clearedCount) => {
+        debugLog(
+          "queue-lifecycle",
+          `cleared reason=${reason} cleared_count=${clearedCount}`,
+        );
+        setQueueDisplay([]);
+      },
+      onRemoved: (item, queueLen) => {
+        debugLog(
+          "queue-lifecycle",
+          `removed item_id=${item.id} kind=${item.kind} queue_len=${queueLen}`,
+        );
+        setQueueDisplay((prev) =>
+          prev.filter((msg) => msg.queueItemId !== item.id),
+        );
+      },
+      onPauseChanged: (pausedCount, queueLen) => {
+        debugLog(
+          "queue-lifecycle",
+          `pause changed paused=${pausedCount} queue_len=${queueLen}`,
+        );
+        const pausedIds = new Set(
+          queue.items.filter((item) => item.paused).map((item) => item.id),
+        );
+        setQueueDisplay((prev) =>
+          prev.map((msg) => {
+            const paused =
+              msg.queueItemId !== undefined && pausedIds.has(msg.queueItemId);
+            if (paused === Boolean(msg.paused)) return msg;
+            return paused
+              ? { ...msg, paused: true }
+              : { ...msg, paused: undefined };
+          }),
+        );
+      },
+    },
+  });
+  return queue;
+}

--- a/src/cli/queue-ordering-wiring.test.ts
+++ b/src/cli/queue-ordering-wiring.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
 import { readInteractiveAppSource } from "@/test-utils/read-interactive-app-source";
 
 function readAppSource(): string {
@@ -36,19 +37,23 @@ describe("queue ordering wiring", () => {
     expect(segment).toContain("queuedOverlayAction,");
   });
 
-  test("queue display trim uses displayable-item count, not mergedCount", () => {
-    const source = readAppSource();
+  test("queue display trim drops consumed items by id, not by head count", () => {
+    const source = readFileSync(
+      new URL("./helpers/tui-queue-runtime.ts", import.meta.url),
+      "utf-8",
+    );
     const start = source.indexOf("onDequeued: (batch) => {");
     const end = source.indexOf("onBlocked: (reason, queueLen) =>");
 
     expect(start).toBeGreaterThan(-1);
     expect(end).toBeGreaterThan(start);
 
+    // A dequeue may skip Esc-parked user messages ahead of the consumed items,
+    // so trimming the display by count would drop the wrong entries.
     const segment = source.slice(start, end);
-    expect(segment).toContain("const displayConsumedCount =");
-    expect(segment).toContain('item.kind === "message"');
-    expect(segment).toContain('item.kind === "task_notification"');
-    expect(segment).toContain("prev.slice(displayConsumedCount)");
+    expect(segment).toContain("batch.items.map((item) => item.id)");
+    expect(segment).toContain("consumed.has(msg.queueItemId)");
+    expect(segment).not.toContain("prev.slice(");
   });
 
   test("onSubmit allows override-only queued submissions", () => {
@@ -62,9 +67,9 @@ describe("queue ordering wiring", () => {
     expect(end).toBeGreaterThan(start);
 
     const segment = source.slice(start, end);
-    expect(segment).toContain(
-      "if (!msg && !hasOverrideContent) return { submitted: false };",
-    );
+    // Empty input is rejected unless it resumes an Esc-parked queue.
+    expect(segment).toContain("if (!msg && !hasOverrideContent) {");
+    expect(segment).toContain("if (paused === 0) return { submitted: false };");
     expect(segment).toContain(
       "if (profileConfirmPending && !msg && !hasOverrideContent)",
     );

--- a/src/cli/tui-interrupt-queue-lifecycle.test.tsx
+++ b/src/cli/tui-interrupt-queue-lifecycle.test.tsx
@@ -282,4 +282,43 @@ describe("TUI interrupt queue lifecycle", () => {
       "arrived after Esc",
     );
   }, 15_000);
+
+  test("Esc parks a typed queued message; a notification still drains; Enter resumes", async () => {
+    const executor = new DelayedInterruptExecutor();
+    const { stdin } = await renderTestApp(executor);
+
+    await typePrompt(stdin, "start turn");
+    await waitFor(() => executor.inputs.length === 1, "the typed initial turn");
+    // A user message queued behind the active turn (source: user).
+    addToMessageQueue({ kind: "user", text: "queued while busy" });
+
+    addToMessageQueue({
+      kind: "task_notification",
+      text: monitorNotification("arrived during turn"),
+    });
+    stdin.push("\u001b");
+    await executor.abortObserved;
+    executor.settleInterruptedTurn();
+
+    // The notification starts a turn on its own; the parked user message does not.
+    await waitFor(
+      () => executor.inputs.length === 2,
+      "the notification turn after Esc",
+    );
+    const notificationTurn = JSON.stringify(executor.inputs[1]?.body);
+    expect(notificationTurn).toContain("arrived during turn");
+    expect(notificationTurn).not.toContain("queued while busy");
+    await sleep(300);
+    expect(executor.inputs).toHaveLength(2);
+
+    // Enter on the empty input is the TUI's Resume.
+    stdin.push("\r");
+    await waitFor(
+      () => executor.inputs.length === 3,
+      "the parked message to run after Enter",
+    );
+    expect(JSON.stringify(executor.inputs[2]?.body)).toContain(
+      "queued while busy",
+    );
+  }, 20_000);
 });

--- a/src/cli/tui-interrupt-queue-lifecycle.test.tsx
+++ b/src/cli/tui-interrupt-queue-lifecycle.test.tsx
@@ -283,42 +283,71 @@ describe("TUI interrupt queue lifecycle", () => {
     );
   }, 15_000);
 
-  test("Esc parks a typed queued message; a notification still drains; Enter resumes", async () => {
-    const executor = new DelayedInterruptExecutor();
-    const { stdin } = await renderTestApp(executor);
+  test.each(["Enter", "new message", "cron event"])(
+    "Esc parks a user message; a notification still drains; %s resumes",
+    async (resumeWith) => {
+      const executor = new DelayedInterruptExecutor();
+      const { stdin } = await renderTestApp(executor);
 
-    await typePrompt(stdin, "start turn");
-    await waitFor(() => executor.inputs.length === 1, "the typed initial turn");
-    // A user message queued behind the active turn (source: user).
-    addToMessageQueue({ kind: "user", text: "queued while busy" });
+      await typePrompt(stdin, "start turn");
+      await waitFor(
+        () => executor.inputs.length === 1,
+        "the typed initial turn",
+      );
+      // A user message queued behind the active turn (source: user).
+      addToMessageQueue({ kind: "user", text: "queued while busy" });
 
-    addToMessageQueue({
-      kind: "task_notification",
-      text: monitorNotification("arrived during turn"),
-    });
-    stdin.push("\u001b");
-    await executor.abortObserved;
-    executor.settleInterruptedTurn();
+      addToMessageQueue(
+        resumeWith === "cron event"
+          ? { kind: "user", source: "cron", text: "scheduled event" }
+          : {
+              kind: "task_notification",
+              text: monitorNotification("arrived during turn"),
+            },
+      );
+      stdin.push("\u001b");
+      await executor.abortObserved;
+      executor.settleInterruptedTurn();
 
-    // The notification starts a turn on its own; the parked user message does not.
-    await waitFor(
-      () => executor.inputs.length === 2,
-      "the notification turn after Esc",
-    );
-    const notificationTurn = JSON.stringify(executor.inputs[1]?.body);
-    expect(notificationTurn).toContain("arrived during turn");
-    expect(notificationTurn).not.toContain("queued while busy");
-    await sleep(300);
-    expect(executor.inputs).toHaveLength(2);
+      // The notification starts a turn on its own; the parked user message does not.
+      await waitFor(
+        () => executor.inputs.length === 2,
+        "the notification turn after Esc",
+      );
+      const notificationTurn = JSON.stringify(executor.inputs[1]?.body);
+      expect(notificationTurn).toContain(
+        resumeWith === "cron event" ? "scheduled event" : "arrived during turn",
+      );
+      expect(notificationTurn).not.toContain("queued while busy");
+      await sleep(300);
+      expect(executor.inputs).toHaveLength(2);
 
-    // Enter on the empty input is the TUI's Resume.
-    stdin.push("\r");
-    await waitFor(
-      () => executor.inputs.length === 3,
-      "the parked message to run after Enter",
-    );
-    expect(JSON.stringify(executor.inputs[2]?.body)).toContain(
-      "queued while busy",
-    );
-  }, 20_000);
+      if (resumeWith !== "new message") {
+        stdin.push("\r");
+      } else {
+        await typePrompt(stdin, "sent after interrupt");
+      }
+      await waitFor(
+        () => executor.inputs.length === 3,
+        "the parked message to run after resuming",
+      );
+      expect(JSON.stringify(executor.inputs[2]?.body)).toContain(
+        "queued while busy",
+      );
+      if (resumeWith === "new message") {
+        await waitFor(
+          () =>
+            JSON.stringify(executor.inputs.slice(2)).includes(
+              "sent after interrupt",
+            ),
+          "the new message to reach the backend",
+        );
+        const resumed = JSON.stringify(executor.inputs.slice(2));
+        expect(resumed.indexOf("queued while busy")).toBeLessThan(
+          resumed.indexOf("sent after interrupt"),
+        );
+      }
+    },
+    20_000,
+  );
 });

--- a/src/cli/tui-queue-coalescing-parity.test.ts
+++ b/src/cli/tui-queue-coalescing-parity.test.ts
@@ -209,6 +209,7 @@ describe("toQueuedMsg", () => {
     expect(toQueuedMsg(item)).toEqual({
       kind: "task_notification",
       text: "<task-notification>done</task-notification>",
+      queueItemId: "item-2",
     });
   });
 

--- a/src/queue/queue-runtime-pause.test.ts
+++ b/src/queue/queue-runtime-pause.test.ts
@@ -1,0 +1,192 @@
+/**
+ * QueueRuntime pause/resume: user messages parked by an interrupt stay
+ * visible but are skipped by every dequeue path; system items keep flowing.
+ */
+import { describe, expect, test } from "bun:test";
+import {
+  type QueueBlockedReason,
+  type QueueItem,
+  QueueRuntime,
+} from "@/queue/queue-runtime";
+
+type EnqueueInput = Parameters<QueueRuntime["enqueue"]>[0];
+
+function userMsg(text: string): EnqueueInput {
+  return { kind: "message", source: "user", content: text } as EnqueueInput;
+}
+
+function notification(text = "<notification/>"): EnqueueInput {
+  return {
+    kind: "task_notification",
+    source: "task_notification",
+    text,
+  } as EnqueueInput;
+}
+
+function textOf(item: QueueItem): string {
+  return item.kind === "message" ? String(item.content) : item.text;
+}
+
+describe("QueueRuntime.pause", () => {
+  test("parks only user messages and reports the count", () => {
+    const q = new QueueRuntime();
+    q.enqueue(userMsg("a"));
+    q.enqueue(notification());
+    q.enqueue(userMsg("b"));
+
+    expect(q.pause()).toBe(2);
+    expect(q.length).toBe(3);
+    expect(q.readyLength).toBe(1);
+    expect(q.pausedCount).toBe(2);
+    expect(q.peekReady().map(textOf)).toEqual(["<notification/>"]);
+    // Paused items remain visible for display.
+    expect(q.items.map((i) => Boolean(i.paused))).toEqual([true, false, true]);
+  });
+
+  test("is idempotent and does not touch items enqueued after the pause", () => {
+    const q = new QueueRuntime();
+    q.enqueue(userMsg("before"));
+    expect(q.pause()).toBe(1);
+    expect(q.pause()).toBe(0);
+    q.enqueue(userMsg("after"));
+    expect(q.readyLength).toBe(1);
+    expect(q.peekReady().map(textOf)).toEqual(["after"]);
+  });
+
+  test("fires onPauseChanged on pause and resume, not on no-op calls", () => {
+    const changes: Array<[number, number]> = [];
+    const q = new QueueRuntime({
+      callbacks: {
+        onPauseChanged: (pausedCount, queueLen) =>
+          changes.push([pausedCount, queueLen]),
+      },
+    });
+    q.enqueue(userMsg("a"));
+    q.enqueue(notification());
+    q.pause();
+    q.pause();
+    q.resume();
+    q.resume();
+    expect(changes).toEqual([
+      [1, 2],
+      [0, 2],
+    ]);
+  });
+});
+
+describe("dequeue paths skip paused items", () => {
+  test("consumeItems takes the first n ready items and leaves paused ones", () => {
+    const dequeued: string[][] = [];
+    const q = new QueueRuntime({
+      callbacks: {
+        onDequeued: (batch) => dequeued.push(batch.items.map(textOf)),
+      },
+    });
+    q.enqueue(userMsg("parked"));
+    q.enqueue(notification("n1"));
+    q.enqueue(notification("n2"));
+    q.pause();
+
+    const batch = q.consumeItems(5);
+    expect(batch?.items.map(textOf)).toEqual(["n1", "n2"]);
+    expect(batch?.queueLenAfter).toBe(1);
+    expect(dequeued).toEqual([["n1", "n2"]]);
+    expect(q.items.map(textOf)).toEqual(["parked"]);
+  });
+
+  test("consumeItems returns null when only paused items remain", () => {
+    const q = new QueueRuntime();
+    q.enqueue(userMsg("parked"));
+    q.pause();
+    expect(q.consumeItems(1)).toBeNull();
+    expect(q.length).toBe(1);
+  });
+
+  test("tryDequeue drains ready coalescables around a paused item", () => {
+    const q = new QueueRuntime();
+    q.enqueue(userMsg("parked"));
+    q.enqueue(notification("n1"));
+    q.enqueue(userMsg("typed after esc"));
+    q.pause();
+    // Both user messages above are now parked; this one arrives afterwards
+    // and is ready, so the batch skips the parked items around it.
+    q.enqueue(userMsg("typed after pause"));
+
+    const batch = q.tryDequeue(null);
+    expect(batch?.items.map(textOf)).toEqual(["n1", "typed after pause"]);
+    expect(q.items.map(textOf)).toEqual(["parked", "typed after esc"]);
+  });
+
+  test("tryDequeue reports paused_by_user once when only paused items remain", () => {
+    const blocked: QueueBlockedReason[] = [];
+    const q = new QueueRuntime({
+      callbacks: { onBlocked: (reason) => blocked.push(reason) },
+    });
+    q.enqueue(userMsg("parked"));
+    q.pause();
+
+    expect(q.tryDequeue(null)).toBeNull();
+    expect(q.tryDequeue(null)).toBeNull();
+    expect(blocked).toEqual(["paused_by_user"]);
+  });
+
+  test("tryDequeue takes a ready barrier alone even behind a paused message", () => {
+    const q = new QueueRuntime();
+    q.enqueue(userMsg("parked"));
+    q.enqueue({
+      kind: "approval_result",
+      source: "system",
+      text: "ok",
+    } as EnqueueInput);
+    q.enqueue(notification("n1"));
+    q.pause();
+
+    const batch = q.tryDequeue(null);
+    expect(batch?.items.map((i) => i.kind)).toEqual(["approval_result"]);
+    expect(q.items.map((i) => i.kind)).toEqual([
+      "message",
+      "task_notification",
+    ]);
+  });
+});
+
+describe("QueueRuntime.resume", () => {
+  test("releases parked items in their original order ahead of later arrivals", () => {
+    const q = new QueueRuntime();
+    q.enqueue(userMsg("first"));
+    q.enqueue(userMsg("second"));
+    q.pause();
+    q.enqueue(userMsg("third"));
+
+    expect(q.resume()).toBe(2);
+    expect(q.pausedCount).toBe(0);
+    const batch = q.tryDequeue(null);
+    expect(batch?.items.map(textOf)).toEqual(["first", "second", "third"]);
+    expect(q.isEmpty).toBe(true);
+  });
+
+  test("resume after a paused_by_user block lets the next tryDequeue re-emit reasons", () => {
+    const blocked: QueueBlockedReason[] = [];
+    const q = new QueueRuntime({
+      callbacks: { onBlocked: (reason) => blocked.push(reason) },
+    });
+    q.enqueue(userMsg("parked"));
+    q.pause();
+    q.tryDequeue(null);
+    q.resume();
+    q.tryDequeue("streaming");
+    expect(blocked).toEqual(["paused_by_user", "streaming"]);
+  });
+
+  test("removeItem and clear work on paused items", () => {
+    const q = new QueueRuntime();
+    const a = q.enqueue(userMsg("a"));
+    q.enqueue(userMsg("b"));
+    q.pause();
+    expect(q.removeItem(a?.id ?? "")?.paused).toBe(true);
+    expect(q.pausedCount).toBe(1);
+    q.clear("cancelled");
+    expect(q.length).toBe(0);
+    expect(q.pausedCount).toBe(0);
+  });
+});

--- a/src/queue/queue-runtime.ts
+++ b/src/queue/queue-runtime.ts
@@ -35,6 +35,13 @@ type QueueItemBase = {
   actingUserId?: string;
   source: QueueItemSource;
   enqueuedAt: number;
+  /**
+   * Parked by a user interrupt. Paused items stay visible in the queue but
+   * are skipped by every dequeue path until `resume()` clears the flag.
+   * Only user-authored messages are ever paused; system-originated items
+   * (task notifications, cron prompts, mod continuations) keep flowing.
+   */
+  paused?: boolean;
 };
 
 export type MessageQueueItem = QueueItemBase & {
@@ -149,6 +156,11 @@ export interface QueueCallbacks {
    * queueLen is the post-removal queue depth.
    */
   onRemoved?: (item: QueueItem, queueLen: number) => void;
+  /**
+   * Fired when pause()/resume() changes which items are parked.
+   * pausedCount is the number of items still paused afterwards.
+   */
+  onPauseChanged?: (pausedCount: number, queueLen: number) => void;
 }
 
 // ── Options ──────────────────────────────────────────────────────
@@ -276,6 +288,12 @@ export class QueueRuntime {
       return null;
     }
 
+    if (this.store.length > 0 && this.readyLength === 0) {
+      // Only parked user messages remain: report that as the blocked reason
+      // (transition-deduplicated like every other reason) and dequeue nothing.
+      return this.tryDequeue("paused_by_user");
+    }
+
     // Unblocked — reset tracking
     this.lastEmittedBlockedReason = null;
     this.blockedEmittedForNonEmpty = false;
@@ -284,28 +302,25 @@ export class QueueRuntime {
       return null;
     }
 
-    // Drain contiguous coalescable items from head
+    // Drain coalescable ready items from the first ready item onward. Paused
+    // items are skipped, never consumed; a ready barrier ends the batch.
     const batch: QueueItem[] = [];
-    const first = this.store[0];
-    while (
-      first !== undefined &&
-      this.store.length > 0 &&
-      isCoalescable(this.store[0]?.kind ?? "approval_result") &&
-      hasSameScope(first, this.store[0] as QueueItem)
-    ) {
-      const item = this.store.shift();
-      if (item) batch.push(item);
-    }
-
-    // If head was a barrier (no coalescables found), dequeue it alone
-    if (batch.length === 0 && this.store.length > 0) {
-      const item = this.store.shift();
-      if (item) batch.push(item);
+    const first = this.store.find((item) => !item.paused);
+    if (first && isCoalescable(first.kind)) {
+      for (const item of this.store) {
+        if (item.paused) continue;
+        if (!isCoalescable(item.kind) || !hasSameScope(first, item)) break;
+        batch.push(item);
+      }
+    } else if (first) {
+      // First ready item is a barrier: dequeue it alone
+      batch.push(first);
     }
 
     if (batch.length === 0) {
       return null;
     }
+    this.removeAll(batch);
 
     // When queue becomes empty after dequeue, reset blocked epoch tracking
     if (this.store.length === 0) {
@@ -332,8 +347,11 @@ export class QueueRuntime {
    */
   consumeItems(n: number): DequeuedBatch | null {
     if (this.store.length === 0 || n <= 0) return null;
-    const count = Math.min(n, this.store.length);
-    const batch = this.store.splice(0, count);
+    // Paused items are skipped: the first `n` ready items are consumed.
+    const batch = this.store.filter((item) => !item.paused).slice(0, n);
+    const count = batch.length;
+    if (count === 0) return null;
+    this.removeAll(batch);
     if (this.store.length === 0) {
       this.blockedEmittedForNonEmpty = false;
     }
@@ -376,6 +394,47 @@ export class QueueRuntime {
     return removed;
   }
 
+  // ── Pause / resume ─────────────────────────────────────────────
+
+  /**
+   * Park every queued user message. Called when the user interrupts: the
+   * interrupted turn stops, and the messages the user queued behind it wait
+   * for an explicit resume or for the user's next message instead of
+   * starting the next turn on their own. System-originated items are not
+   * affected. Returns the number of items newly paused.
+   */
+  pause(): number {
+    let changed = 0;
+    for (const item of this.store) {
+      if (item.kind === "message" && item.source === "user" && !item.paused) {
+        item.paused = true;
+        changed += 1;
+      }
+    }
+    if (changed > 0) {
+      this.blockedEmittedForNonEmpty = false;
+      this.safeCallback("onPauseChanged", this.pausedCount, this.store.length);
+    }
+    return changed;
+  }
+
+  /** Release every paused item. Returns the number of items resumed. */
+  resume(): number {
+    let changed = 0;
+    for (const item of this.store) {
+      if (item.paused) {
+        delete item.paused;
+        changed += 1;
+      }
+    }
+    if (changed > 0) {
+      this.lastEmittedBlockedReason = null;
+      this.blockedEmittedForNonEmpty = false;
+      this.safeCallback("onPauseChanged", 0, this.store.length);
+    }
+    return changed;
+  }
+
   // ── Clear ──────────────────────────────────────────────────────
 
   /** Remove all items and fire onCleared. */
@@ -398,6 +457,15 @@ export class QueueRuntime {
     return this.store.length === 0;
   }
 
+  /** Items a dequeue may take right now (everything that is not paused). */
+  get readyLength(): number {
+    return this.store.reduce((n, item) => (item.paused ? n : n + 1), 0);
+  }
+
+  get pausedCount(): number {
+    return this.store.length - this.readyLength;
+  }
+
   get items(): readonly QueueItem[] {
     return this.store.slice();
   }
@@ -406,7 +474,22 @@ export class QueueRuntime {
     return this.store.slice();
   }
 
+  /** Like peek(), without paused items. Dequeue planners must use this. */
+  peekReady(): readonly QueueItem[] {
+    return this.store.filter((item) => !item.paused);
+  }
+
   // ── Internals ──────────────────────────────────────────────────
+
+  /** Remove the given items (by identity) from the store, preserving order. */
+  private removeAll(items: readonly QueueItem[]): void {
+    const removing = new Set(items);
+    let write = 0;
+    for (const item of this.store) {
+      if (!removing.has(item)) this.store[write++] = item;
+    }
+    this.store.length = write;
+  }
 
   private makeItem(input: Omit<QueueItem, "id" | "enqueuedAt">): QueueItem {
     return {

--- a/src/types/protocol-queue-lifecycle.test.ts
+++ b/src/types/protocol-queue-lifecycle.test.ts
@@ -125,8 +125,9 @@ describe("QueueBlockedEvent wire shape", () => {
       command_running: true,
       interrupt_in_progress: true,
       runtime_busy: true,
+      paused_by_user: true,
     } satisfies Record<QueueBlockedReason, true>;
-    expect(Object.keys(reasons)).toHaveLength(6);
+    expect(Object.keys(reasons)).toHaveLength(7);
   });
 });
 

--- a/src/types/protocol.ts
+++ b/src/types/protocol.ts
@@ -447,6 +447,8 @@ export interface QueueBatchDequeuedEvent extends MessageEnvelope {
  * - command_running: Slash command is executing
  * - interrupt_in_progress: User interrupt (Esc) is being processed
  * - runtime_busy: Generic busy state (e.g., listen-client turn in flight)
+ * - paused_by_user: Only user messages parked by an interrupt remain; they
+ *   wait for an explicit resume or the user's next message
  */
 export type QueueBlockedReason =
   | "streaming"
@@ -454,7 +456,8 @@ export type QueueBlockedReason =
   | "overlay_open"
   | "command_running"
   | "interrupt_in_progress"
-  | "runtime_busy";
+  | "runtime_busy"
+  | "paused_by_user";
 
 /**
  * Emitted only on blocked-reason state transitions (not on every dequeue

--- a/src/types/protocol.ts
+++ b/src/types/protocol.ts
@@ -391,6 +391,8 @@ export interface QueueRuntimeItemWire {
   content: MessageCreate["content"] | string;
   /** ISO8601 UTC enqueue timestamp. */
   enqueued_at: string;
+  /** User input held by interrupt until resume or the next user message. */
+  paused?: boolean;
 }
 
 /**

--- a/src/types/protocol_v2.ts
+++ b/src/types/protocol_v2.ts
@@ -448,6 +448,7 @@ export interface QueueMessage {
   source: QueueMessageSource;
   content: MessageCreate["content"] | string;
   enqueued_at: string;
+  paused?: boolean; // parked by abort_message/Esc until resume_queue/next input
 }
 
 export interface DeviceStatusUpdateMessage extends RuntimeEnvelope {
@@ -460,10 +461,7 @@ export interface LoopStatusUpdateMessage extends RuntimeEnvelope {
   loop_status: LoopState;
 }
 
-/**
- * Full queue snapshot plus exact dequeue/cancellation transitions. Emitted on
- * mutation; transitions are ordered and cannot be inferred from absence.
- */
+/** Full queue snapshot plus ordered dequeue/cancel transitions; emitted on mutation. */
 export interface QueueUpdateMessage extends RuntimeEnvelope {
   type: "update_queue";
   queue: QueueMessage[];
@@ -2455,6 +2453,7 @@ export type WsProtocolCommand =
   | InputCommand
   | ChangeDeviceStateCommand
   | AbortMessageCommand
+  | import("./queue-update-protocol").ResumeQueueCommand
   | SyncCommand
   | RuntimeStartCommand
   | TeleportProtocol.TeleportProtocolCommand
@@ -2556,6 +2555,7 @@ export type WsProtocolMessage =
   | SubagentStateUpdateMessage
   | ExternalToolCallRequestMessage
   | AbortMessageResponseMessage
+  | import("./queue-update-protocol").ResumeQueueResponseMessage
   | SyncResponseMessage
   | RuntimeExternalToolsUpdateResponseMessage
   | TerminalOutputMessage

--- a/src/types/queue-update-protocol.ts
+++ b/src/types/queue-update-protocol.ts
@@ -1,4 +1,29 @@
+import type { ConversationRuntimeScope } from "./runtime-scope";
+
 export interface QueueRemovalTransition {
   client_message_id: string;
   disposition: "dequeued" | "cancelled";
+}
+
+/**
+ * Release queue items parked by a user interrupt (`abort_message` / Esc) so
+ * they start the next turn. A new `input` message resumes the queue
+ * implicitly; this command resumes it without adding a message (the "Resume"
+ * affordance). Parked items carry `paused: true` in `update_queue` snapshots.
+ */
+export interface ResumeQueueCommand {
+  type: "resume_queue";
+  runtime: ConversationRuntimeScope;
+  /** When provided, app-server sends resume_queue_response on the control channel. */
+  request_id?: string;
+}
+
+export interface ResumeQueueResponseMessage {
+  type: "resume_queue_response";
+  request_id: string;
+  runtime: ConversationRuntimeScope;
+  /** Number of queue items released by this command. */
+  resumed: number;
+  success: boolean;
+  error?: string;
 }

--- a/src/utils/message-queue-bridge.ts
+++ b/src/utils/message-queue-bridge.ts
@@ -19,6 +19,8 @@ export type QueuedMessage = {
   actingUserId?: string;
   /** QueueRuntime-assigned ID for targeted remove/edit operations. */
   queueItemId?: string;
+  /** Parked by Esc; waits for Enter on an empty input or the next message. */
+  paused?: boolean;
 };
 
 type QueueAdder = (message: QueuedMessage) => void;

--- a/src/utils/message-queue-bridge.ts
+++ b/src/utils/message-queue-bridge.ts
@@ -11,6 +11,8 @@
 export type QueuedMessage = {
   kind: "user" | "task_notification";
   text: string;
+  /** Preserve scheduled origin even when its prompt is rendered as user text. */
+  source?: "cron";
   /** Optional parent agent scope for routing in listener mode. */
   agentId?: string;
   /** Optional parent conversation scope for routing in listener mode. */

--- a/src/websocket/listener/commands/queue.ts
+++ b/src/websocket/listener/commands/queue.ts
@@ -1,5 +1,7 @@
 import type WebSocket from "ws";
+import type { RemoveQueueItemCommand } from "@/types/protocol_v2";
 import type { ResumeQueueCommand } from "@/types/queue-update-protocol";
+import { emitQueueUpdateIfOpen } from "@/websocket/listener/protocol-outbound";
 import { scheduleQueuePump } from "@/websocket/listener/queue";
 import type {
   ListenerRuntime,
@@ -8,13 +10,9 @@ import type {
 } from "@/websocket/listener/types";
 import type { GetOrCreateScopedRuntime, SafeSocketSend } from "./types";
 
-/**
- * `resume_queue`: release queue items parked by `abort_message` and pump the
- * queue so the released user messages start the next turn without a new
- * `input` message (the "Resume" affordance).
- */
-export function handleResumeQueueCommand(
-  command: ResumeQueueCommand,
+/** Mutate the listener's queue without submitting a new user message. */
+export function handleQueueCommand(
+  command: ResumeQueueCommand | RemoveQueueItemCommand,
   deps: {
     listener: ListenerRuntime;
     socket: WebSocket;
@@ -29,6 +27,24 @@ export function handleResumeQueueCommand(
     command.runtime.agent_id,
     command.runtime.conversation_id || "default",
   );
+  if (command.type === "remove_queue_item") {
+    const removed = scopedRuntime.queueRuntime.removeItem(command.item_id);
+    deps.safeSocketSend(
+      deps.socket,
+      {
+        type: "remove_queue_item_response",
+        request_id: command.request_id,
+        success: removed !== null,
+        item_id: command.item_id,
+      },
+      "remove_queue_item_response",
+      "remove_queue_item",
+    );
+    // Even a missing item requires a snapshot to repair a stale client queue.
+    emitQueueUpdateIfOpen(deps.listener, command.runtime);
+    return;
+  }
+
   const resumed = scopedRuntime.queueRuntime.resume();
   scheduleQueuePump(
     scopedRuntime,

--- a/src/websocket/listener/commands/resume-queue.ts
+++ b/src/websocket/listener/commands/resume-queue.ts
@@ -1,0 +1,53 @@
+import type WebSocket from "ws";
+import type { ResumeQueueCommand } from "@/types/queue-update-protocol";
+import { scheduleQueuePump } from "@/websocket/listener/queue";
+import type {
+  ListenerRuntime,
+  ProcessQueuedTurn,
+  StartListenerOptions,
+} from "@/websocket/listener/types";
+import type { GetOrCreateScopedRuntime, SafeSocketSend } from "./types";
+
+/**
+ * `resume_queue`: release queue items parked by `abort_message` and pump the
+ * queue so the released user messages start the next turn without a new
+ * `input` message (the "Resume" affordance).
+ */
+export function handleResumeQueueCommand(
+  command: ResumeQueueCommand,
+  deps: {
+    listener: ListenerRuntime;
+    socket: WebSocket;
+    opts: StartListenerOptions;
+    processQueuedTurn: ProcessQueuedTurn;
+    getOrCreateScopedRuntime: GetOrCreateScopedRuntime;
+    safeSocketSend: SafeSocketSend;
+  },
+): void {
+  const scopedRuntime = deps.getOrCreateScopedRuntime(
+    deps.listener,
+    command.runtime.agent_id,
+    command.runtime.conversation_id || "default",
+  );
+  const resumed = scopedRuntime.queueRuntime.resume();
+  scheduleQueuePump(
+    scopedRuntime,
+    deps.socket,
+    deps.opts,
+    deps.processQueuedTurn,
+  );
+  if (command.request_id) {
+    deps.safeSocketSend(
+      deps.socket,
+      {
+        type: "resume_queue_response",
+        request_id: command.request_id,
+        runtime: command.runtime,
+        resumed,
+        success: true,
+      },
+      "resume_queue_response",
+      "resume_queue",
+    );
+  }
+}

--- a/src/websocket/listener/control-inputs-pause.test.ts
+++ b/src/websocket/listener/control-inputs-pause.test.ts
@@ -1,0 +1,178 @@
+/**
+ * abort_message parks the user's queued messages (Codex-style "queue paused
+ * because you interrupted"). System items still drain once the interrupted
+ * lease settles; parked items wait for resume_queue or the next user message.
+ */
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { handleAbortMessageInput } from "./control-inputs";
+import { getOrCreateScopedRuntime } from "./conversation-runtime";
+import { enqueueInboundUserMessage } from "./inbound-queue";
+import { createRuntime } from "./lifecycle";
+import { scheduleQueuePump } from "./queue";
+import { setActiveRuntime } from "./runtime";
+import type { ListenerTransport } from "./transport";
+import { finishListenerTurn } from "./turn-terminal";
+import type {
+  ConversationRuntime,
+  IncomingMessage,
+  StartListenerOptions,
+} from "./types";
+
+function createOpenTransport(): ListenerTransport {
+  return {
+    kind: "local",
+    bufferedAmount: 0,
+    isOpen: () => true,
+    send: () => {},
+  };
+}
+
+async function waitFor(predicate: () => boolean): Promise<void> {
+  for (let attempt = 0; attempt < 200; attempt += 1) {
+    if (predicate()) {
+      return;
+    }
+    await Bun.sleep(1);
+  }
+  throw new Error("Timed out waiting for listener queue state");
+}
+
+function enqueueUser(runtime: ConversationRuntime, text: string): void {
+  expect(
+    enqueueInboundUserMessage(runtime, {
+      type: "message",
+      agentId: "agent-1",
+      conversationId: "conv-1",
+      messages: [{ role: "user", content: text }],
+    }),
+  ).toBe(true);
+}
+
+function enqueueNotification(runtime: ConversationRuntime, text: string): void {
+  runtime.queueRuntime.enqueue({
+    kind: "task_notification",
+    source: "task_notification",
+    text,
+    agentId: "agent-1",
+    conversationId: "conv-1",
+  } as Parameters<typeof runtime.queueRuntime.enqueue>[0]);
+}
+
+/**
+ * Start an active turn, queue `queuedBeforeAbort`, abort it, and settle the
+ * cancellation. Returns the processed turns and the runtime.
+ */
+async function interruptWithQueuedItems(params: {
+  queuedBeforeAbort: (runtime: ConversationRuntime) => void;
+  queuedAfterAbort?: (runtime: ConversationRuntime) => void;
+}) {
+  const listener = createRuntime();
+  const runtime = getOrCreateScopedRuntime(listener, "agent-1", "conv-1");
+  const socket = createOpenTransport();
+  const options = {} as StartListenerOptions;
+  const lease = runtime.turnLifecycle.begin({
+    origin: "message",
+    workingDirectory: process.cwd(),
+  });
+  runtime.turnLifecycle.setRunId(lease, "run-1");
+  const processedTurns: IncomingMessage[] = [];
+  const processQueuedTurn = mock(async (incoming: IncomingMessage) => {
+    processedTurns.push(incoming);
+  });
+  setActiveRuntime(listener);
+  params.queuedBeforeAbort(runtime);
+
+  expect(
+    await handleAbortMessageInput(
+      listener,
+      {
+        command: {
+          type: "abort_message",
+          runtime: { agent_id: "agent-1", conversation_id: "conv-1" },
+          run_id: "run-1",
+        },
+        socket,
+        opts: options,
+        processQueuedTurn,
+      },
+      {
+        cancelRun: async () => {},
+        cancelConversation: async () => {},
+      },
+    ),
+  ).toBe(true);
+  params.queuedAfterAbort?.(runtime);
+
+  expect(
+    finishListenerTurn(runtime, lease, {
+      stopReason: "cancelled",
+      socket,
+      runId: "run-1",
+      agentId: "agent-1",
+      conversationId: "conv-1",
+    }).finished,
+  ).toBe(true);
+  await waitFor(
+    () =>
+      runtime.turnLifecycle.kind === "idle" &&
+      !runtime.queuePumpActive &&
+      !runtime.queuePumpScheduled,
+  );
+  return { runtime, socket, options, processQueuedTurn, processedTurns };
+}
+
+describe("abort_message parks queued user messages", () => {
+  afterEach(() => setActiveRuntime(null));
+
+  test("parked user messages wait while a notification queued during the interrupt drains", async () => {
+    const { runtime, processedTurns } = await interruptWithQueuedItems({
+      queuedBeforeAbort: (r) => enqueueUser(r, "queued before esc"),
+      queuedAfterAbort: (r) => enqueueNotification(r, "<monitor-done/>"),
+    });
+
+    expect(processedTurns).toHaveLength(1);
+    const drained = JSON.stringify(processedTurns[0]?.messages);
+    expect(drained).toContain("<monitor-done/>");
+    expect(drained).not.toContain("queued before esc");
+    // The parked message is still there, flagged paused, and nothing is pumping.
+    expect(runtime.queueRuntime.length).toBe(1);
+    expect(runtime.queueRuntime.pausedCount).toBe(1);
+    expect(runtime.queueRuntime.items[0]?.paused).toBe(true);
+    expect(runtime.turnLifecycle.kind).toBe("idle");
+  });
+
+  test("resume releases parked messages and the pump starts their turn", async () => {
+    const { runtime, socket, options, processQueuedTurn, processedTurns } =
+      await interruptWithQueuedItems({
+        queuedBeforeAbort: (r) => enqueueUser(r, "queued before esc"),
+      });
+    expect(processedTurns).toHaveLength(0);
+
+    expect(runtime.queueRuntime.resume()).toBe(1);
+    scheduleQueuePump(runtime, socket, options, processQueuedTurn);
+    await waitFor(() => processedTurns.length === 1);
+
+    expect(JSON.stringify(processedTurns[0]?.messages)).toContain(
+      "queued before esc",
+    );
+    expect(runtime.queueRuntime.length).toBe(0);
+  });
+
+  test("a new user message resumes the parked ones and runs after them", async () => {
+    const { runtime, socket, options, processQueuedTurn, processedTurns } =
+      await interruptWithQueuedItems({
+        queuedBeforeAbort: (r) => enqueueUser(r, "queued before esc"),
+      });
+
+    enqueueUser(runtime, "typed after esc");
+    expect(runtime.queueRuntime.pausedCount).toBe(0);
+    scheduleQueuePump(runtime, socket, options, processQueuedTurn);
+    await waitFor(() => runtime.queueRuntime.length === 0);
+
+    const all = JSON.stringify(processedTurns.map((turn) => turn.messages));
+    expect(all.indexOf("queued before esc")).toBeGreaterThan(-1);
+    expect(all.indexOf("queued before esc")).toBeLessThan(
+      all.indexOf("typed after esc"),
+    );
+  });
+});

--- a/src/websocket/listener/control-inputs.ts
+++ b/src/websocket/listener/control-inputs.ts
@@ -481,6 +481,10 @@ export async function handleAbortMessageInput(
   const cancellation = scopedRuntime.turnLifecycle.requestCancellation({
     waitForExternalSettlement: hasActiveTurn && Boolean(scopedRuntime.agentId),
   });
+  // Interrupt semantics: the current turn stops and the user's queued messages
+  // park until resume_queue or the user's next message. System items (task
+  // notifications, cron, mod continuations) still drain once idle.
+  scopedRuntime.queueRuntime.pause();
   const interruptedRunId = cancellation.runId;
   const pendingRequestsSnapshot = hasPendingApprovals
     ? resolvedDeps.getPendingControlRequests(listener, scope)

--- a/src/websocket/listener/conversation-runtime.ts
+++ b/src/websocket/listener/conversation-runtime.ts
@@ -45,6 +45,13 @@ export function ensureConversationQueueRuntime(
           conversation_id: runtime.conversationId,
         });
       },
+      onPauseChanged: () => {
+        // Paused flags ride on the update_queue snapshot.
+        scheduleQueueEmit(listener, {
+          agent_id: runtime.agentId,
+          conversation_id: runtime.conversationId,
+        });
+      },
       onCleared: (_reason, _clearedCount, items) => {
         runtime.pendingTurns = 0;
         scheduleQueueEmit(

--- a/src/websocket/listener/inbound-queue.ts
+++ b/src/websocket/listener/inbound-queue.ts
@@ -32,6 +32,9 @@ export function enqueueInboundUserMessage(
     return false;
   }
 
+  // A new user message releases anything parked by an earlier interrupt, so
+  // the parked messages run first and this one follows in order.
+  runtime.queueRuntime.resume();
   const enqueuedItem = runtime.queueRuntime.enqueue({
     kind: "message",
     source: "user",

--- a/src/websocket/listener/message-router.test.ts
+++ b/src/websocket/listener/message-router.test.ts
@@ -530,6 +530,90 @@ describe("listener message router ownership handoff", () => {
     expect(runtime.queueRuntime.length).toBe(0);
   });
 
+  test("resume_queue releases interrupt-parked items and broadcasts paused flags", async () => {
+    const listener = createRuntime();
+    const runtime = getOrCreateScopedRuntime(listener, "agent-1", "conv-1");
+    const socket = new MockSocket();
+    listener.socket = socket as unknown as WebSocket;
+    const sent: unknown[] = [];
+    const processedTurns: IncomingMessage[] = [];
+    setActiveRuntime(listener);
+
+    const handleMessage = createListenerMessageHandler({
+      runtime: listener,
+      socket: socket as unknown as WebSocket,
+      opts: makeListenerOptions(),
+      processQueuedTurn: async (incoming) => {
+        processedTurns.push(incoming);
+      },
+      fileCommandSession: { handle: () => false },
+      getParsedRuntimeScope: () => null,
+      replaySyncStateForRuntime: async () => {},
+      getOrCreateScopedRuntime: () => runtime,
+      handleApprovalResponseInput: async () => false,
+      handleChangeDeviceStateInput: async () => false,
+      handleAbortMessageInput: async () => false,
+      stampInboundUserMessageOtids: (incoming) => incoming,
+      safeSocketSend: (_target, payload) => {
+        sent.push(payload);
+        return true;
+      },
+      runDetachedListenerTask: () => {},
+      trackListenerError: () => {},
+      processIncomingMessage: async () => {},
+    });
+
+    expect(
+      enqueueInboundUserMessage(runtime, {
+        type: "message",
+        agentId: "agent-1",
+        conversationId: "conv-1",
+        messages: [
+          { role: "user", content: "parked", client_message_id: "cm-parked" },
+        ],
+      }),
+    ).toBe(true);
+    expect(runtime.queueRuntime.pause()).toBe(1);
+    await Promise.resolve();
+    const snapshots = () =>
+      socket.sentPayloads
+        .map(
+          (payload) =>
+            JSON.parse(payload) as {
+              type: string;
+              queue?: Array<{ paused?: boolean }>;
+            },
+        )
+        .filter((payload) => payload.type === "update_queue");
+    expect(snapshots().at(-1)?.queue).toEqual([
+      expect.objectContaining({ paused: true }),
+    ]);
+
+    await handleMessage(
+      Buffer.from(
+        JSON.stringify({
+          type: "resume_queue",
+          request_id: "resume-1",
+          runtime: { agent_id: "agent-1", conversation_id: "conv-1" },
+        }),
+      ),
+    );
+    await waitFor(() => processedTurns.length === 1);
+
+    expect(sent).toContainEqual(
+      expect.objectContaining({
+        type: "resume_queue_response",
+        request_id: "resume-1",
+        resumed: 1,
+        success: true,
+      }),
+    );
+    expect(runtime.queueRuntime.length).toBe(0);
+    expect(JSON.stringify(processedTurns[0]?.messages)).toContain("parked");
+    const lastQueue = snapshots().at(-1)?.queue ?? [];
+    expect(lastQueue.some((item) => item.paused)).toBe(false);
+  });
+
   test("delegates registered service commands and returns their protocol messages", async () => {
     const listener = createRuntime();
     const runtime = getOrCreateScopedRuntime(listener, "agent-1", "conv-1");

--- a/src/websocket/listener/message-router.ts
+++ b/src/websocket/listener/message-router.ts
@@ -28,7 +28,7 @@ import { handleCronProtocolCommand } from "./commands/cron";
 import { handleGitBranchCommand } from "./commands/git-branches";
 import { handleMemfsSyncedMemoryProtocolCommand } from "./commands/memory-command-sync";
 import { handleModelToolsetCommand } from "./commands/model-toolset";
-import { handleResumeQueueCommand } from "./commands/resume-queue";
+import { handleQueueCommand } from "./commands/queue";
 import { handleRuntimeStartProtocolCommand } from "./commands/runtime-start";
 import { handleSecretsCommand } from "./commands/secrets";
 import { handleSettingsProtocolCommand } from "./commands/settings";
@@ -54,10 +54,7 @@ import {
   parseServerMessage,
 } from "./protocol-inbound";
 import { summarizeV2Command } from "./protocol-logging";
-import {
-  emitDeviceStatusUpdate,
-  emitQueueUpdateIfOpen,
-} from "./protocol-outbound";
+import { emitDeviceStatusUpdate } from "./protocol-outbound";
 import {
   scheduleQueuePump,
   shouldProcessInboundMessageDirectly,
@@ -728,43 +725,17 @@ export function createListenerMessageHandler(
         return;
       }
 
-      if (parsed.type === "resume_queue") {
-        handleResumeQueueCommand(parsed, {
+      if (
+        parsed.type === "resume_queue" ||
+        parsed.type === "remove_queue_item"
+      ) {
+        handleQueueCommand(parsed, {
           listener: runtime,
           socket,
           opts,
           processQueuedTurn,
           getOrCreateScopedRuntime,
           safeSocketSend,
-        });
-        return;
-      }
-
-      if (parsed.type === "remove_queue_item") {
-        const scopedRuntime = getOrCreateScopedRuntime(
-          runtime,
-          parsed.runtime.agent_id,
-          parsed.runtime.conversation_id || "default",
-        );
-        const removed = scopedRuntime.queueRuntime.removeItem(parsed.item_id);
-        // Emit a response so the client knows if the item was found/removed
-        safeSocketSend(
-          socket,
-          {
-            type: "remove_queue_item_response",
-            request_id: parsed.request_id,
-            success: removed !== null,
-            item_id: parsed.item_id,
-          },
-          "remove_queue_item_response",
-          "remove_queue_item",
-        );
-        // Broadcast the authoritative queue snapshot even when the item was
-        // NOT found: a consumer removing an already-drained item is holding
-        // a stale queue copy, and this snapshot repairs it. (LET-11174)
-        emitQueueUpdateIfOpen(runtime, {
-          agent_id: parsed.runtime.agent_id,
-          conversation_id: parsed.runtime.conversation_id,
         });
         return;
       }

--- a/src/websocket/listener/message-router.ts
+++ b/src/websocket/listener/message-router.ts
@@ -28,6 +28,7 @@ import { handleCronProtocolCommand } from "./commands/cron";
 import { handleGitBranchCommand } from "./commands/git-branches";
 import { handleMemfsSyncedMemoryProtocolCommand } from "./commands/memory-command-sync";
 import { handleModelToolsetCommand } from "./commands/model-toolset";
+import { handleResumeQueueCommand } from "./commands/resume-queue";
 import { handleRuntimeStartProtocolCommand } from "./commands/runtime-start";
 import { handleSecretsCommand } from "./commands/secrets";
 import { handleSettingsProtocolCommand } from "./commands/settings";
@@ -724,6 +725,18 @@ export function createListenerMessageHandler(
           }
           throw error;
         }
+        return;
+      }
+
+      if (parsed.type === "resume_queue") {
+        handleResumeQueueCommand(parsed, {
+          listener: runtime,
+          socket,
+          opts,
+          processQueuedTurn,
+          getOrCreateScopedRuntime,
+          safeSocketSend,
+        });
         return;
       }
 

--- a/src/websocket/listener/protocol-inbound.test.ts
+++ b/src/websocket/listener/protocol-inbound.test.ts
@@ -194,6 +194,36 @@ describe("teleport protocol-inbound validators", () => {
   });
 });
 
+describe("resume_queue protocol-inbound validators", () => {
+  test("accepts the resume_queue wire shape with and without request_id", () => {
+    const withRequestId = {
+      type: "resume_queue" as const,
+      request_id: "resume-1",
+      runtime: { agent_id: "agent-1", conversation_id: "conv-1" },
+    };
+    const withoutRequestId = {
+      type: "resume_queue" as const,
+      runtime: { agent_id: "agent-1", conversation_id: "conv-1" },
+    };
+    expect(
+      parseServerMessage(Buffer.from(JSON.stringify(withRequestId))),
+    ).toEqual(withRequestId);
+    expect(
+      parseServerMessage(Buffer.from(JSON.stringify(withoutRequestId))),
+    ).toEqual(withoutRequestId);
+  });
+
+  test("rejects resume_queue without a runtime scope", () => {
+    expect(
+      parseServerMessage(
+        Buffer.from(
+          JSON.stringify({ type: "resume_queue", request_id: "resume-1" }),
+        ),
+      ),
+    ).toBeNull();
+  });
+});
+
 describe("cron pause protocol-inbound validators", () => {
   test("accepts the exact pause and resume wire shapes", () => {
     const pause = {

--- a/src/websocket/listener/protocol-inbound.ts
+++ b/src/websocket/listener/protocol-inbound.ts
@@ -120,6 +120,7 @@ import {
   isGetCwdMapCommand,
   isSetBootWorkingDirectoryCommand,
 } from "./cwd-protocol-inbound";
+import { isResumeQueueCommand } from "./queue-pause-protocol-inbound";
 
 export { isConnectProviderCommand } from "./connect-provider-protocol-inbound";
 
@@ -452,9 +453,7 @@ function isChangeDeviceStateCommand(
 }
 
 function isAbortMessageCommand(value: unknown): value is AbortMessageCommand {
-  if (!value || typeof value !== "object") {
-    return false;
-  }
+  if (!value || typeof value !== "object") return false;
   const candidate = value as {
     type?: unknown;
     runtime?: unknown;
@@ -2085,6 +2084,7 @@ export function parseServerMessage(
       isInputCommand(parsed) ||
       isChangeDeviceStateCommand(parsed) ||
       isAbortMessageCommand(parsed) ||
+      isResumeQueueCommand(parsed) ||
       isSyncCommand(parsed) ||
       isRuntimeStartCommand(parsed) ||
       isRuntimeExternalToolsUpdateCommand(parsed) ||

--- a/src/websocket/listener/protocol-outbound.ts
+++ b/src/websocket/listener/protocol-outbound.ts
@@ -342,9 +342,8 @@ export function buildLoopStatus(
       scopedAgentId,
       scopedConversationId,
     ),
-    // Gate on the *reported* status so downgrades (interrupted cache) also
-    // clear the executing set, and stale runtime state never leaks into
-    // frames emitted while the loop is not executing tools.
+    // Gate on the *reported* status so downgrades (interrupted cache) also clear
+    // the executing set and stale state never leaks into non-executing frames.
     executing_tool_call_ids:
       status === "EXECUTING_CLIENT_SIDE_TOOL" && conversationRuntime
         ? [...conversationRuntime.turnLifecycle.executingToolCallIds]
@@ -375,6 +374,7 @@ export function buildQueueSnapshot(
     source: item.source,
     content: item.kind === "message" ? item.content : item.text,
     enqueued_at: new Date(item.enqueuedAt).toISOString(),
+    ...(item.paused ? { paused: true } : {}),
   }));
 }
 

--- a/src/websocket/listener/queue-pause-protocol-inbound.ts
+++ b/src/websocket/listener/queue-pause-protocol-inbound.ts
@@ -1,0 +1,20 @@
+import type { ResumeQueueCommand } from "@/types/queue-update-protocol";
+import { isRuntimeScope } from "./protocol-validation";
+
+/** Wire validator for `resume_queue` (release interrupt-parked queue items). */
+export function isResumeQueueCommand(
+  value: unknown,
+): value is ResumeQueueCommand {
+  if (!value || typeof value !== "object") return false;
+  const candidate = value as {
+    type?: unknown;
+    runtime?: unknown;
+    request_id?: unknown;
+  };
+  return (
+    candidate.type === "resume_queue" &&
+    isRuntimeScope(candidate.runtime) &&
+    (candidate.request_id === undefined ||
+      typeof candidate.request_id === "string")
+  );
+}

--- a/src/websocket/listener/queue.ts
+++ b/src/websocket/listener/queue.ts
@@ -286,7 +286,7 @@ export function consumeQueuedTurn(runtime: ConversationRuntime): {
   dequeuedBatch: DequeuedBatch;
   queuedTurn: IncomingMessage;
 } | null {
-  const queuedItems = runtime.queueRuntime.peek();
+  const queuedItems = runtime.queueRuntime.peekReady();
   const firstQueuedItem = queuedItems[0];
   if (!firstQueuedItem || !isCoalescable(firstQueuedItem.kind)) {
     return null;
@@ -451,6 +451,15 @@ async function drainQueuedMessages(
       const blockedReason = computeListenerQueueBlockedReason(runtime);
       if (blockedReason) {
         runtime.queueRuntime.tryDequeue(blockedReason);
+        return;
+      }
+
+      if (runtime.queueRuntime.readyLength === 0) {
+        // Only interrupt-parked user messages remain: report it once and wait
+        // for resume_queue or the next inbound message.
+        if (runtime.queueRuntime.length > 0) {
+          runtime.queueRuntime.tryDequeue("paused_by_user");
+        }
         return;
       }
 


### PR DESCRIPTION
## Summary

Interrupting an agent should stop the current turn and pause the user's queued messages, without preventing Monitor and subagent notifications from waking it. This change gives the TUI and listener that same behavior through their shared `QueueRuntime`.

Sending a new message releases paused messages ahead of the new input. `resume_queue` releases them without adding a message; the TUI uses Enter on an empty input. Queue snapshots carry `paused: true` so clients can display the paused state. System events can run without releasing paused user messages.

Follows the merged cancellation fix [#4201](https://github.com/letta-ai/letta-code/pull/4201). Rebased onto its squash merge; this diff contains only the pause/resume follow-up. Client Resume controls and relay forwarding are in the separate LET-12269 companion change. Headless keeps its existing scripted behavior.

## Before and after

Before: interrupt held the TUI queue implicitly, while the listener automatically drained queued user messages.

After:
1. Interrupt cancels the active turn and marks existing user queue items paused.
2. Once cancellation settles, system events can run; user messages remain queued.
3. New user input or `resume_queue` releases the paused items in order.
4. Clients receive updated queue snapshots with the paused flags removed.

`resume_queue` is a control command, not a model message:

```json
{"type":"resume_queue","request_id":"resume-1","runtime":{"agent_id":"agent-example","conversation_id":"conv-example"}}
```

The correlated response contains `success` and the number of items `resumed`. No synthetic user input is generated.

## Testing

The Ink regression mounts the production TUI with a fake backend, interrupts a typed turn, and verifies that a notification runs while a queued user message stays paused. It covers resuming with Enter and with newly typed text, plus a scheduled prompt passing through without releasing user messages.

The new-input case failed on the original implementation because the new prompt reached the backend first. The repair queues the new input before releasing the paused queue. Listener tests cover abort, notification delivery, explicit resume, new-message ordering, and correlated protocol responses.

The production TUI was also exercised with an isolated local agent and GPT-5 Mini: Esc leaves a user message paused, Enter releases it, and newly typed input is sent after the paused message. Notification bypass is covered by the deterministic tests; the live pause recording did not start a Monitor and does not claim that coverage. Companion client verification remains separate.

Earlier full CI exposed eight teleport tests affected by shared channel-route state. Those failures reproduced on unchanged main and the existing test-isolation repair was included in the now-merged base. No production teleport change is included here.

## Visual proof

Production TUI, isolated local agent, GPT-5 Mini. These recordings show user-message pause and resume; notification bypass is verified separately by the tests.

| Enter resumes | New input resumes in order |
| --- | --- |
| [![Esc pauses the queue; Enter resumes](https://chat.letta.com/artifacts/7166f66e-3ea3-4c84-b16b-187dcf430529)](https://chat.letta.com/artifacts/606ce379-0655-44c9-8a5f-6883d8650dee.mp4) | [![New input resumes the paused queue](https://chat.letta.com/artifacts/fde44212-eb30-4804-aaaf-cacd30175665)](https://chat.letta.com/artifacts/e215161f-10e5-4765-a92b-25a6843d12ce.mp4) |

| Paused, dark | Paused, light |
| --- | --- |
| ![Paused queue in dark terminal](https://chat.letta.com/artifacts/fd523b3d-ec8b-418e-95b3-0045e51d7dbc) | ![Paused queue in light terminal](https://chat.letta.com/artifacts/6934c615-3fe7-44ee-a9c5-14b40f37a7b8) |

## Breadcrumbs

- Origin and requested behavior: [#4168](https://github.com/letta-ai/letta-code/issues/4168) exposed the missing TUI wake-up; this follow-up makes user-message pause explicit instead of relying on that missing wake-up.
- Follows merged: [#4201](https://github.com/letta-ai/letta-code/pull/4201).
- Test-isolation repair included in the base: [#4307](https://github.com/letta-ai/letta-code/pull/4307), with the matching [earlier Linux failure log](https://github.com/letta-ai/letta-code/actions/runs/34311638655/job/102339492967).
- Original implementation: Claude Code; [implementation session](https://claude.ai/code/session_01UAnjNvh53FXWiS6bf143Ef).
- Rebase and follow-up verification: [`conv-8ca6ea46-fdb4-4a09-86ac-b720362dfd2f`](https://chat.letta.com/chat/agent-b86b0d3a-c425-4c88-86b9-44171f178713?conversation=conv-8ca6ea46-fdb4-4a09-86ac-b720362dfd2f).
