### PR TITLE
fix(cli): preserve local catalog handles in reasoning picker

### DIFF
--- a/src/cli/app/use-configuration-handlers.test.tsx
+++ b/src/cli/app/use-configuration-handlers.test.tsx
@@ -1,0 +1,241 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { Readable, Writable } from "node:stream";
+import { getSupportedThinkingLevels } from "@earendil-works/pi-ai";
+import { getBuiltinModels } from "@earendil-works/pi-ai/providers/all";
+import { render } from "ink";
+import { type ComponentProps, useState } from "react";
+import stripAnsi from "strip-ansi";
+import { clearAvailableModelsCache } from "@/agent/available-models";
+import { models } from "@/agent/model";
+import { toRuntimeCatalogModels } from "@/agent/remote-model-catalog";
+import { ModelReasoningSelector } from "@/cli/components/ModelReasoningSelector";
+import {
+  type ModelSelectorSelection,
+  registryHandleForBackendModel,
+} from "@/cli/components/ModelSelector";
+import { createContextTracker } from "@/cli/helpers/context-tracker";
+import { setupRuntimeModelCatalogFixture } from "@/test-utils/runtime-model-catalog";
+import { useConfigurationHandlers } from "./use-configuration-handlers";
+
+setupRuntimeModelCatalogFixture();
+afterEach(clearAvailableModelsCache);
+
+type Handlers = ReturnType<typeof useConfigurationHandlers>;
+type Context = Parameters<typeof useConfigurationHandlers>[0];
+type Prompt = Omit<
+  ComponentProps<typeof ModelReasoningSelector>,
+  "onSelect" | "onCancel"
+> | null;
+
+class CaptureStream extends Writable {
+  columns = 100;
+  rows = 24;
+  isTTY = true;
+  chunks: string[] = [];
+
+  override _write(
+    chunk: Buffer | string,
+    _encoding: BufferEncoding,
+    callback: (error?: Error | null) => void,
+  ) {
+    this.chunks.push(String(chunk));
+    callback();
+  }
+}
+
+function createContext(): Context {
+  const noop = () => {};
+  const command = {
+    id: "test-model-command",
+    input: "/model",
+    update: noop,
+    finish: noop,
+    fail: noop,
+  };
+  return {
+    activeOverlay: "model",
+    agentId: "test-agent",
+    agentIdRef: { current: "test-agent" },
+    agentState: null,
+    commandRunner: { start: () => command, getHandle: () => command },
+    consumeOverlayCommand: () => null,
+    contextTrackerRef: { current: createContextTracker() },
+    conversationIdRef: { current: "test-conversation" },
+    currentModelHandle: null,
+    currentModelId: null,
+    currentReasoningEffort: null,
+    currentToolset: null,
+    isAgentBusy: () => true,
+    llmConfig: null,
+    llmConfigRef: { current: null },
+    maybeRecordToolsetChangeReminder: noop,
+    resetPendingReasoningCycle: noop,
+    setActiveOverlay: noop,
+    setAgentState: noop,
+    setConversationOverrideContextWindowLimit: noop,
+    setConversationOverrideModelSettings: noop,
+    setCurrentModelHandle: noop,
+    setCurrentModelId: noop,
+    setHasAvailableLocalModels: noop,
+    setCurrentPersonalityId: noop,
+    setCurrentSystemPromptId: noop,
+    setCurrentToolset: noop,
+    setCurrentToolsetPreference: noop,
+    setHasConversationModelOverride: noop,
+    setLlmConfig: noop,
+    setModelReasoningPrompt: noop,
+    setQueuedOverlayAction: noop,
+    setTempModelOverride: noop,
+    withCommandLock: async () => {
+      throw new Error("Picker tests must not write backend configuration");
+    },
+  };
+}
+
+async function exercisePicker(
+  selection: ModelSelectorSelection,
+  columns: number,
+) {
+  clearAvailableModelsCache();
+  const captured: {
+    handlers?: Handlers;
+    prompt?: Prompt;
+    selected?: ModelSelectorSelection;
+  } = {};
+  function Harness() {
+    const [prompt, setPrompt] = useState<Prompt>(null);
+    captured.prompt = prompt;
+    captured.handlers = useConfigurationHandlers({
+      ...createContext(),
+      setModelReasoningPrompt: setPrompt,
+    });
+    return prompt ? (
+      <ModelReasoningSelector
+        {...prompt}
+        onSelect={(option) => {
+          captured.selected = option.selection;
+        }}
+        onCancel={() => setPrompt(null)}
+      />
+    ) : null;
+  }
+  const stdout = new CaptureStream();
+  stdout.columns = columns;
+  const stdin = new Readable({ read() {} }) as NodeJS.ReadStream;
+  stdin.isTTY = true;
+  stdin.setRawMode = () => stdin;
+  stdin.ref = () => stdin;
+  stdin.unref = () => stdin;
+  const instance = render(<Harness />, {
+    stdout: stdout as CaptureStream & NodeJS.WriteStream,
+    stdin,
+    stderr: stdout as CaptureStream & NodeJS.WriteStream,
+    patchConsole: false,
+    exitOnCtrlC: false,
+  });
+  try {
+    await new Promise((resolve) => setTimeout(resolve, 60));
+    expect(captured.handlers).toBeDefined();
+    await captured.handlers?.handleModelSelect(selection);
+    await new Promise((resolve) => setTimeout(resolve, 60));
+    expect(captured.prompt).toBeTruthy();
+    const output = stripAnsi(stdout.chunks.join(""));
+    expect(output).toContain("Set your model's reasoning settings");
+    expect(output).toContain("Medium");
+    const options = captured.prompt?.options ?? [];
+    expect(options.some((option) => option.effort === "high")).toBe(true);
+    stdin.push("\u001b[C");
+    await new Promise((resolve) => setTimeout(resolve, 60));
+    expect(stripAnsi(stdout.chunks.join(""))).toContain("High");
+    stdin.push("\r");
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(captured.selected?.handle).toBe(selection.handle);
+    expect(captured.selected?.updateArgs).toMatchObject({
+      reasoning_effort: "high",
+      provider_type: selection.updateArgs?.provider_type,
+    });
+    stdin.push("\u001b");
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(captured.prompt).toBeNull();
+    return options;
+  } finally {
+    instance.unmount();
+    instance.cleanup();
+    stdin.destroy();
+    stdout.destroy();
+  }
+}
+
+describe("model reasoning picker", () => {
+  for (const columns of [60, 100]) {
+    test.each(["gpt-5.6-sol", "gpt-6-astra"])(
+      `opens local %s reasoning and selects high at ${columns} columns`,
+      async (modelId) => {
+        const model = getBuiltinModels("openai-codex").find(
+          (entry) => entry.id === modelId,
+        );
+        if (!model) throw new Error(`Missing catalog model: ${modelId}`);
+        const handle = `openai-codex/${modelId}`;
+        const levels = getSupportedThinkingLevels(model);
+        models.splice(
+          0,
+          models.length,
+          ...toRuntimeCatalogModels([
+            {
+              handle,
+              label: model.name,
+              providerType: "chatgpt_oauth",
+              maxContextWindow: model.contextWindow,
+              maxOutputTokens: model.maxTokens,
+              reasoningLevels: levels,
+            },
+          ]),
+        );
+        const options = await exercisePicker(
+          {
+            id: handle,
+            handle,
+            label: model.name,
+            description: "",
+            registryHandle: registryHandleForBackendModel(
+              handle,
+              "chatgpt_oauth",
+            ),
+            updateArgs: {
+              provider_type: "chatgpt_oauth",
+              context_window: model.contextWindow,
+            },
+          },
+          columns,
+        );
+        expect(options.map((option) => option.effort)).toEqual(
+          levels.map((level) => (level === "off" ? "none" : level)),
+        );
+      },
+    );
+  }
+
+  test.each([
+    ["lc-openai/gpt-5.4", "openai/gpt-5.4", "openai"],
+    [
+      "chatgpt-personal/gpt-5.6-sol",
+      "chatgpt-plus-pro/gpt-5.6-sol",
+      "chatgpt_oauth",
+    ],
+  ])(
+    "preserves Cloud alias %s and its registry tiers",
+    async (handle, registryHandle, providerType) => {
+      await exercisePicker(
+        {
+          id: handle,
+          handle,
+          label: handle,
+          registryHandle,
+          description: "",
+          updateArgs: { provider_type: providerType },
+        },
+        100,
+      );
+    },
+  );
+});

