### PR TITLE
fix: support Kitty CSI-u Option key sequences

### DIFF
--- a/src/cli/components/PasteAwareTextInput.test.tsx
+++ b/src/cli/components/PasteAwareTextInput.test.tsx
@@ -1,0 +1,75 @@
+import { expect, test } from "bun:test";
+import { Readable, Writable } from "node:stream";
+import { render } from "ink";
+import { PasteAwareTextInput } from "./PasteAwareTextInput";
+
+class OutputStream extends Writable {
+  columns = 100;
+  rows = 24;
+  isTTY = true;
+
+  override _write(
+    _chunk: Buffer | string,
+    _encoding: BufferEncoding,
+    callback: (error?: Error | null) => void,
+  ) {
+    callback();
+  }
+}
+
+function createInputStream(): NodeJS.ReadStream {
+  const input = new Readable({ read() {} }) as NodeJS.ReadStream;
+  input.isTTY = true;
+  input.setRawMode = () => input;
+  input.ref = () => input;
+  input.unref = () => input;
+  return input;
+}
+
+async function applyInput(
+  sequences: string[],
+  cursorPosition?: number,
+): Promise<string> {
+  const stdin = createInputStream();
+  let value = "alpha beta";
+  const instance = render(
+    <PasteAwareTextInput
+      value={value}
+      onChange={(nextValue) => {
+        value = nextValue;
+      }}
+      cursorPosition={cursorPosition}
+    />,
+    {
+      stdout: new OutputStream() as OutputStream & NodeJS.WriteStream,
+      stdin,
+      debug: false,
+      patchConsole: false,
+      exitOnCtrlC: false,
+    },
+  );
+
+  try {
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    for (const sequence of sequences) {
+      stdin.push(sequence);
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    }
+    return value;
+  } finally {
+    instance.unmount();
+    instance.cleanup();
+  }
+}
+
+test("Kitty Alt+Backspace deletes the previous word", async () => {
+  expect(await applyInput(["\x1b[127;3u"])).toBe("alpha ");
+});
+
+test("Kitty Alt+b moves to the previous word before text insertion", async () => {
+  expect(await applyInput(["\x1b[98;3u", "X"])).toBe("alpha Xbeta");
+});
+
+test("Kitty Alt+f moves to the next word before text insertion", async () => {
+  expect(await applyInput(["\x1b[102;3u", "X"], 0)).toBe("alpha Xbeta");
+});

