### PR TITLE
fix(skills): document Letta Code invocation fields in creating-skills

### DIFF
--- a/src/skills/builtin/creating-skills/SKILL.md
+++ b/src/skills/builtin/creating-skills/SKILL.md
@@ -64,7 +64,7 @@ processing-pdfs/
 
 Every SKILL.md in Letta Code consists of:
 
-- **Frontmatter** (YAML): Contains `name` and `description` fields. These are the only fields that the Letta Code agent reads to determine when the skill gets used, thus it is very important to be clear and comprehensive in describing what the skill is, and when it should be used.
+- **Frontmatter** (YAML): Contains `name` and `description` fields. The Letta Code agent reads these to determine when the skill gets used (an optional `when_to_use` field, when present, is appended to the description as additional trigger guidance), thus it is very important to be clear and comprehensive in describing what the skill is, and when it should be used.
 - **Body** (Markdown): Instructions and guidance for using the skill. Only loaded AFTER the skill triggers (if at all).
 
 #### Bundled Resources (optional)
@@ -325,7 +325,7 @@ description: Extracts text and tables from PDF files, fills forms, and merges do
 ---
 ```
 
-**Note:** The spec allows optional fields (`license`, `compatibility`, `metadata`, `allowed-tools`) but most skills don't need them. See [agentskills.io/specification](https://agentskills.io/specification) for details.
+**Note:** The spec allows optional fields (`license`, `compatibility`, `metadata`, `allowed-tools`) but most skills don't need them. See [agentskills.io/specification](https://agentskills.io/specification) for details. Letta Code additionally supports optional invocation fields: `when_to_use` (extra trigger guidance appended to the description), `argument-hint` (hint shown after the command in slash-command autocomplete), `disable-model-invocation` (set `true` to hide the skill from automatic model invocation), and `user-invocable` (set `false` to hide the skill from slash-command invocation).
 
 ##### Body
 

--- a/src/skills/builtin/creating-skills/scripts/validate-skill.ts
+++ b/src/skills/builtin/creating-skills/scripts/validate-skill.ts
@@ -26,6 +26,11 @@ const ALLOWED_PROPERTIES = new Set([
   "compatibility",
   "metadata",
   "allowed-tools",
+  // Letta Code invocation fields (see src/agent/skills.ts)
+  "when_to_use",
+  "argument-hint",
+  "disable-model-invocation",
+  "user-invocable",
 ]);
 
 export const MAX_SKILL_NAME_LENGTH = 64;


### PR DESCRIPTION
## Summary

- Fix stale claim that `name` and `description` are "the only fields that the Letta Code agent reads to determine when the skill gets used"
- Document the four Letta Code invocation fields (`when_to_use`, `argument-hint`, `disable-model-invocation`, `user-invocable`) in the frontmatter guidance
- Extend `validate-skill.ts` ALLOWED_PROPERTIES to accept these fields without warnings

## Stale claims and current owning source

**Frontmatter "only fields" claim** (SKILL.md line 67): Said `name` and `description` are the only fields read to determine when the skill gets used. The harness also reads:
- `when_to_use` — appended to description for triggering (src/agent/skills.ts:471)
- `disable-model-invocation` — gates model auto-invocation (src/agent/skills.ts:149)
- `user-invocable` — gates slash-command invocation (src/agent/skills.ts:153)
- `argument-hint` — shown in slash autocomplete (src/cli/components/SlashCommandAutocomplete.tsx:119)

These are tested in `src/agent/skills-discovery.test.ts` line 332 and used by bundled skill `generating-mod-envs`.

## Focused validation

- `bun test src/skills/skill-creator-scripts.test.ts` — 21 pass
- `bun test src/agent/skills-discovery.test.ts` — 11 pass
- `bun run check` — 12/12 checks pass

## Note

Complements PR #4281 (different claims: token units and validation-checks list).

Builtin-skill-watch: creating-skills@de54f4a461b6-6195325287477617

👾 Generated with [Letta Code](https://letta.com)

Co-Authored-By: Letta Code <noreply@letta.com>