### PR TITLE
fix(ci): run agent watchers with letta/auto

### DIFF
--- a/.github/workflows/builtin-skills-agent-watch.yml
+++ b/.github/workflows/builtin-skills-agent-watch.yml
@@ -194,7 +194,7 @@ jobs:
           letta_args: --new
           track_progress: ""
           tracking_comment: "false"
-          model: auto
+          model: letta/auto
           prompt: ${{ steps.prompt.outputs.prompt }}
 
       - name: Name watcher conversation

--- a/.github/workflows/claude-agent-watch.yml
+++ b/.github/workflows/claude-agent-watch.yml
@@ -176,7 +176,7 @@ jobs:
           letta_args: --new
           track_progress: ""
           tracking_comment: "false"
-          model: auto
+          model: letta/auto
           prompt: ${{ steps.prompt.outputs.prompt }}
 
       - name: Name watcher conversation

--- a/.github/workflows/codex-agent-watch.yml
+++ b/.github/workflows/codex-agent-watch.yml
@@ -130,7 +130,7 @@ jobs:
           letta_args: --new
           track_progress: ""
           tracking_comment: "false"
-          model: auto
+          model: letta/auto
           prompt: ${{ steps.prompt.outputs.prompt }}
 
       - name: Name watcher conversation

--- a/.github/workflows/pi-ai-agent-watch.yml
+++ b/.github/workflows/pi-ai-agent-watch.yml
@@ -140,7 +140,7 @@ jobs:
           letta_args: --new
           track_progress: ""
           tracking_comment: "false"
-          model: auto
+          model: letta/auto
           prompt: ${{ steps.prompt.outputs.prompt }}
 
       - name: Name watcher conversation


### PR DESCRIPTION
## Summary

The four agent watchers currently ask Letta Code Action for the generic `auto` model selection. These automation runs should use the hosted `letta/auto` selection so they do not consume the Team Pro usage allowance that has been rejecting watcher turns.

This changes the Codex, Claude, pi-ai, and built-in skill watcher dispatches to pass `model: letta/auto`.

## Verification

- `bun run check`, all 12 checks passed
- parsed all four edited workflow files with the repository's installed YAML parser
- inspected the branch diff and confirmed the model input is the only change

## Breadcrumbs

- Linear: LET-12106
- Letta conversation: [`conv-7f83fb60-984c-4b0f-bfd9-9930a87dad1c`](https://chat.letta.com/chat/agent-cd664b86-4d28-49b7-8ad6-60677eaff9be?conversation=conv-7f83fb60-984c-4b0f-bfd9-9930a87dad1c)
- Origin: no single regression introduced this; the existing watcher dispatches came from [#3896](https://github.com/letta-ai/letta-code/pull/3896), [#3925](https://github.com/letta-ai/letta-code/pull/3925), [#3952](https://github.com/letta-ai/letta-code/pull/3952), and [#4060](https://github.com/letta-ai/letta-code/pull/4060)
- Root-cause evidence: private production evidence is recorded in LET-12106

## AI Disclosure

- [ ] This pull request was written entirely by a human
- [ ] This pull request was written with AI assistance and reviewed and edited by a human
- [x] I have read the [AI Policy](https://github.com/letta-ai/letta-code/blob/main/AI_POLICY.md) and agree to its terms

## AI Tool(s) Used

Letta Code

## Human Verification

Pending human review.
