### PR TITLE
fix(websocket): clamp registration retry delays

### DIFF
--- a/src/websocket/listen-register.test.ts
+++ b/src/websocket/listen-register.test.ts
@@ -1,4 +1,5 @@
-import { beforeEach, describe, expect, it, mock } from "bun:test";
+import { beforeEach, describe, expect, it, mock, spyOn } from "bun:test";
+
 import {
   deriveListenerInstanceId,
   registerWithCloud,
@@ -273,6 +274,101 @@ describe("registerWithCloud", () => {
 
     expect(result.connectionId).toBe("conn-4");
     expect(slept).toEqual([1000]);
+  });
+
+  it("clamps Retry-After sleep to the remaining total retry budget", async () => {
+    let now = 1_000_000;
+    const clock = spyOn(Date, "now").mockImplementation(() => now);
+    mockFetch.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          error: "Rate limit exceeded for this endpoint.",
+          errorCode: "route_rps_rate_limit_exceeded",
+        }),
+        {
+          status: 429,
+          headers: {
+            "Content-Type": "application/json",
+            "Retry-After": "3600",
+          },
+        },
+      ),
+    );
+
+    const slept: number[] = [];
+
+    try {
+      await expect(
+        registerWithCloudRetry(defaultOpts, {
+          fetchImpl: mockFetch as unknown as typeof fetch,
+          maxDurationMs: 1000,
+          random: () => 0,
+          sleep: async (delayMs) => {
+            slept.push(delayMs);
+            now += delayMs;
+          },
+        }),
+      ).rejects.toThrow("route_rps_rate_limit_exceeded");
+    } finally {
+      clock.mockRestore();
+    }
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(slept).toEqual([1000]);
+  });
+
+  it("preserves Infinity maxDurationMs behavior", async () => {
+    let now = 1_000_000;
+    const clock = spyOn(Date, "now").mockImplementation(() => now);
+    mockFetch
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            error: "Rate limit exceeded for this endpoint.",
+            errorCode: "route_rps_rate_limit_exceeded",
+          }),
+          {
+            status: 429,
+            headers: {
+              "Content-Type": "application/json",
+              "Retry-After": "3600",
+            },
+          },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            connectionId: "conn-infinity",
+            wsUrl: "wss://example.com",
+          }),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          },
+        ),
+      );
+
+    const slept: number[] = [];
+
+    try {
+      const result = await registerWithCloudRetry(defaultOpts, {
+        fetchImpl: mockFetch as unknown as typeof fetch,
+        maxDurationMs: Infinity,
+        random: () => 0,
+        sleep: async (delayMs) => {
+          slept.push(delayMs);
+          now += delayMs;
+        },
+      });
+
+      expect(result.connectionId).toBe("conn-infinity");
+    } finally {
+      clock.mockRestore();
+    }
+
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(slept).toEqual([3_600_000]);
   });
 
   it("adds bounded positive jitter to retry delays", async () => {

--- a/src/websocket/listen-register.ts
+++ b/src/websocket/listen-register.ts
@@ -262,13 +262,18 @@ export async function registerWithCloudRetry(
         jitterWindow > 0
           ? Math.floor((callbacks?.random ?? Math.random)() * jitterWindow)
           : 0;
-      const retryDelay = delay + jitter;
+      const remainingDurationMs = maxDurationMs - elapsed;
+      const retryDelay = Math.min(delay + jitter, remainingDurationMs);
 
       if (error instanceof Error) {
         callbacks?.onRetry?.(attempt, retryDelay, error);
       }
 
       await sleep(retryDelay);
+
+      if (Date.now() - startTime >= maxDurationMs) {
+        throw error;
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary

Registration retry delays now respect the remaining `maxDurationMs` budget. Retry-After and exponential backoff sleeps are capped before the next attempt, while explicitly unbounded re-registration with `Infinity` is preserved. This does not change the timeout behavior of an individual registration HTTP request.

## Verification

- `bun test src/websocket/listen-register.test.ts`
- `bun run check`

## AI Disclosure

- [ ] This pull request was written entirely by a human
- [ ] This pull request was written with AI assistance and reviewed and edited by a human
- [x] I have read the [AI Policy](https://github.com/letta-ai/letta-code/blob/main/AI_POLICY.md) and agree to its terms

## AI Tool(s) Used

Letta Code

## Human Verification

Pending human review before this draft is marked ready.

## Breadcrumbs

- Linear: LET-12214
- Letta conversation: [`conv-e54845da-0699-4f78-9096-0813f1fca390`](https://chat.letta.com/chat/agent-a8cc2084-940f-4741-95c9-ace741b16c4e?conversation=conv-e54845da-0699-4f78-9096-0813f1fca390)
- Origin: [#2372](https://github.com/letta-ai/letta-code/pull/2372) added Retry-After handling without bounding the sleep to the remaining deadline.


