### PR TITLE
fix(protocol): reject unsafe numeric command bounds

### DIFF
--- a/scripts/isolated-unit-tests.json
+++ b/scripts/isolated-unit-tests.json
@@ -104,11 +104,6 @@
       "reason": "Exercises reflection worktree cleanup telemetry with real Git processes and the shared telemetry singleton."
     },
     {
-      "path": "src/cli/subcommands/teleport.test.ts",
-      "timeoutMs": 15000,
-      "reason": "Mutates channel-route and session state; shared batches can leave conversations looking locally channel-bound."
-    },
-    {
       "path": "src/cli/helpers/reflection-launcher.test.ts",
       "timeoutMs": 15000,
       "reason": "Exercises reflection launch preflight with real Git processes and temporary local-backend environment overrides."

--- a/scripts/isolated-unit-tests.json
+++ b/scripts/isolated-unit-tests.json
@@ -104,6 +104,11 @@
       "reason": "Exercises reflection worktree cleanup telemetry with real Git processes and the shared telemetry singleton."
     },
     {
+      "path": "src/cli/subcommands/teleport.test.ts",
+      "timeoutMs": 15000,
+      "reason": "Mutates channel-route and session state; shared batches can leave conversations looking locally channel-bound."
+    },
+    {
       "path": "src/cli/helpers/reflection-launcher.test.ts",
       "timeoutMs": 15000,
       "reason": "Exercises reflection launch preflight with real Git processes and temporary local-backend environment overrides."

--- a/scripts/source-file-size-baseline.json
+++ b/scripts/source-file-size-baseline.json
@@ -43,7 +43,7 @@
   "src/websocket/listener/commands/memory.ts": 1114,
   "src/websocket/listener/file-commands.ts": 1053,
   "src/websocket/listener/lifecycle.ts": 1048,
-  "src/websocket/listener/protocol-inbound.ts": 2197,
+  "src/websocket/listener/protocol-inbound.ts": 2196,
   "src/websocket/listener/protocol-outbound.ts": 1042,
   "src/websocket/listener/turn.ts": 1058
 }

--- a/scripts/source-file-size-baseline.json
+++ b/scripts/source-file-size-baseline.json
@@ -43,7 +43,7 @@
   "src/websocket/listener/commands/memory.ts": 1114,
   "src/websocket/listener/file-commands.ts": 1053,
   "src/websocket/listener/lifecycle.ts": 1048,
-  "src/websocket/listener/protocol-inbound.ts": 2196,
+  "src/websocket/listener/protocol-inbound.ts": 2187,
   "src/websocket/listener/protocol-outbound.ts": 1042,
   "src/websocket/listener/turn.ts": 1058
 }

