### PR TITLE
fix(skills): correct stale CLI flags in dispatching-coding-agents

### DIFF
--- a/src/skills/builtin/dispatching-coding-agents/SKILL.md
+++ b/src/skills/builtin/dispatching-coding-agents/SKILL.md
@@ -66,7 +66,7 @@ Different agents have different strengths. Track what works in your memory over 
 - Use `--max-budget-usd N` (Claude Code) to cap spend on exploratory tasks
 
 ### Known quirks
-- **Claude Code can hang on large repos** with unrestricted tools — consider `--allowedTools "Read Grep Glob"` (no Bash) and shorter timeouts for research tasks
+- **Claude Code can hang on large repos** with unrestricted tools — consider `--tools "Read Grep Glob"` (no Bash) and shorter timeouts for research tasks
 - **Codex compactions can destroy long trajectories** — for very long tasks, prefer multiple shorter sessions over one marathon
 - **Opus tends to over-generate** — produces more code than necessary. Good for exploration, verify before applying.
 
@@ -135,7 +135,7 @@ cd /path/to/repo && claude -p "Read /tmp/my-plan.md and critique it. What am I m
 
 ## Handling Failures
 
-- **Timeout**: If an agent times out (especially Claude Code on large repos), try: (1) a shorter, more focused prompt, (2) restricting tools with `--allowedTools`, (3) switching to Codex which handles large repos better
+- **Timeout**: If an agent times out (especially Claude Code on large repos), try: (1) a shorter, more focused prompt, (2) restricting tools with `--tools`, (3) switching to Codex which handles large repos better
 - **Garbage output**: If results are incoherent, the prompt was probably too vague. Rewrite with more specific file paths and clearer instructions.
 - **Session errors**: Claude Code can hit "stale approval from interrupted session" — `--dangerously-skip-permissions` prevents this. If Codex errors, start a fresh `exec` session.
 - **Compaction mid-task**: If a Codex session runs long enough to compact, it may lose earlier context. Break long tasks into smaller sequential sessions.
@@ -153,12 +153,13 @@ claude -p "YOUR PROMPT" --model MODEL --dangerously-skip-permissions
 | `-p` / `--print` | Non-interactive mode, prints response and exits |
 | `--dangerously-skip-permissions` | Skip approval prompts (prevents stale approval errors on timeout) |
 | `--model MODEL` | Alias or model name accepted by the installed CLI; omit to use the configured default |
-| `--effort LEVEL` | `low`, `medium`, `high` — controls reasoning depth |
+| `--effort LEVEL` | `low`, `medium`, `high`, `xhigh`, `max` — controls reasoning depth |
 | `--append-system-prompt "..."` | Inject additional system instructions |
-| `--allowedTools "Bash Edit Read"` | Restrict available tools |
+| `--tools "Bash Edit Read"` | Restrict available tools |
+| `--allowedTools "Bash(git log *)"` | Tools that execute without permission prompts |
 | `--max-budget-usd N` | Cap spend for the invocation |
 | `--add-dir DIR` | Allow access to an additional directory; does not change the working directory |
-| `--output-format json` | Structured output with `session_id`, `cost_usd`, `duration_ms` |
+| `--output-format json` | Structured output with `session_id`, `total_cost_usd`, `duration_ms` |
 
 Set Claude Code's working directory with `cd /path/to/repo && claude ...` in the Bash command, not with a Claude flag.
 


### PR DESCRIPTION
## Summary

Builtin-skill-watch audit found 3 stale claims in the `dispatching-coding-agents` skill that contradict current official documentation:

1. **`--effort` levels incomplete** — The skill listed only `low`, `medium`, `high`. The [model-config docs](https://code.claude.com/docs/en/model-config) and `claude --help` (v2.1.251) confirm `low`, `medium`, `high`, `xhigh`, `max`.

2. **`--allowedTools` mislabeled as "Restrict available tools"** — Per the [Claude Code CLI reference](https://code.claude.com/docs/en/cli-reference), `--allowedTools` controls which tools execute *without prompting for permission*. To restrict which tools are available, the docs explicitly say to use `--tools` instead. The skill used `--allowedTools` for restriction in 3 places (CLI table, known quirks, handling failures).

3. **`--output-format json` field name wrong** — The skill said `cost_usd` but the actual JSON output field is `total_cost_usd`.

## Changes

- `SKILL.md`: Added `xhigh`/`max` to effort levels, replaced `--allowedTools` with `--tools` for restricting tools (3 locations), added separate `--allowedTools` row for permission control, fixed `cost_usd` → `total_cost_usd`

## Verification

- `bun test src/skills/dispatching-coding-agents.test.ts` — 3/3 pass
- `bun run check` — 12/12 checks pass

## Provenance

- Builtin-skill-watch: dispatching-coding-agents@852ca244b002-c516fc8398d056f4
- Workflow: https://github.com/letta-ai/letta-code/actions/runs/34206836510
- Tracker: #4065

👾 Generated with [Letta Code](https://letta.com)

Co-Authored-By: Letta Code <noreply@letta.com>