### PR TITLE
fix(context-doctor): remove incorrect persona.md requirement claim

### DIFF
--- a/src/skills/builtin/context-doctor/ROOT_MEMORY.md
+++ b/src/skills/builtin/context-doctor/ROOT_MEMORY.md
@@ -65,7 +65,7 @@ The context in the memory filesystem should have a clear structure, with a well-
 
 #### Invalid context format
 Files in the memory filesystem must follow certain structural requirements: 
-- Must have root `MEMORY.md` and root `persona.md`
+- Must have root `MEMORY.md` for MemFS v2 (API-backed memory)
 - Root and child `MEMORY.md` files have no frontmatter; every other memory Markdown file has exactly `name` and `description` frontmatter
 - Must NOT have overlapping file and folder names (e.g. `human.md` and `human/identity.md`)
 - Must follow specification for skills (e.g. `skills/{skill_name}/`) with the format:


### PR DESCRIPTION
Builtin-skill-watch: context-doctor@de54f4a461b6-389a143851e69ff2

## Selected skill
`context-doctor` - Identify and repair degradation in system prompt, external memory, and skills preventing you from following instructions or remembering information as well as you should.

## Stale claim
The skill incorrectly stated that `persona.md` is a required root file alongside `MEMORY.md`.

## Current owning source
`src/agent/memory-constraints.ts` - The memory constraints validator only requires `MEMORY.md` for MemFS v2 (API-backed memory). The `persona.md` file is a convention used in example memory structures, not a structural requirement enforced by the validator.

## Validation performed
- Checked `memory-constraints.ts` for persona validation: none found
- Verified memory structure detection in `memory-format.ts`: only checks for `MEMORY.md` marker
- Confirmed with official MemFS docs: example shows `persona.md` under `system/` as convention, not requirement
- Ran `bun run check`: all 12 checks pass

🏥