### PR TITLE
feat(headless): propagate typed environment failures

### DIFF
--- a/scripts/source-file-size-baseline.json
+++ b/scripts/source-file-size-baseline.json
@@ -21,7 +21,7 @@
   "src/cli/mods/local-mod-loader.test.ts": 1043,
   "src/cli/reflection-transcript.test.ts": 1084,
   "src/cli/subcommands/skills.ts": 1264,
-  "src/headless.ts": 4986,
+  "src/headless.ts": 4979,
   "src/hooks/integration.test.ts": 1147,
   "src/index.ts": 2773,
   "src/mods/learning-harness.ts": 2434,
@@ -45,5 +45,5 @@
   "src/websocket/listener/lifecycle.ts": 1048,
   "src/websocket/listener/protocol-inbound.ts": 2207,
   "src/websocket/listener/protocol-outbound.ts": 1044,
-  "src/websocket/listener/turn.ts": 1058
+  "src/websocket/listener/turn.ts": 1055
 }

--- a/src/agent/terminal-failure.test.ts
+++ b/src/agent/terminal-failure.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from "bun:test";
+import { APIError } from "@letta-ai/letta-client/core/error";
+import { ApiRequestError } from "@/backend/api/request";
+import {
+  createEnvironmentTerminalFailure,
+  createTerminalFailure,
+  TerminalFailureError,
+} from "./terminal-failure";
+
+describe("terminal failure normalization", () => {
+  test("classifies a credit rejection without exposing the raw response", () => {
+    const error = new APIError(
+      402,
+      {
+        error: "raw provider detail",
+        reasons: ["letta-tier-usage-exceeded", "not-enough-credits"],
+      },
+      undefined,
+      new Headers(),
+    );
+
+    expect(
+      createTerminalFailure({
+        stage: "agent_turn",
+        message: "Your account does not have credits for this model.",
+        error,
+        clientMessageIds: ["cm-1"],
+      }),
+    ).toEqual({
+      stage: "agent_turn",
+      code: "not-enough-credits",
+      message: "Your account does not have credits for this model.",
+      http_status: 402,
+      retryable: false,
+      client_message_ids: ["cm-1"],
+    });
+  });
+
+  test("classifies sandbox startup failures with bounded safe copy", () => {
+    const error = new ApiRequestError(
+      'API error (500): {"errorCode":"SANDBOX_CREATION_FAILED","message":"secret upstream detail"}',
+      500,
+      '{"errorCode":"SANDBOX_CREATION_FAILED","message":"secret upstream detail"}',
+    );
+
+    expect(createEnvironmentTerminalFailure(error, "sandbox_start")).toEqual({
+      stage: "sandbox_start",
+      code: "SANDBOX_CREATION_FAILED",
+      message: "The Cloud sandbox could not be started.",
+      http_status: 500,
+      retryable: true,
+      client_message_ids: [],
+    });
+  });
+
+  test("preserves an already normalized remote failure", () => {
+    const failure = createTerminalFailure({
+      stage: "agent_turn",
+      message: "Safe failure",
+    });
+    expect(
+      createEnvironmentTerminalFailure(
+        new TerminalFailureError(failure),
+        "environment_turn",
+      ),
+    ).toBe(failure);
+  });
+});

