### PR TITLE
fix(app-server): keep OpenAI SSE streams alive

### DIFF
--- a/src/websocket/app-server-openai-common.ts
+++ b/src/websocket/app-server-openai-common.ts
@@ -10,10 +10,30 @@ import type {
 } from "@/websocket/app-server-openai-turn";
 
 const MAX_REQUEST_BODY_BYTES = 20 * 1024 * 1024;
+const OPENAI_SSE_HEARTBEAT_INTERVAL_MS = 30_000;
 
 export interface OpenAiCompatOptions {
   authPolicy: WebsocketAuthPolicy;
   onLog?: (message: string) => void;
+  /** @internal OpenAI 兼容 SSE 心跳间隔的测试覆盖（毫秒）。 */
+  sseHeartbeatIntervalMs?: number;
+}
+
+export function startOpenAiSseHeartbeat(
+  response: ServerResponse,
+  isClientClosed: () => boolean,
+  intervalMs = OPENAI_SSE_HEARTBEAT_INTERVAL_MS,
+): () => void {
+  if (!Number.isFinite(intervalMs) || intervalMs <= 0) return () => {};
+
+  const timer = setInterval(() => {
+    if (isClientClosed() || response.destroyed || response.writableEnded) {
+      return;
+    }
+    response.write(": keepalive\n\n");
+  }, intervalMs);
+  timer.unref?.();
+  return () => clearInterval(timer);
 }
 
 export interface OpenAiChatMessagePart {

--- a/src/websocket/app-server-openai-heartbeat.test.ts
+++ b/src/websocket/app-server-openai-heartbeat.test.ts
@@ -1,0 +1,127 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import type { Backend } from "@/backend";
+import { __testSetBackend } from "@/backend";
+import { type AppServerHandle, startAppServer } from "@/websocket/app-server";
+import {
+  __testResetConversationMap,
+  __testSetRunTurnImpl,
+} from "@/websocket/app-server-openai";
+
+const TEST_AGENT = {
+  id: "agent-local-heartbeat",
+  name: "Heartbeat Agent",
+  created_at: "2026-01-01T00:00:00Z",
+};
+
+function fakeBackend(): Backend {
+  return {
+    listAgents: async () => [TEST_AGENT],
+    createConversation: async () => ({
+      id: "conversation-heartbeat",
+      agent_id: TEST_AGENT.id,
+    }),
+    deleteConversation: async () => ({}),
+  } as unknown as Backend;
+}
+
+function httpUrl(handle: AppServerHandle, pathname: string): string {
+  const url = new URL(handle.url);
+  url.protocol = "http:";
+  return `${url.origin}${pathname}`;
+}
+
+function stubSlowTurn(): void {
+  __testSetRunTurnImpl(async ({ onAssistantText }) => {
+    await new Promise((resolve) => setTimeout(resolve, 60));
+    onAssistantText?.("done");
+    return {
+      text: "done",
+      usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+      error: null,
+    };
+  });
+}
+
+async function readUntilHeartbeat(response: Response): Promise<string> {
+  const reader = response.body?.getReader();
+  if (!reader) throw new Error("Expected a streaming response body");
+
+  const decoder = new TextDecoder();
+  let output = "";
+  const timeout = setTimeout(() => {
+    void reader.cancel();
+  }, 1000);
+  try {
+    while (!output.includes(": keepalive\n\n")) {
+      const chunk = await reader.read();
+      if (chunk.done) break;
+      output += decoder.decode(chunk.value, { stream: true });
+    }
+    return output;
+  } finally {
+    clearTimeout(timeout);
+    await reader.cancel();
+  }
+}
+
+describe("OpenAI-compatible SSE heartbeat", () => {
+  let handle: AppServerHandle | null = null;
+
+  afterEach(async () => {
+    if (handle) {
+      await handle.close();
+      handle = null;
+    }
+    __testSetRunTurnImpl(null);
+    __testResetConversationMap();
+    __testSetBackend(null);
+  });
+
+  test("keeps a quiet chat-completions stream alive", async () => {
+    __testSetBackend(fakeBackend());
+    stubSlowTurn();
+    handle = await startAppServer({
+      listen: "ws://127.0.0.1:0",
+      openaiApi: true,
+      openaiSseHeartbeatIntervalMs: 10,
+      initializeRuntime: async () => {},
+    });
+
+    const response = await fetch(httpUrl(handle, "/v1/chat/completions"), {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        model: TEST_AGENT.name,
+        messages: [{ role: "user", content: "wait" }],
+        stream: true,
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(await readUntilHeartbeat(response)).toContain(": keepalive\n\n");
+  });
+
+  test("keeps a quiet Responses stream alive", async () => {
+    __testSetBackend(fakeBackend());
+    stubSlowTurn();
+    handle = await startAppServer({
+      listen: "ws://127.0.0.1:0",
+      openaiApi: true,
+      openaiSseHeartbeatIntervalMs: 10,
+      initializeRuntime: async () => {},
+    });
+
+    const response = await fetch(httpUrl(handle, "/v1/responses"), {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        model: TEST_AGENT.name,
+        input: "wait",
+        stream: true,
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(await readUntilHeartbeat(response)).toContain(": keepalive\n\n");
+  });
+});

--- a/src/websocket/app-server-openai-responses.ts
+++ b/src/websocket/app-server-openai-responses.ts
@@ -17,6 +17,7 @@ import {
   resolveConversationId,
   sendJson,
   sendOpenAiError,
+  startOpenAiSseHeartbeat,
 } from "@/websocket/app-server-openai-common";
 import type { ToolCallEvent } from "@/websocket/app-server-openai-tools";
 import {
@@ -684,8 +685,10 @@ export async function handleResponses(
   const createdAt = Math.floor(Date.now() / 1000);
   let sequenceNumber = 0;
   let clientClosed = false;
+  let stopHeartbeat = () => {};
   response.on("close", () => {
     clientClosed = true;
+    stopHeartbeat();
   });
   const emit = streaming
     ? (event: Record<string, unknown>) => {
@@ -701,6 +704,11 @@ export async function handleResponses(
       "cache-control": "no-cache",
       connection: "keep-alive",
     });
+    stopHeartbeat = startOpenAiSseHeartbeat(
+      response,
+      () => clientClosed,
+      options.sseHeartbeatIntervalMs,
+    );
     emit?.({
       type: "response.created",
       response: makeResponse(
@@ -744,6 +752,7 @@ export async function handleResponses(
       error: "failed to run agent turn",
     };
   }
+  stopHeartbeat();
 
   // Test seams may return a completed outcome without invoking callbacks.
   if (builder.output.length === 0) {

--- a/src/websocket/app-server-openai.ts
+++ b/src/websocket/app-server-openai.ts
@@ -23,6 +23,7 @@ import {
   resolveConversationId,
   sendJson,
   sendOpenAiError,
+  startOpenAiSseHeartbeat,
 } from "@/websocket/app-server-openai-common";
 import {
   handleResponses,
@@ -228,8 +229,10 @@ async function handleChatCompletions(
   const created = Math.floor(Date.now() / 1000);
   const streaming = body.stream === true;
   let clientClosed = false;
+  let stopHeartbeat = () => {};
   response.on("close", () => {
     clientClosed = true;
+    stopHeartbeat();
   });
 
   if (streaming) {
@@ -238,6 +241,11 @@ async function handleChatCompletions(
       "cache-control": "no-cache",
       connection: "keep-alive",
     });
+    stopHeartbeat = startOpenAiSseHeartbeat(
+      response,
+      () => clientClosed,
+      options.sseHeartbeatIntervalMs,
+    );
     response.write(
       chatCompletionChunk(
         completionId,
@@ -302,6 +310,7 @@ async function handleChatCompletions(
       error: "failed to run agent turn",
     };
   }
+  stopHeartbeat();
   const fullText = outcome.text;
   const usage = {
     prompt_tokens: outcome.usage.prompt_tokens,

--- a/src/websocket/app-server.ts
+++ b/src/websocket/app-server.ts
@@ -55,6 +55,8 @@ export interface StartAppServerOptions {
   connectionName?: string;
   /** Serve OpenAI-compatible models, Chat Completions, and Responses routes. */
   openaiApi?: boolean;
+  /** @internal OpenAI 兼容 SSE 心跳间隔的测试覆盖（毫秒）。 */
+  openaiSseHeartbeatIntervalMs?: number;
   onListening?: (info: AppServerListeningInfo) => void;
   onLog?: (message: string) => void;
   /** @internal Test override for the liveness ping cadence (ms). */
@@ -292,6 +294,7 @@ export async function startAppServer(
       void handleOpenAiCompatRequest(request, response, {
         authPolicy,
         onLog: options.onLog,
+        sseHeartbeatIntervalMs: options.openaiSseHeartbeatIntervalMs,
       });
       return;
     }


### PR DESCRIPTION
## Summary

OpenAI-compatible streaming responses currently emit bytes only when the agent produces a response or tool event. A long tool or subagent interval with no stream event leaves `/v1/chat/completions` and `/v1/responses` silent, so clients such as VS Code Copilot Chat and Open WebUI can treat a healthy turn as a dead HTTP connection.

The cause is that both handlers await `runBridgeTurn()` without a periodic SSE write. This change emits the standard SSE comment `: keepalive` every 30 seconds during streaming requests. The shared heartbeat is started only after streaming headers are sent, does not consume Responses sequence numbers, and is stopped when the turn settles or the client disconnects. Non-streaming requests are unchanged.

Fixes #3647

## Verification

- `bun test src/websocket/app-server-openai-heartbeat.test.ts --timeout 5000` — 2 pass, 0 fail (RED before the fix; GREEN after the fix)
- `bun test src/websocket/app-server-openai-heartbeat.test.ts src/websocket/app-server-openai.test.ts src/websocket/app-server-openai-responses.test.ts --timeout 15000` — 32 pass, 0 fail
- `bun test src/websocket --timeout 15000` — pass, 0 fail
- `bun run check` — all 12 checks pass
- `bun run build` — bundle and declarations built successfully
- `node ./letta.js --help` — Node bundle smoke test passed
- Node runtime helper smoke test — built `app-server-openai-common.ts` and observed heartbeat writes from Node

## Risk and scope

- Heartbeats are SSE comments, so compliant clients ignore them while the HTTP connection remains active.
- Responses API event sequence numbers remain contiguous because heartbeats are not protocol data events.
- No external VS Code or Open WebUI service was called; client-specific end-to-end behavior remains outside this local test scope.

## AI Disclosure

- [ ] This pull request was written entirely by a human
- [x] This pull request was written with AI assistance and reviewed and edited by a human
- [x] I have read the [AI Policy](https://github.com/letta-ai/letta-code/blob/main/AI_POLICY.md) and agree to its terms

## AI Tool(s) Used

Codex was used to investigate the repository and GitHub issues, implement the change, run the tests, and draft this pull request. The complete diff and test evidence were reviewed before submission.

## Human Verification

I have reviewed and understand every change in this pull request and take responsibility for its correctness.
