### PR TITLE
fix(skills): correct messaging-agents response format and add cloud computer option

### DIFF
--- a/src/skills/builtin/messaging-agents/SKILL.md
+++ b/src/skills/builtin/messaging-agents/SKILL.md
@@ -78,12 +78,21 @@ letta -p --from-agent $LETTA_AGENT_ID \
   "message text"
 ```
 
+Use `--computer cloud` to route through the target agent's cloud sandbox:
+
+```bash
+letta -p --from-agent $LETTA_AGENT_ID \
+  --agent <id> \
+  --computer cloud \
+  "message text"
+```
+
 **Arguments:**
 | Arg | Required | Description |
 |-----|----------|-------------|
 | `--agent <id>` | Yes | Target agent ID to message |
 | `--from-agent <id>` | Yes | Sender agent ID (injects agent-to-agent system reminder) |
-| `--computer <selector>` | No | Route through an online computer by connection name, device ID, or connection ID |
+| `--computer <selector>` | No | Route through `cloud` (target agent's cloud sandbox) or an online computer by connection name, device ID, or connection ID |
 | `"message text"` | Yes | Message body (positional after flags) |
 
 **Example:**
@@ -93,13 +102,17 @@ letta -p --from-agent $LETTA_AGENT_ID \
   "What do you know about the authentication system?"
 ```
 
-**Response:**
+**Response (JSON format with `--output json`):**
 ```json
 {
-  "conversation_id": "conversation-xyz789",
-  "response": "The authentication system uses JWT tokens...",
+  "type": "result",
+  "subtype": "success",
+  "is_error": false,
+  "result": "The authentication system uses JWT tokens...",
   "agent_id": "agent-abc123",
-  "agent_name": "BackendExpert"
+  "conversation_id": "conversation-xyz789",
+  "environment": { "source": "same-environment" },
+  "usage": { "prompt_tokens": 120, "completion_tokens": 80, "total_tokens": 200, "step_count": 1 }
 }
 ```
 


### PR DESCRIPTION
## Summary

- Fixed the JSON response example in the messaging-agents skill: the field was listed as `response` but the actual output uses `result`; the nonexistent `agent_name` field was removed and replaced with the actual output schema (`type`, `subtype`, `is_error`, `environment`, `usage`)
- Added the `cloud` option to the `--computer` flag description and added a usage example, matching the source code in `args.ts` and `environments.ts`

## Evidence

Verified against `src/headless.ts` at commit `701f2a53`:

- JSON output (lines 3374-3383): uses `result` not `response`, no `agent_name` field, includes `type`, `subtype`, `is_error`, `usage`
- `--computer` flag (args.ts line 188): "Route headless message through `cloud` or a computer by name, device ID, or connection ID"
- `isCloudEnvironmentSelector` (headless.ts lines 684-690): explicitly checks for "cloud" or "cloud-sandbox"
- environments.ts line 40: "Use --computer cloud to route through the target agent's cloud sandbox"

## Note

The `archive_status=archived` claim for listing hidden conversations (line 180) could not be verified from the letta-code codebase. The code sets `hidden: true` on conversation creation, which is a separate field from `archived`. The SDK conversation list API supports `archive_status` but does not have a `hidden` filter parameter. This may need server-side verification.

Generated with Letta Code

Co-Authored-By: Letta Code <noreply@letta.com>