### PR TITLE
fix(ci): retry Codex release fetches

### DIFF
--- a/scripts/codex-watch/release-analysis.test.ts
+++ b/scripts/codex-watch/release-analysis.test.ts
@@ -1,5 +1,6 @@
 import {
   findLatestStableReleaseAfter,
+  listStableReleases,
   type Release,
   releaseNotesForRange,
 } from "./release-analysis.ts";
@@ -47,5 +48,91 @@ describe("Codex stable release range", () => {
     expect(() => findLatestStableReleaseAfter(STABLES, "rust-v0.0.9")).toThrow(
       "Could not find terminal release rust-v0.0.9",
     );
+  });
+});
+
+describe("Codex GitHub release fetch", () => {
+  test("retries a server error before succeeding", async () => {
+    const sleeps: number[] = [];
+    let requests = 0;
+
+    const releases = await listStableReleases({
+      fetchImpl: (async () => {
+        requests++;
+        if (requests === 1) {
+          return new Response("Gateway Timeout", { status: 504 });
+        }
+        return new Response(JSON.stringify(STABLES), { status: 200 });
+      }) as typeof fetch,
+      sleep: async (delayMs) => {
+        sleeps.push(delayMs);
+      },
+    });
+
+    expect(requests).toBe(2);
+    expect(sleeps).toEqual([1000]);
+    expect(releases).toEqual(STABLES);
+  });
+
+  test("retries a network error before succeeding", async () => {
+    const sleeps: number[] = [];
+    let requests = 0;
+
+    const releases = await listStableReleases({
+      fetchImpl: (async () => {
+        requests++;
+        if (requests === 1) throw new TypeError("fetch failed: ECONNRESET");
+        return new Response(JSON.stringify(STABLES), { status: 200 });
+      }) as typeof fetch,
+      sleep: async (delayMs) => {
+        sleeps.push(delayMs);
+      },
+    });
+
+    expect(requests).toBe(2);
+    expect(sleeps).toEqual([1000]);
+    expect(releases).toEqual(STABLES);
+  });
+
+  test("stops after the bounded retry budget", async () => {
+    const sleeps: number[] = [];
+    let requests = 0;
+
+    const result = listStableReleases({
+      fetchImpl: (async () => {
+        requests++;
+        return new Response("Gateway Timeout", { status: 504 });
+      }) as typeof fetch,
+      sleep: async (delayMs) => {
+        sleeps.push(delayMs);
+      },
+    });
+
+    await expect(result).rejects.toThrow(
+      "GitHub releases API failed (504): Gateway Timeout",
+    );
+    expect(requests).toBe(3);
+    expect(sleeps).toEqual([1000, 2000]);
+  });
+
+  test("fails immediately on a client error", async () => {
+    const sleeps: number[] = [];
+    let requests = 0;
+
+    const result = listStableReleases({
+      fetchImpl: (async () => {
+        requests++;
+        return new Response("Not Found", { status: 404 });
+      }) as typeof fetch,
+      sleep: async (delayMs) => {
+        sleeps.push(delayMs);
+      },
+    });
+
+    await expect(result).rejects.toThrow(
+      "GitHub releases API failed (404): Not Found",
+    );
+    expect(requests).toBe(1);
+    expect(sleeps).toEqual([]);
   });
 });

--- a/scripts/codex-watch/release-analysis.ts
+++ b/scripts/codex-watch/release-analysis.ts
@@ -21,6 +21,8 @@ export const WATCHED_PATHS = [
 ];
 
 const MAX_COMMITS_PER_PATH = 8;
+const GITHUB_RELEASES_FETCH_ATTEMPTS = 3;
+const GITHUB_RELEASES_RETRY_DELAY_MS = 1_000;
 
 export interface Release {
   tag_name: string;
@@ -167,7 +169,12 @@ export async function analyzeCodexRelease(
   }
 }
 
