### PR TITLE
fix(skills): update acquiring-skills project paths to .agents/skills/

### DIFF
--- a/src/skills/builtin/acquiring-skills/SKILL.md
+++ b/src/skills/builtin/acquiring-skills/SKILL.md
@@ -225,7 +225,7 @@ For manual installation:
 |----------|------|-------------|
 | **Agent-scoped** | `~/.letta/agents/<agent-id>/memory/skills/<skill>/` | Skills for a single agent (default) |
 | **Global** | `~/.letta/skills/<skill>/` | General-purpose skills useful across projects |
-| **Project** | `.skills/<skill>/` | Project-specific skills |
+| **Project** | `.agents/skills/<skill>/` | Project-specific skills (`.skills/` is a legacy fallback) |
 
 **Rule**: Default to **agent-scoped**. Use **project** for repo-specific skills. Use **global** only if all agents should inherit the skill.
 
@@ -242,7 +242,7 @@ rm -rf /tmp/skills-temp
 
 ## Registering New Skills
 
-After installing (via CLI or manual copy), skills are automatically discovered on the next message. Skills are discovered from `~/.letta/skills/`, `.skills/`, and agent-scoped `~/.letta/agents/<agent-id>/memory/skills/` directories.
+After installing (via CLI or manual copy), skills are automatically discovered on the next message. Skills are discovered from `.agents/skills/` (with `.skills/` as a legacy fallback), `~/.letta/skills/`, and agent-scoped `~/.letta/agents/<agent-id>/memory/skills/` directories.
 
 ## Search Strategy
 


### PR DESCRIPTION
Builtin-skill-watch: acquiring-skills@2823362103cc-3f3c501f85ae2c88

## Selected skill

`acquiring-skills` (`src/skills/builtin/acquiring-skills/SKILL.md`)

## Stale claim

The SKILL.md referenced `.skills/` as the project skills directory in two places:
1. **Installation Locations table** (line 228): `| **Project** | `.skills/<skill>/` | Project-specific skills |`
2. **Registering New Skills section** (line 245): "Skills are discovered from `~/.letta/skills/`, `.skills/`, and agent-scoped `~/.letta/agents/<agent-id>/memory/skills/` directories."

The canonical project skills directory has been `.agents/skills/` since PR #3131 (June 2026). `.skills/` is now a legacy fallback.

## Current owning source

- `src/agent/skills.ts`: `PROJECT_SKILLS_DIR = join(".agents", "skills")` (canonical), `SKILLS_DIR = ".skills"` (legacy)
- `src/agent/client-skills.ts`: discovers from `.agents/skills/` (primary) and `.skills/` (legacy)
- `src/tools/impl/skill.ts`: search order uses `.agents/skills/` first
- Official docs (docs.letta.com/configuration/skills): `.agents/skills/` is the primary project-local location
- `src/skills/builtin/self-configuration/SKILL.md` already uses the correct paths

## Focused validation

- `bun test src/cli/subcommands/skills.test.ts` — 22 pass, 0 fail
- `bun test src/agent/skills-discovery.test.ts` — 10 pass, 0 fail
- `bun run check` — 12/12 checks passed

👾 Generated with [Letta Code](https://letta.com)

Co-Authored-By: Letta Code <noreply@letta.com>