--- a/src/agent/terminal-failure.ts
+++ b/src/agent/terminal-failure.ts
@@ -1,0 +1,182 @@
+import { APIError } from "@letta-ai/letta-client/core/error";
+import { ApiRequestError } from "@/backend/api/request";
+import type { TerminalFailure } from "@/types/terminal-failure";
+
+const MAX_MACHINE_FIELD_LENGTH = 128;
+const MAX_MESSAGE_LENGTH = 512;
+const MAX_CLIENT_MESSAGE_IDS = 32;
+const MAX_CLIENT_MESSAGE_ID_LENGTH = 256;
+const MACHINE_FIELD_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return typeof value === "object" && value !== null
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function parseResponseBody(error: unknown): Record<string, unknown> | null {
+  if (!(error instanceof ApiRequestError)) return null;
+  try {
+    return asRecord(JSON.parse(error.responseText));
+  } catch {
+    return null;
+  }
+}
+
+function machineField(value: unknown): string | null {
+  if (
+    typeof value !== "string" ||
+    value.length === 0 ||
+    value.length > MAX_MACHINE_FIELD_LENGTH ||
+    !MACHINE_FIELD_PATTERN.test(value)
+  ) {
+    return null;
+  }
+  return value;
+}
+
+function recordsFromError(error: unknown): Record<string, unknown>[] {
+  const records: Record<string, unknown>[] = [];
+  const append = (value: unknown): void => {
+    const record = asRecord(value);
+    if (!record) return;
+    records.push(record);
+    const nested = asRecord(record.error);
+    if (nested) records.push(nested);
+  };
+
+  if (error instanceof APIError) append(error.error);
+  append(parseResponseBody(error));
+  append(error);
+  return records;
+}
+
+function extractFailureCode(
+  error: unknown,
+  details: unknown,
+  fallback: string,
+): string {
+  const records = [...recordsFromError(error), ...recordsFromError(details)];
+  const reasons = records.flatMap((record) =>
+    Array.isArray(record.reasons)
+      ? record.reasons.flatMap((reason) => {
+          const parsed = machineField(reason);
+          return parsed ? [parsed] : [];
+        })
+      : [],
+  );
+  if (reasons.includes("not-enough-credits")) {
+    return "not-enough-credits";
+  }
+
+  for (const record of records) {
+    for (const key of [
+      "errorCode",
+      "error_code",
+      "code",
+      "error_type",
+      "type",
+    ]) {
+      const parsed = machineField(record[key]);
+      if (parsed) return parsed;
+    }
+  }
+
+  return reasons[0] ?? fallback;
+}
+
+function extractHttpStatus(error: unknown, details: unknown): number | null {
+  for (const value of [error, details]) {
+    const status = asRecord(value)?.status;
+    if (typeof status === "number" && Number.isInteger(status)) {
+      return status >= 100 && status <= 599 ? status : null;
+    }
+  }
+  return null;
+}
+
+function sanitizeMessage(value: string): string {
+  const withoutControls = Array.from(value, (character) => {
+    const code = character.charCodeAt(0);
+    return code < 32 || (code >= 127 && code <= 159) ? " " : character;
+  }).join("");
+  const normalized = withoutControls.replace(/\s+/g, " ").trim();
+  return (normalized || "The operation failed.").slice(0, MAX_MESSAGE_LENGTH);
+}
+
+function isRetryable(status: number | null, code: string): boolean {
+  if (status === 408 || status === 429 || (status !== null && status >= 500)) {
+    return true;
+  }
+  return /(?:timeout|temporar|unavailable|connection|llm_api_error)/i.test(
+    code,
+  );
+}
+
+function fallbackCode(stage: string): string {
+  const normalized = stage.replace(/_/g, "-");
+  return `${normalized}-failed`;
+}
+
+export function createTerminalFailure(params: {
+  stage: string;
+  message: string;
+  error?: unknown;
+  details?: unknown;
+  retryable?: boolean;
+  clientMessageIds?: string[];
+}): TerminalFailure {
+  const stage = machineField(params.stage) ?? "unknown";
+  const code = extractFailureCode(
+    params.error,
+    params.details,
+    fallbackCode(stage),
+  );
+  const httpStatus = extractHttpStatus(params.error, params.details);
+  return {
+    stage,
+    code,
+    message: sanitizeMessage(params.message),
+    http_status: httpStatus,
+    retryable: params.retryable ?? isRetryable(httpStatus, code),
+    client_message_ids: [
+      ...new Set(
+        (params.clientMessageIds ?? []).filter(
+          (id) => id.length > 0 && id.length <= MAX_CLIENT_MESSAGE_ID_LENGTH,
+        ),
+      ),
+    ].slice(0, MAX_CLIENT_MESSAGE_IDS),
+  };
+}
+
+export class TerminalFailureError extends Error {
+  constructor(readonly failure: TerminalFailure) {
+    super(failure.message);
+    this.name = "TerminalFailureError";
+  }
+}
+
+export function createEnvironmentTerminalFailure(
+  error: unknown,
+  stage:
+    | "sandbox_start"
+    | "environment_connect"
+    | "environment_dispatch"
+    | "environment_turn",
+): TerminalFailure {
+  if (error instanceof TerminalFailureError) return error.failure;
+
+  const code = extractFailureCode(error, undefined, fallbackCode(stage));
+  const message =
+    code === "SANDBOX_CREATION_FAILED"
+      ? "The Cloud sandbox could not be started."
+      : stage === "sandbox_start"
+        ? "The Cloud sandbox could not be started."
+        : stage === "environment_connect"
+          ? "Could not connect to the execution environment."
+          : stage === "environment_dispatch"
+            ? "Could not send the prompt to the execution environment."
+            : "The remote agent turn did not complete.";
+
+  return createTerminalFailure({ stage, message, error });
+}

