### PR TITLE
fix(tools): resolve LS relative paths from runtime cwd

### DIFF
--- a/src/tools/impl/ls.ts
+++ b/src/tools/impl/ls.ts
@@ -1,6 +1,7 @@
 import { readdir, stat } from "node:fs/promises";
-import { join, resolve } from "node:path";
+import { isAbsolute, join, resolve } from "node:path";
 import picomatch from "picomatch";
+import { getCurrentWorkingDirectory } from "@/runtime-context";
 import LSSchema from "@/tools/schemas/LS.json";
 import { LIMITS } from "./truncation.js";
 import { validateParamTypes, validateRequiredParams } from "./validation.js";
@@ -25,7 +26,10 @@ export async function ls(
     "LS",
   );
   const { path: inputPath, ignore = [] } = args;
-  const dirPath = resolve(inputPath);
+  const userCwd = getCurrentWorkingDirectory();
+  const dirPath = isAbsolute(inputPath)
+    ? inputPath
+    : resolve(userCwd, inputPath);
   try {
     const items = await readdir(dirPath);
     const filteredItems = items.filter(

--- a/src/tools/ls.test.ts
+++ b/src/tools/ls.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
+import { runWithRuntimeContext } from "@/runtime-context";
 import { TestDirectory } from "@/test-utils/test-fs";
 import { ls } from "@/tools/impl/ls";
 
@@ -20,6 +21,33 @@ describe("LS tool", () => {
     expect(result.content[0]?.text).toContain("file1.txt");
     expect(result.content[0]?.text).toContain("file2.txt");
     expect(result.content[0]?.text).toContain("subdir/");
+  });
+
+  test("resolves relative paths from runtime working directory", async () => {
+    testDir = new TestDirectory();
+    const workspace = testDir.createDir("workspace");
+    testDir.createFile("workspace/relative-file.txt", "");
+
+    const result = await runWithRuntimeContext(
+      { workingDirectory: workspace },
+      () => ls({ path: "." }),
+    );
+
+    expect(result.content[0]?.text).toContain("relative-file.txt");
+  });
+
+  test("preserves absolute paths when runtime working directory differs", async () => {
+    testDir = new TestDirectory();
+    const workspace = testDir.createDir("workspace");
+    const absoluteTarget = testDir.createDir("absolute-target");
+    testDir.createFile("absolute-target/absolute-file.txt", "");
+
+    const result = await runWithRuntimeContext(
+      { workingDirectory: workspace },
+      () => ls({ path: absoluteTarget }),
+    );
+
+    expect(result.content[0]?.text).toContain("absolute-file.txt");
   });
 
   test("shows directories with trailing slash", async () => {


### PR DESCRIPTION
## Summary

Relative LS paths now resolve from the conversation runtime working directory instead of the listener process directory. Absolute paths retain their existing behavior.

## Verification

- `bun test src/tools/ls.test.ts`
- `bun run check`

## AI Disclosure

- [ ] This pull request was written entirely by a human
- [ ] This pull request was written with AI assistance and reviewed and edited by a human
- [x] I have read the [AI Policy](https://github.com/letta-ai/letta-code/blob/main/AI_POLICY.md) and agree to its terms

## AI Tool(s) Used

Letta Code

## Human Verification

Pending human review before this draft is marked ready.

## Breadcrumbs

- Linear: LET-12211
- Letta conversation: [`conv-e54845da-0699-4f78-9096-0813f1fca390`](https://chat.letta.com/chat/agent-a8cc2084-940f-4741-95c9-ace741b16c4e?conversation=conv-e54845da-0699-4f78-9096-0813f1fca390)
- Origin: [Initial implementation](https://github.com/letta-ai/letta-code/commit/70ac76040d3c332c5ef7b047373de78e13fc3198) resolved paths against `process.cwd()`.


