### PR TITLE
fix(listener): classify websocket policy closes

### DIFF
--- a/scripts/source-file-size-baseline.json
+++ b/scripts/source-file-size-baseline.json
@@ -42,7 +42,7 @@
   "src/websocket/listen-client-protocol.test.ts": 5819,
   "src/websocket/listener/commands/memory.ts": 1114,
   "src/websocket/listener/file-commands.ts": 1053,
-  "src/websocket/listener/lifecycle.ts": 1048,
+  "src/websocket/listener/lifecycle.ts": 1042,
   "src/websocket/listener/protocol-inbound.ts": 2197,
   "src/websocket/listener/protocol-outbound.ts": 1042,
   "src/websocket/listener/turn.ts": 1058

--- a/src/websocket/listener/auth-lifecycle.test.ts
+++ b/src/websocket/listener/auth-lifecycle.test.ts
@@ -622,6 +622,83 @@ describe("listener auth lifecycle", () => {
     expect(connections).toHaveLength(1);
   });
 
+  test("registration-invalidating 1008 relay reasons request re-registration", async () => {
+    const reasons = [
+      "Environment not found",
+      "Connection not found",
+      "Listener pair is not current",
+      "Listener attempt is stale",
+      "Listener pair is no longer current",
+    ];
+
+    for (const [index, reason] of reasons.entries()) {
+      const onNeedsReregister = mock(() => {});
+      const onError = mock((_error: Error) => {});
+      await startClient({ onNeedsReregister, onError });
+      await waitFor(
+        () => connections.length >= index + 1,
+        `socket did not open for ${reason}`,
+      );
+
+      connections.at(-1)?.close(1008, reason);
+      await waitFor(
+        () => onNeedsReregister.mock.calls.length === 1,
+        `${reason} did not request re-registration`,
+      );
+
+      expect(onError).not.toHaveBeenCalled();
+      expect(getActiveRuntime()).toBeNull();
+    }
+  });
+
+  test("unrelated 1008 relay policy reasons fail terminally without re-registering", async () => {
+    const onDisconnected = mock(() => {});
+    const onNeedsReregister = mock(() => {});
+    const onError = mock((_error: Error) => {});
+    await startClient({ onDisconnected, onNeedsReregister, onError });
+    await waitFor(
+      () => connections.length === 1,
+      "initial socket did not open",
+    );
+
+    connections[0]?.close(1008, "No cloud API key configured");
+    await waitFor(
+      () => onError.mock.calls.length === 1,
+      "policy close did not surface a terminal diagnostic",
+    );
+
+    expect(onNeedsReregister).not.toHaveBeenCalled();
+    expect(onDisconnected).not.toHaveBeenCalled();
+    expect(onError.mock.calls[0]?.[0].message).toBe(
+      "Listener WebSocket rejected by relay policy (1008: No cloud API key configured)",
+    );
+    expect(getActiveRuntime()).toBeNull();
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(connections).toHaveLength(1);
+  });
+
+  test("unrecognized 1008 relay policy reasons fail terminally without re-registering", async () => {
+    const onNeedsReregister = mock(() => {});
+    const onError = mock((_error: Error) => {});
+    await startClient({ onNeedsReregister, onError });
+    await waitFor(
+      () => connections.length === 1,
+      "initial socket did not open",
+    );
+
+    connections[0]?.close(1008, "Paired listener channels not enabled");
+    await waitFor(
+      () => onError.mock.calls.length === 1,
+      "unrecognized policy close did not surface a terminal diagnostic",
+    );
+
+    expect(onNeedsReregister).not.toHaveBeenCalled();
+    expect(onError.mock.calls[0]?.[0].message).toBe(
+      "Listener WebSocket rejected by relay policy (1008: Paired listener channels not enabled)",
+    );
+    expect(getActiveRuntime()).toBeNull();
+  });
+
   test("1008 re-registration closes tear down same-process runtime state", async () => {
     const onNeedsReregister = mock(() => {});
     await startClient({ onNeedsReregister });

--- a/src/websocket/listener/lifecycle.ts
+++ b/src/websocket/listener/lifecycle.ts
@@ -59,6 +59,7 @@ import {
   reloadListenerModAdapter,
 } from "./mod-adapter";
 import { loadPersistedPermissionModeMap } from "./permission-mode";
+import { handleTerminalPolicyClose } from "./policy-close";
 import {
   clearProcessServices,
   installProcessEventRouting,
@@ -984,14 +985,7 @@ async function connectWithRetry(
       stopRuntime(runtime, true);
 
       if (code === 1008) {
-        if (isDebugEnabled()) {
-          console.log("[Listen] Environment not found, re-registering...");
-        }
-        if (opts.onNeedsReregister) {
-          opts.onNeedsReregister();
-        } else {
-          opts.onDisconnected();
-        }
+        handleTerminalPolicyClose(reasonText, opts);
         return;
       }
 

--- a/src/websocket/listener/policy-close.ts
+++ b/src/websocket/listener/policy-close.ts
@@ -1,0 +1,42 @@
+const REGISTRATION_INVALIDATING_POLICY_CLOSE_REASONS = new Set([
+  "environment not found",
+  "connection not found",
+  "listener pair is not current",
+  "listener pair is no longer current",
+  "listener attempt is stale",
+]);
+
+export interface TerminalPolicyCloseHandlers {
+  onDisconnected: () => void;
+  onError: (error: Error) => void;
+  onNeedsReregister?: () => void;
+}
+
+function normalizePolicyCloseReason(reason: string): string {
+  return reason.trim().replace(/\s+/g, " ").toLowerCase();
+}
+
+function shouldReregisterAfterPolicyClose(reason: string): boolean {
+  return REGISTRATION_INVALIDATING_POLICY_CLOSE_REASONS.has(
+    normalizePolicyCloseReason(reason),
+  );
+}
+
+function formatTerminalPolicyCloseError(reason: string): Error {
+  const reasonText = reason.trim() || "no reason provided";
+  return new Error(
+    `Listener WebSocket rejected by relay policy (1008: ${reasonText})`,
+  );
+}
+
+export function handleTerminalPolicyClose(
+  reason: string,
+  handlers: TerminalPolicyCloseHandlers,
+): void {
+  if (shouldReregisterAfterPolicyClose(reason)) {
+    handlers.onNeedsReregister?.() ?? handlers.onDisconnected();
+    return;
+  }
+
+  handlers.onError(formatTerminalPolicyCloseError(reason));
+}


### PR DESCRIPTION
## Summary

WebSocket policy closes now trigger re-registration only for known registration-invalidating relay reasons. Unrelated 1008 policy and authentication failures terminate with their actual reason instead of entering a futile environment-registration loop.

## Verification

- `bun test src/websocket/listener/auth-lifecycle.test.ts`
- `bun run check`

## AI Disclosure

- [ ] This pull request was written entirely by a human
- [ ] This pull request was written with AI assistance and reviewed and edited by a human
- [x] I have read the [AI Policy](https://github.com/letta-ai/letta-code/blob/main/AI_POLICY.md) and agree to its terms

## AI Tool(s) Used

Letta Code

## Human Verification

Pending human review before this draft is marked ready.

## Breadcrumbs

- Linear: LET-12219
- Letta conversation: [`conv-e54845da-0699-4f78-9096-0813f1fca390`](https://chat.letta.com/chat/agent-a8cc2084-940f-4741-95c9-ace741b16c4e?conversation=conv-e54845da-0699-4f78-9096-0813f1fca390)
- Origin: [#1171](https://github.com/letta-ai/letta-code/pull/1171) treated every 1008 close as an expired environment.

