### PR TITLE
fix(skills): correct image generation error response format

### DIFF
--- a/src/skills/builtin/image-generation/SKILL.md
+++ b/src/skills/builtin/image-generation/SKILL.md
@@ -119,6 +119,7 @@ DATA_URL="data:image/png;base64,$(base64 < input.png | tr -d '\n')"
 
 - **Billing**: every success charges credits; don't loop needlessly, and report
   `credits_charged`.
-- **Errors**: `402` = insufficient credits (`credits_required` in body); `400`/`500`
-  return `{ "message": "..." }` — surface it to the user.
+- **Errors**: `402` = insufficient credits (`credits_required` in body);
+  `400` validation errors return `{ "issues": [...], "name": "ZodError" }`;
+  `500` errors return `{ "message": "..." }`. Surface any error to the user.
 - Only `flux`, `gemini`, and `openai` are supported here.


### PR DESCRIPTION
## Summary

- Builtin-skill-watch: image-generation@852ca244b002-c3aac2d4340009ec
- Selected skill: `image-generation`

## Stale claim and current owning source

The image-generation skill claimed `400`/`500` errors both return `{ "message": "..." }`. In reality, `400` validation errors return a ZodError shape `{"issues":[...],"name":"ZodError"}` while `500` errors return `{"message":"..."}`. An agent following the skill literally would try `response.message` on a 400 validation error and get `undefined`, failing to surface the actual validation details.

Verified by probing `POST /v1/images/generations`:
- Empty body → `400` with `{"issues":[...],"name":"ZodError"}`
- Invalid model name → `500` with `{"message":"Flux image generation failed (404)"}`

## Focused validation

- `bun run check` — all 12 checks passed
- Skill frontmatter validation — passed
- All other skill claims (providers, field types, ranges, defaults, response shape) verified via API probes and source code inspection

## Test plan

- [ ] Review that the error format description matches the actual API behavior
- [ ] Verify no other claims in the skill were affected