### PR TITLE
docs(skills): fix alwaysAsk permission and surface capabilities in creating-mods

### DIFF
--- a/src/skills/builtin/creating-mods/SKILL.md
+++ b/src/skills/builtin/creating-mods/SKILL.md
@@ -7,7 +7,7 @@ description: Creates and edits trusted local Letta Code mods, including tools, s
 
 Use this skill to create or update trusted Letta Code mod files. Mods are trusted local code that add small composable capabilities through mod APIs, not by importing app internals. Dynamic agent/conversation/workspace/model state is passed as `ctx` to tool, command, event, and permission callbacks (panels receive live `agent`/`model` in their render context); do not read mutable global context for model-callable behavior. Prefer scoped handles (`ctx.conversation`, `ctx.cwd`, `ctx.agent`) and guard optional UI with `letta.capabilities`.
 
-Capabilities vary by surface — not every surface loads every capability. The TUI/headless host can load tools, commands, events, UI, and providers; the desktop listener loads tools, commands, providers, and tool/turn events, but not panel UI. Always guard each registration on the capabilities its behavior needs.
+Capabilities vary by surface — not every surface loads every capability. The TUI host can load tools, commands, events, UI panels, permissions, and providers; headless can load tools, events (all), permissions, and providers, but not commands or UI panels; the desktop listener can load tools, commands, permissions, providers, and tool/turn events, but not lifecycle/compact/llm events or panel UI. Always guard each registration on the capabilities its behavior needs.
 
 ## Choose where the mod file lives
 

--- a/src/skills/builtin/creating-mods/references/permissions.md
+++ b/src/skills/builtin/creating-mods/references/permissions.md
@@ -60,6 +60,7 @@ Return one of:
 ```ts
 { decision: "allow", reason?: string }
 { decision: "ask", reason?: string }
+{ decision: "alwaysAsk", reason?: string }
 { decision: "deny", reason?: string }
 undefined // no opinion
 ```
@@ -67,6 +68,7 @@ undefined // no opinion
 Composition rules across overlays:
 
 - `deny` wins
+- then `alwaysAsk`
 - then `ask`
 - then `allow`
 - `undefined` means no opinion


### PR DESCRIPTION
## Summary

- Add missing `alwaysAsk` to permission decision return values and composition rules in `permissions.md`
- Fix SKILL.md surface capabilities claim: headless cannot load commands or UI panels; desktop listener has permissions enabled

## Verified against source

- `ModPermissionDecision` is `"allow" | "ask" | "alwaysAsk" | "deny"` (`src/mods/types.ts:617`), `composePermissionDecision` order is deny > alwaysAsk > ask > allow (`src/mods/permission-registry.ts:144-153`)
- `HEADLESS_MOD_CAPABILITIES`: `commands: false`, `ui.panels: false` (`src/headless-mod-adapter.ts:21-36`)
- `LISTENER_MOD_CAPABILITIES`: `permissions: true`, `events.lifecycle: false`, `events.compact: false`, `events.llm: false` (`src/websocket/listener/mod-adapter.ts:24-39`)
- `TUI_MOD_CAPABILITIES`: all capabilities enabled (`src/cli/mods/capabilities.ts:3-18`)

Builtin-skill-watch: creating-mods@701f2a536782-700be11ff9c44b1d