--- a/src/backend/api/agents.ts
+++ b/src/backend/api/agents.ts
@@ -1,3 +1,4 @@
+import type { TerminalFailure } from "@/types/terminal-failure";
 import { apiRequest } from "./request";
 
 export async function getAgentContextOverview<T>(
@@ -42,6 +43,8 @@ export interface AgentRuntimeStatusEntry {
   loop_state: { status: string } | null;
   active_run_ids: string[];
   last_activity_at: number;
+  /** Last terminal listener failure, correlated to its consumed inputs. */
+  failure?: TerminalFailure | null;
 }
 
 export interface AgentRuntimeStatusSnapshot {

--- a/src/headless-environment-output.test.ts
+++ b/src/headless-environment-output.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "bun:test";
+import { ApiRequestError } from "@/backend/api/request";
+import { buildEnvironmentFailureOutput } from "./headless-environment-output";
+
+describe("headless environment failure output", () => {
+  test("emits a safe typed stream-json result for sandbox startup failures", () => {
+    const output = buildEnvironmentFailureOutput({
+      error: new ApiRequestError(
+        'API error (500): {"errorCode":"SANDBOX_CREATION_FAILED","message":"secret detail"}',
+        500,
+        '{"errorCode":"SANDBOX_CREATION_FAILED","message":"secret detail"}',
+      ),
+      stage: "sandbox_start",
+      agentId: "agent-1",
+      conversationId: "conv-1",
+      sessionId: "session-1",
+      durationMs: 12.4,
+      durationApiMs: 4.6,
+    });
+
+    expect(output.stream).toEqual(
+      expect.objectContaining({
+        type: "result",
+        subtype: "error",
+        result: "The Cloud sandbox could not be started.",
+        stop_reason: "error",
+        failure: {
+          stage: "sandbox_start",
+          code: "SANDBOX_CREATION_FAILED",
+          message: "The Cloud sandbox could not be started.",
+          http_status: 500,
+          retryable: true,
+          client_message_ids: [],
+        },
+      }),
+    );
+    expect(JSON.stringify(output)).not.toContain("secret detail");
+  });
+});

--- a/src/headless-environment-output.ts
+++ b/src/headless-environment-output.ts
@@ -1,0 +1,81 @@
+import type { EnvironmentConnection } from "@/backend/api/environments";
+import type { ResultMessage } from "@/types/protocol";
+import type { TerminalFailure } from "@/types/terminal-failure";
+import { createEnvironmentTerminalFailure } from "./agent/terminal-failure";
+
+export type ReplyEnvironmentMetadata =
+  | { source: "same-environment" }
+  | {
+      source: "explicit" | "cloud-sandbox";
+      input: string;
+      id: string;
+      connection_id: string;
+      device_id: string;
+      name: string;
+    };
+
+export function buildEnvironmentResponseMetadata(params: {
+  source: Extract<
+    ReplyEnvironmentMetadata,
+    { source: "explicit" | "cloud-sandbox" }
+  >["source"];
+  input: string;
+  connectionId: string;
+  environment: EnvironmentConnection;
+}): ReplyEnvironmentMetadata {
+  return {
+    source: params.source,
+    input: params.input,
+    id: params.environment.id,
+    connection_id: params.connectionId,
+    device_id: params.environment.deviceId,
+    name: params.environment.connectionName,
+  };
+}
+
+type EnvironmentFailureStage =
+  | "sandbox_start"
+  | "environment_connect"
+  | "environment_dispatch"
+  | "environment_turn";
+
+export function buildEnvironmentFailureOutput(params: {
+  error: unknown;
+  stage: EnvironmentFailureStage;
+  environment?: ReplyEnvironmentMetadata;
+  agentId: string | null;
+  conversationId: string;
+  sessionId: string;
+  durationMs: number;
+  durationApiMs: number;
+}): {
+  failure: TerminalFailure;
+  json: Record<string, unknown>;
+  stream: ResultMessage & { environment?: ReplyEnvironmentMetadata };
+} {
+  const failure = createEnvironmentTerminalFailure(params.error, params.stage);
+  const result = {
+    subtype: "error" as const,
+    duration_ms: Math.round(params.durationMs),
+    duration_api_ms: Math.round(params.durationApiMs),
+    num_turns: params.stage === "environment_turn" ? 1 : 0,
+    result: failure.message,
+    agent_id: params.agentId,
+    conversation_id: params.conversationId,
+    ...(params.environment ? { environment: params.environment } : {}),
+    usage: null,
+    stop_reason: "error" as const,
+    failure,
+  };
+  return {
+    failure,
+    json: { type: "result", is_error: true, ...result },
+    stream: {
+      type: "result",
+      session_id: params.sessionId,
+      run_ids: [],
+      uuid: `result-${params.agentId}-${Date.now()}`,
+      ...result,
+    },
+  };
+}

--- a/src/headless-environment-response.test.ts
+++ b/src/headless-environment-response.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
+import { TerminalFailureError } from "@/agent/terminal-failure";
 import type { AgentRuntimeStatusSnapshot } from "@/backend/api/agents";
 import type { EnvironmentConnection } from "@/backend/api/environments";
 import { ApiRequestError } from "@/backend/api/request";
@@ -542,6 +543,52 @@ describe("runtime-status wait mode", () => {
     userMessage("msg-user", "otid-1", "run-1", 10),
     toolMessage("msg-tool", "run-1", 11),
   ];
+
+  test("surfaces a correlated terminal listener failure before an input message persists", async () => {
+    const failure = {
+      stage: "agent_turn",
+      code: "not-enough-credits",
+      message: "Your account does not have credits for this model.",
+      http_status: 402,
+      retryable: false,
+      client_message_ids: ["client-message-1"],
+    };
+    const backend = {
+      async retrieveRun() {
+        throw new Error("should not retrieve a run");
+      },
+      async listConversationMessages() {
+        return [];
+      },
+    };
+
+    let caught: unknown;
+    try {
+      await waitForEnvironmentAssistantMessage({
+        backend: backend as never,
+        agentId: "agent-1",
+        conversationId: "conv-1",
+        otid: "otid-1",
+        clientMessageId: "client-message-1",
+        deps: {
+          getAgentRuntimeStatus: async () => {
+            const snapshot = runtimeSnapshot("conv-1", "IDLE");
+            const [status] = snapshot.statuses;
+            if (!status) throw new Error("missing test status");
+            return {
+              ...snapshot,
+              statuses: [{ ...status, failure }],
+            };
+          },
+        },
+      });
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(TerminalFailureError);
+    expect((caught as TerminalFailureError).failure).toEqual(failure);
+  });
 
   test("a non-IDLE record is progress: waits past inactivity with no new messages and no run polling", async () => {
     const clock = makeClock();

--- a/src/headless-environment-response.ts
+++ b/src/headless-environment-response.ts
@@ -2,6 +2,10 @@ import { randomUUID } from "node:crypto";
 import type { MessageCreate } from "@letta-ai/letta-client/resources/agents/agents";
 import type { Message as LettaMessage } from "@letta-ai/letta-client/resources/agents/messages";
 import type { StopReasonType } from "@letta-ai/letta-client/resources/runs/runs";
+import {
+  createEnvironmentTerminalFailure,
+  TerminalFailureError,
+} from "@/agent/terminal-failure";
 import type { Backend } from "@/backend";
 import {
   type AgentRuntimeStatusEntry,
@@ -12,10 +16,32 @@ import {
   type EnvironmentConnection,
   getEnvironmentConnection,
   isEnvironmentOnline,
+  resolveAgentSandboxConnectionId,
+  resolveEnvironmentConnectionId,
   type SendEnvironmentMessageBody,
+  sendEnvironmentMessage,
 } from "@/backend/api/environments";
 import { ApiRequestError } from "@/backend/api/request";
 import { toolFilter } from "@/tools/filter";
+
+export function isCloudEnvironmentSelector(
+  selector: string | boolean | undefined,
+): boolean {
+  if (typeof selector !== "string") return false;
+  const normalized = selector.trim().toLowerCase();
+  return normalized === "cloud" || normalized === "cloud-sandbox";
+}
+
+export function getEnvironmentRoutedMessagingUnsupportedReason(
+  environment: EnvironmentConnection,
+): string | null {
+  if (environment.metadata?.environmentMessageProtocol === "v2-input") {
+    return null;
+  }
+  return `Computer ${environment.connectionName} (${environment.deviceId}) is running Letta Code ${
+    environment.metadata?.lettaCodeVersion ?? "unknown"
+  } and does not advertise computer-routed headless messaging support. Update that runtime or omit --computer to use same-computer messaging.`;
+}
 
 /**
  * Build the POST body for an environment-routed turn.
@@ -33,6 +59,7 @@ export function buildEnvironmentCreateMessageBody(params: {
   conversationId: string | null;
   content: MessageCreate["content"];
   otid: string;
+  clientMessageId?: string;
 }): SendEnvironmentMessageBody {
   const clientToolAllowlist = toolFilter.getEnabledTools();
   return {
@@ -45,11 +72,76 @@ export function buildEnvironmentCreateMessageBody(params: {
       {
         role: "user",
         content: params.content,
-        client_message_id: randomUUID(),
+        client_message_id: params.clientMessageId ?? randomUUID(),
         otid: params.otid,
       },
     ],
   };
+}
+
+export async function resolveHeadlessEnvironmentRouting(params: {
+  selector: string;
+  useCloudSandbox: boolean;
+  agentId: string;
+  conversationId: string;
+}): Promise<Awaited<ReturnType<typeof resolveAgentSandboxConnectionId>>> {
+  try {
+    return params.useCloudSandbox
+      ? await resolveAgentSandboxConnectionId(params.agentId, {
+          conversationId: params.conversationId,
+        })
+      : await resolveEnvironmentConnectionId(params.selector);
+  } catch (error) {
+    const stage = params.useCloudSandbox
+      ? "sandbox_start"
+      : "environment_connect";
+    throw new TerminalFailureError(
+      createEnvironmentTerminalFailure(error, stage),
+    );
+  }
+}
+
+export async function sendAndWaitForEnvironmentAssistantMessage(params: {
+  backend: Backend;
+  connectionId: string;
+  deviceId: string;
+  agentId: string;
+  conversationId: string;
+  content: MessageCreate["content"];
+}): Promise<{ text: string; stopReason: StopReasonType | null }> {
+  const otid = randomUUID();
+  const clientMessageId = randomUUID();
+  try {
+    await sendEnvironmentMessage(
+      params.connectionId,
+      buildEnvironmentCreateMessageBody({
+        agentId: params.agentId,
+        conversationId: params.conversationId,
+        content: params.content,
+        otid,
+        clientMessageId,
+      }),
+    );
+  } catch (error) {
+    throw new TerminalFailureError(
+      createEnvironmentTerminalFailure(error, "environment_dispatch"),
+    );
+  }
+
+  try {
+    return await waitForEnvironmentAssistantMessage({
+      backend: params.backend,
+      agentId: params.agentId,
+      conversationId: params.conversationId,
+      otid,
+      clientMessageId,
+      deviceId: params.deviceId,
+    });
+  } catch (error) {
+    throw new TerminalFailureError(
+      createEnvironmentTerminalFailure(error, "environment_turn"),
+    );
+  }
 }
 
 function pageItems<T>(page: unknown): T[] {
@@ -199,6 +291,8 @@ export async function waitForEnvironmentAssistantMessage(params: {
   agentId: string;
   conversationId: string;
   otid: string;
+  /** Client message identity used to correlate a terminal listener failure. */
+  clientMessageId?: string;
   /** Device to liveness-check while waiting. Omitting skips online checks. */
   deviceId?: string;
   maxWaitMs?: number;
@@ -367,6 +461,12 @@ export async function waitForEnvironmentAssistantMessage(params: {
             ) ??
             (snapshot.statuses.length === 1 ? snapshot.statuses[0] : null) ??
             null;
+          if (
+            params.clientMessageId &&
+            status?.failure?.client_message_ids.includes(params.clientMessageId)
+          ) {
+            throw new TerminalFailureError(status.failure);
+          }
           if (status && !isRuntimeTurnOver(status)) {
             lastProgressAt = now();
             runtimeTurnOverAt = null;

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -71,12 +71,7 @@ import {
   type ConversationMessageStreamBody,
   getBackend,
 } from "./backend";
-import {
-  type EnvironmentConnection,
-  resolveAgentSandboxConnectionId,
-  resolveEnvironmentConnectionId,
-  sendEnvironmentMessage,
-} from "./backend/api/environments";
+import type { EnvironmentConnection } from "./backend/api/environments";
 import type { ParsedCliArgs } from "./cli/args";
 import {
   normalizeConversationShorthandFlags,
@@ -117,8 +112,15 @@ import {
 } from "./cli/startup-flag-validation";
 import { SYSTEM_REMINDER_CLOSE, SYSTEM_REMINDER_OPEN } from "./constants";
 import {
-  buildEnvironmentCreateMessageBody,
-  waitForEnvironmentAssistantMessage,
+  buildEnvironmentFailureOutput,
+  buildEnvironmentResponseMetadata,
+  type ReplyEnvironmentMetadata,
+} from "./headless-environment-output";
+import {
+  getEnvironmentRoutedMessagingUnsupportedReason,
+  isCloudEnvironmentSelector,
+  resolveHeadlessEnvironmentRouting,
+  sendAndWaitForEnvironmentAssistantMessage,
 } from "./headless-environment-response";
 import {
   clearHeadlessClientToolRules,
@@ -646,38 +648,6 @@ async function writeFinalHeadlessStdout(text: string): Promise<void> {
   });
 }
 
-type ReplyEnvironmentMetadata =
-  | {
-      source: "same-environment";
-    }
-  | {
-      source: "explicit" | "cloud-sandbox";
-      input: string;
-      id: string;
-      connection_id: string;
-      device_id: string;
-      name: string;
-    };
-
-function buildEnvironmentResponseMetadata(params: {
-  source: Extract<
-    ReplyEnvironmentMetadata,
-    { source: "explicit" | "cloud-sandbox" }
-  >["source"];
-  input: string;
-  connectionId: string;
-  environment: EnvironmentConnection;
-}): ReplyEnvironmentMetadata {
-  return {
-    source: params.source,
-    input: params.input,
-    id: params.environment.id,
-    connection_id: params.connectionId,
-    device_id: params.environment.deviceId,
-    name: params.environment.connectionName,
-  };
-}
-
 function formatAgentReplyMetadata(params: {
   agentId: string;
   conversationId: string;
@@ -688,25 +658,6 @@ function formatAgentReplyMetadata(params: {
     conversation_id: params.conversationId,
     ...(params.environment ? { environment: params.environment } : {}),
   });
-}
-
-function isCloudEnvironmentSelector(
-  selector: string | boolean | undefined,
-): boolean {
-  if (typeof selector !== "string") return false;
-  const normalized = selector.trim().toLowerCase();
-  return normalized === "cloud" || normalized === "cloud-sandbox";
-}
-
-function getEnvironmentRoutedMessagingUnsupportedReason(
-  environment: EnvironmentConnection,
-): string | null {
-  if (environment.metadata?.environmentMessageProtocol === "v2-input") {
-    return null;
-  }
-  return `Computer ${environment.connectionName} (${environment.deviceId}) is running Letta Code ${
-    environment.metadata?.lettaCodeVersion ?? "unknown"
-  } and does not advertise computer-routed headless messaging support. Update that runtime or omit --computer to use same-computer messaging.`;
 }
 
 export async function handleHeadlessCommand(
@@ -1873,6 +1824,35 @@ export async function handleHeadlessCommand(
     }
     return await flushAndExit(code);
   };
+  const exitWithEnvironmentFailure = async (params: {
+    error: unknown;
+    stage:
+      | "sandbox_start"
+      | "environment_connect"
+      | "environment_dispatch"
+      | "environment_turn";
+    environment?: ReplyEnvironmentMetadata;
+  }): Promise<never> => {
+    const stats = sessionStats.getSnapshot();
+    const output = buildEnvironmentFailureOutput({
+      ...params,
+      agentId: publicAgentId,
+      conversationId,
+      sessionId,
+      durationMs: stats.totalWallMs,
+      durationApiMs: stats.totalApiMs,
+    });
+    if (outputFormat === "json") {
+      await writeFinalHeadlessStdout(
+        `${JSON.stringify(output.json, null, 2)}\n`,
+      );
+    } else if (outputFormat === "stream-json") {
+      await writeWireMessageAsync(output.stream);
+    } else {
+      console.error(`Error: ${output.failure.message}`);
+    }
+    return await exitHeadless(1, `headless_${output.failure.stage}_failed`);
+  };
 
   // Output init event for stream-json format
   if (outputFormat === "stream-json") {
@@ -2126,9 +2106,24 @@ ${SYSTEM_REMINDER_CLOSE}
   if (usesRemoteEnvironment) {
     const environmentSelector = String(explicitEnvironmentSelector);
     const useCloudSandbox = isCloudEnvironmentSelector(environmentSelector);
-    const environmentRouting = useCloudSandbox
-      ? await resolveAgentSandboxConnectionId(agent.id, { conversationId })
-      : await resolveEnvironmentConnectionId(environmentSelector);
+    let environmentRouting: {
+      connectionId: string;
+      environment: EnvironmentConnection;
+    };
+    let environmentResult: { text: string; stopReason: StopReasonType | null };
+    try {
+      environmentRouting = await resolveHeadlessEnvironmentRouting({
+        selector: environmentSelector,
+        useCloudSandbox,
+        agentId: agent.id,
+        conversationId,
+      });
+    } catch (error) {
+      return await exitWithEnvironmentFailure({
+        error,
+        stage: useCloudSandbox ? "sandbox_start" : "environment_connect",
+      });
+    }
     const { connectionId, environment } = environmentRouting;
     const responseEnvironment = buildEnvironmentResponseMetadata({
       source: useCloudSandbox ? "cloud-sandbox" : "explicit",
@@ -2194,24 +2189,22 @@ ${SYSTEM_REMINDER_CLOSE}
       }
       await exitHeadless(1, "headless_environment_unsupported");
     }
-    const otid = randomUUID();
-    await sendEnvironmentMessage(
-      connectionId,
-      buildEnvironmentCreateMessageBody({
+    try {
+      environmentResult = await sendAndWaitForEnvironmentAssistantMessage({
+        backend,
+        connectionId,
+        deviceId: environment.deviceId,
         agentId: agent.id,
         conversationId,
         content: contentParts,
-        otid,
-      }),
-    );
-
-    const environmentResult = await waitForEnvironmentAssistantMessage({
-      backend,
-      agentId: agent.id,
-      conversationId,
-      otid,
-      deviceId: environment.deviceId,
-    });
+      });
+    } catch (error) {
+      return await exitWithEnvironmentFailure({
+        error,
+        stage: "environment_turn",
+        environment: responseEnvironment,
+      });
+    }
     const stats = sessionStats.getSnapshot();
 
     if (outputFormat === "json") {

--- a/src/types/loop-status-protocol.ts
+++ b/src/types/loop-status-protocol.ts
@@ -1,3 +1,5 @@
+import type { TerminalFailure } from "./terminal-failure";
+
 export type LoopStatus =
   | "SENDING_API_REQUEST"
   | "WAITING_FOR_API_RESPONSE"
@@ -22,4 +24,6 @@ export interface LoopState {
    * events, which are unrecoverable if a frame is lost.
    */
   executing_tool_call_ids: string[];
+  /** Last terminal failure, cleared when the next turn starts. */
+  failure?: TerminalFailure;
 }

--- a/src/types/protocol.ts
+++ b/src/types/protocol.ts
@@ -20,6 +20,7 @@ import type {
 import type { CreateBlock } from "@letta-ai/letta-client/resources/blocks/blocks";
 import type { StopReasonType } from "@letta-ai/letta-client/resources/runs/runs";
 import type { ToolReturnMessage as LettaToolReturnMessage } from "@letta-ai/letta-client/resources/tools";
+import type { TerminalFailure } from "./terminal-failure";
 
 // Re-export letta-client types that consumers may need
 export type {
@@ -335,6 +336,8 @@ export interface ResultMessage extends MessageEnvelope {
    * Uses StopReasonType from letta-client (e.g., 'error', 'max_steps', 'llm_api_error').
    */
   stop_reason?: StopReasonType;
+  /** Safe structured failure details for automation consumers. */
+  failure?: TerminalFailure;
 }
 
 // ═══════════════════════════════════════════════════════════════

--- a/src/types/terminal-failure.ts
+++ b/src/types/terminal-failure.ts
@@ -1,0 +1,15 @@
+/** Safe, machine-readable reason a turn could not produce a result. */
+export interface TerminalFailure {
+  /** Execution boundary that failed. */
+  stage: string;
+  /** Stable machine-readable classification. */
+  code: string;
+  /** Bounded, user-safe explanation. */
+  message: string;
+  /** Upstream HTTP status when one exists. */
+  http_status: number | null;
+  /** Whether retrying the operation may succeed without user intervention. */
+  retryable: boolean;
+  /** Input identities consumed by the failed turn, used for correlation. */
+  client_message_ids: string[];
+}

--- a/src/websocket/listener/loop-state-executing-tools.test.ts
+++ b/src/websocket/listener/loop-state-executing-tools.test.ts
@@ -112,6 +112,25 @@ describe("loop state executing tool call ids", () => {
     expect(loopStatus.status).toBe("WAITING_ON_INPUT");
     expect(loopStatus.executing_tool_call_ids).toEqual([]);
   });
+
+  test("carries the last terminal failure until the next turn starts", () => {
+    const runtime = createScopedRuntime();
+    runtime.lastTerminalFailure = {
+      stage: "agent_turn",
+      code: "not-enough-credits",
+      message: "No credits remain.",
+      http_status: 402,
+      retryable: false,
+      client_message_ids: ["client-message-1"],
+    };
+
+    expect(
+      buildLoopStatus(runtime.listener, {
+        agent_id: "agent-1",
+        conversation_id: "conv-a",
+      }).failure,
+    ).toEqual(runtime.lastTerminalFailure);
+  });
 });
 
 describe("emitToolExecutionAbortedEvents", () => {

--- a/src/websocket/listener/protocol-outbound.ts
+++ b/src/websocket/listener/protocol-outbound.ts
@@ -344,13 +344,13 @@ export function buildLoopStatus(
       scopedAgentId,
       scopedConversationId,
     ),
-    // Gate on the *reported* status so downgrades (interrupted cache) also
-    // clear the executing set, and stale runtime state never leaks into
-    // frames emitted while the loop is not executing tools.
+    // Gate on the *reported* status so downgrades clear the executing set and
+    // stale runtime state never leaks while the loop is not executing tools.
     executing_tool_call_ids:
       status === "EXECUTING_CLIENT_SIDE_TOOL" && conversationRuntime
         ? [...conversationRuntime.turnLifecycle.executingToolCallIds]
         : [],
+    failure: conversationRuntime?.lastTerminalFailure ?? undefined,
   };
 }
 export function buildQueueSnapshot(

--- a/src/websocket/listener/runtime.ts
+++ b/src/websocket/listener/runtime.ts
@@ -265,8 +265,7 @@ export function createConversationRuntime(
     get lastStopReason() {
       return turnLifecycle.lastStopReason;
     },
-    lastTerminalLoopErrorMessage: null,
-    lastTerminalLoopErrorRunId: null,
+    lastTerminalFailure: null,
     get isProcessing() {
       return turnLifecycle.isProcessing;
     },

--- a/src/websocket/listener/turn-correlation.ts
+++ b/src/websocket/listener/turn-correlation.ts
@@ -22,6 +22,7 @@ function takeDequeuedClientMessageIds(
 export interface TurnCorrelation {
   appendDequeuedBatch: (batchId: string) => void;
   observeRun: (runId: string) => void;
+  getClientMessageIds: () => string[];
 }
 
 export function buildTurnCorrelationSnapshot(
@@ -73,6 +74,9 @@ export function createTurnCorrelation(
     }
   }
   return {
+    getClientMessageIds() {
+      return [...clientMessageIds];
+    },
     appendDequeuedBatch(nextBatchId) {
       for (const clientMessageId of takeDequeuedClientMessageIds(
         runtime,

--- a/src/websocket/listener/turn-terminal-protocol.test.ts
+++ b/src/websocket/listener/turn-terminal-protocol.test.ts
@@ -60,6 +60,37 @@ test("finishListenerTurn emits exactly one correlated terminal event", () => {
   ]);
 });
 
+test("finishListenerTurn retains a safe correlated API failure", () => {
+  const listener = createRuntime();
+  const runtime = getOrCreateScopedRuntime(listener, "agent-1", "conv-1");
+  const lease = runtime.turnLifecycle.begin({
+    origin: "message",
+    workingDirectory: process.cwd(),
+  });
+
+  finishListenerTurn(runtime, lease, {
+    stopReason: "error",
+    conversationId: "conv-1",
+    error: "Your account does not have credits for this model.",
+    failureSource: new APIError(
+      402,
+      { error: "raw detail", reasons: ["not-enough-credits"] },
+      undefined,
+      new Headers(),
+    ),
+    clientMessageIds: ["client-message-1"],
+  });
+
+  expect(runtime.lastTerminalFailure).toEqual({
+    stage: "agent_turn",
+    code: "not-enough-credits",
+    message: "Your account does not have credits for this model.",
+    http_status: 402,
+    retryable: false,
+    client_message_ids: ["client-message-1"],
+  });
+});
+
 test("terminal error formatting preserves classifications and rejects raw fallbacks", () => {
   const unknownApiError = new APIError(
     500,

--- a/src/websocket/listener/turn-terminal.ts
+++ b/src/websocket/listener/turn-terminal.ts
@@ -1,3 +1,4 @@
+import { createTerminalFailure } from "@/agent/terminal-failure";
 import type { StopReasonType } from "@/types/protocol_v2";
 import { TO_SUBSCRIBERS } from "./connection";
 import {
@@ -20,12 +21,22 @@ export function finishListenerTurn(
     conversationId: string;
     turnId?: string;
     error?: string;
+    failureSource?: unknown;
+    clientMessageIds?: string[];
   },
 ): TurnFinishTransition {
   const transition = runtime.turnLifecycle.finish(lease, options.stopReason);
   if (!transition.finished) {
     return transition;
   }
+  runtime.lastTerminalFailure = options.error
+    ? createTerminalFailure({
+        stage: "agent_turn",
+        message: options.error,
+        details: options.failureSource,
+        clientMessageIds: options.clientMessageIds,
+      })
+    : null;
 
   // Explicit abort projects the interrupted state when it moves the lease to
   // cancelling. Only server-originated cancellation reaches finish from active.

--- a/src/websocket/listener/turn.ts
+++ b/src/websocket/listener/turn.ts
@@ -192,6 +192,7 @@ async function handleIncomingMessageInner(
         ...options,
         socket: options.socket ?? socket,
         turnId: activeDequeuedBatchId,
+        clientMessageIds: turnCorrelation.getClientMessageIds(),
       }),
     );
   const finishIfInterrupted = (runId?: string | null): boolean => {
@@ -211,8 +212,7 @@ async function handleIncomingMessageInner(
     return true;
   };
   try {
-    runtime.lastTerminalLoopErrorMessage = null;
-    runtime.lastTerminalLoopErrorRunId = null;
+    runtime.lastTerminalFailure = null;
     setTurnLoopStatus(runtime, turnLease, "SENDING_API_REQUEST", {
       agent_id: agentId ?? null,
       conversation_id: conversationId,
@@ -257,7 +257,7 @@ async function handleIncomingMessageInner(
       if (!transition.finished) {
         return;
       }
-      const formattedError = emitLoopErrorNotice(socket, runtime, {
+      emitLoopErrorNotice(socket, runtime, {
         message: setup.reason,
         stopReason: "cancelled",
         isTerminal: true,
@@ -266,7 +266,6 @@ async function handleIncomingMessageInner(
         cancelRequested: turnAbortSignal.aborted,
         abortSignal: turnAbortSignal,
       });
-      runtime.lastTerminalLoopErrorMessage = formattedError ?? setup.reason;
       return;
     }
     let turnInput = setup.turnInput;
@@ -825,18 +824,17 @@ async function handleIncomingMessageInner(
           agentId,
           conversationId,
           error: terminalError,
+          failureSource: runErrorInfo,
         });
         if (!transition.finished) {
           break;
         }
-        const formattedError = emitLoopErrorNotice(socket, runtime, {
+        emitLoopErrorNotice(socket, runtime, {
           ...noticeParams,
           stopReason: effectiveStopReason,
           isTerminal: true,
           runId: terminalRunId,
         });
-        runtime.lastTerminalLoopErrorMessage = formattedError ?? errorMessage;
-        runtime.lastTerminalLoopErrorRunId = terminalRunId ?? null;
         break;
       }
 
@@ -861,16 +859,19 @@ async function handleIncomingMessageInner(
       });
       if (approvalResult.kind === "error") {
         const terminalRunId = runId || runtime.activeRunId;
+        const terminalError = getSafeTerminalError({
+          message: approvalResult.message,
+        });
         const transition = finishTurn({
           stopReason: "error",
           agentId,
           conversationId,
-          error: getSafeTerminalError({ message: approvalResult.message }),
+          error: terminalError,
         });
         if (!transition.finished) {
           return;
         }
-        const formattedError = emitLoopErrorNotice(socket, runtime, {
+        emitLoopErrorNotice(socket, runtime, {
           message: approvalResult.message,
           stopReason: "error",
           isTerminal: true,
@@ -878,9 +879,6 @@ async function handleIncomingMessageInner(
           agentId,
           conversationId,
         });
-        runtime.lastTerminalLoopErrorMessage =
-          formattedError ?? approvalResult.message;
-        runtime.lastTerminalLoopErrorRunId = terminalRunId ?? null;
         return;
       }
 
@@ -1003,18 +1001,17 @@ async function handleIncomingMessageInner(
       agentId: agentId || null,
       conversationId,
       error: terminalError,
+      failureSource: error,
     });
     if (!transition.finished) {
       return;
     }
-    const formattedError = emitLoopErrorNotice(socket, runtime, {
+    emitLoopErrorNotice(socket, runtime, {
       ...noticeParams,
       stopReason: "error",
       isTerminal: true,
       runId: terminalRunId,
     });
-    runtime.lastTerminalLoopErrorMessage = formattedError ?? errorMessage;
-    runtime.lastTerminalLoopErrorRunId = terminalRunId ?? null;
     if (isDebugEnabled()) {
       console.error("[Listen] Error handling message:", error);
     }

--- a/src/websocket/listener/types.ts
+++ b/src/websocket/listener/types.ts
@@ -35,6 +35,7 @@ import type {
   ServiceCommandRequest,
   ServiceCommandResponse,
 } from "@/types/service-protocol";
+import type { TerminalFailure } from "@/types/terminal-failure";
 import type { ListenerTransport } from "./transport";
 import type { TurnLifecycle } from "./turn-lifecycle";
 
@@ -218,8 +219,7 @@ export type ConversationRuntime = {
   pendingApprovalResolvers: Map<string, PendingApprovalResolver>;
   recoveredApprovalState: RecoveredApprovalState | null;
   readonly lastStopReason: StopReasonType | null;
-  lastTerminalLoopErrorMessage: string | null;
-  lastTerminalLoopErrorRunId: string | null;
+  lastTerminalFailure: TerminalFailure | null;
   readonly isProcessing: boolean;
   readonly activeWorkingDirectory: string | null;
   expectedWorktreePath: string | null;


### PR DESCRIPTION
## Summary

A headless turn routed through another computer should fail as soon as that listener reports a terminal error. Today the listener emits a safe error notice, but the headless process cannot associate it with the submitted prompt, so quota rejections can end as generic missing-reply failures.

This adds a bounded terminal failure contract to listener loop status. The headless process sends one `client_message_id`, matches the returned failure to that input, emits a final `type: "result"`, `subtype: "error"` envelope, and exits nonzero. Sandbox startup and computer connection failures use the same result shape.

## Before and after

Before:

1. Headless mode sent the prompt to the selected computer.
2. A terminal listener error returned the conversation to `WAITING_ON_INPUT` without a correlated reason.
3. Headless mode waited for an assistant reply and eventually produced a generic error.

After:

1. Headless mode sends the prompt with a stable `client_message_id`.
2. The listener records a safe `failure` with the IDs consumed by that turn and includes it in loop status.
3. Cloud keeps the failure in conversation runtime status after the listener releases ownership.
4. Headless mode matches the ID and immediately emits the structured error result.

## Review notes

The failure object contains only `stage`, `code`, `message`, `http_status`, `retryable`, and `client_message_ids`. Raw API errors are used only to choose the code and status; the emitted message comes from the existing safe error formatter or fixed sandbox copy.

Cloud must deploy its additive runtime-status field before this behavior can work through a managed sandbox. That dependency and the release follow-up are tracked in LET-12110.

## Verification

- `bun test src/agent/terminal-failure.test.ts src/headless-environment-output.test.ts src/headless-environment-response.test.ts src/websocket/listener/turn-terminal-protocol.test.ts src/websocket/listener/loop-state-executing-tools.test.ts`, 34 tests passed
- `bun run typecheck`, passed
- `bun run check`, all 12 checks passed

The listener tests cover a real 402 `APIError`, safe code selection, input correlation, and terminal loop-status projection. The headless tests cover correlated Cloud failures and the final sandbox 500 stream result. A deployed managed-sandbox run remains gated on the Cloud rollout and first Letta Code release containing this change.

## Breadcrumbs

- Requested in: LET-12110
- Letta conversation: [`conv-7f83fb60-984c-4b0f-bfd9-9930a87dad1c`](https://chat.letta.com/chat/agent-cd664b86-4d28-49b7-8ad6-60677eaff9be?conversation=conv-7f83fb60-984c-4b0f-bfd9-9930a87dad1c)
- Related: [letta-code-action#33](https://github.com/letta-ai/letta-code-action/pull/33)

## AI Disclosure

- [ ] This pull request was written entirely by a human
- [ ] This pull request was written with AI assistance and reviewed and edited by a human
- [x] I have read the [AI Policy](https://github.com/letta-ai/letta-code/blob/main/AI_POLICY.md) and agree to its terms

## AI Tool(s) Used

Letta Code

## Human Verification

Pending human review.
