### PR TITLE
fix(mcp): fall back to legacy HTTP+SSE for http-configured servers

### DIFF
--- a/src/mcp-client.test.ts
+++ b/src/mcp-client.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test } from "bun:test";
+import * as http from "node:http";
+import type { AddressInfo } from "node:net";
 import { fileURLToPath } from "node:url";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { SSEServerTransport } from "@modelcontextprotocol/sdk/server/sse.js";
+import { z } from "zod";
 import { connectMcpServer, connectStdioMcpServer } from "@/mcp-client";
 
 const EVERYTHING_SERVER = fileURLToPath(
@@ -76,5 +81,89 @@ describe("client-side MCP", () => {
         command: "/nonexistent/mcp-server",
       }),
     ).rejects.toThrow();
+  });
+
+  test("falls back to legacy HTTP+SSE when an http-configured server only speaks SSE", async () => {
+    const mcp = new McpServer({ name: "legacy-sse", version: "1.0.0" });
+    mcp.registerTool(
+      "echo",
+      {
+        description: "Echo a message",
+        inputSchema: { message: z.string() },
+      },
+      async ({ message }) => ({
+        content: [{ type: "text" as const, text: `Echo: ${message}` }],
+      }),
+    );
+
+    const transports = new Map<string, SSEServerTransport>();
+    const httpServer = http.createServer((req, res) => {
+      if (req.method === "GET" && req.url === "/sse") {
+        const transport = new SSEServerTransport("/messages", res);
+        transports.set(transport.sessionId, transport);
+        mcp.connect(transport).catch(() => undefined);
+        return;
+      }
+      if (req.method === "POST" && req.url?.startsWith("/messages")) {
+        const sessionId = new URL(req.url, "http://localhost").searchParams.get(
+          "sessionId",
+        );
+        const transport = sessionId ? transports.get(sessionId) : undefined;
+        if (transport) {
+          transport.handlePostMessage(req, res).catch(() => undefined);
+          return;
+        }
+      }
+      // No streamable HTTP endpoint: answer every other method/url with 404,
+      // like a server that only speaks the legacy HTTP+SSE transport.
+      res.writeHead(404).end();
+    });
+    await new Promise<void>((resolve) =>
+      httpServer.listen(0, "127.0.0.1", resolve),
+    );
+    const { port } = httpServer.address() as AddressInfo;
+
+    const server = await connectMcpServer({
+      name: "legacy-sse",
+      transport: "http",
+      url: `http://127.0.0.1:${port}/sse`,
+    });
+
+    try {
+      expect(server.tools.map((tool) => tool.name)).toContain("echo");
+      const result = await server.callTool("echo", { message: "hello" });
+      expect(result.content).toEqual([{ type: "text", text: "Echo: hello" }]);
+    } finally {
+      await server.close();
+      await Promise.all(
+        [...transports.values()].map((transport) =>
+          transport.close().catch(() => undefined),
+        ),
+      );
+      await mcp.close().catch(() => undefined);
+      httpServer.close();
+    }
+  });
+
+  test("does not fall back to SSE for other streamable HTTP errors", async () => {
+    const httpServer = http.createServer((_req, res) => {
+      res.writeHead(500).end();
+    });
+    await new Promise<void>((resolve) =>
+      httpServer.listen(0, "127.0.0.1", resolve),
+    );
+    const { port } = httpServer.address() as AddressInfo;
+
+    try {
+      await expect(
+        connectMcpServer({
+          name: "broken",
+          transport: "http",
+          url: `http://127.0.0.1:${port}/sse`,
+        }),
+      ).rejects.toThrow("Error POSTing to endpoint");
+    } finally {
+      httpServer.close();
+    }
   });
 });

--- a/src/mcp-client.ts
+++ b/src/mcp-client.ts
@@ -8,7 +8,10 @@ import {
   getDefaultEnvironment,
   StdioClientTransport,
 } from "@modelcontextprotocol/sdk/client/stdio.js";
