### PR TITLE
fix(local): preserve streamed reasoning chunk boundaries

### DIFF
--- a/src/backend/local/local-message-projection.test.ts
+++ b/src/backend/local/local-message-projection.test.ts
@@ -30,7 +30,7 @@ describe("projectLocalMessageToStoredMessages", () => {
     const message = assistantMessage([
       {
         type: "thinking",
-        thinking: "First summary",
+        thinking: "First summary\n\n",
         thinkingSignature: "signature-1",
       },
       {
@@ -57,6 +57,25 @@ describe("projectLocalMessageToStoredMessages", () => {
     expect(message.content).toEqual([
       expect.objectContaining({ thinkingSignature: "signature-1" }),
       expect.objectContaining({ thinkingSignature: "signature-2" }),
+    ]);
+  });
+
+  test("preserves token boundaries across adjacent thinking chunks", () => {
+    const projected = projectLocalMessageToStoredMessages(
+      assistantMessage([
+        { type: "thinking", thinking: "ост" },
+        { type: "thinking", thinking: "орожно" },
+      ]),
+      "agent-1",
+      "conversation-1",
+      "2026-07-12T00:00:00.000Z",
+    );
+
+    expect(projected).toEqual([
+      expect.objectContaining({
+        message_type: "reasoning_message",
+        reasoning: "осторожно",
+      }),
     ]);
   });
 

--- a/src/backend/local/local-message-projection.ts
+++ b/src/backend/local/local-message-projection.ts
@@ -263,7 +263,7 @@ export function projectLocalMessageToStoredMessages(
     if (pendingReasoningContent.length > 0) {
       const reasoningMessage = projectThinkingContent(
         message,
-        pendingReasoningContent.join("\n\n"),
+        pendingReasoningContent.join(""),
         pendingReasoningStartIndex,
         date,
         agentId,


### PR DESCRIPTION
## Summary

Fixes #4247.

Reasoning chunks from a single streamed assistant message were persisted with an unconditional blank line between every adjacent chunk. When a provider split a token across chunks, the inserted separators produced visible word-split and double/triple-newline artifacts in reasoning transcripts.

### Root cause

`projectLocalMessageToStoredMessages` used `pendingReasoningContent.join("\n\n")`. The array contains stream fragments, not paragraph-level messages, so the projection layer was inventing formatting at every transport boundary.

### Solution

Concatenate adjacent reasoning fragments exactly as emitted with `join("")`. Provider-emitted whitespace and paragraph boundaries remain unchanged, while token boundaries are no longer split by the client. Reasoning sections separated by assistant text or tool calls keep their existing grouping and IDs.

### Risk and scope

This is limited to local transcript projection. It does not change provider requests, streaming control flow, assistant text, tool calls, compaction, or explicit newlines already present in a chunk. The regression test covers a Cyrillic token split across two fragments and the existing grouping test now verifies explicit newlines are preserved.

## Verification

- Focused RED/GREEN: the new regression test failed on the old implementation because it received an inserted blank line; it passes after the fix.
- `bun test src/backend/local/local-message-projection.test.ts` — 3 passed, 0 failed.
- `bun test src/backend/local-backend.test.ts` — 38 passed, 0 failed.
- `bun test src/backend/local` — 102 passed, 0 failed.
- `bun run check` — all 12 checks passed.
- `bun run build` — passed.
- `env HOME=/private/tmp/letta-reasoning-home node ./letta.js --help` — passed.

## AI Disclosure

- [ ] This pull request was written entirely by a human
- [x] This pull request was written with AI assistance and reviewed and edited by a human
- [x] I have read the [AI Policy](https://github.com/letta-ai/letta-code/blob/main/AI_POLICY.md) and agree to its terms

## AI Tool(s) Used

OpenAI Codex was used to research Issue #4247 and related pull requests, inspect the production path, write the regression test and implementation, run verification, and draft this pull request.

## Human Verification

I have reviewed and understand every change in this pull request and take responsibility for its correctness.