### PR TITLE
feat(ci): watch Codex model instruction content

### DIFF
--- a/.github/agent-prompts/codex-agent-watch.md
+++ b/.github/agent-prompts/codex-agent-watch.md
@@ -62,6 +62,10 @@ Many upstream Codex tool changes are upstream-only: MCP/plugin internals, Respon
 
 When Codex and Letta Code implement the same tool contract, implementation behavior is part of the mirror. Compare parsing, path resolution, mutation ordering, and failure semantics even when schemas and descriptions are unchanged. If the upstream diff introduces behavior that the local mirror lacks, treat it as `local_change_required` unless you can show that the difference is intentionally inapplicable locally. Do not dismiss it as a minor implementation improvement.
 
+## Instruction-content changes
+
+The detector also flags changes to model instruction content in models.json (`base_instructions`, `model_messages`, `instructions_template`) and newly added models that ship instructions. Letta Code does not mirror Codex model prompts, so these usually close as `no_local_impact`. Still read the changed instruction text: check it for tool-contract implications, and summarize noteworthy behavioral guidance (steering, user-input handling, dissatisfaction handling) in the tracker note so owners can decide whether to adopt the pattern in the Letta Code system prompt.
+
 ## Tracker updates
 
 The prompt provides:

--- a/scripts/codex-watch/diff-models-json.test.ts
+++ b/scripts/codex-watch/diff-models-json.test.ts
@@ -70,6 +70,63 @@ describe("diffModelsJson", () => {
     expect(diff.added_models).toEqual(["gpt-5.6"]);
     expect(diff.removed_models).toEqual(["gpt-5.4"]);
   });
