### PR TITLE
test(teleport): isolate channel route state

### DIFF
--- a/src/cli/subcommands/teleport.test.ts
+++ b/src/cli/subcommands/teleport.test.ts
@@ -1,7 +1,12 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import type { apiRequest } from "@/backend/api/request";
 import { ApiRequestError } from "@/backend/api/request";
-import { __testOverrideLoadRoutes, loadRoutes } from "@/channels/routing";
+import { getSupportedChannelIds } from "@/channels/plugin-registry";
+import {
+  __testOverrideLoadRoutes,
+  clearAllRoutes,
+  loadRoutes,
+} from "@/channels/routing";
 import {
   formatTeleportApiError,
   resolveTeleportSession,
@@ -12,6 +17,14 @@ const CLOUD_ENV = {
   LETTA_AGENT_ID: "agent-1",
   LETTA_CONVERSATION_ID: "conv-1",
 };
+
+function resetTeleportRouteState(): void {
+  __testOverrideLoadRoutes(() => []);
+  for (const channelId of getSupportedChannelIds()) {
+    loadRoutes(channelId);
+  }
+  clearAllRoutes();
+}
 
 async function withEnvironment<T>(
   values: Record<string, string | undefined>,
@@ -59,6 +72,15 @@ function captureOutput(): {
 }
 
 describe("teleport subcommand", () => {
+  beforeEach(() => {
+    resetTeleportRouteState();
+  });
+
+  afterEach(() => {
+    resetTeleportRouteState();
+    __testOverrideLoadRoutes(null);
+  });
+
   test("prints help and returns 0", async () => {
     const out = captureOutput();
     try {


### PR DESCRIPTION
## Summary

- Fixes LET-12238 by resetting shared channel route state before and after every teleport subcommand test.
- Keeps the production teleport route guard unchanged; this only makes the test file deterministic against stale Slack/Telegram route state.
- Origin: https://github.com/letta-ai/letta-code/pull/4223 / e0739382
- Generating conversation: https://chat.letta.com/chat/agent-a8cc2084-940f-4741-95c9-ace741b16c4e?conversation=conv-e54845da-0699-4f78-9096-0813f1fca390

## Verification

- [x] `bun test src/cli/subcommands/teleport.test.ts` — pass
- [x] `bun test src/channels/registry-command-routing.test.ts src/cli/subcommands/teleport.test.ts` — pass
- [x] `bun run check` — pass
- [ ] `bun run scripts/run-unit-tests.cjs` — local run still has unrelated existing/environment failures outside teleport: pinned agents base URL scoping, list_dir relative path temp cleanup, node-pty spawn, and show_config Python execution

## AI Disclosure

- [ ] This pull request was written entirely by a human
- [x] This pull request was written with AI assistance and reviewed and edited by a human
- [x] I have read the [AI Policy](https://github.com/letta-ai/letta-code/blob/main/AI_POLICY.md) and agree to its terms

## AI Tool(s) Used

Letta Code

## Human Verification

Pending human verification.