### PR TITLE
fix(listener): ignore superseded runtime_start state

### DIFF
--- a/src/websocket/listener/commands/runtime-start-skill-sources.test.ts
+++ b/src/websocket/listener/commands/runtime-start-skill-sources.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import type WebSocket from "ws";
 import { __testSetBackend, type AgentCreateBody } from "@/backend";
 import { LocalBackend } from "@/backend/local";
+import { settingsManager } from "@/settings-manager";
 import {
   clearExternalTools,
   prepareToolExecutionContextForModel,
@@ -126,10 +127,8 @@ describe("runtime_start skill sources", () => {
     }
   });
 
-  test("delayed older runtime_start does not overwrite newer state for the same connection runtime", async () => {
-    const storageDir = await mkdtemp(join(tmpdir(), "runtime-generation-"));
-    const firstCwd = await mkdtemp(join(tmpdir(), "runtime-generation-old-"));
-    const secondCwd = await mkdtemp(join(tmpdir(), "runtime-generation-new-"));
+  test("serializes same-scope runtime_start before source-tag mutations", async () => {
+    const storageDir = await mkdtemp(join(tmpdir(), "runtime-source-tags-"));
     try {
       const backend = new LocalBackend({
         storageDir,
@@ -137,55 +136,233 @@ describe("runtime_start skill sources", () => {
       });
       __testSetBackend(backend);
       const agent = await backend.createAgent({
-        name: "Generation guarded worker",
+        name: "Source tag worker",
         model: "anthropic/claude-sonnet-4-6",
       } as AgentCreateBody);
       const conversation = await backend.createConversation({
         agent_id: agent.id,
       });
       const listener = createRuntime();
-      const responses: Array<{ request_id: string; success: boolean }> = [];
-      const replayed: string[] = [];
-      let retrieveCount = 0;
-      let firstRetrieveStarted!: () => void;
-      let releaseFirstRetrieve!: () => void;
-      const firstRetrieveReady = new Promise<void>((resolve) => {
-        firstRetrieveStarted = resolve;
+      const responses: string[] = [];
+      const updates: string[] = [];
+      const originalUpdateConversation =
+        backend.updateConversation.bind(backend);
+      let firstUpdateStarted!: () => void;
+      let releaseFirstUpdate!: () => void;
+      const firstUpdateReady = new Promise<void>((resolve) => {
+        firstUpdateStarted = resolve;
       });
-      const firstRetrieveBlocked = new Promise<void>((resolve) => {
-        releaseFirstRetrieve = resolve;
+      const firstUpdateBlocked = new Promise<void>((resolve) => {
+        releaseFirstUpdate = resolve;
       });
+      backend.updateConversation = async (conversationId, body) => {
+        updates.push(
+          (Reflect.get(body, "tags") as string[] | undefined)?.join(",") ??
+            "none",
+        );
+        if (updates.length === 1) {
+          firstUpdateStarted();
+          await firstUpdateBlocked;
+        }
+        return originalUpdateConversation(conversationId, body);
+      };
       const context = {
         socket: {} as WebSocket,
         connectionId: "test-connection",
         runtime: listener,
         safeSocketSend: (_socket: WebSocket, payload: unknown) => {
-          const message = payload as { request_id: string; success: boolean };
-          responses.push({
-            request_id: message.request_id,
-            success: message.success,
-          });
+          responses.push((payload as { request_id: string }).request_id);
+          return true;
+        },
+        runDetachedListenerTask: () => {},
+        getOrCreateScopedRuntime,
+        replaySyncStateForRuntime: async () => {},
+      };
+
+      const first = handleRuntimeStartCommand(
+        {
+          type: "runtime_start",
+          request_id: "first",
+          agent_id: agent.id,
+          conversation_id: conversation.id,
+          conversation_source_tags: ["channel:slack"],
+          recover_approvals: false,
+        },
+        context,
+      );
+      await firstUpdateReady;
+      const second = handleRuntimeStartCommand(
+        {
+          type: "runtime_start",
+          request_id: "second",
+          agent_id: agent.id,
+          conversation_id: conversation.id,
+          conversation_source_tags: ["origin:schedule"],
+          recover_approvals: false,
+        },
+        context,
+      );
+      await Bun.sleep(10);
+      expect(responses).toEqual([]);
+      expect(updates).toEqual(["channel:slack"]);
+      releaseFirstUpdate();
+      await Promise.all([first, second]);
+
+      const updated = await backend.retrieveConversation(conversation.id);
+      expect(responses).toEqual(["first", "second"]);
+      expect(updates).toEqual([
+        "channel:slack",
+        "channel:slack,origin:schedule",
+      ]);
+      expect(Reflect.get(updated, "tags")).toEqual([
+        "channel:slack",
+        "origin:schedule",
+      ]);
+    } finally {
+      await rm(storageDir, { recursive: true, force: true });
+    }
+  });
+
+  test("keeps distinct runtime_start scopes concurrent", async () => {
+    const storageDir = await mkdtemp(join(tmpdir(), "runtime-distinct-"));
+    try {
+      const backend = new LocalBackend({
+        storageDir,
+        executionMode: "deterministic",
+      });
+      __testSetBackend(backend);
+      const agent = await backend.createAgent({
+        name: "Distinct scope worker",
+        model: "anthropic/claude-sonnet-4-6",
+      } as AgentCreateBody);
+      const firstConversation = await backend.createConversation({
+        agent_id: agent.id,
+      });
+      const secondConversation = await backend.createConversation({
+        agent_id: agent.id,
+      });
+      const listener = createRuntime();
+      const responses: string[] = [];
+      const originalUpdateConversation =
+        backend.updateConversation.bind(backend);
+      let firstUpdateStarted!: () => void;
+      let releaseFirstUpdate!: () => void;
+      const firstUpdateReady = new Promise<void>((resolve) => {
+        firstUpdateStarted = resolve;
+      });
+      const firstUpdateBlocked = new Promise<void>((resolve) => {
+        releaseFirstUpdate = resolve;
+      });
+      backend.updateConversation = async (conversationId, body) => {
+        if (conversationId === firstConversation.id) {
+          firstUpdateStarted();
+          await firstUpdateBlocked;
+        }
+        return originalUpdateConversation(conversationId, body);
+      };
+      const context = {
+        socket: {} as WebSocket,
+        connectionId: "test-connection",
+        runtime: listener,
+        safeSocketSend: (_socket: WebSocket, payload: unknown) => {
+          responses.push((payload as { request_id: string }).request_id);
+          return true;
+        },
+        runDetachedListenerTask: () => {},
+        getOrCreateScopedRuntime,
+        replaySyncStateForRuntime: async () => {},
+      };
+
+      const first = handleRuntimeStartCommand(
+        {
+          type: "runtime_start",
+          request_id: "first",
+          agent_id: agent.id,
+          conversation_id: firstConversation.id,
+          conversation_source_tags: ["channel:slack"],
+          recover_approvals: false,
+        },
+        context,
+      );
+      await firstUpdateReady;
+      await handleRuntimeStartCommand(
+        {
+          type: "runtime_start",
+          request_id: "second",
+          agent_id: agent.id,
+          conversation_id: secondConversation.id,
+          conversation_source_tags: ["origin:schedule"],
+          recover_approvals: false,
+        },
+        context,
+      );
+      expect(responses).toEqual(["second"]);
+      releaseFirstUpdate();
+      await first;
+      expect(responses).toEqual(["second", "first"]);
+    } finally {
+      await rm(storageDir, { recursive: true, force: true });
+    }
+  });
+
+  test("serializes same-scope runtime_start before cwd mutations", async () => {
+    const storageDir = await mkdtemp(join(tmpdir(), "runtime-cwd-"));
+    const firstCwd = await mkdtemp(join(tmpdir(), "runtime-cwd-old-"));
+    const secondCwd = await mkdtemp(join(tmpdir(), "runtime-cwd-new-"));
+    const originalLoadProjectSettings =
+      settingsManager.loadProjectSettings.bind(settingsManager);
+    try {
+      const backend = new LocalBackend({
+        storageDir,
+        executionMode: "deterministic",
+      });
+      __testSetBackend(backend);
+      const agent = await backend.createAgent({
+        name: "CWD guarded worker",
+        model: "anthropic/claude-sonnet-4-6",
+      } as AgentCreateBody);
+      const conversation = await backend.createConversation({
+        agent_id: agent.id,
+      });
+      const listener = createRuntime();
+      const responses: string[] = [];
+      const replayed: string[] = [];
+      let firstCwdLoadStarted!: () => void;
+      let releaseFirstCwdLoad!: () => void;
+      let blockedFirstCwd = false;
+      const firstCwdLoadReady = new Promise<void>((resolve) => {
+        firstCwdLoadStarted = resolve;
+      });
+      const firstCwdLoadBlocked = new Promise<void>((resolve) => {
+        releaseFirstCwdLoad = resolve;
+      });
+      settingsManager.loadProjectSettings = async (workingDirectory) => {
+        if (workingDirectory === firstCwd && !blockedFirstCwd) {
+          blockedFirstCwd = true;
+          firstCwdLoadStarted();
+          await firstCwdLoadBlocked;
+        }
+        return originalLoadProjectSettings(workingDirectory);
+      };
+      const context = {
+        socket: {} as WebSocket,
+        connectionId: "test-connection",
+        runtime: listener,
+        safeSocketSend: (_socket: WebSocket, payload: unknown) => {
+          responses.push((payload as { request_id: string }).request_id);
           return true;
         },
         runDetachedListenerTask: () => {},
         getOrCreateScopedRuntime,
         replaySyncStateForRuntime: async () => {
-          replayed.push(responses.at(-1)?.request_id ?? "missing-response");
-        },
-        retrieveConversation: async (conversationId: string) => {
-          retrieveCount += 1;
-          if (retrieveCount === 1) {
-            firstRetrieveStarted();
-            await firstRetrieveBlocked;
-          }
-          return backend.retrieveConversation(conversationId);
+          replayed.push(responses.at(-1) ?? "missing-response");
         },
       };
 
-      const older = handleRuntimeStartCommand(
+      const first = handleRuntimeStartCommand(
         {
           type: "runtime_start",
-          request_id: "older",
+          request_id: "first",
           agent_id: agent.id,
           conversation_id: conversation.id,
           cwd: firstCwd,
@@ -206,11 +383,11 @@ describe("runtime_start skill sources", () => {
         },
         context,
       );
-      await firstRetrieveReady;
-      const newer = handleRuntimeStartCommand(
+      await firstCwdLoadReady;
+      const second = handleRuntimeStartCommand(
         {
           type: "runtime_start",
-          request_id: "newer",
+          request_id: "second",
           agent_id: agent.id,
           conversation_id: conversation.id,
           cwd: secondCwd,
@@ -231,20 +408,18 @@ describe("runtime_start skill sources", () => {
         },
         context,
       );
-      await newer;
-      releaseFirstRetrieve();
-      await older;
+      await Bun.sleep(10);
+      expect(responses).toEqual([]);
+      releaseFirstCwdLoad();
+      await Promise.all([first, second]);
 
       const scoped = getOrCreateScopedRuntime(
         listener,
         agent.id,
         conversation.id,
       );
-      expect(responses).toEqual([
-        { request_id: "newer", success: true },
-        { request_id: "older", success: false },
-      ]);
-      expect(replayed).toEqual(["newer"]);
+      expect(responses).toEqual(["first", "second"]);
+      expect(replayed).toEqual(["first", "second"]);
       expect(scoped.skillSources).toEqual(["global"]);
       expect(
         getConversationWorkingDirectory(listener, agent.id, conversation.id),
@@ -264,6 +439,7 @@ describe("runtime_start skill sources", () => {
         "newer_tool",
       ]);
     } finally {
+      settingsManager.loadProjectSettings = originalLoadProjectSettings;
       await rm(firstCwd, { recursive: true, force: true });
       await rm(secondCwd, { recursive: true, force: true });
       await rm(storageDir, { recursive: true, force: true });

--- a/src/websocket/listener/commands/runtime-start-skill-sources.test.ts
+++ b/src/websocket/listener/commands/runtime-start-skill-sources.test.ts
@@ -5,13 +5,19 @@ import { join } from "node:path";
 import type WebSocket from "ws";
 import { __testSetBackend, type AgentCreateBody } from "@/backend";
 import { LocalBackend } from "@/backend/local";
+import {
+  clearExternalTools,
+  prepareToolExecutionContextForModel,
+} from "@/tools/manager";
 import { getOrCreateScopedRuntime } from "@/websocket/listener/conversation-runtime";
+import { getConversationWorkingDirectory } from "@/websocket/listener/cwd";
 import { createRuntime } from "@/websocket/listener/lifecycle";
 import { evictConversationRuntimeIfIdle } from "@/websocket/listener/runtime";
 import { handleRuntimeStartCommand } from "./runtime-start";
 
 describe("runtime_start skill sources", () => {
   afterEach(() => {
+    clearExternalTools();
     __testSetBackend(null);
   });
 
@@ -116,6 +122,150 @@ describe("runtime_start skill sources", () => {
         "project",
       ]);
     } finally {
+      await rm(storageDir, { recursive: true, force: true });
+    }
+  });
+
+  test("delayed older runtime_start does not overwrite newer state for the same connection runtime", async () => {
+    const storageDir = await mkdtemp(join(tmpdir(), "runtime-generation-"));
+    const firstCwd = await mkdtemp(join(tmpdir(), "runtime-generation-old-"));
+    const secondCwd = await mkdtemp(join(tmpdir(), "runtime-generation-new-"));
+    try {
+      const backend = new LocalBackend({
+        storageDir,
+        executionMode: "deterministic",
+      });
+      __testSetBackend(backend);
+      const agent = await backend.createAgent({
+        name: "Generation guarded worker",
+        model: "anthropic/claude-sonnet-4-6",
+      } as AgentCreateBody);
+      const conversation = await backend.createConversation({
+        agent_id: agent.id,
+      });
+      const listener = createRuntime();
+      const responses: Array<{ request_id: string; success: boolean }> = [];
+      const replayed: string[] = [];
+      let retrieveCount = 0;
+      let firstRetrieveStarted!: () => void;
+      let releaseFirstRetrieve!: () => void;
+      const firstRetrieveReady = new Promise<void>((resolve) => {
+        firstRetrieveStarted = resolve;
+      });
+      const firstRetrieveBlocked = new Promise<void>((resolve) => {
+        releaseFirstRetrieve = resolve;
+      });
+      const context = {
+        socket: {} as WebSocket,
+        connectionId: "test-connection",
+        runtime: listener,
+        safeSocketSend: (_socket: WebSocket, payload: unknown) => {
+          const message = payload as { request_id: string; success: boolean };
+          responses.push({
+            request_id: message.request_id,
+            success: message.success,
+          });
+          return true;
+        },
+        runDetachedListenerTask: () => {},
+        getOrCreateScopedRuntime,
+        replaySyncStateForRuntime: async () => {
+          replayed.push(responses.at(-1)?.request_id ?? "missing-response");
+        },
+        retrieveConversation: async (conversationId: string) => {
+          retrieveCount += 1;
+          if (retrieveCount === 1) {
+            firstRetrieveStarted();
+            await firstRetrieveBlocked;
+          }
+          return backend.retrieveConversation(conversationId);
+        },
+      };
+
+      const older = handleRuntimeStartCommand(
+        {
+          type: "runtime_start",
+          request_id: "older",
+          agent_id: agent.id,
+          conversation_id: conversation.id,
+          cwd: firstCwd,
+          mode: "strict",
+          skill_sources: ["project"],
+          recover_approvals: false,
+          external_tools: [
+            {
+              tools: [
+                {
+                  name: "older_tool",
+                  description: "Older tool",
+                  parameters: { type: "object", properties: {} },
+                },
+              ],
+            },
+          ],
+        },
+        context,
+      );
+      await firstRetrieveReady;
+      const newer = handleRuntimeStartCommand(
+        {
+          type: "runtime_start",
+          request_id: "newer",
+          agent_id: agent.id,
+          conversation_id: conversation.id,
+          cwd: secondCwd,
+          mode: "unrestricted",
+          skill_sources: ["global"],
+          recover_approvals: false,
+          external_tools: [
+            {
+              tools: [
+                {
+                  name: "newer_tool",
+                  description: "Newer tool",
+                  parameters: { type: "object", properties: {} },
+                },
+              ],
+            },
+          ],
+        },
+        context,
+      );
+      await newer;
+      releaseFirstRetrieve();
+      await older;
+
+      const scoped = getOrCreateScopedRuntime(
+        listener,
+        agent.id,
+        conversation.id,
+      );
+      expect(responses).toEqual([
+        { request_id: "newer", success: true },
+        { request_id: "older", success: false },
+      ]);
+      expect(replayed).toEqual(["newer"]);
+      expect(scoped.skillSources).toEqual(["global"]);
+      expect(
+        getConversationWorkingDirectory(listener, agent.id, conversation.id),
+      ).toBe(secondCwd);
+      const preparedTools = await prepareToolExecutionContextForModel(
+        "anthropic/claude-sonnet-4-6",
+        {
+          clientToolAllowlist: ["older_tool", "newer_tool"],
+          runtimeContext: {
+            connectionId: "test-connection",
+            agentId: agent.id,
+            conversationId: conversation.id,
+          },
+        },
+      );
+      expect(preparedTools.clientTools.map((tool) => tool.name)).toEqual([
+        "newer_tool",
+      ]);
+    } finally {
+      await rm(firstCwd, { recursive: true, force: true });
+      await rm(secondCwd, { recursive: true, force: true });
       await rm(storageDir, { recursive: true, force: true });
     }
   });

--- a/src/websocket/listener/commands/runtime-start.ts
+++ b/src/websocket/listener/commands/runtime-start.ts
@@ -67,64 +67,57 @@ type CreatedResources = {
   conversation: boolean;
 };
 
-type RuntimeStartGenerationState = {
-  nextGeneration: number;
-  latestByRuntime: Map<string, number>;
-};
-
-const runtimeStartGenerationByListener = new WeakMap<
+const runtimeStartQueuesByListener = new WeakMap<
   ListenerRuntime,
-  RuntimeStartGenerationState
+  Map<string, Promise<void>>
 >();
 
-function getRuntimeStartGenerationState(
+function getRuntimeStartQueues(
   runtime: ListenerRuntime,
-): RuntimeStartGenerationState {
-  let state = runtimeStartGenerationByListener.get(runtime);
-  if (!state) {
-    state = { nextGeneration: 0, latestByRuntime: new Map() };
-    runtimeStartGenerationByListener.set(runtime, state);
+): Map<string, Promise<void>> {
+  let queues = runtimeStartQueuesByListener.get(runtime);
+  if (!queues) {
+    queues = new Map();
+    runtimeStartQueuesByListener.set(runtime, queues);
   }
-  return state;
+  return queues;
 }
 
-function beginRuntimeStartRequest(runtime: ListenerRuntime): number {
-  const state = getRuntimeStartGenerationState(runtime);
-  state.nextGeneration += 1;
-  return state.nextGeneration;
-}
-
-function getRuntimeStartGenerationKey(scope: RuntimeStartScope): string {
-  return getConversationRuntimeKey(scope.agent_id, scope.conversation_id);
-}
-
-function markLatestRuntimeStartRequest(
-  runtime: ListenerRuntime,
-  _connectionId: ListenerConnectionId,
-  scope: RuntimeStartScope,
-  generation: number,
-): boolean {
-  const state = getRuntimeStartGenerationState(runtime);
-  const key = getRuntimeStartGenerationKey(scope);
-  const latest = state.latestByRuntime.get(key) ?? 0;
-  if (generation < latest) {
-    return false;
+function getRuntimeStartSerializationKey(
+  parsed: RuntimeStartCommand,
+): string | null {
+  if (hasString(parsed.conversation_id)) {
+    if (parsed.conversation_id !== "default") {
+      return `conversation:${parsed.conversation_id}`;
+    }
+    if (hasString(parsed.agent_id)) {
+      return getConversationRuntimeKey(parsed.agent_id, "default");
+    }
   }
-  state.latestByRuntime.set(key, generation);
-  return true;
+
+  if (hasString(parsed.agent_id) && parsed.create_conversation === undefined) {
+    return getConversationRuntimeKey(parsed.agent_id, "default");
+  }
+
+  return null;
 }
 
-function isLatestRuntimeStartRequest(
+async function enqueueRuntimeStartForScope(
   runtime: ListenerRuntime,
-  _connectionId: ListenerConnectionId,
-  scope: RuntimeStartScope,
-  generation: number,
-): boolean {
-  const state = getRuntimeStartGenerationState(runtime);
-  return (
-    state.latestByRuntime.get(getRuntimeStartGenerationKey(scope)) ===
-    generation
-  );
+  key: string,
+  task: () => Promise<void>,
+): Promise<void> {
+  const queues = getRuntimeStartQueues(runtime);
+  const previous = queues.get(key) ?? Promise.resolve();
+  const next = previous.catch(() => {}).then(task);
+  queues.set(key, next);
+  try {
+    await next;
+  } finally {
+    if (queues.get(key) === next) {
+      queues.delete(key);
+    }
+  }
 }
 
 function buildDefaultConversation(agent: AgentState): Conversation {
@@ -182,23 +175,6 @@ function sendRuntimeStartResponse(
     "listener_runtime_start_send_failed",
     "listener_runtime_start",
   );
-}
-
-function sendSupersededRuntimeStartResponse(
-  context: RuntimeStartCommandContext,
-  parsed: RuntimeStartCommand,
-  agent: AgentState | null,
-  conversation: Conversation | null,
-  created: CreatedResources,
-): boolean {
-  return sendRuntimeStartResponse(context, parsed, {
-    success: false,
-    runtime: null,
-    agent,
-    conversation,
-    created,
-    error: "Superseded by a newer runtime_start request",
-  });
 }
 
 function validateRuntimeStartShape(parsed: RuntimeStartCommand): void {
@@ -479,7 +455,36 @@ export async function handleRuntimeStartCommand(
   parsed: RuntimeStartCommand,
   context: RuntimeStartCommandContext,
 ): Promise<boolean> {
-  const generation = beginRuntimeStartRequest(context.runtime);
+  try {
+    validateRuntimeStartShape(parsed);
+  } catch (error) {
+    sendRuntimeStartResponse(context, parsed, {
+      success: false,
+      runtime: null,
+      agent: null,
+      conversation: null,
+      created: { agent: false, conversation: false },
+      error: getErrorMessage(error, "Failed to start runtime"),
+    });
+    return true;
+  }
+
+  const serializationKey = getRuntimeStartSerializationKey(parsed);
+  const run = async () => {
+    await runRuntimeStartCommand(parsed, context);
+  };
+  if (serializationKey) {
+    await enqueueRuntimeStartForScope(context.runtime, serializationKey, run);
+  } else {
+    await run();
+  }
+  return true;
+}
+
+async function runRuntimeStartCommand(
+  parsed: RuntimeStartCommand,
+  context: RuntimeStartCommandContext,
+): Promise<void> {
   const created = { agent: false, conversation: false };
   let agent: AgentState | null = null;
   let conversation: Conversation | null = null;
@@ -487,7 +492,6 @@ export async function handleRuntimeStartCommand(
   let shouldReplayState = false;
 
   try {
-    validateRuntimeStartShape(parsed);
     agent = await resolveRuntimeStartAgent(parsed, created);
     conversation = await resolveRuntimeStartConversation(
       parsed,
@@ -499,44 +503,10 @@ export async function handleRuntimeStartCommand(
     );
     runtimeScope = buildRuntimeScope(agent, conversation);
     const { connectionId } = context;
-    if (
-      !markLatestRuntimeStartRequest(
-        context.runtime,
-        connectionId,
-        runtimeScope,
-        generation,
-      )
-    ) {
-      sendSupersededRuntimeStartResponse(
-        context,
-        parsed,
-        agent,
-        conversation,
-        created,
-      );
-      return true;
-    }
     conversation = await applyRuntimeStartConversationSourceTags(
       parsed,
       conversation,
     );
-    if (
-      !isLatestRuntimeStartRequest(
-        context.runtime,
-        connectionId,
-        runtimeScope,
-        generation,
-      )
-    ) {
-      sendSupersededRuntimeStartResponse(
-        context,
-        parsed,
-        agent,
-        conversation,
-        created,
-      );
-      return true;
-    }
     const assertConnectionOpen = () => {
       if (
         context.runtime.connections.size > 0 &&
@@ -554,23 +524,6 @@ export async function handleRuntimeStartCommand(
       runtimeScope.conversation_id,
     );
     await applyRuntimeStartState(parsed, context, runtimeScope, scopedRuntime);
-    if (
-      !isLatestRuntimeStartRequest(
-        context.runtime,
-        connectionId,
-        runtimeScope,
-        generation,
-      )
-    ) {
-      sendSupersededRuntimeStartResponse(
-        context,
-        parsed,
-        agent,
-        conversation,
-        created,
-      );
-      return true;
-    }
     assertConnectionOpen();
     subscribeListenerConnection(context.runtime, connectionId, runtimeScope);
     registerRuntimeExternalTools(
@@ -581,23 +534,6 @@ export async function handleRuntimeStartCommand(
     );
 
     if (parsed.wait_for_replay) {
-      if (
-        !isLatestRuntimeStartRequest(
-          context.runtime,
-          connectionId,
-          runtimeScope,
-          generation,
-        )
-      ) {
-        sendSupersededRuntimeStartResponse(
-          context,
-          parsed,
-          agent,
-          conversation,
-          created,
-        );
-        return true;
-      }
       await context.replaySyncStateForRuntime(
         context.runtime,
         context.socket,
@@ -607,23 +543,6 @@ export async function handleRuntimeStartCommand(
           forceDeviceStatus: parsed.force_device_status !== false,
         },
       );
-      if (
-        !isLatestRuntimeStartRequest(
-          context.runtime,
-          connectionId,
-          runtimeScope,
-          generation,
-        )
-      ) {
-        sendSupersededRuntimeStartResponse(
-          context,
-          parsed,
-          agent,
-          conversation,
-          created,
-        );
-        return true;
-      }
     }
     const sent = sendRuntimeStartResponse(context, parsed, {
       success: true,
@@ -644,16 +563,7 @@ export async function handleRuntimeStartCommand(
     });
   }
 
-  if (
-    shouldReplayState &&
-    runtimeScope &&
-    isLatestRuntimeStartRequest(
-      context.runtime,
-      context.connectionId,
-      runtimeScope,
-      generation,
-    )
-  ) {
+  if (shouldReplayState && runtimeScope) {
     await context.replaySyncStateForRuntime(
       context.runtime,
       context.socket,
@@ -664,8 +574,6 @@ export async function handleRuntimeStartCommand(
       },
     );
   }
-
-  return true;
 }
 
 export function handleRuntimeStartProtocolCommand(

--- a/src/websocket/listener/commands/runtime-start.ts
+++ b/src/websocket/listener/commands/runtime-start.ts
@@ -28,6 +28,7 @@ import {
   persistPermissionModeMapForRuntime,
 } from "@/websocket/listener/permission-mode";
 import { isRuntimeStartCommand } from "@/websocket/listener/protocol-inbound";
+import { getConversationRuntimeKey } from "@/websocket/listener/runtime";
 import { assertRuntimeWorkspaceSandboxChangeAllowed } from "@/websocket/listener/runtime-workspace-sandbox";
 import type {
   ConversationRuntime,
@@ -65,6 +66,66 @@ type CreatedResources = {
   agent: boolean;
   conversation: boolean;
 };
+
+type RuntimeStartGenerationState = {
+  nextGeneration: number;
+  latestByRuntime: Map<string, number>;
+};
+
+const runtimeStartGenerationByListener = new WeakMap<
+  ListenerRuntime,
+  RuntimeStartGenerationState
+>();
+
+function getRuntimeStartGenerationState(
+  runtime: ListenerRuntime,
+): RuntimeStartGenerationState {
+  let state = runtimeStartGenerationByListener.get(runtime);
+  if (!state) {
+    state = { nextGeneration: 0, latestByRuntime: new Map() };
+    runtimeStartGenerationByListener.set(runtime, state);
+  }
+  return state;
+}
+
+function beginRuntimeStartRequest(runtime: ListenerRuntime): number {
+  const state = getRuntimeStartGenerationState(runtime);
+  state.nextGeneration += 1;
+  return state.nextGeneration;
+}
+
+function getRuntimeStartGenerationKey(scope: RuntimeStartScope): string {
+  return getConversationRuntimeKey(scope.agent_id, scope.conversation_id);
+}
+
+function markLatestRuntimeStartRequest(
+  runtime: ListenerRuntime,
+  _connectionId: ListenerConnectionId,
+  scope: RuntimeStartScope,
+  generation: number,
+): boolean {
+  const state = getRuntimeStartGenerationState(runtime);
+  const key = getRuntimeStartGenerationKey(scope);
+  const latest = state.latestByRuntime.get(key) ?? 0;
+  if (generation < latest) {
+    return false;
+  }
+  state.latestByRuntime.set(key, generation);
+  return true;
+}
+
+function isLatestRuntimeStartRequest(
+  runtime: ListenerRuntime,
+  _connectionId: ListenerConnectionId,
+  scope: RuntimeStartScope,
+  generation: number,
+): boolean {
+  const state = getRuntimeStartGenerationState(runtime);
+  return (
+    state.latestByRuntime.get(getRuntimeStartGenerationKey(scope)) ===
+    generation
+  );
+}
 
 function buildDefaultConversation(agent: AgentState): Conversation {
   const now = new Date().toISOString();
@@ -121,6 +182,23 @@ function sendRuntimeStartResponse(
     "listener_runtime_start_send_failed",
     "listener_runtime_start",
   );
+}
+
+function sendSupersededRuntimeStartResponse(
+  context: RuntimeStartCommandContext,
+  parsed: RuntimeStartCommand,
+  agent: AgentState | null,
+  conversation: Conversation | null,
+  created: CreatedResources,
+): boolean {
+  return sendRuntimeStartResponse(context, parsed, {
+    success: false,
+    runtime: null,
+    agent,
+    conversation,
+    created,
+    error: "Superseded by a newer runtime_start request",
+  });
 }
 
 function validateRuntimeStartShape(parsed: RuntimeStartCommand): void {
@@ -401,6 +479,7 @@ export async function handleRuntimeStartCommand(
   parsed: RuntimeStartCommand,
   context: RuntimeStartCommandContext,
 ): Promise<boolean> {
+  const generation = beginRuntimeStartRequest(context.runtime);
   const created = { agent: false, conversation: false };
   let agent: AgentState | null = null;
   let conversation: Conversation | null = null;
@@ -418,12 +497,46 @@ export async function handleRuntimeStartCommand(
       context.retrieveConversation ??
         ((id) => getBackend().retrieveConversation(id)),
     );
+    runtimeScope = buildRuntimeScope(agent, conversation);
+    const { connectionId } = context;
+    if (
+      !markLatestRuntimeStartRequest(
+        context.runtime,
+        connectionId,
+        runtimeScope,
+        generation,
+      )
+    ) {
+      sendSupersededRuntimeStartResponse(
+        context,
+        parsed,
+        agent,
+        conversation,
+        created,
+      );
+      return true;
+    }
     conversation = await applyRuntimeStartConversationSourceTags(
       parsed,
       conversation,
     );
-    runtimeScope = buildRuntimeScope(agent, conversation);
-    const { connectionId } = context;
+    if (
+      !isLatestRuntimeStartRequest(
+        context.runtime,
+        connectionId,
+        runtimeScope,
+        generation,
+      )
+    ) {
+      sendSupersededRuntimeStartResponse(
+        context,
+        parsed,
+        agent,
+        conversation,
+        created,
+      );
+      return true;
+    }
     const assertConnectionOpen = () => {
       if (
         context.runtime.connections.size > 0 &&
@@ -441,6 +554,23 @@ export async function handleRuntimeStartCommand(
       runtimeScope.conversation_id,
     );
     await applyRuntimeStartState(parsed, context, runtimeScope, scopedRuntime);
+    if (
+      !isLatestRuntimeStartRequest(
+        context.runtime,
+        connectionId,
+        runtimeScope,
+        generation,
+      )
+    ) {
+      sendSupersededRuntimeStartResponse(
+        context,
+        parsed,
+        agent,
+        conversation,
+        created,
+      );
+      return true;
+    }
     assertConnectionOpen();
     subscribeListenerConnection(context.runtime, connectionId, runtimeScope);
     registerRuntimeExternalTools(
@@ -451,6 +581,23 @@ export async function handleRuntimeStartCommand(
     );
 
     if (parsed.wait_for_replay) {
+      if (
+        !isLatestRuntimeStartRequest(
+          context.runtime,
+          connectionId,
+          runtimeScope,
+          generation,
+        )
+      ) {
+        sendSupersededRuntimeStartResponse(
+          context,
+          parsed,
+          agent,
+          conversation,
+          created,
+        );
+        return true;
+      }
       await context.replaySyncStateForRuntime(
         context.runtime,
         context.socket,
@@ -460,6 +607,23 @@ export async function handleRuntimeStartCommand(
           forceDeviceStatus: parsed.force_device_status !== false,
         },
       );
+      if (
+        !isLatestRuntimeStartRequest(
+          context.runtime,
+          connectionId,
+          runtimeScope,
+          generation,
+        )
+      ) {
+        sendSupersededRuntimeStartResponse(
+          context,
+          parsed,
+          agent,
+          conversation,
+          created,
+        );
+        return true;
+      }
     }
     const sent = sendRuntimeStartResponse(context, parsed, {
       success: true,
@@ -480,7 +644,16 @@ export async function handleRuntimeStartCommand(
     });
   }
 
-  if (shouldReplayState && runtimeScope) {
+  if (
+    shouldReplayState &&
+    runtimeScope &&
+    isLatestRuntimeStartRequest(
+      context.runtime,
+      context.connectionId,
+      runtimeScope,
+      generation,
+    )
+  ) {
     await context.replaySyncStateForRuntime(
       context.runtime,
       context.socket,


### PR DESCRIPTION
## Summary
- LET-12217: serialize same-scope runtime_start handling before async resolution and mutation boundaries.
- Preserves concurrency for distinct conversation scopes while covering source tags, mode/cwd/sandbox/skill sources, external tools, subscription, replay, and response ordering.
- Cleans up per-scope queue entries after completion to avoid retained keys.

## Test plan
- [x] bun test src/websocket/listener/commands/runtime-start-skill-sources.test.ts
- [x] bun test src/websocket/listen-client-protocol.test.ts src/websocket/listener/protocol-inbound.test.ts src/websocket/listener/external-tools.test.ts
- [x] bun run check
- [ ] Human verification pending

## Metadata
- Ticket: LET-12217
- Origin: 01d328b1
- Conversation: https://chat.letta.com/chat/agent-a8cc2084-940f-4741-95c9-ace741b16c4e?conversation=conv-e54845da-0699-4f78-9096-0813f1fca390

## Draft status

Focused regression coverage and `bun run check` pass. The platform matrix currently falls back to the full suite because the impact planner reads an unavailable synthetic merge SHA, then hits pre-existing state leakage in `src/cli/subcommands/teleport.test.ts`. Human review and CI resolution remain before ready.

