### PR TITLE
fix(backend): preserve assistant segment identities through history hydration

### DIFF
--- a/src/backend/dev/provider-turn-executor.ts
+++ b/src/backend/dev/provider-turn-executor.ts
@@ -13,6 +13,7 @@ import {
 import type {
   LocalAssistantMessage,
   LocalMessage,
+  LocalStreamSegment,
 } from "@/backend/local/local-message";
 import type {
   LocalAgentRecord,
@@ -395,6 +396,54 @@ function otidForContentSegment(
   return otid;
 }
 
+function withStreamProvenance(
+  message: LocalMessage,
+  assistantOtids: Map<number, string>,
+  reasoningOtids: Map<number, string>,
+  toolOtids: Map<number, string>,
+): LocalMessage {
+  if (message.role !== "assistant") return message;
+  const segments: LocalStreamSegment[] = [];
+  for (let start = 0; start < message.content.length; ) {
+    const content = message.content[start];
+    if (!content) break;
+    let end = start + 1;
+    if (content.type !== "toolCall") {
+      while (message.content[end]?.type === content.type) end++;
+    }
+    const messageType =
+      content.type === "text"
+        ? "assistant_message"
+        : content.type === "thinking"
+          ? "reasoning_message"
+          : "approval_request_message";
+    const otid = (
+      content.type === "text"
+        ? assistantOtids
+        : content.type === "thinking"
+          ? reasoningOtids
+          : toolOtids
+    ).get(start);
+    if (otid) {
+      segments.push({
+        content_start_index: start,
+        content_end_index: end,
+        message_type: messageType,
+        otid,
+      });
+    }
+    start = end;
+  }
+  if (segments.length === 0) return message;
+  return {
+    ...message,
+    metadata: {
+      ...message.metadata,
+      stream_provenance: { version: 1, segments },
+    },
+  };
+}
+
 function createProviderLettaStream(
   events: AsyncIterable<ProviderStreamEvent>,
   contextTokensEstimate?: number,
@@ -408,6 +457,7 @@ function createProviderLettaStream(
       let sawUsageStatistics = false;
       const assistantOtids = new Map<number, string>();
       const reasoningOtids = new Map<number, string>();
+      const toolOtids = new Map<number, string>();
       try {
         for await (const event of events) {
           if (event.type === "error") {
@@ -416,7 +466,19 @@ function createProviderLettaStream(
           }
 
           if (event.type === "local-message") {
-            yield createLocalMessageChunk(event.message);
+            yield createLocalMessageChunk(
+              withStreamProvenance(
+                event.message,
+                assistantOtids,
+                reasoningOtids,
+                toolOtids,
+              ),
+            );
+            if (event.message.role === "assistant") {
+              assistantOtids.clear();
+              reasoningOtids.clear();
+              toolOtids.clear();
+            }
             continue;
           }
 
@@ -458,8 +520,13 @@ function createProviderLettaStream(
 
           if (part.type === "toolcall_end") {
             sawToolCall = true;
+            const otid =
+              toolOtids.get(part.contentIndex) ??
+              `provider-tool-${part.contentIndex}-${randomUUID()}`;
+            toolOtids.set(part.contentIndex, otid);
             yield {
               message_type: "approval_request_message",
+              otid,
               tool_call: {
                 tool_call_id: part.toolCall.id,
                 name: part.toolCall.name,

--- a/src/backend/local/local-message-correlation.test.ts
+++ b/src/backend/local/local-message-correlation.test.ts
@@ -6,7 +6,19 @@ import type {
   ConversationMessageCreateBody,
   ConversationMessageListBody,
 } from "@/backend";
-import { LocalStore } from "@/backend/local/local-store";
+import type { HeadlessTurnExecutorInput } from "@/backend/dev/headless-turn-executor";
+import {
+  ProviderTurnExecutor,
+  providerLocalMessage,
+  providerStreamPart,
+} from "@/backend/dev/provider-turn-executor";
+import { emptyLocalUsage, type LocalAssistantMessage } from "./local-message";
+import { projectLocalMessageToStoredMessages } from "./local-message-projection";
+import { LocalStore } from "./local-store";
+import {
+  getAttachedLocalMessage,
+  type ProviderStreamPart,
+} from "./local-stream-chunks";
 
 const temporaryDirectories: string[] = [];
 
@@ -25,6 +37,130 @@ afterEach(async () => {
       }),
     ),
   );
+});
+
+describe("local assistant segment correlation", () => {
+  test("retains exact live identities through persistence, reload and replay", async () => {
+    const storageDir = await createStorageDirectory();
+    const agentId = "agent-local-segments";
+    const store = new LocalStore(agentId, { storageDir });
+    const message: LocalAssistantMessage = {
+      id: "provider-final",
+      role: "assistant",
+      content: [
+        { type: "text", text: "same" },
+        { type: "text", text: " adjacent" },
+        { type: "toolCall", id: "call-1", name: "Read", arguments: {} },
+        { type: "text", text: "same" },
+        { type: "thinking", thinking: "" },
+        { type: "thinking", thinking: "reason" },
+        { type: "text", text: "same" },
+      ],
+      api: "openai-responses",
+      provider: "openai",
+      model: "test",
+      usage: emptyLocalUsage(),
+      stopReason: "toolUse",
+      timestamp: 1,
+    };
+    const executor = new ProviderTurnExecutor({
+      async *stream() {
+        for (const [contentIndex, content] of message.content.entries()) {
+          if (content.type === "thinking" && !content.thinking) continue;
+          yield providerStreamPart({
+            type:
+              content.type === "text"
+                ? "text_delta"
+                : content.type === "thinking"
+                  ? "thinking_delta"
+                  : "toolcall_end",
+            contentIndex,
+            partial: message,
+            ...(content.type === "toolCall"
+              ? { toolCall: content }
+              : {
+                  delta:
+                    content.type === "text" ? content.text : content.thinking,
+                }),
+          } as ProviderStreamPart);
+        }
+        yield providerLocalMessage(message);
+        yield providerStreamPart({
+          type: "done",
+          reason: "toolUse",
+          message,
+        } as ProviderStreamPart);
+      },
+    });
+    const input = {
+      conversationId: "default",
+      agentId,
+      agent: { id: agentId, model: "openai/test", model_settings: {} },
+      body: { messages: [] },
+      history: [],
+      uiMessages: [],
+    } as unknown as HeadlessTurnExecutorInput;
+    const liveOtids: string[] = [];
+    let snapshot: LocalAssistantMessage | undefined;
+    for await (const chunk of await executor.execute(input)) {
+      const stored = store.appendStreamChunk("default", agentId, chunk);
+      const otid = (stored as { otid?: string }).otid;
+      if (otid && liveOtids.at(-1) !== otid) liveOtids.push(otid);
+      const attached = getAttachedLocalMessage(chunk);
+      if (attached?.role === "assistant") snapshot = attached;
+    }
+    expect(liveOtids).toHaveLength(5);
+    expect(new Set(liveOtids).size).toBe(5);
+    expect(snapshot?.metadata?.stream_provenance).toEqual({
+      version: 1,
+      segments: (
+        [
+          [0, 2, "assistant_message"],
+          [2, 3, "approval_request_message"],
+          [3, 4, "assistant_message"],
+          [4, 6, "reasoning_message"],
+          [6, 7, "assistant_message"],
+        ] as const
+      ).map(([start, end, type], index) => ({
+        content_start_index: start,
+        content_end_index: end,
+        message_type: type,
+        otid: liveOtids[index] ?? "missing",
+      })),
+    });
+    const list = (source: LocalStore) =>
+      source.listConversationMessages("default", {
+        agent_id: agentId,
+        order: "asc",
+      } as ConversationMessageListBody);
+    const history = list(store);
+    expect(history.map((row) => (row as { otid?: string }).otid)).toEqual(
+      liveOtids,
+    );
+    const reloaded = new LocalStore(agentId, { storageDir });
+    expect(list(reloaded)).toEqual(history);
+    expect(list(reloaded)).toEqual(history);
+    expect(
+      reloaded.listLocalMessages("default", agentId)[0]?.metadata
+        ?.stream_provenance,
+    ).toEqual(snapshot?.metadata?.stream_provenance);
+    // Independent executions with identical text must never alias.
+    const secondOtids: string[] = [];
+    for await (const chunk of await executor.execute(input)) {
+      const otid = (chunk as { otid?: string }).otid;
+      if (otid) secondOtids.push(otid);
+    }
+    expect(secondOtids.every((otid) => !liveOtids.includes(otid))).toBe(true);
+    // Legacy rows retain their IDs without fabricated provenance.
+    expect(
+      projectLocalMessageToStoredMessages(
+        message,
+        agentId,
+        "default",
+        "2026-01-01",
+      ).every((row) => !("otid" in row)),
+    ).toBe(true);
+  });
 });
 
 describe("local user message correlation", () => {

--- a/src/backend/local/local-message-projection.ts
+++ b/src/backend/local/local-message-projection.ts
@@ -117,6 +117,24 @@ function toolResultToStoredReturnValue(
   });
 }
 
+function segmentIdentity(
+  message: LocalAssistantMessage,
+  contentStartIndex: number,
+  messageType:
+    | "assistant_message"
+    | "reasoning_message"
+    | "approval_request_message",
+): { otid?: string } {
+  const provenance = message.metadata?.stream_provenance;
+  if (provenance?.version !== 1) return {};
+  const segment = provenance.segments.find(
+    (entry) =>
+      entry.content_start_index === contentStartIndex &&
+      entry.message_type === messageType,
+  );
+  return segment ? { otid: segment.otid } : {};
+}
+
 function projectThinkingContent(
   message: LocalAssistantMessage,
   reasoning: string,
@@ -132,6 +150,7 @@ function projectThinkingContent(
     agent_id: agentId,
     conversation_id: conversationId,
     message_type: "reasoning_message",
+    ...segmentIdentity(message, contentStartIndex, "reasoning_message"),
     reasoning,
   } as StoredMessage;
 }
@@ -139,6 +158,7 @@ function projectThinkingContent(
 function projectToolCallContent(
   message: LocalAssistantMessage,
   content: ToolCall,
+  contentIndex: number,
   date: string,
   agentId: string,
   conversationId: string,
@@ -149,6 +169,7 @@ function projectToolCallContent(
     agent_id: agentId,
     conversation_id: conversationId,
     message_type: "approval_request_message",
+    ...segmentIdentity(message, contentIndex, "approval_request_message"),
     tool_call: {
       tool_call_id: content.id,
       name: content.name,
@@ -254,6 +275,7 @@ export function projectLocalMessageToStoredMessages(
       message_type: "assistant_message",
       role: "assistant",
       content: pendingTextContent,
+      ...segmentIdentity(message, pendingTextStartIndex, "assistant_message"),
     } as StoredMessage);
     pendingTextContent = [];
     pendingTextStartIndex = -1;
@@ -285,10 +307,10 @@ export function projectLocalMessageToStoredMessages(
 
     if (isThinkingContent(content)) {
       flushPendingText();
+      if (pendingReasoningStartIndex === -1) {
+        pendingReasoningStartIndex = contentIndex;
+      }
       if (content.thinking.length > 0) {
-        if (pendingReasoningStartIndex === -1) {
-          pendingReasoningStartIndex = contentIndex;
-        }
         pendingReasoningContent.push(content.thinking);
       }
       continue;
@@ -298,7 +320,14 @@ export function projectLocalMessageToStoredMessages(
       flushPendingText();
       flushPendingReasoning();
       messages.push(
-        projectToolCallContent(message, content, date, agentId, conversationId),
+        projectToolCallContent(
+          message,
+          content,
+          contentIndex,
+          date,
+          agentId,
+          conversationId,
+        ),
       );
       continue;
     }

--- a/src/backend/local/local-message.ts
+++ b/src/backend/local/local-message.ts
@@ -21,7 +21,25 @@ export interface LocalMessageProviderMetadata {
   usage?: unknown;
 }
 
+/** Exact live identities, indexed into the persisted assistant content array.
+ * Adjacent text/thinking blocks form one segment; tools form individual segments.
+ * Missing entries mean no live identity is known (including legacy history).
+ */
+export interface LocalStreamSegment {
+  content_start_index: number;
+  content_end_index: number; // Exclusive.
+  message_type:
+    | "assistant_message"
+    | "reasoning_message"
+    | "approval_request_message";
+  otid: string;
+}
+
 export interface LocalMessageMetadata {
+  stream_provenance?: {
+    version: 1;
+    segments: LocalStreamSegment[];
+  };
   created_at?: string;
   updated_at?: string;
   agent_id?: string;

--- a/src/backend/provider-turn-executor.test.ts
+++ b/src/backend/provider-turn-executor.test.ts
@@ -226,6 +226,44 @@ describe("ProviderTurnExecutor", () => {
     expect(reasoningOtids[0]).not.toBe(reasoningOtids[2]);
   });
 
+  test("scopes segment identities to each final assistant snapshot", async () => {
+    const adapter: ProviderStreamAdapter = {
+      async *stream() {
+        for (let index = 0; index < 2; index++) {
+          const message = assistantMessage();
+          yield providerStreamPart(
+            part({
+              type: "text_delta",
+              contentIndex: 0,
+              delta: "done",
+              partial: message,
+            }),
+          );
+          yield providerLocalMessage(message);
+          yield providerStreamPart(
+            part({ type: "done", reason: "stop", message }),
+          );
+        }
+      },
+    };
+    const chunks = await collect(
+      await new ProviderTurnExecutor(adapter).execute(input()),
+    );
+    const otids = chunks
+      .filter((chunk) => chunk.message_type === "assistant_message")
+      .map((chunk) => (chunk as { otid?: string }).otid);
+    const snapshots = chunks
+      .map(getAttachedLocalMessage)
+      .filter((message) => message !== undefined);
+    expect(otids).toHaveLength(2);
+    expect(otids[0]).not.toBe(otids[1]);
+    expect(
+      snapshots.map(
+        (message) => message.metadata?.stream_provenance?.segments[0]?.otid,
+      ),
+    ).toEqual(otids);
+  });
+
   test("emits final local assistant messages as state-only chunks before stop_reason", async () => {
     const finalMessage = assistantMessage();
     const adapter: ProviderStreamAdapter = {


### PR DESCRIPTION
## Summary
- Persist versioned per-content-segment stream OTIDs on final assistant snapshots and project the same OTIDs through history.
- Keep independent repeated text, reasoning and tool segments distinct; legacy rows receive no fabricated identity.
- Companion mobile integration: https://github.com/oculairmedia/letta-mobile/pull/1496. Native wrapper integration and coordinated deployment remain required; this PR does not repair previously discarded provenance.

## Test plan
- [x] Prior implementation validation: bun run check (12 checks, including TypeScript).
- [x] Prior implementation validation: 39 focused/adjacent tests passed, including persistence/reload and text/tool/text identity coverage.
- [x] Prior implementation validation: Node 22 isolated bundle smoke test.
- [x] Commit-time git diff --check.
- [ ] Full distribution build and coordinated Android/backend end-to-end verification.

No installed bundles or conversation history were modified. Source starts at upstream 62b0fde4; compatibility with deployed 0.30.29 must be validated before deployment.

👾 Generated with [Letta Code](https://letta.com)