### PR TITLE
fix(skills): correct debugPanelEnabled description in desktop preferences skill

### DIFF
--- a/src/skills/builtin/editing-letta-code-desktop-preferences/SKILL.md
+++ b/src/skills/builtin/editing-letta-code-desktop-preferences/SKILL.md
@@ -28,7 +28,7 @@ User-editable preference keys:
 
 System-managed keys (do not edit directly):
 - `artifactsByAgent`: per-agent artifacts panel state, written by Desktop UI.
-- `debugPanelEnabled`: developer debug panel, controlled via app menus.
+- `debugPanelEnabled`: developer debug panel setting, controls listener debug output (Cmd+J toggles sidebar visibility).
 - `remoteAppServerEnabled`: Remote App Server toggle, applied at startup.
 - `remoteAppServerUrl`: Remote App Server URL, configured via preferences UI.
 


### PR DESCRIPTION
## Summary
- Fixed `debugPanelEnabled` description in the `editing-letta-code-desktop-preferences` skill
- Old description said "controlled via app menus" but the debug panel sidebar is toggled via Cmd+J keyboard shortcut, and `debugPanelEnabled` in the preferences file is never written by any UI code (only read by `listenerManager.ts` to set an env var)
- Updated to accurately describe what the key controls

## Test plan
- [x] Verified against `letta-cloud` source: `preferencesStorage.ts`, `DebugPanelSidebar.tsx`, `listenerManager.ts`
- [x] All 16 other claims in the skill confirmed accurate
- [x] Pre-commit hooks pass (tsc, layer boundary, filename casing)

Builtin-skill-watch: editing-letta-code-desktop-preferences@701f2a536782-c2890b151ebf58d0

👾 Generated with [Letta Code](https://letta.com)

Co-Authored-By: Letta Code <noreply@letta.com>