--- a/src/cli/app/use-configuration-handlers.ts
+++ b/src/cli/app/use-configuration-handlers.ts
@@ -1,5 +1,3 @@
-// src/cli/app/useConfigurationHandlers.ts
-
 import type { AgentState } from "@letta-ai/letta-client/resources/agents/agents";
 import type { LlmConfig } from "@letta-ai/letta-client/resources/models/models";
 import {
@@ -380,7 +378,9 @@ export function useConfigurationHandlers(ctx: ConfigurationHandlersContext) {
               reasoningCapabilities,
             })
           : getReasoningTierOptionsForHandle(
-              registryHandle,
+              models.some((entry) => entry.handle === modelHandle)
+                ? modelHandle
+                : registryHandle,
               selectedContextWindow,
               reasoningCapabilities,
             );


### PR DESCRIPTION
## Summary

Fixes #4294.

Prefer the actual selected model handle when it exists in the runtime catalog, retaining the registry-handle fallback for Cloud aliases.

On the local backend, ChatGPT OAuth reasoning tiers are registered under handles such as `openai-codex/gpt-6-astra`. The configuration handler instead looked up the normalized Cloud handle, `chatgpt-plus-pro/gpt-6-astra`, received no tiers, and skipped the reasoning picker.

This is a lookup correction, not a hardcoded reasoning ladder or a change to provider payloads. It preserves the existing OpenAI-compatible proxy path. The obsolete filename comment at the top of the handler was removed to keep the oversized file within its existing line-count baseline.