-import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import {
+  StreamableHTTPClientTransport,
+  StreamableHTTPError,
+} from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
 
 interface McpServerConfigBase {
@@ -104,19 +107,36 @@ export async function connectMcpServer(
       await client.connect(transport);
     } catch (error) {
       if (
+        config.transport === "http" &&
+        error instanceof StreamableHTTPError &&
+        (error.code === 404 || error.code === 405)
+      ) {
+        // MCP backwards compatibility: a server that only speaks the legacy
+        // HTTP+SSE transport answers POSTs to the streamable endpoint with
+        // 404/405. Fall back to SSE, as the MCP spec describes.
+        await client
+          .close()
+          .catch(() => transport.close().catch(() => undefined));
+        client = new Client(options.clientInfo ?? DEFAULT_CLIENT_INFO);
+        await client.connect(
+          createTransport({ ...config, transport: "sse" }, options),
+        );
+      } else if (
         !(error instanceof UnauthorizedError) ||
         !options.oauth?.waitForAuthorizationCode ||
         !supportsOAuthCompletion(transport)
       ) {
         throw error;
+      } else {
+        const authorizationCode =
+          await options.oauth.waitForAuthorizationCode();
+        await transport.finishAuth(authorizationCode);
+        await client
+          .close()
+          .catch(() => transport.close().catch(() => undefined));
+        client = new Client(options.clientInfo ?? DEFAULT_CLIENT_INFO);
+        await client.connect(createTransport(config, options));
       }
-      const authorizationCode = await options.oauth.waitForAuthorizationCode();
-      await transport.finishAuth(authorizationCode);
-      await client
-        .close()
-        .catch(() => transport.close().catch(() => undefined));
-      client = new Client(options.clientInfo ?? DEFAULT_CLIENT_INFO);
-      await client.connect(createTransport(config, options));
     }
     await options.oauth?.close();
     const response = await client.listTools();


### PR DESCRIPTION
## Summary

- `connectMcpServer` now retries with the SSE transport when an `http`-configured MCP server answers the streamable-endpoint POST with 404/405, per the MCP spec's backwards-compatibility guidance.
- Previously such servers (legacy HTTP+SSE only) never connected; the user had to know to switch the config to `transport: "sse"`.

Mirrors a Claude Code 2.1.265 fix: "Fixed MCP servers configured as `http` that only speak the legacy HTTP+SSE transport never connecting; Claude Code now falls back to SSE as the MCP spec describes."

## Test plan

- [x] `bun test src/mcp-client.test.ts` — 6 pass (new: end-to-end fallback against a real legacy SSE server built with the SDK's `SSEServerTransport`; and no fallback on a 500 streamable error)
- [x] `bun run typecheck` — clean
- [x] `bunx @biomejs/biome check` — clean

## Provenance

Claude-watch: claude@2.1.265:docs:d1a287aa7a20dba0d9e431683c9a91ea87bceaae6f508386a1bd01ba5d481d91:runtime:53422544f0ba9f07c07e61dc3e12ea827d0a5b502c275634e4d33a5f3f9f3247

Package: @anthropic-ai/claude-code@2.1.265 (previous audited: 2.1.263)
Release: https://github.com/anthropics/claude-code/releases/tag/v2.1.265

Evidence: release notes + changelog (https://code.claude.com/docs/en/changelog.md). Runtime inventory unchanged (no tools added/removed, probes pass); docs diff outside the changelog is Claude-surface-only (VS Code, Desktop, gateway, plugins). Reviewed all model-facing guidance items: recovery notices (local interrupt recovery is already a one-liner), artifact untrusted-content summary (local ReadArtifactFile reads local Desktop artifacts, no summarization), advisor tool, claude-api skill (no local mirrors). The headless `cd`-persistence fix does not apply: Letta Code's Bash contract deliberately scopes `cd` to a single call and conversation cwd already persists across turns via SetWorkingDirectory.

👾 Generated with [Letta Code](https://letta.com)

Co-Authored-By: Letta Code <noreply@letta.com>