### PR TITLE
fix(listener): preserve accepted input receipts across eviction

### DIFF
--- a/src/websocket/listener/inbound-dispatch.test.ts
+++ b/src/websocket/listener/inbound-dispatch.test.ts
@@ -17,7 +17,7 @@ import { getOrCreateScopedRuntime } from "./conversation-runtime";
 import { dispatchInboundMessageWhenReady } from "./inbound-dispatch";
 import { createRuntime } from "./lifecycle";
 import { getOrCreateConversationPermissionModeStateRef } from "./permission-mode";
-import { setActiveRuntime } from "./runtime";
+import { evictConversationRuntimeIfIdle, setActiveRuntime } from "./runtime";
 import { isListenerTransportOpen, type ListenerTransport } from "./transport";
 import { handleApprovalStop } from "./turn-approval";
 import { createTurnInputState } from "./turn-input-state";
@@ -217,6 +217,91 @@ test("direct App Server turn follows a subscribed client after origin disconnect
   expect(branchResult?.kind).toBe("terminal");
   expect(executeApprovalBatch).toHaveBeenCalledTimes(1);
   expect(sendApprovalContinuation).toHaveBeenCalledTimes(1);
+});
+
+test("accepted input disposition survives idle runtime eviction", async () => {
+  const listener = createRuntime();
+  setActiveRuntime(listener);
+  const socket = new MockSocket();
+  const options = makeOptions("client-a");
+  const scope = { agent_id: "agent-1", conversation_id: "conversation-1" };
+  const processIncomingMessage = mock(async () => {});
+  const acknowledgements: Array<{
+    accepted: boolean;
+    disposition?: "started" | "queued";
+  }> = [];
+
+  const runtime = getOrCreateScopedRuntime(
+    listener,
+    scope.agent_id,
+    scope.conversation_id,
+  );
+  dispatchInboundMessageWhenReady({
+    listener,
+    runtime,
+    incoming: {
+      type: "message",
+      connectionId: "client-a",
+      agentId: scope.agent_id,
+      conversationId: scope.conversation_id,
+      messages: [
+        {
+          role: "user",
+          content: "Run once",
+          client_message_id: "cm-accepted-once",
+        },
+      ],
+    },
+    socket: socket as never,
+    options,
+    processQueuedTurn: mock(async () => {}),
+    processIncomingMessage,
+    trackListenerError: mock(() => {}),
+    onInputAccepted: (result) => acknowledgements.push(result),
+  });
+
+  await runtime.messageQueue;
+  expect(processIncomingMessage).toHaveBeenCalledTimes(1);
+  expect(acknowledgements).toEqual([
+    { accepted: true, disposition: "started" },
+  ]);
+  expect(evictConversationRuntimeIfIdle(runtime)).toBe(true);
+
+  const recreatedRuntime = getOrCreateScopedRuntime(
+    listener,
+    scope.agent_id,
+    scope.conversation_id,
+  );
+  dispatchInboundMessageWhenReady({
+    listener,
+    runtime: recreatedRuntime,
+    incoming: {
+      type: "message",
+      connectionId: "client-a",
+      agentId: scope.agent_id,
+      conversationId: scope.conversation_id,
+      messages: [
+        {
+          role: "user",
+          content: "Run once",
+          client_message_id: "cm-accepted-once",
+        },
+      ],
+    },
+    socket: socket as never,
+    options,
+    processQueuedTurn: mock(async () => {}),
+    processIncomingMessage,
+    trackListenerError: mock(() => {}),
+    onInputAccepted: (result) => acknowledgements.push(result),
+  });
+
+  await recreatedRuntime.messageQueue;
+  expect(processIncomingMessage).toHaveBeenCalledTimes(1);
+  expect(acknowledgements).toEqual([
+    { accepted: true, disposition: "started" },
+    { accepted: true, disposition: "started" },
+  ]);
 });
 
 test("direct remote turn follows the replacement WS pair after reconnect", async () => {

--- a/src/websocket/listener/runtime.ts
+++ b/src/websocket/listener/runtime.ts
@@ -68,6 +68,8 @@ export function clearRuntimeTimers(runtime: ListenerRuntime): void {
  */
 export const WORKTREE_WATCHER_IDLE_STOP_MS = 30 * 60 * 1000;
 
+const MAX_ACCEPTED_INPUT_DISPOSITION_SCOPES = 256;
+
 type WatcherIdleStop = {
   timer: ReturnType<typeof setTimeout>;
   /** Structural view of WorktreeWatcherState; a type import would cycle. */
@@ -232,6 +234,40 @@ export function getConversationRuntimeKey(
   return `agent:${normalizedAgentId ?? "__unknown__"}::conversation:${normalizedConversationId}`;
 }
 
+function getOrCreateAcceptedInputDispositions(
+  listener: ListenerRuntime,
+  runtimeKey: string,
+): Map<string, "started" | "queued"> {
+  if (!listener.acceptedInputDispositionsByConversation) {
+    listener.acceptedInputDispositionsByConversation = new Map();
+  }
+  const dispositionsByConversation =
+    listener.acceptedInputDispositionsByConversation;
+  const existing = dispositionsByConversation.get(runtimeKey);
+  if (existing) {
+    dispositionsByConversation.delete(runtimeKey);
+    dispositionsByConversation.set(runtimeKey, existing);
+    return existing;
+  }
+
+  const dispositions = new Map<string, "started" | "queued">();
+  dispositionsByConversation.set(runtimeKey, dispositions);
+  while (
+    dispositionsByConversation.size > MAX_ACCEPTED_INPUT_DISPOSITION_SCOPES
+  ) {
+    let oldestEvictedRuntimeKey: string | undefined;
+    for (const key of dispositionsByConversation.keys()) {
+      if (key !== runtimeKey && !listener.conversationRuntimes.has(key)) {
+        oldestEvictedRuntimeKey = key;
+        break;
+      }
+    }
+    if (!oldestEvictedRuntimeKey) break;
+    dispositionsByConversation.delete(oldestEvictedRuntimeKey);
+  }
+  return dispositions;
+}
+
 export function createConversationRuntime(
   listener: ListenerRuntime,
   agentId?: string | null,
@@ -259,7 +295,10 @@ export function createConversationRuntime(
     activeConnectionId: null,
     turnLifecycle,
     messageQueue: Promise.resolve(),
-    acceptedInputDispositions: new Map(),
+    acceptedInputDispositions: getOrCreateAcceptedInputDispositions(
+      listener,
+      runtimeKey,
+    ),
     pendingApprovalResolvers: new Map(),
     recoveredApprovalState: null,
     get lastStopReason() {

--- a/src/websocket/listener/types.ts
+++ b/src/websocket/listener/types.ts
@@ -376,6 +376,11 @@ export type ListenerRuntime = {
   connectionId: string | null;
   connectionName: string | null;
   conversationRuntimes: Map<string, ConversationRuntime>;
+  /** Recently accepted ingress IDs survive idle conversation runtime eviction. */
+  acceptedInputDispositionsByConversation?: Map<
+    string,
+    Map<string, "started" | "queued">
+  >;
   /** Recent run-to-send snapshots survive idle conversation runtime eviction. */
   clientMessageIdsByRunIdByConversation?: Map<string, Map<string, string[]>>;
   /** Per-conversation worktree directory watchers for CWD auto-detection fallback. */


### PR DESCRIPTION
## Summary

Accepted input dispositions now survive idle `ConversationRuntime` eviction in bounded listener-scoped storage. Redelivery of a previously accepted `client_message_id` returns the original disposition without executing a second turn.

## Verification

- `bun test src/websocket/listener/inbound-dispatch.test.ts`
- `bun run check`

## AI Disclosure

- [ ] This pull request was written entirely by a human
- [ ] This pull request was written with AI assistance and reviewed and edited by a human
- [x] I have read the [AI Policy](https://github.com/letta-ai/letta-code/blob/main/AI_POLICY.md) and agree to its terms

## AI Tool(s) Used

Letta Code

## Human Verification

Pending human review before this draft is marked ready.

## Breadcrumbs

- Linear: LET-12213
- Letta conversation: [`conv-e54845da-0699-4f78-9096-0813f1fca390`](https://chat.letta.com/chat/agent-a8cc2084-940f-4741-95c9-ace741b16c4e?conversation=conv-e54845da-0699-4f78-9096-0813f1fca390)
- Origin: [#3633](https://github.com/letta-ai/letta-code/pull/3633) added accepted-input receipts to the evictable runtime.

