### PR TITLE
fix(terminal): flush final PTY output before exit

### DIFF
--- a/src/websocket/terminal-handler.test.ts
+++ b/src/websocket/terminal-handler.test.ts
@@ -37,47 +37,50 @@ describe("makeOutputBatcher", () => {
     expect(flushed).toEqual(["tail output"]);
   });
 
-  test("Bun emits buffered PTY output before terminal exit", async () => {
-    const messages: Array<Record<string, unknown>> = [];
-    const socket = {
-      readyState: WebSocket.OPEN,
-      send: (raw: string) => messages.push(JSON.parse(raw)),
-    } as unknown as WebSocket;
-    const terminalId = "bun-exit-order";
-    const connectionId = "terminal-handler-test";
+  test.skipIf(process.platform === "win32")(
+    "Bun emits buffered PTY output before terminal exit",
+    async () => {
+      const messages: Array<Record<string, unknown>> = [];
+      const socket = {
+        readyState: WebSocket.OPEN,
+        send: (raw: string) => messages.push(JSON.parse(raw)),
+      } as unknown as WebSocket;
+      const terminalId = "bun-exit-order";
+      const connectionId = "terminal-handler-test";
 
-    handleTerminalSpawn(
-      { terminal_id: terminalId, cols: 80, rows: 24 },
-      socket,
-      process.cwd(),
-      connectionId,
-    );
-    await waitFor(() =>
-      messages.some(({ type }) => type === "terminal_spawned"),
-    );
-    handleTerminalInput(
-      { terminal_id: terminalId, data: "printf '__FINAL_TAIL__'; exit\n" },
-      connectionId,
-    );
-    await waitFor(() =>
-      messages.some(({ type }) => type === "terminal_exited"),
-    );
+      handleTerminalSpawn(
+        { terminal_id: terminalId, cols: 80, rows: 24 },
+        socket,
+        process.cwd(),
+        connectionId,
+      );
+      await waitFor(() =>
+        messages.some(({ type }) => type === "terminal_spawned"),
+      );
+      handleTerminalInput(
+        { terminal_id: terminalId, data: "printf '__FINAL_TAIL__'; exit\n" },
+        connectionId,
+      );
+      await waitFor(() =>
+        messages.some(({ type }) => type === "terminal_exited"),
+      );
 
-    const exitIndex = messages.findIndex(
-      ({ type }) => type === "terminal_exited",
-    );
-    const outputBeforeExit = messages
-      .slice(0, exitIndex)
-      .filter(({ type }) => type === "terminal_output")
-      .map(({ data }) => String(data))
-      .join("");
-    expect(outputBeforeExit).toContain("__FINAL_TAIL__");
-    expect(
-      messages
-        .slice(exitIndex + 1)
-        .some(({ type }) => type === "terminal_output"),
-    ).toBe(false);
-  });
+      const exitIndex = messages.findIndex(
+        ({ type }) => type === "terminal_exited",
+      );
+      const outputBeforeExit = messages
+        .slice(0, exitIndex)
+        .filter(({ type }) => type === "terminal_output")
+        .map(({ data }) => String(data))
+        .join("");
+      expect(outputBeforeExit).toContain("__FINAL_TAIL__");
+      expect(
+        messages
+          .slice(exitIndex + 1)
+          .some(({ type }) => type === "terminal_output"),
+      ).toBe(false);
+    },
+  );
 
   test("lets terminal exit follow the final output", () => {
     const messages: string[] = [];

--- a/src/websocket/terminal-handler.test.ts
+++ b/src/websocket/terminal-handler.test.ts
@@ -1,5 +1,25 @@
-import { describe, expect, test } from "bun:test";
-import { makeOutputBatcher } from "./terminal-handler";
+import { afterEach, describe, expect, test } from "bun:test";
+import WebSocket from "ws";
+import {
+  handleTerminalInput,
+  handleTerminalSpawn,
+  killAllTerminals,
+  makeOutputBatcher,
+} from "./terminal-handler";
+
+afterEach(() => killAllTerminals());
+
+async function waitFor(
+  predicate: () => boolean,
+  timeoutMs = 5_000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!predicate()) {
+    if (Date.now() >= deadline)
+      throw new Error("timed out waiting for terminal");
+    await Bun.sleep(10);
+  }
+}
 
 describe("makeOutputBatcher", () => {
   test("flushes buffered output synchronously and only once", async () => {
@@ -15,6 +35,48 @@ describe("makeOutputBatcher", () => {
 
     await Bun.sleep(25);
     expect(flushed).toEqual(["tail output"]);
+  });
+
+  test("Bun emits buffered PTY output before terminal exit", async () => {
+    const messages: Array<Record<string, unknown>> = [];
+    const socket = {
+      readyState: WebSocket.OPEN,
+      send: (raw: string) => messages.push(JSON.parse(raw)),
+    } as unknown as WebSocket;
+    const terminalId = "bun-exit-order";
+    const connectionId = "terminal-handler-test";
+
+    handleTerminalSpawn(
+      { terminal_id: terminalId, cols: 80, rows: 24 },
+      socket,
+      process.cwd(),
+      connectionId,
+    );
+    await waitFor(() =>
+      messages.some(({ type }) => type === "terminal_spawned"),
+    );
+    handleTerminalInput(
+      { terminal_id: terminalId, data: "printf '__FINAL_TAIL__'; exit\n" },
+      connectionId,
+    );
+    await waitFor(() =>
+      messages.some(({ type }) => type === "terminal_exited"),
+    );
+
+    const exitIndex = messages.findIndex(
+      ({ type }) => type === "terminal_exited",
+    );
+    const outputBeforeExit = messages
+      .slice(0, exitIndex)
+      .filter(({ type }) => type === "terminal_output")
+      .map(({ data }) => String(data))
+      .join("");
+    expect(outputBeforeExit).toContain("__FINAL_TAIL__");
+    expect(
+      messages
+        .slice(exitIndex + 1)
+        .some(({ type }) => type === "terminal_output"),
+    ).toBe(false);
   });
 
   test("lets terminal exit follow the final output", () => {

--- a/src/websocket/terminal-handler.test.ts
+++ b/src/websocket/terminal-handler.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "bun:test";
+import { makeOutputBatcher } from "./terminal-handler";
+
+describe("makeOutputBatcher", () => {
+  test("flushes buffered output synchronously and only once", async () => {
+    const flushed: string[] = [];
+    const batcher = makeOutputBatcher((data) => flushed.push(data));
+
+    batcher.push("tail ");
+    batcher.push("output");
+    batcher.flush();
+    batcher.flush();
+
+    expect(flushed).toEqual(["tail output"]);
+
+    await Bun.sleep(25);
+    expect(flushed).toEqual(["tail output"]);
+  });
+
+  test("lets terminal exit follow the final output", () => {
+    const messages: string[] = [];
+    const batcher = makeOutputBatcher(() => messages.push("terminal_output"));
+
+    batcher.push("tail");
+    batcher.flush();
+    messages.push("terminal_exited");
+
+    expect(messages).toEqual(["terminal_output", "terminal_exited"]);
+  });
+});

--- a/src/websocket/terminal-handler.ts
+++ b/src/websocket/terminal-handler.ts
@@ -134,6 +134,10 @@ function spawnBun(
   const outputBatcher = makeOutputBatcher((data) =>
     sendTerminalMessage(socket, { type: "terminal_output", terminal_id, data }),
   );
+  let markTerminalClosed: (() => void) | undefined;
+  const terminalClosed = new Promise<void>((resolve) => {
+    markTerminalClosed = resolve;
+  });
 
   const proc = Bun.spawn([shell], {
     cwd,
@@ -143,6 +147,9 @@ function spawnBun(
       rows: rows || 24,
       data: (_t: unknown, chunk: Uint8Array) =>
         outputBatcher.push(new TextDecoder().decode(chunk)),
+      // Bun's process exit and PTY EOF are separate lifecycle events. Waiting
+      // for both keeps the exit notification behind every data callback.
+      exit: () => markTerminalClosed?.(),
     },
   });
 
@@ -160,7 +167,7 @@ function spawnBun(
     throw new Error("Bun.spawn terminal object missing — API unavailable");
   }
 
-  proc.exited.then((exitCode) => {
+  Promise.all([proc.exited, terminalClosed]).then(([exitCode]) => {
     const current = terminals.get(terminalKey);
     if (current && current.pid === proc.pid) {
       outputBatcher.flush();

--- a/src/websocket/terminal-handler.ts
+++ b/src/websocket/terminal-handler.ts
@@ -92,9 +92,7 @@ function sendTerminalMessage(
 }
 
 /** Create a flush-on-size-or-timer output batcher. */
-function makeOutputBatcher(
-  onFlush: (data: string) => void,
-): (chunk: string) => void {
+export function makeOutputBatcher(onFlush: (data: string) => void) {
   let buffer = "";
   let timer: ReturnType<typeof setTimeout> | null = null;
 
@@ -109,7 +107,7 @@ function makeOutputBatcher(
     }
   };
 
-  return (chunk: string) => {
+  const push = (chunk: string) => {
     buffer += chunk;
     if (buffer.length >= MAX_BUFFER_BYTES) {
       flush();
@@ -117,6 +115,8 @@ function makeOutputBatcher(
       timer = setTimeout(flush, FLUSH_INTERVAL_MS);
     }
   };
+
+  return { push, flush };
 }
 
 // ── Bun spawn ──────────────────────────────────────────────────────────────
@@ -131,7 +131,7 @@ function spawnBun(
   socket: WebSocket,
 ): TerminalSession {
   const terminalKey = getTerminalKey(connectionId, terminal_id);
-  const handleData = makeOutputBatcher((data) =>
+  const outputBatcher = makeOutputBatcher((data) =>
     sendTerminalMessage(socket, { type: "terminal_output", terminal_id, data }),
   );
 
@@ -142,7 +142,7 @@ function spawnBun(
       cols: cols || 80,
       rows: rows || 24,
       data: (_t: unknown, chunk: Uint8Array) =>
-        handleData(new TextDecoder().decode(chunk)),
+        outputBatcher.push(new TextDecoder().decode(chunk)),
     },
   });
 
@@ -163,6 +163,7 @@ function spawnBun(
   proc.exited.then((exitCode) => {
     const current = terminals.get(terminalKey);
     if (current && current.pid === proc.pid) {
+      outputBatcher.flush();
       terminals.delete(terminalKey);
       sendTerminalMessage(socket, {
         type: "terminal_exited",
@@ -213,7 +214,7 @@ function spawnNodePty(
   // eslint-disable-next-line @typescript-eslint/no-require-imports
   const pty = require("node-pty") as NodePtyModule;
 
-  const handleData = makeOutputBatcher((data) =>
+  const outputBatcher = makeOutputBatcher((data) =>
     sendTerminalMessage(socket, { type: "terminal_output", terminal_id, data }),
   );
 
@@ -229,11 +230,12 @@ function spawnNodePty(
     },
   });
 
-  ptyProcess.onData(handleData);
+  ptyProcess.onData(outputBatcher.push);
 
   ptyProcess.onExit(({ exitCode }: NodePtyExitEvent) => {
     const current = terminals.get(terminalKey);
     if (current && current.pid === ptyProcess.pid) {
+      outputBatcher.flush();
       terminals.delete(terminalKey);
       sendTerminalMessage(socket, {
         type: "terminal_exited",


### PR DESCRIPTION
## Summary

Terminal output is buffered for up to one batch interval, but both the node-pty and Bun exit paths currently emit `terminal_exited` without flushing that buffer. Fast commands can therefore lose their final output or deliver it after the exit notification.

This change gives the output batcher an explicit idempotent `flush`, calls it before emitting exit, and makes the Bun path wait for both process exit and PTY EOF so every data callback settles first. Tests cover synchronous one-time flushing, output-before-exit ordering, and a real Bun PTY process. The POSIX-specific PTY smoke is skipped on Windows.

## Verification

- exact Bun 1.3.14 and Node 22.19
- `bun run check`: 12/12 checks passed
- `bun run build`: passed
- native `node-pty` rebuilt for Node 22.19 and loaded successfully
- built Node-target smoke using real `node-pty`: final marker appeared before `terminal_exited`, with no later output

## AI Disclosure

- [ ] This pull request was written entirely by a human
- [x] This pull request was written with AI assistance and reviewed and edited by a human
- [x] I have read the [AI Policy](https://github.com/letta-ai/letta-code/blob/main/AI_POLICY.md) and agree to its terms

## AI Tool(s) Used

OpenAI Codex was used to inspect the relevant code and repository history, assist with the implementation and regression tests, run the verification plan, and review the final patch. The submitter reviewed and understands the resulting changes.

## Human Verification

I have reviewed and understand every change in this pull request and take responsibility for its correctness.
