### PR TITLE
docs(skills): add turn_end event and alwaysAsk permission to creating-mods

### DIFF
--- a/src/skills/builtin/creating-mods/references/events.md
+++ b/src/skills/builtin/creating-mods/references/events.md
@@ -59,7 +59,7 @@ letta.events.on("tool_start", (event, ctx) => {
 
 Lifecycle, turn, tool, compaction, and llm events are wired today.
 
-Lifecycle handlers are notification-only and should not return values. `turn_start` handlers can transform or cancel outbound user-message turns. `tool_start` handlers can transform the tool arguments before execution. Compaction and llm handlers are notification-only.
+Lifecycle handlers are notification-only and should not return values. `turn_start` handlers can transform or cancel outbound user-message turns. `turn_end` handlers can append a follow-up turn via `{ continue: "..." }`. `tool_start` handlers can transform the tool arguments before execution. Compaction and llm handlers are notification-only.
 
 `compact_start`/`compact_end` and `llm_start`/`llm_end` only fire on the **local backend**, where compaction and provider requests run client-side. On the Letta Cloud backend that work happens server-side and these events do not fire, so guard with `letta.capabilities.events.compact` / `letta.capabilities.events.llm` for portable mods.
 
@@ -71,6 +71,7 @@ Lifecycle handlers are notification-only and should not return values. `turn_sta
 "tool_start"
 "tool_end"
 "turn_start"
+"turn_end"
 "compact_start"
 "compact_end"
 "llm_start"
@@ -229,6 +230,29 @@ If multiple handlers cancel, the first valid cancel reason wins. A valid reason 
 Handlers run in registration order. Later handlers see the current input after earlier mutations/returns. If a handler throws, its partial `event.input` mutation is rolled back and the error is recorded as a mod diagnostic.
 
 `turn_start` is intentionally a trusted local mod point: it can rewrite user messages, approval results, and ordering. Keep transforms focused and unsurprising.
+
+`turn_end` event:
+
+```ts
+{
+  agentId: string | null;
+  conversationId: string | null;
+  stopReason: string;
+  assistantMessage?: string;
+}
+```
+
+`turn_end` fires after a turn completes, carrying the stop reason and the assistant's final message. Handlers can return `{ continue: "..." }` to append a follow-up user message and start a new turn:
+
+```ts
+letta.events.on("turn_end", (event) => {
+  if (event.stopReason === "tool_use" && needsFollowUp(event.conversationId)) {
+    return { continue: "Check the results and continue." };
+  }
+});
+```
+
+The first handler that returns a `continue` wins; later handlers are shadowed. `continue` is best-effort and never blocks turn completion. A throwing handler is isolated and never breaks the turn.
 
 `compact_start` event:
 

--- a/src/skills/builtin/creating-mods/references/permissions.md
+++ b/src/skills/builtin/creating-mods/references/permissions.md
@@ -60,13 +60,17 @@ Return one of:
 ```ts
 { decision: "allow", reason?: string }
 { decision: "ask", reason?: string }
+{ decision: "alwaysAsk", reason?: string }
 { decision: "deny", reason?: string }
 undefined // no opinion
 ```
 
+`alwaysAsk` forces human approval even in unrestricted/yolo mode. Use it for tools that represent a human gate rather than a risky operation (see `approvalPolicy: "alwaysAsk"` in `tools.md`).
+
 Composition rules across overlays:
 
 - `deny` wins
+- then `alwaysAsk`
 - then `ask`
 - then `allow`
 - `undefined` means no opinion


### PR DESCRIPTION
## Summary

- Add `turn_end` event to the supported events list and document its event shape, `{ continue: "..." }` result contract, and handler semantics in `events.md`
- Add `alwaysAsk` permission decision to the return values list and composition rules in `permissions.md`

Both features are fully implemented in the source (`ModEventName`, `ModTurnEndEvent`, `ModTurnEndResult`, `ModPermissionDecision`, `permission-registry.ts` composition logic) but were missing from the skill documentation.

Builtin-skill-watch: creating-mods@701f2a536782-700be11ff9c44b1d

## Test plan

- [x] `bun run check` passes (12/12 checks)
- [x] Diff is documentation-only (2 markdown files in `src/skills/builtin/creating-mods/references/`)

👾 Generated with [Letta Code](https://letta.com)

Co-Authored-By: Letta Code <noreply@letta.com>