-export async function listStableReleases(): Promise<Release[]> {
+export async function listStableReleases(
+  options: {
+    fetchImpl?: typeof fetch;
+    sleep?: (delayMs: number) => Promise<void>;
+  } = {},
+): Promise<Release[]> {
   const releases: Release[] = [];
   const headers: Record<string, string> = {
     Accept: "application/vnd.github+json",
@@ -175,15 +182,15 @@ export async function listStableReleases(): Promise<Release[]> {
   };
   const token = process.env.GH_TOKEN || process.env.GITHUB_TOKEN;
   if (token) headers.Authorization = `Bearer ${token}`;
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const sleep =
+    options.sleep ??
+    ((delayMs: number) =>
+      new Promise<void>((resolve) => setTimeout(resolve, delayMs)));
 
   for (let page = 1; page <= 10; page++) {
     const url = `https://api.github.com/repos/${CODEX_REPO}/releases?per_page=100&page=${page}`;
-    const res = await fetch(url, { headers });
-    if (!res.ok) {
-      throw new Error(
-        `GitHub releases API failed (${res.status}): ${await res.text()}`,
-      );
-    }
+    const res = await fetchGitHubReleasesPage(url, headers, fetchImpl, sleep);
     const batch = (await res.json()) as Release[];
     releases.push(...batch);
     if (batch.length < 100) break;
@@ -191,6 +198,49 @@ export async function listStableReleases(): Promise<Release[]> {
   return releases
     .filter(isStableRelease)
     .sort((a, b) => (a.published_at ?? "").localeCompare(b.published_at ?? ""));
+}
+
+async function fetchGitHubReleasesPage(
+  url: string,
+  headers: Record<string, string>,
+  fetchImpl: typeof fetch,
+  sleep: (delayMs: number) => Promise<void>,
+): Promise<Response> {
+  for (let attempt = 1; ; attempt++) {
+    let response: Response;
+    try {
+      response = await fetchImpl(url, { headers });
+    } catch (error) {
+      if (attempt === GITHUB_RELEASES_FETCH_ATTEMPTS) {
+        throw new Error(
+          `GitHub releases API request failed after ${attempt} attempts: ${String(error)}`,
+          { cause: error },
+        );
+      }
+      await retryGitHubReleasesFetch(attempt, String(error), sleep);
+      continue;
+    }
+
+    if (response.ok) return response;
+
+    const message = `GitHub releases API failed (${response.status}): ${await response.text()}`;
+    if (response.status < 500 || attempt === GITHUB_RELEASES_FETCH_ATTEMPTS) {
+      throw new Error(message);
+    }
+    await retryGitHubReleasesFetch(attempt, message, sleep);
+  }
+}
+
+async function retryGitHubReleasesFetch(
+  attempt: number,
+  error: string,
+  sleep: (delayMs: number) => Promise<void>,
+): Promise<void> {
+  const delayMs = GITHUB_RELEASES_RETRY_DELAY_MS * 2 ** (attempt - 1);
+  console.warn(
+    `${error}; retrying GitHub releases request in ${delayMs}ms (${attempt}/${GITHUB_RELEASES_FETCH_ATTEMPTS})`,
+  );
+  await sleep(delayMs);
 }
 
 function isStableRelease(release: Release): boolean {


### PR DESCRIPTION
## Summary

The Codex watcher currently fails the whole scheduled run when one GitHub Releases page returns a transient server error or the connection closes. The next schedule retries the release later, but that turns a short upstream interruption into a red run and delays the review by up to two hours.

This retries each Releases page up to three times with one- and two-second delays. Network exceptions and 5xx responses retry; client errors still fail immediately.

## Verification

- `bun test scripts/codex-watch`, 36 tests passed
- `bun run check`, all 12 checks passed
- focused tests cover recovery from HTTP 504 and `ECONNRESET`, exhausted retries, and fail-fast HTTP 404 behavior

## Breadcrumbs

- Linear: LET-12107
- Letta conversation: [`conv-7f83fb60-984c-4b0f-bfd9-9930a87dad1c`](https://chat.letta.com/chat/agent-cd664b86-4d28-49b7-8ad6-60677eaff9be?conversation=conv-7f83fb60-984c-4b0f-bfd9-9930a87dad1c)
- Origin: the direct fail-on-first-request fetch was introduced in [#3896](https://github.com/letta-ai/letta-code/pull/3896); no later regression was found
- Root-cause evidence: [HTTP 504 run](https://github.com/letta-ai/letta-code/actions/runs/33881614396), [connection-reset run](https://github.com/letta-ai/letta-code/actions/runs/33861474496)

## AI Disclosure

- [ ] This pull request was written entirely by a human
- [ ] This pull request was written with AI assistance and reviewed and edited by a human
- [x] I have read the [AI Policy](https://github.com/letta-ai/letta-code/blob/main/AI_POLICY.md) and agree to its terms

## AI Tool(s) Used

Letta Code

## Human Verification

Pending human review.
