### PR TITLE
fix(skills): clarify which context requirements are enforced in context-doctor ROOT_MEMORY.md

### DIFF
--- a/src/skills/builtin/context-doctor/ROOT_MEMORY.md
+++ b/src/skills/builtin/context-doctor/ROOT_MEMORY.md
@@ -64,21 +64,18 @@ The context in the memory filesystem should have a clear structure, with a well-
 - Rewrite unclear or low-quality content
 
 #### Invalid context format
-Files in the memory filesystem must follow certain structural requirements: 
-- Must have root `MEMORY.md` and root `persona.md`
-- Root and child `MEMORY.md` files have no frontmatter; every other memory Markdown file has exactly `name` and `description` frontmatter
-- Must NOT have overlapping file and folder names (e.g. `human.md` and `human/identity.md`)
-- Must follow specification for skills (e.g. `skills/{skill_name}/`) with the format:
-```
-skill-name/
-├── SKILL.md          # Required: metadata + instructions
-├── scripts/          # Optional: executable code
-├── references/       # Optional: documentation
-├── assets/           # Optional: templates, resources
-└── ...               # Any additional files or directories
-```
+Files in the memory filesystem should follow certain structural conventions. Some are enforced by the system, others are recommendations:
 
-**Solution**: Reorganize files to follow the required structure
+**Enforced requirements (pre-commit hooks will reject violations)**:
+- Root `MEMORY.md` must exist (required for root-layout format detection)
+- Root and child `MEMORY.md` files have no frontmatter; every other memory Markdown file has exactly `name` and `description` frontmatter
+- Skills must use the directory format: `skills/{skill_name}/SKILL.md` with optional `scripts/`, `references/`, `assets/` subdirectories. Flat skill files like `skills/foo.md` are rejected.
+
+**Strongly recommended (not enforced, but best practice)**:
+- Include a root `persona.md` to define your identity. The system handles missing persona gracefully, but identity drift is a real risk without it.
+- Avoid overlapping file and folder names (e.g. `human.md` AND `human/`). The system tolerates overlaps, but they make memory harder to navigate and can confuse agents about which path to use.
+
+**Solution**: Reorganize files to follow the recommended structure
 
 ### Poor use of progressive disclosure
 Only critical information should be in the system prompt, since it's passed on every turn. Use progressive disclosure so that context only *sometimes* needed can be dynamically retrieved.


### PR DESCRIPTION
## Summary

The `ROOT_MEMORY.md` variant of the context-doctor skill (served to memfs-v2 root-layout agents) presented recommendations as "structural requirements" when they are actually just guidance. This could cause agents to waste time fixing issues that aren't actually problems.

## Changes

- Split "Invalid context format" section into enforced vs recommended
- Clarify that root `persona.md` is strongly recommended but not required (system handles missing persona gracefully)
- Clarify that overlapping file/folder names should be avoided but are tolerated (no system enforcement)
- Keep frontmatter rules and skills directory format as enforced (pre-commit hooks reject violations)

Mirrors the approach of PR #4078 which addresses the same issue in `SKILL.md` (the v1 variant).

## Validation

- Verified claims against source code:
  - `src/agent/memory-git-hooks.ts` — pre-commit hook enforces frontmatter rules and skills directory format, does NOT require `persona.md` or check overlapping names
  - `src/backend/local/system-prompt-compilation.ts` — persona.md is optional (if check)
  - `src/agent/memory-format.ts` — root `MEMORY.md` required for v2 format detection
- `bun test src/agent/prompt-assets.test.ts` — 23 pass, 0 fail
- `bun test src/tools/skill-tool.test.ts` — 21 pass, 0 fail
- `bun run check` — 12/12 checks passed

Builtin-skill-watch: context-doctor@9167b001406a-a6447d29d109156b

👾 Generated with [Letta Code](https://letta.com)