--- a/src/cli/components/PasteAwareTextInput.tsx
+++ b/src/cli/components/PasteAwareTextInput.tsx
@@ -111,13 +111,44 @@ const OPTION_LEFT_PATTERN = /^\u001b\[(?:1;)?(?:3|4|7|8|9)D$/;
 // biome-ignore lint/suspicious/noControlCharactersInRegex: Terminal escape sequences require ESC control character
 const OPTION_RIGHT_PATTERN = /^\u001b\[(?:1;)?(?:3|4|7|8|9)C$/;
 
-function detectOptionWordDirection(sequence: string): WordDirection | null {
+export function detectOptionWordDirection(
+  sequence: string,
+): WordDirection | null {
   if (!sequence.startsWith("\u001b")) return null;
   if (sequence === "\u001bb" || sequence === "\u001bB") return "left";
   if (sequence === "\u001bf" || sequence === "\u001bF") return "right";
   if (OPTION_LEFT_PATTERN.test(sequence)) return "left";
   if (OPTION_RIGHT_PATTERN.test(sequence)) return "right";
+
+  // Kitty's CSI-u protocol encodes Alt/Option as bit 2 in the modifier
+  // field (the wire value is 1 + bitmask).  Keep handling the traditional
+  // ESC-prefixed forms above, but also recognize the CSI-u form emitted by
+  // terminals such as Kitty, Ghostty, and iTerm2.
+  // biome-ignore lint/suspicious/noControlCharactersInRegex: Terminal escape sequence requires ESC.
+  const csiUMatch = sequence.match(/^\u001b\[(\d+);(\d+)(?::(\d+))?u$/);
+  if (csiUMatch) {
+    const keycode = Number(csiUMatch[1]);
+    const modifier = Number(csiUMatch[2]) - 1;
+    const event = csiUMatch[3] ? Number(csiUMatch[3]) : 1;
+    if (event !== 3 && (modifier & 2) !== 0) {
+      const key = String.fromCharCode(keycode).toLowerCase();
+      if (key === "b") return "left";
+      if (key === "f") return "right";
+    }
+  }
+
   return null;
+}
+
+/** Return true for a pressed/repeated Kitty Alt+Backspace sequence. */
+export function isKittyOptionDeleteSequence(sequence: string): boolean {
+  // biome-ignore lint/suspicious/noControlCharactersInRegex: Terminal escape sequence requires ESC.
+  const match = sequence.match(/^\u001b\[127;(\d+)(?::(\d+))?u$/);
+  if (!match) return false;
+
+  const modifier = Number(match[1]) - 1;
+  const event = match[2] ? Number(match[2]) : 1;
+  return event !== 3 && (modifier & 2) !== 0;
 }
 
 export function PasteAwareTextInput({
@@ -564,7 +595,8 @@ export function PasteAwareTextInput({
         sequence === "\x1b\x7f" ||
         sequence === "\x1b\x08" ||
         sequence === "\x1b\b" ||
-        sequence === "\x17"
+        sequence === "\x17" ||
+        isKittyOptionDeleteSequence(sequence)
       ) {
         deletePreviousWord();
         return;

--- a/src/cli/use-input-key-sequences.test.ts
+++ b/src/cli/use-input-key-sequences.test.ts
@@ -1,4 +1,8 @@
 import { describe, expect, test } from "bun:test";
+import {
+  detectOptionWordDirection,
+  isKittyOptionDeleteSequence,
+} from "@/cli/components/PasteAwareTextInput";
 
 const useInputModuleUrl = new URL(
   "../../node_modules/ink/build/hooks/use-input.js",
@@ -82,5 +86,21 @@ describe("use-input key sequence handling", () => {
     expect(
       t.shouldSuppressBareEnterAfterModifiedEnter("\n", true, "darwin"),
     ).toBe(false);
+  });
+
+  test("recognizes Kitty CSI-u Option word navigation", () => {
+    expect(detectOptionWordDirection("\x1b[98;3u")).toBe("left");
+    expect(detectOptionWordDirection("\x1b[102;3u")).toBe("right");
+    expect(detectOptionWordDirection("\x1b[98;3:1u")).toBe("left");
+    expect(detectOptionWordDirection("\x1b[98;3:3u")).toBeNull();
+    expect(detectOptionWordDirection("\x1b[98;2u")).toBeNull();
+  });
+
+  test("recognizes Kitty CSI-u Option+Backspace without key-release events", () => {
+    expect(isKittyOptionDeleteSequence("\x1b[127;3u")).toBe(true);
+    expect(isKittyOptionDeleteSequence("\x1b[127;3:2u")).toBe(true);
+    expect(isKittyOptionDeleteSequence("\x1b[127;3:3u")).toBe(false);
+    expect(isKittyOptionDeleteSequence("\x1b[127;2u")).toBe(false);
+    expect(isKittyOptionDeleteSequence("\x1b[126;3u")).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

Fixes #4187 by handling Kitty CSI-u modified key sequences in the raw terminal input path used by `PasteAwareTextInput`.

Terminals that enable Kitty keyboard protocol encode Option/Alt combinations as CSI-u sequences. Ink's parser does not surface these sequences as the traditional ESC-prefixed forms, and the raw handler previously ignored them. As a result, Option+Backspace inserted no deletion and Option+b/f did not move the word cursor.

## Changes

- Decode CSI-u key events and recognize Alt/Option+`b` and Alt/Option+`f` for word navigation.
- Recognize Alt/Option+Backspace (`CSI 127;3u`) for previous-word deletion.
- Ignore Kitty key-release events (`:3`) so a held key cannot trigger an extra operation on release.
- Keep the existing ESC+key, Ctrl+W, arrow, and normal text-input behavior unchanged.
- Export the small decoders for focused protocol tests.

## Verification

Baseline reproduction on the parent commit (`32b4e7c4ed84032b859af93e1ccbea2fa7953231`) with real Ink/Readable TTY input:

- Kitty Alt+Backspace: expected `alpha `, received `alpha beta`.
- Kitty Alt+b then `X`: expected `alpha Xbeta`, received `alpha betaX`.
- Kitty Alt+f from cursor 0 then `X`: expected `alpha Xbeta`, received `Xalpha beta`.

After this change:

- `PATH=/Users/zifeiyu/.bun/bin:$PATH bun test src/cli/components/PasteAwareTextInput.test.tsx src/cli/use-input-key-sequences.test.ts` — **9 passed, 0 failed, 28 assertions**.
- `PATH=/Users/zifeiyu/.bun/bin:$PATH bun run check` — **12/12 checks passed** (cycle check processed 1,950 files; Biome checked 1,863 files; TypeScript typecheck passed).
- `git diff --check` — passed.

## Compatibility and boundaries

The decoder only accepts CSI-u key events with the expected key codes and the Alt modifier bit. Unknown modifiers, non-Alt events, and release events are ignored and continue through normal input handling. Traditional terminal sequences remain supported.

## AI Disclosure

- [ ] This pull request was written entirely by a human
- [x] This pull request was written with AI assistance and reviewed and edited by a human
- [x] I have read the [AI Policy](https://github.com/letta-ai/letta-code/blob/main/AI_POLICY.md) and agree to its terms

## AI Tool(s) Used

OpenAI Codex (ChatGPT) was used for issue research, implementation, automated tests, and PR drafting. The human submitter reviewed and edited the changes and is responsible for the final submission.

## Human Verification

I have reviewed and understand every change in this pull request and take responsibility for its correctness. I reproduced the reported behavior before the patch and verified the focused regression tests after the patch.