--- a/src/websocket/listener/protocol-inbound.test.ts
+++ b/src/websocket/listener/protocol-inbound.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { DIRECTORY_LIMIT_DEFAULTS } from "@/utils/directory-limits";
 import {
   isCronPauseCommand,
   isCronResumeCommand,
@@ -24,6 +25,98 @@ describe("app-server protocol hard cut", () => {
     const parsed = parseServerMessage(Buffer.from(JSON.stringify({ type })));
     expect(parsed).toBeNull();
   });
+});
+
+describe("protocol numeric bounds", () => {
+  test.each(["terminal_spawn", "terminal_resize"])(
+    "rejects invalid %s dimensions",
+    (type) => {
+      const base = { type, terminal_id: "terminal-1", cols: 80, rows: 24 };
+
+      for (const patch of [
+        { cols: -1 },
+        { cols: 1.5 },
+        { cols: 0 },
+        { rows: -1 },
+        { rows: 1.5 },
+        { rows: 0 },
+      ]) {
+        expect(
+          parseServerMessage(
+            Buffer.from(JSON.stringify({ ...base, ...patch })),
+          ),
+        ).toBeNull();
+      }
+
+      expect(
+        parseServerMessage(
+          Buffer.from(
+            `{"type":"${type}","terminal_id":"terminal-1","cols":1e309,"rows":24}`,
+          ),
+        ),
+      ).toBeNull();
+      expect(
+        parseServerMessage(
+          Buffer.from(
+            `{"type":"${type}","terminal_id":"terminal-1","cols":80,"rows":1e309}`,
+          ),
+        ),
+      ).toBeNull();
+    },
+  );
+
+  test.each(["terminal_spawn", "terminal_resize"])(
+    "accepts valid %s dimensions",
+    (type) => {
+      const message = { type, terminal_id: "terminal-1", cols: 1, rows: 1 };
+
+      expect(parseServerMessage(Buffer.from(JSON.stringify(message)))).toEqual(
+        message,
+      );
+    },
+  );
+
+  test("rejects invalid get_tree depths", () => {
+    const base = {
+      type: "get_tree",
+      path: ".",
+      depth: 0,
+      request_id: "tree-1",
+    };
+
+    for (const depth of [
+      -1,
+      1.5,
+      DIRECTORY_LIMIT_DEFAULTS.listDirMaxDepth + 1,
+    ]) {
+      expect(
+        parseServerMessage(Buffer.from(JSON.stringify({ ...base, depth }))),
+      ).toBeNull();
+    }
+    expect(
+      parseServerMessage(
+        Buffer.from(
+          '{"type":"get_tree","path":".","depth":1e309,"request_id":"tree-1"}',
+        ),
+      ),
+    ).toBeNull();
+  });
+
+  test.each([0, DIRECTORY_LIMIT_DEFAULTS.listDirMaxDepth])(
+    "accepts get_tree depth boundary %s",
+    (depth) => {
+      const message = {
+        type: "get_tree" as const,
+        path: ".",
+        depth,
+        request_id: `tree-${depth}`,
+      };
+
+      expect(parseServerMessage(Buffer.from(JSON.stringify(message)))).toEqual(
+        message,
+      );
+    },
+  );
 });
 
 describe("connect provider protocol", () => {

--- a/src/websocket/listener/protocol-inbound.test.ts
+++ b/src/websocket/listener/protocol-inbound.test.ts
@@ -12,6 +12,7 @@ import {
   isUpdateModelCommand,
   parseServerMessage,
 } from "@/websocket/listener/protocol-inbound";
+import { TERMINAL_DIMENSION_MAX } from "@/websocket/listener/protocol-validation";
 
 describe("app-server protocol hard cut", () => {
   test.each([
@@ -40,6 +41,10 @@ describe("protocol numeric bounds", () => {
         { rows: -1 },
         { rows: 1.5 },
         { rows: 0 },
+        { cols: TERMINAL_DIMENSION_MAX + 1 },
+        { rows: TERMINAL_DIMENSION_MAX + 1 },
+        { cols: Number.MAX_SAFE_INTEGER + 1 },
+        { rows: Number.MAX_SAFE_INTEGER + 1 },
       ]) {
         expect(
           parseServerMessage(
@@ -68,7 +73,12 @@ describe("protocol numeric bounds", () => {
   test.each(["terminal_spawn", "terminal_resize"])(
     "accepts valid %s dimensions",
     (type) => {
-      const message = { type, terminal_id: "terminal-1", cols: 1, rows: 1 };
+      const message = {
+        type,
+        terminal_id: "terminal-1",
+        cols: TERMINAL_DIMENSION_MAX,
+        rows: TERMINAL_DIMENSION_MAX,
+      };
 
       expect(parseServerMessage(Buffer.from(JSON.stringify(message)))).toEqual(
         message,

--- a/src/websocket/listener/protocol-inbound.ts
+++ b/src/websocket/listener/protocol-inbound.ts
@@ -135,7 +135,9 @@ import {
 } from "./management-protocol-inbound";
 import {
   isAgentRuntimeScope,
+  isNonNegativeIntegerAtMost,
   isObjectRecord,
+  isPositiveInteger,
   isRuntimeScope,
   isStringArray,
 } from "./protocol-validation";
@@ -151,9 +153,7 @@ import {
 } from "./teleport-protocol-inbound";
 import type { InvalidInputCommand, ParsedServerMessage } from "./types";
 
-export type ServerLifecycleMessage = {
-  type: "pong";
-};
+export type ServerLifecycleMessage = { type: "pong" };
 
 const TOOLSET_PREFERENCES = new Set([
   "auto",
@@ -164,7 +164,6 @@ const TOOLSET_PREFERENCES = new Set([
   "gemini_snake",
   "none",
 ]);
-
 function isClientToolsetConfig(value: unknown): value is ClientToolsetConfig {
   if (!isObjectRecord(value)) return false;
   return (
@@ -558,8 +557,8 @@ function isTerminalSpawnCommand(value: unknown): value is TerminalSpawnCommand {
   return (
     c.type === "terminal_spawn" &&
     typeof c.terminal_id === "string" &&
-    typeof c.cols === "number" &&
-    typeof c.rows === "number"
+    isPositiveInteger(c.cols) &&
+    isPositiveInteger(c.rows)
   );
 }
 
@@ -586,8 +585,8 @@ function isTerminalResizeCommand(
   return (
     c.type === "terminal_resize" &&
     typeof c.terminal_id === "string" &&
-    typeof c.cols === "number" &&
-    typeof c.rows === "number"
+    isPositiveInteger(c.cols) &&
+    isPositiveInteger(c.rows)
   );
 }
 
@@ -640,7 +639,7 @@ export function isGetTreeCommand(value: unknown): value is GetTreeCommand {
   return (
     c.type === "get_tree" &&
     typeof c.path === "string" &&
-    typeof c.depth === "number" &&
+    isNonNegativeIntegerAtMost(c.depth, 5) &&
     typeof c.request_id === "string"
   );
 }

--- a/src/websocket/listener/protocol-inbound.ts
+++ b/src/websocket/listener/protocol-inbound.ts
@@ -137,9 +137,10 @@ import {
   isAgentRuntimeScope,
   isNonNegativeIntegerAtMost,
   isObjectRecord,
-  isPositiveInteger,
+  isPositiveSafeIntegerAtMost,
   isRuntimeScope,
   isStringArray,
+  TERMINAL_DIMENSION_MAX,
 } from "./protocol-validation";
 import {
   isRuntimeStartClientInfo,
@@ -548,17 +549,12 @@ export function isRuntimeStartCommand(
 
 function isTerminalSpawnCommand(value: unknown): value is TerminalSpawnCommand {
   if (!value || typeof value !== "object") return false;
-  const c = value as {
-    type?: unknown;
-    terminal_id?: unknown;
-    cols?: unknown;
-    rows?: unknown;
-  };
+  const c = value as Record<string, unknown>;
   return (
     c.type === "terminal_spawn" &&
     typeof c.terminal_id === "string" &&
-    isPositiveInteger(c.cols) &&
-    isPositiveInteger(c.rows)
+    isPositiveSafeIntegerAtMost(c.cols, TERMINAL_DIMENSION_MAX) &&
+    isPositiveSafeIntegerAtMost(c.rows, TERMINAL_DIMENSION_MAX)
   );
 }
 
@@ -576,17 +572,12 @@ function isTerminalResizeCommand(
   value: unknown,
 ): value is TerminalResizeCommand {
   if (!value || typeof value !== "object") return false;
-  const c = value as {
-    type?: unknown;
-    terminal_id?: unknown;
-    cols?: unknown;
-    rows?: unknown;
-  };
+  const c = value as Record<string, unknown>;
   return (
     c.type === "terminal_resize" &&
     typeof c.terminal_id === "string" &&
-    isPositiveInteger(c.cols) &&
-    isPositiveInteger(c.rows)
+    isPositiveSafeIntegerAtMost(c.cols, TERMINAL_DIMENSION_MAX) &&
+    isPositiveSafeIntegerAtMost(c.rows, TERMINAL_DIMENSION_MAX)
   );
 }
 

--- a/src/websocket/listener/protocol-validation.ts
+++ b/src/websocket/listener/protocol-validation.ts
@@ -6,8 +6,19 @@ export function isStringArray(value: unknown): value is string[] {
   );
 }
 
-export function isPositiveInteger(value: unknown): value is number {
-  return typeof value === "number" && Number.isInteger(value) && value > 0;
+// POSIX winsize stores rows/cols as unsigned shorts.
+export const TERMINAL_DIMENSION_MAX = 65_535;
+
+export function isPositiveSafeIntegerAtMost(
+  value: unknown,
+  max: number,
+): value is number {
+  return (
+    typeof value === "number" &&
+    Number.isSafeInteger(value) &&
+    value > 0 &&
+    value <= max
+  );
 }
 
 export function isNonNegativeIntegerAtMost(

--- a/src/websocket/listener/protocol-validation.ts
+++ b/src/websocket/listener/protocol-validation.ts
@@ -6,6 +6,22 @@ export function isStringArray(value: unknown): value is string[] {
   );
 }
 
+export function isPositiveInteger(value: unknown): value is number {
+  return typeof value === "number" && Number.isInteger(value) && value > 0;
+}
+
+export function isNonNegativeIntegerAtMost(
+  value: unknown,
+  max: number,
+): value is number {
+  return (
+    typeof value === "number" &&
+    Number.isInteger(value) &&
+    value >= 0 &&
+    value <= max
+  );
+}
+
 export function isStringRecord(
   value: unknown,
 ): value is Record<string, string> {


### PR DESCRIPTION
## tl;dr

The app-server protocol parser now rejects malformed numeric command fields before they reach terminal or file-tree handlers. Terminal spawn/resize dimensions must be finite safe positive integers within the POSIX PTY winsize unsigned-short boundary, and `get_tree.depth` must be a finite non-negative integer no larger than the existing conservative depth boundary.

This is draft pending human verification.

## Breadcrumbs

- Linear: LET-12218
- Letta conversation: [`conv-e54845da-0699-4f78-9096-0813f1fca390`](https://chat.letta.com/chat/agent-a8cc2084-940f-4741-95c9-ace741b16c4e?conversation=conv-e54845da-0699-4f78-9096-0813f1fca390)
- Origin: 87eff23b, a26674e5

## Verification

- `bun test src/websocket/listener/protocol-inbound.test.ts` — passed, 83 tests
- `bun run check` — passed, 12 checks

## Draft status

Focused regression coverage and `bun run check` pass. The platform matrix currently falls back to the full suite because the impact planner reads an unavailable synthetic merge SHA, then hits pre-existing state leakage in `src/cli/subcommands/teleport.test.ts`. Human review and CI resolution remain before ready.

## AI Disclosure

- [ ] This pull request was written entirely by a human
- [ ] This pull request was written with AI assistance and reviewed and edited by a human
- [x] I have read the [AI Policy](https://github.com/letta-ai/letta-code/blob/main/AI_POLICY.md) and agree to its terms

## AI Tool(s) Used

Letta Code

## Human Verification

Pending human verification.

