### PR TITLE
fix(skills): correct debugPanelEnabled control mechanism

### DIFF
--- a/src/skills/builtin/editing-letta-code-desktop-preferences/SKILL.md
+++ b/src/skills/builtin/editing-letta-code-desktop-preferences/SKILL.md
@@ -28,7 +28,7 @@ User-editable preference keys:
 
 System-managed keys (do not edit directly):
 - `artifactsByAgent`: per-agent artifacts panel state, written by Desktop UI.
-- `debugPanelEnabled`: developer debug panel, controlled via app menus.
+- `debugPanelEnabled`: developer debug panel data collection toggle.
 - `remoteAppServerEnabled`: Remote App Server toggle, applied at startup.
 - `remoteAppServerUrl`: Remote App Server URL, configured via preferences UI.
 


### PR DESCRIPTION
Builtin-skill-watch: editing-letta-code-desktop-preferences@de54f4a461b6-44a69b6772868c3f

**Selected skill:** `editing-letta-code-desktop-preferences`

**Stale claim:** `debugPanelEnabled: developer debug panel, controlled via app menus`

**Current owning source:** letta-cloud `apps/code-desktop/electron/src/preferencesStorage.ts` defines the preference; `listenerManager.ts` reads it to set `LETTA_DESKTOP_DEBUG_PANEL` env var. No menu writer exists in current letta-cloud main.

**Focused validation:** Source inspection confirmed no writer for `debugPanelEnabled` in the Desktop app. The preference gates listener WebSocket traffic collection and is only settable via direct JSON edit (this skill) or generic IPC.

**Changes:**
- Removed stale "controlled via app menus" claim
- Updated description to reflect current behavior