### PR TITLE
fix(skills): update initializing-memory for current subagent model and permissions

### DIFF
--- a/src/skills/builtin/initializing-memory/ROOT_MEMORY.md
+++ b/src/skills/builtin/initializing-memory/ROOT_MEMORY.md
@@ -235,7 +235,7 @@ The goal is to extract user personality, preferences, coding patterns, and proje
 #### Prerequisites
 
 - `letta.js` must be built (`bun run build`) — subagents spawn via this binary
-- Use `subagent_type: "history-analyzer"` — cheaper model (sonnet), has `bypassPermissions`, creates its own worktree
+- Use `subagent_type: "history-analyzer"` — model: auto, runs with `--permission-mode unrestricted`, creates its own worktree
 - The `history-analyzer` subagent has the normalized trajectory format docs inlined — workers never need to know any harness's native format
 
 #### Steps
@@ -564,7 +564,6 @@ Launch exploration subagents in a **single message** so they run concurrently.
 Agent({
   subagent_type: "general-purpose",
   description: "Explore API layer",
-  run_in_background: true,
   prompt: `Read the implementation in src/api/.
 
 Return:
@@ -577,7 +576,6 @@ Return:
 Agent({
   subagent_type: "general-purpose",
   description: "Explore frontend layer",
-  run_in_background: true,
   prompt: `Read the implementation in src/ui/.
 
 Return:
@@ -590,7 +588,6 @@ Return:
 Agent({
   subagent_type: "general-purpose",
   description: "Explore shared systems",
-  run_in_background: true,
   prompt: `Read the implementation in src/shared/.
 
 Return:

--- a/src/skills/builtin/initializing-memory/SKILL.md
+++ b/src/skills/builtin/initializing-memory/SKILL.md
@@ -239,7 +239,7 @@ The goal is to extract user personality, preferences, coding patterns, and proje
 #### Prerequisites
 
 - `letta.js` must be built (`bun run build`) — subagents spawn via this binary
-- Use `subagent_type: "history-analyzer"` — cheaper model (sonnet), has `bypassPermissions`, creates its own worktree
+- Use `subagent_type: "history-analyzer"` — model: auto, runs with `--permission-mode unrestricted`, creates its own worktree
 - The `history-analyzer` subagent has the normalized trajectory format docs inlined — workers never need to know any harness's native format
 
 #### Steps
@@ -568,7 +568,6 @@ Launch exploration subagents in a **single message** so they run concurrently.
 Agent({
   subagent_type: "general-purpose",
   description: "Explore API layer",
-  run_in_background: true,
   prompt: `Read the implementation in src/api/.
 
 Return:
@@ -581,7 +580,6 @@ Return:
 Agent({
   subagent_type: "general-purpose",
   description: "Explore frontend layer",
-  run_in_background: true,
   prompt: `Read the implementation in src/ui/.
 
 Return:
@@ -594,7 +592,6 @@ Return:
 Agent({
   subagent_type: "general-purpose",
   description: "Explore shared systems",
-  run_in_background: true,
   prompt: `Read the implementation in src/shared/.
 
 Return:


### PR DESCRIPTION
## Summary
- Update history-analyzer description: `model: auto` (not `sonnet`), `--permission-mode unrestricted` (not `bypassPermissions`)
- Remove stale `run_in_background: true` from Agent tool examples (not in Task tool schema)

## Evidence
- `src/agent/subagents/builtin/history-analyzer.md` frontmatter: `model: auto`
- `src/agent/subagents/manager.ts` line 293: `--permission-mode unrestricted`
- `src/permissions/mode.ts` line 23: `bypassPermissions` renamed to `unrestricted`
- `src/tools/schemas/Task.json`: no `run_in_background` field

Builtin-skill-watch: initializing-memory@9167b001406a-70604a0213924796

Co-Authored-By: Letta Code <noreply@letta.com>