### PR TITLE
fix(skills): update dispatching-coding-agents with current CLI behavior

### DIFF
--- a/src/skills/builtin/dispatching-coding-agents/SKILL.md
+++ b/src/skills/builtin/dispatching-coding-agents/SKILL.md
@@ -66,7 +66,7 @@ Different agents have different strengths. Track what works in your memory over 
 - Use `--max-budget-usd N` (Claude Code) to cap spend on exploratory tasks
 
 ### Known quirks
-- **Claude Code can hang on large repos** with unrestricted tools — consider `--allowedTools "Read Grep Glob"` (no Bash) and shorter timeouts for research tasks
+- **Claude Code can hang on large repos** with unrestricted tools — consider `--tools "Read Grep Glob"` (no Bash) and shorter timeouts for research tasks
 - **Codex compactions can destroy long trajectories** — for very long tasks, prefer multiple shorter sessions over one marathon
 - **Opus tends to over-generate** — produces more code than necessary. Good for exploration, verify before applying.
 
@@ -135,7 +135,7 @@ cd /path/to/repo && claude -p "Read /tmp/my-plan.md and critique it. What am I m
 
 ## Handling Failures
 
-- **Timeout**: If an agent times out (especially Claude Code on large repos), try: (1) a shorter, more focused prompt, (2) restricting tools with `--allowedTools`, (3) switching to Codex which handles large repos better
+- **Timeout**: If an agent times out (especially Claude Code on large repos), try: (1) a shorter, more focused prompt, (2) restricting tools with `--tools`, (3) switching to Codex which handles large repos better
 - **Garbage output**: If results are incoherent, the prompt was probably too vague. Rewrite with more specific file paths and clearer instructions.
 - **Session errors**: Claude Code can hit "stale approval from interrupted session" — `--dangerously-skip-permissions` prevents this. If Codex errors, start a fresh `exec` session.
 - **Compaction mid-task**: If a Codex session runs long enough to compact, it may lose earlier context. Break long tasks into smaller sequential sessions.
@@ -153,12 +153,13 @@ claude -p "YOUR PROMPT" --model MODEL --dangerously-skip-permissions
 | `-p` / `--print` | Non-interactive mode, prints response and exits |
 | `--dangerously-skip-permissions` | Skip approval prompts (prevents stale approval errors on timeout) |
 | `--model MODEL` | Alias or model name accepted by the installed CLI; omit to use the configured default |
-| `--effort LEVEL` | `low`, `medium`, `high` — controls reasoning depth |
+| `--effort LEVEL` | `low`, `medium`, `high`, `xhigh`, `max` — controls reasoning depth |
 | `--append-system-prompt "..."` | Inject additional system instructions |
-| `--allowedTools "Bash Edit Read"` | Restrict available tools |
+| `--allowedTools "Bash Edit Read"` | Tools that execute without prompting for permission |
+| `--tools "Read Grep Glob"` | Restrict which built-in tools are available |
 | `--max-budget-usd N` | Cap spend for the invocation |
 | `--add-dir DIR` | Allow access to an additional directory; does not change the working directory |
-| `--output-format json` | Structured output with `session_id`, `cost_usd`, `duration_ms` |
+| `--output-format json` | Structured output with `session_id`, `total_cost_usd`, `duration_ms` |
 
 Set Claude Code's working directory with `cd /path/to/repo && claude ...` in the Bash command, not with a Claude flag.
 
@@ -174,7 +175,6 @@ codex exec "YOUR PROMPT" --sandbox workspace-write
 | `-m MODEL` | Model accepted by the installed CLI; omit to use the configured default |
 | `--sandbox MODE` | Select a read-only or writable sandbox |
 | `-C DIR` | Set working directory |
-| `--search` | Enable web search tool |
 | `review` | Native code review — `codex review --uncommitted` or `codex exec review "prompt"` |
 
 ## Session Management

--- a/src/skills/dispatching-coding-agents.test.ts
+++ b/src/skills/dispatching-coding-agents.test.ts
@@ -41,4 +41,27 @@ describe("dispatching-coding-agents skill", () => {
     expect(skill).not.toContain("--full-auto");
     expect(skill).not.toMatch(/Bash tool.{0,40}`workdir`/i);
   });
+
+  test("lists current Claude Code effort levels", () => {
+    expect(skill).toContain("`xhigh`");
+    expect(skill).toContain("`max`");
+  });
+
+  test("uses correct JSON output field name", () => {
+    expect(skill).toContain("`total_cost_usd`");
+    expect(skill).not.toContain("`cost_usd`");
+  });
+
+  test("distinguishes --allowedTools from --tools", () => {
+    expect(skill).toContain("--tools");
+    expect(skill).toContain("without prompting for permission");
+  });
+
+  test("does not list --search as a codex exec flag", () => {
+    const codexSection = skill.slice(
+      skill.indexOf("### Codex"),
+      skill.indexOf("## Session Management"),
+    );
+    expect(codexSection).not.toContain("--search");
+  });
 });


### PR DESCRIPTION
## Summary

Corrects five stale claims in the `dispatching-coding-agents` built-in skill, verified against Claude Code v2.1.251 and Codex v0.151.0:

1. **`--effort` levels**: added `xhigh` and `max` (skill only listed `low`, `medium`, `high`)
2. **`--output-format json` field**: fixed `cost_usd` → `total_cost_usd`
3. **`--allowedTools` description**: fixed from "restrict available tools" to "tools that execute without prompting for permission"; added `--tools` as the correct flag for restricting available tools
4. **Known quirks / Handling Failures**: replaced `--allowedTools` with `--tools` where the intent is to restrict tool availability
5. **Codex `--search` flag**: removed from `codex exec` reference table (only available on the top-level `codex` interactive command, not on `exec`)

`best` model alias kept as-is (confirmed valid via web search).

## Test plan

- [x] All 7 tests pass (3 existing + 4 new)
- [x] `bun run check` — 12/12 checks pass

👾 Generated with [Letta Code](https://letta.com)