### PR TITLE
ci: pin letta-code-action to a commit SHA in letta.yml

### DIFF
--- a/.github/workflows/letta.yml
+++ b/.github/workflows/letta.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 1
-      - uses: letta-ai/letta-code-action@v0
+      - uses: letta-ai/letta-code-action@b50e45b91c77d5a7b8a64f4088bedcd8c442bd13 # v0.0.6
         with:
           letta_api_key: ${{ secrets.LETTA_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

`.github/workflows/letta.yml` still references `letta-ai/letta-code-action@v0`, a mutable tag. Every other workflow that consumes this action (`review.yml`, `claude-agent-watch.yml`, `codex-agent-watch.yml`, `pi-ai-agent-watch.yml`, `sync-tools-to-cloud.yml`, `builtin-skills-agent-watch.yml`) already pins it to a full commit SHA, so this looks like the one workflow that was missed.

`letta.yml` is also the workflow with the broadest untrusted trigger surface for this action:

- Triggers: `issue_comment` (created), `issues` (opened, assigned), `pull_request_review_comment` (created) — all of which any public GitHub user can fire on a public repo, no write access required.
- Permissions: `contents: write`, `issues: write`, `pull-requests: write`.
- Secrets in scope for the action step: `secrets.LETTA_API_KEY`, `secrets.GITHUB_TOKEN`.

Right now `v0` resolves to `b50e45b91c77d5a7b8a64f4088bedcd8c442bd13` (the `v0.0.6` release). Since it's a regular mutable tag (not a GitHub-immutable release), that pointer can move — e.g. via a compromised maintainer token on the action repo, a mistaken force-push, or a mis-tagged release. If it ever did, every future issue comment / PR review comment on this repo would run whatever `v0` now resolves to, with write access and both secrets available. That's a bigger blast radius than a normal unpinned-action nit because the trigger doesn't require any repo permissions at all.

## Fix

Pin `letta.yml` to the exact commit SHA `v0` currently resolves to, so behavior is unchanged and only the trust model changes:

```diff
-      - uses: letta-ai/letta-code-action@v0
+      - uses: letta-ai/letta-code-action@b50e45b91c77d5a7b8a64f4088bedcd8c442bd13 # v0.0.6
```

This brings `letta.yml` in line with the SHA-pinning convention already used by every other workflow that calls this action.

## Verification

- Confirmed via `gh api repos/letta-ai/letta-code-action/tags` and `/releases` that `v0` is a plain mutable tag pointing at `b50e45b91c77d5a7b8a64f4088bedcd8c442bd13` (same commit as the `v0.0.6` release) and that none of that repo's releases are marked `immutable`.
- Confirmed (`grep -rn "letta-code-action@" .github/workflows/`) that `letta.yml` was the only one of the seven workflows using this action still on a mutable ref; the rest are already pinned to full SHAs (`4b8e508a523ff576fee09be1432d6f39158c272c`, `244cc9e80c77cfebdb3ec8e146e018a5fe0af027`).
- `python -c "import yaml; yaml.safe_load(open('.github/workflows/letta.yml'))"` parses the edited file without error.
- One-line diff, no behavior change: the pinned SHA is exactly what `v0` resolves to today, so this run's outcome is unaffected — it only removes the ability for a future tag move to change what runs.
- Did not attempt to trigger `letta.yml` itself, since that requires `secrets.LETTA_API_KEY` / `secrets.GITHUB_TOKEN` that only exist in the upstream repo's Actions context, not on this fork.

## AI Disclosure

- [ ] This pull request was written entirely by a human
- [x] This pull request was written with AI assistance and reviewed and edited by a human
- [x] I have read the [AI Policy](https://github.com/letta-ai/letta-code/blob/main/AI_POLICY.md) and agree to its terms

## AI Tool(s) Used

Claude Code (Claude Sonnet 5) — used to search the workflow files for unpinned/mutable action references, cross-check the finding against `letta-ai/letta-code-action`'s tags and releases via the GitHub API, and draft the fix and this description. I reviewed the diff, the API output, and the git history myself before opening this PR.

## Human Verification

I have reviewed and understand every change in this pull request and take responsibility for its correctness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
