### PR TITLE
fix(skills): correct scheduled tasks claim in self-configuration

### DIFF
--- a/src/skills/builtin/self-configuration/SKILL.md
+++ b/src/skills/builtin/self-configuration/SKILL.md
@@ -432,7 +432,7 @@ letta cron list
 letta cron add --name "weekly-review" --description "Weekly project review" --prompt "Ask the user for the weekly project review." --cron "0 9 * * 1" --agent "$AGENT_ID" --conversation "$CONVERSATION_ID"
 ```
 
-Scheduled tasks fire only while a Letta session/listener is running. Cron bindings can target other agents/conversations visible to the account; verify agent and conversation IDs explicitly when exact routing matters.
+Local cron tasks (`--runner local`) fire only while a Letta session/listener is running. Cloud schedules (`--runner cloud`, the default for cloud agents) are durable and fire from a cloud worker regardless of local listener state. Cron bindings can target other agents/conversations visible to the account; verify agent and conversation IDs explicitly when exact routing matters.
 
 ## CLI startup flags
 


### PR DESCRIPTION
## Summary
- Fix stale claim: skill stated "Scheduled tasks fire only while a Letta session/listener is running"
- This was only true for local cron tasks (`--runner local`)
- Cloud schedules (`--runner cloud`, the default for cloud agents) are durable and fire from a cloud worker regardless of local listener state

Builtin-skill-watch: self-configuration@de54f4a461b6-6ab3e6ca22daf38d

## Stale claim
- **Claim**: "Scheduled tasks fire only while a Letta session/listener is running"
- **Current source**: `letta cron add --help` shows `--runner` option with `cloud` (durable, default for cloud agents) and `local` (session-only)

## Focused validation
- Ran `letta cron add --help` to verify runner options
- Ran `bun run check` (all 12 checks pass)

👾 Generated with [Letta Code](https://letta.com)