+
+  test("detects instruction content changes without tool mentions", () => {
+    const diff = diffModelsJson(
+      models(model("gpt-5.6")),
+      models(
+        model("gpt-5.6", {
+          base_instructions:
+            "Use apply_patch and multi_tool_use.parallel. The user may send a new message while you are still working. Treat it as steering the active task.",
+        }),
+      ),
+    );
+
+    expect(diff.has_tool_schema_change).toBe(false);
+    expect(diff.has_prompt_tool_change).toBe(false);
+    expect(diff.has_instruction_content_change).toBe(true);
+    expect(diff.instruction_content_deltas).toEqual(["gpt-5.6"]);
+  });
+
+  test("detects top-level instructions_template changes", () => {
+    const diff = diffModelsJson(
+      models(model("gpt-5.6")),
+      models(
+        model("gpt-5.6", {
+          instructions_template: "Answer briefly, then resume the active task.",
+        }),
+      ),
+    );
+
+    expect(diff.has_instruction_content_change).toBe(true);
+  });
+
+  test("flags added models that ship instructions", () => {
+    const diff = diffModelsJson(
+      models(model("gpt-5.5")),
+      models(
+        model("gpt-5.5"),
+        model("gpt-6-astra"),
+        model("gpt-5.6-bare", {
+          base_instructions: "",
+          model_messages: {},
+        }),
+      ),
+    );
+
+    expect(diff.added_models).toEqual(["gpt-6-astra", "gpt-5.6-bare"]);
+    expect(diff.added_models_with_instructions).toEqual(["gpt-6-astra"]);
+  });
+
+  test("no instruction change when text is identical", () => {
+    const diff = diffModelsJson(
+      models(model("gpt-5.5")),
+      models(model("gpt-5.5")),
+    );
+
+    expect(diff.has_instruction_content_change).toBe(false);
+    expect(diff.instruction_content_deltas).toEqual([]);
+  });
 });
 
 describe("decideVerdict", () => {
@@ -130,6 +187,43 @@ describe("decideVerdict", () => {
       decideVerdict({
         models_diff,
         prompt_md_changed: true,
+        tools_dir_changed: false,
+        apply_patch_dir_changed: false,
+        parse_error: false,
+      }),
+    ).toBe("prompt-only update");
+  });
+
+  test("returns prompt-only update for instruction content changes", () => {
+    const models_diff = diffModelsJson(
+      models(model("gpt-5.6")),
+      models(
+        model("gpt-5.6", {
+          base_instructions:
+            "The user may send a new message while you are still working.",
+        }),
+      ),
+    );
+    expect(
+      decideVerdict({
+        models_diff,
+        prompt_md_changed: false,
+        tools_dir_changed: false,
+        apply_patch_dir_changed: false,
+        parse_error: false,
+      }),
+    ).toBe("prompt-only update");
+  });
+
+  test("returns prompt-only update for added models with instructions", () => {
+    const models_diff = diffModelsJson(
+      models(model("gpt-5.5")),
+      models(model("gpt-5.5"), model("gpt-6-astra")),
+    );
+    expect(
+      decideVerdict({
+        models_diff,
+        prompt_md_changed: false,
         tools_dir_changed: false,
         apply_patch_dir_changed: false,
         parse_error: false,

--- a/scripts/codex-watch/diff-models-json.ts
+++ b/scripts/codex-watch/diff-models-json.ts
@@ -1,9 +1,11 @@
 /**
  * Structured diff of openai/codex `codex-rs/models-manager/models.json`.
  *
- * We don't care about every field — only the ones that affect the tool/schema
- * surface exposed to the model. When any of these change, the letta-code
- * harness (src/agent/prompts/source_codex.md and src/tools/*) may need updating.
+ * We watch two surfaces: tool/schema fields that affect the tool surface
+ * exposed to the model (letta-code mirrors these in src/agent/prompts/source_codex.md
+ * and src/tools/*), and model instruction content (base_instructions /
+ * model_messages / instructions_template), whose behavioral guidance is worth
+ * reviewing even when no local mirror changes.
  */
 
 /** Tool-relevant fields lifted off each model entry in models.json. */
@@ -18,7 +20,7 @@ export interface ModelToolConfig {
   experimental_supported_tools?: string[];
   input_modalities?: string[];
   truncation_policy?: unknown;
-  /** Tool names mentioned anywhere in base_instructions / instructions_template. */
+  /** Tool names mentioned anywhere in the model instruction text. */
   prompt_tool_mentions: string[];
 }
 
@@ -48,10 +50,16 @@ export interface ModelsDiff {
   added_models: string[];
   removed_models: string[];
   field_deltas: ToolFieldDelta[];
+  /** Slugs of existing models whose instruction content changed. */
+  instruction_content_deltas: string[];
+  /** Added models that ship instruction content. */
+  added_models_with_instructions: string[];
   /** True if any field_delta is in TOOL_SCHEMA_FIELDS. */
   has_tool_schema_change: boolean;
   /** True if any prompt_tool_mentions added or removed. */
   has_prompt_tool_change: boolean;
+  /** True if any existing model's instruction content changed. */
+  has_instruction_content_change: boolean;
 }
 
 /** Fields whose change implies a tool-schema update may be needed in letta-code. */
@@ -74,16 +82,15 @@ function collectMentions(text: string): string[] {
   return Array.from(found).sort();
 }
 
+function slugOf(model: Record<string, unknown>): string {
+  return typeof model.slug === "string" ? model.slug : "<unknown>";
+}
+
 export function extractToolConfig(
   model: Record<string, unknown>,
 ): ModelToolConfig {
-  const slug = typeof model.slug === "string" ? model.slug : "<unknown>";
-  const promptText = [
-    typeof model.base_instructions === "string" ? model.base_instructions : "",
-    typeof model.model_messages === "object" && model.model_messages !== null
-      ? JSON.stringify(model.model_messages)
-      : "",
-  ].join("\n");
+  const slug = slugOf(model);
+  const promptText = extractInstructionText(model);
   return {
     slug,
     apply_patch_tool_type: model.apply_patch_tool_type as string | undefined,
@@ -107,6 +114,25 @@ export function extractToolConfig(
 
 function equal(a: unknown, b: unknown): boolean {
   return JSON.stringify(a) === JSON.stringify(b);
+}
+
+/**
+ * Full model instruction text whose content we watch for behavioral prompt
+ * changes (e.g. steering or user-input guidance), not just tool mentions.
+ */
+export function extractInstructionText(model: Record<string, unknown>): string {
+  const parts = [
+    typeof model.base_instructions === "string" ? model.base_instructions : "",
+    typeof model.model_messages === "object" &&
+    model.model_messages !== null &&
+    Object.keys(model.model_messages).length > 0
+      ? JSON.stringify(model.model_messages)
+      : "",
+    typeof model.instructions_template === "string"
+      ? model.instructions_template
+      : "",
+  ];
+  return parts.filter((part) => part.length > 0).join("\n");
 }
 
 /** Compute the diff between two models.json payloads. */
@@ -135,6 +161,26 @@ export function diffModelsJson(prev: ModelsJson, curr: ModelsJson): ModelsDiff {
   let has_tool_schema_change = false;
   let has_prompt_tool_change = false;
 
+  const prevInstructions = new Map<string, string>();
+  const currInstructions = new Map<string, string>();
+  for (const m of prev.models) {
+    prevInstructions.set(slugOf(m), extractInstructionText(m));
+  }
+  for (const m of curr.models) {
+    currInstructions.set(slugOf(m), extractInstructionText(m));
+  }
+
+  const instruction_content_deltas: string[] = [];
+  for (const [slug, prevText] of prevInstructions) {
+    const currText = currInstructions.get(slug);
+    if (currText === undefined || prevText === currText) continue;
+    instruction_content_deltas.push(slug);
+  }
+
+  const added_models_with_instructions = added_models.filter(
+    (slug) => (currInstructions.get(slug) ?? "").length > 0,
+  );
+
   const fieldsToCompare = [
     ...TOOL_SCHEMA_FIELDS,
     "supports_image_detail_original",
@@ -159,8 +205,11 @@ export function diffModelsJson(prev: ModelsJson, curr: ModelsJson): ModelsDiff {
     added_models,
     removed_models,
     field_deltas,
+    instruction_content_deltas,
+    added_models_with_instructions,
     has_tool_schema_change,
     has_prompt_tool_change,
+    has_instruction_content_change: instruction_content_deltas.length > 0,
   };
 }
 
@@ -195,7 +244,12 @@ export function decideVerdict(input: VerdictInput): Verdict {
     return "tool-surface review needed";
   }
 
-  if (input.models_diff.has_prompt_tool_change || input.prompt_md_changed) {
+  if (
+    input.models_diff.has_prompt_tool_change ||
+    input.models_diff.has_instruction_content_change ||
+    input.models_diff.added_models_with_instructions.length > 0 ||
+    input.prompt_md_changed
+  ) {
     return "prompt-only update";
   }
 


### PR DESCRIPTION
## Summary
- the codex-agent-watch detector only surfaced tool-surface drift (tool schema fields, tool-name mentions in model prompts). behavioral guidance in codex `models.json` (steering / user-input handling) changed with no tool mentions, so releases carrying it were recorded as no-op (e.g. the sol/astra steering guidance jin found in rust-v0.153.x)
- extend the models.json differ to track instruction content (`base_instructions`, `model_messages`, `instructions_template`) and flag newly added models that ship instructions
- both surface as the existing `prompt-only update` verdict, so Amelia reviews them and summarizes noteworthy behavioral guidance in the tracker note for owners
- add a short section to the review agent prompt explaining instruction-content changes

## Validation
- `bun test scripts/codex-watch/`: 42 pass (6 new tests)
- dry-run against rust-v0.153.0...rust-v0.153.4 (the range that carried the steering guidance, previously no-op): now returns `prompt-only update`, with instruction content deltas on `gpt-5.6-luna` / `codex-auto-review` and `gpt-6-astra` flagged as an added model with instructions
- biome clean on changed files

requested by @kl2806