### PR TITLE
fix(skills): correct stale system-prompt claim in managing-shared-memory

### DIFF
--- a/src/skills/builtin/managing-shared-memory/SKILL.md
+++ b/src/skills/builtin/managing-shared-memory/SKILL.md
@@ -87,6 +87,6 @@ letta shared-memory history shared-notes --path docs/plan.md
 
 ## Notes and Limits
 
-- Shared memory is not part of your system prompt. Writing to it does not change your in-context memory — for that, edit your memory blocks or MemFS files.
+- Your system prompt lists each attached repository (its path and top-level files), but that projection only refreshes on recompile. Writing to shared memory does not change your in-context memory — for that, edit your memory blocks or MemFS files.
 - Attaching is asynchronous on the server; `letta shared-memory attach` waits for the attachment to be visible before cloning.
 - SDK/API equivalent for programmatic callers: `@letta-ai/letta-agent-sdk` exposes these operations as `client.repositories` (with `files` and `versions` helpers), and shared memory can be attached for a session's lifetime via `resources: [{ type: "repository", repositoryId }]` on cloud sessions. The REST resource is `/v1/repositories`.


### PR DESCRIPTION
Builtin-skill-watch: managing-shared-memory@de54f4a461b6-7496f1fbb7a9acd9

## Summary

Audit of the `managing-shared-memory` builtin skill found one stale claim:

- **Stale claim**: "Shared memory is not part of your system prompt." (Notes and Limits)
- **Current behavior**: The agent system prompt *does* list each attached repository — its path and top-level files — inside a `<shared_memory>` section, refreshed on recompile. The skill itself already says attach "recompiles the system prompt projection", so the bullet also contradicted its own attach description.

Evidence:
- Official docs (docs.letta.com/concepts/shared-memory): "The agents system prompt lists the repository path and its top-level files."
- Producer source: `renderAttachedRepositoriesProjection` in letta-cloud (`libs/service-core-runtime/src/lib/core-runtime/systemPrompt/pierreRendering.ts`) renders the `<shared_memory>` block with the repository location and root `MEMORY.md` content (or top-level file tree) into the system prompt.
- The skills own attach section references the system-prompt projection.

## Change

Smallest truthful update to the one stale bullet; the operative guidance (writing to shared memory does not change in-context memory) is preserved:

> Your system prompt lists each attached repository (its path and top-level files), but that projection only refreshes on recompile. Writing to shared memory does not change your in-context memory — for that, edit your memory blocks or MemFS files.

## Validation

- Focused tests: `bun test src/agent/skills-agent-availability.test.ts src/cli/subcommands/shared-memory.test.ts src/agent/attached-repository-git-sync.test.ts` — 27 pass
- `bun run check` — 12/12 pass
- All other skill claims (CLI subcommand surface, mount location `$MEMORY_DIR/../<name>`, post-turn push with rebase-retry-once, sync error messages, cross-agent guard, SDK surface) verified against current source and docs