Added regression coverage that exercises the real configuration hook and Ink reasoning selector using the installed pi-ai catalog:

- Local GPT-5.6 Sol and GPT-6 Astra at 60 and 100 columns.
- Cloud OpenAI and ChatGPT provider aliases.
- Rendering, right-arrow navigation, selecting `high`, cancellation, and preservation of the selected provider handle.

Related context: #4003 and #4287. This PR only addresses `/model`; it does not change the separate reasoning-tab cycle path.

## Verification

- Before the patch: the four local selector cases failed; the two Cloud-alias controls passed.
- After the patch, the following focused suite passed with **97 tests, 0 failures, 230 assertions**:

```bash
bun test src/cli/app/use-configuration-handlers.test.tsx \
  src/agent/model-tier-selection.test.ts \
  src/cli/components/ModelSelector-byok-custom-provider.test.tsx \
  src/cli/app/use-reasoning-cycle.test.ts \
  src/agent/modify-local.test.ts
```

- `bun run check`: **12/12 checks passed**.
- `bun run build`: passed.
- `node ./letta.js --version`: `0.31.14 (Letta Code)`.
- The user launched the patched build with Bun, opened `/model`, and confirmed successful Astra selection with high reasoning:

```text
Switched to openai-codex/gpt-6-astra (high reasoning)
```

The interactive verification confirms the selection path, not independent inspection of the outbound provider payload. Automated picker tests do not write live backend configuration or use credentials.

## AI Disclosure

- [ ] This pull request was written entirely by a human
- [x] This pull request was written with AI assistance and reviewed and edited by a human
- [x] I have read the [AI Policy](https://github.com/letta-ai/letta-code/blob/main/AI_POLICY.md) and agree to its terms

## AI Tool(s) Used

Letta Code (Ethan): source investigation, implementation, regression tests, validation, and report drafting. The user reproduced the bug, verified the patched build interactively, and reviewed and approved the changes and submission.

## Human Verification

I have reviewed and understand every change in this pull request and take responsibility for its correctness.
