### PR TITLE
test(shared-memory): verify completed-turn auto-push

### DIFF
--- a/scripts/isolated-unit-tests.json
+++ b/scripts/isolated-unit-tests.json
@@ -1,6 +1,11 @@
 {
   "tests": [
     {
+      "path": "src/websocket/listener/turn-cleanup-shared-memory.e2e.test.ts",
+      "timeoutMs": 30000,
+      "reason": "Runs real Git pushes while replacing global fetch and mutating the backend, settings, MemFS URL, and a synthetic agent mount."
+    },
+    {
       "path": "src/auth/desktop-credentials.test.ts",
       "timeoutMs": 30000,
       "reason": "Builds Bun and Node child fixtures with Bun.build; running channel imports afterward in the same Bun process produces alias-resolution failures."

--- a/scripts/isolated-unit-tests.json
+++ b/scripts/isolated-unit-tests.json
@@ -3,7 +3,7 @@
     {
       "path": "src/websocket/listener/turn-cleanup-shared-memory.e2e.test.ts",
       "timeoutMs": 30000,
-      "reason": "Runs real Git pushes while replacing global fetch and mutating the backend, settings, MemFS URL, and a synthetic agent mount."
+      "reason": "Runs real Git pushes while replacing global fetch and mutating the backend, settings, auth environment, MemFS URL, and a synthetic agent mount."
     },
     {
       "path": "src/auth/desktop-credentials.test.ts",

--- a/src/websocket/listener/turn-cleanup-shared-memory.e2e.test.ts
+++ b/src/websocket/listener/turn-cleanup-shared-memory.e2e.test.ts
@@ -15,6 +15,7 @@ const AGENT_ID = `agent-shared-memory-post-turn-e2e-${randomUUID()}`;
 const REPOSITORY_NAME = "shared-notes";
 const originalFetch = globalThis.fetch;
 const originalMemfsBaseUrl = process.env.LETTA_MEMFS_BASE_URL;
+const originalApiKey = process.env.LETTA_API_KEY;
 const tempDirs: string[] = [];
 
 function git(cwd: string, args: string[]): string {
@@ -27,6 +28,7 @@ function configureIdentity(repo: string): void {
 }
 
 beforeAll(async () => {
+  process.env.LETTA_API_KEY = "shared-memory-post-turn-e2e-token";
   await settingsManager.initialize();
   globalThis.fetch = mock(async (input) => {
     const url = String(input);
@@ -60,6 +62,11 @@ afterEach(() => {
 
 afterAll(async () => {
   globalThis.fetch = originalFetch;
+  if (originalApiKey === undefined) {
+    delete process.env.LETTA_API_KEY;
+  } else {
+    process.env.LETTA_API_KEY = originalApiKey;
+  }
   await settingsManager.reset();
 });
 

--- a/src/websocket/listener/turn-cleanup-shared-memory.e2e.test.ts
+++ b/src/websocket/listener/turn-cleanup-shared-memory.e2e.test.ts
@@ -1,0 +1,142 @@
+import { afterAll, afterEach, beforeAll, expect, mock, test } from "bun:test";
+import { execFileSync } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { getRepositoryMountDir } from "@/agent/memory-git";
+import { __testSetBackend, type Backend } from "@/backend";
+import { settingsManager } from "@/settings-manager";
+import { getOrCreateScopedRuntime } from "./conversation-runtime";
+import { createRuntime } from "./lifecycle";
+import { runListenerTurnCleanup } from "./turn-cleanup";
+
+const AGENT_ID = `agent-shared-memory-post-turn-e2e-${randomUUID()}`;
+const REPOSITORY_NAME = "shared-notes";
+const originalFetch = globalThis.fetch;
+const originalMemfsBaseUrl = process.env.LETTA_MEMFS_BASE_URL;
+const tempDirs: string[] = [];
+
+function git(cwd: string, args: string[]): string {
+  return execFileSync("git", args, { cwd, encoding: "utf8" }).trim();
+}
+
+function configureIdentity(repo: string): void {
+  git(repo, ["config", "user.name", "Shared Memory E2E"]);
+  git(repo, ["config", "user.email", "shared-memory-e2e@letta.com"]);
+}
+
+beforeAll(async () => {
+  await settingsManager.initialize();
+  globalThis.fetch = mock(async (input) => {
+    const url = String(input);
+    if (url.includes(`/v1/agents/${AGENT_ID}/repositories`)) {
+      return Response.json({
+        repositories: [
+          {
+            id: "repo-shared-notes",
+            name: REPOSITORY_NAME,
+            is_primary: false,
+            permissions: "read_write",
+          },
+        ],
+      });
+    }
+    throw new Error(`Unexpected fetch in shared-memory E2E: ${url}`);
+  }) as unknown as typeof fetch;
+});
+
+afterEach(() => {
+  if (originalMemfsBaseUrl === undefined) {
+    delete process.env.LETTA_MEMFS_BASE_URL;
+  } else {
+    process.env.LETTA_MEMFS_BASE_URL = originalMemfsBaseUrl;
+  }
+  __testSetBackend(null);
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+afterAll(async () => {
+  globalThis.fetch = originalFetch;
+  await settingsManager.reset();
+});
+
+test("completed listener turn cleanup pushes an attached shared-memory commit", async () => {
+  const root = mkdtempSync(join(tmpdir(), "shared-memory-post-turn-e2e-"));
+  tempDirs.push(root);
+  const remote = join(root, "remote.git");
+  const seed = join(root, "seed");
+  const mount = getRepositoryMountDir(AGENT_ID, REPOSITORY_NAME);
+  tempDirs.push(dirname(mount));
+
+  mkdirSync(seed, { recursive: true });
+  git(root, ["init", "--bare", remote]);
+  git(seed, ["init", "--initial-branch=main"]);
+  configureIdentity(seed);
+  writeFileSync(join(seed, "MEMORY.md"), "# Shared memory\n", "utf8");
+  git(seed, ["add", "MEMORY.md"]);
+  git(seed, ["commit", "-m", "initialize shared memory"]);
+  git(seed, ["remote", "add", "origin", remote]);
+  git(seed, ["push", "-u", "origin", "main"]);
+  git(remote, ["symbolic-ref", "HEAD", "refs/heads/main"]);
+
+  mkdirSync(join(mount, ".."), { recursive: true });
+  git(root, ["clone", remote, mount]);
+  configureIdentity(mount);
+  writeFileSync(
+    join(mount, "turn-note.md"),
+    "committed during the turn\n",
+    "utf8",
+  );
+  git(mount, ["add", "turn-note.md"]);
+  git(mount, ["commit", "-m", "record completed turn"]);
+  const localSha = git(mount, ["rev-parse", "HEAD"]);
+  const remoteShaBefore = git(remote, ["rev-parse", "main"]);
+
+  __testSetBackend({
+    capabilities: {
+      remoteMemfs: true,
+      localMemfs: false,
+    },
+  } as unknown as Backend);
+  process.env.LETTA_MEMFS_BASE_URL = root;
+  git(mount, [
+    "remote",
+    "set-url",
+    "origin",
+    join(root, "v1", "git", AGENT_ID, "repositories", `${REPOSITORY_NAME}.git`),
+  ]);
+  mkdirSync(join(root, "v1", "git", AGENT_ID, "repositories"), {
+    recursive: true,
+  });
+  git(root, [
+    "clone",
+    "--bare",
+    remote,
+    join(root, "v1", "git", AGENT_ID, "repositories", `${REPOSITORY_NAME}.git`),
+  ]);
+
+  const listener = createRuntime();
+  const runtime = getOrCreateScopedRuntime(listener, AGENT_ID, "conv-e2e");
+  await runListenerTurnCleanup({
+    runtime,
+    agentId: AGENT_ID,
+    normalizedAgentId: AGENT_ID,
+    conversationId: "conv-e2e",
+    finalized: true,
+  });
+
+  const postTurnRemote = join(
+    root,
+    "v1",
+    "git",
+    AGENT_ID,
+    "repositories",
+    `${REPOSITORY_NAME}.git`,
+  );
+  expect(remoteShaBefore).not.toBe(localSha);
+  expect(git(postTurnRemote, ["rev-parse", "main"])).toBe(localSha);
+  expect(git(mount, ["rev-list", "--count", "@{u}..HEAD"])).toBe("0");
+});


### PR DESCRIPTION
## Summary

PR #4103 added automatic post-turn pushes for clean committed shared-memory changes and thoroughly tests the Git synchronizer itself. The completed-turn lifecycle still lacked a regression gate proving listener cleanup actually reaches that synchronizer.

This adds one isolated E2E test that drives finalized listener cleanup through the real post-turn coordinator, attached-repository discovery, and Git push. It commits a turn-produced file in a temporary attached checkout, then verifies the real bare remote advances to that commit and the checkout has no unpushed commits. Only the repository-list HTTP boundary is stubbed; `syncAttachedRepositories` and Git behavior remain real. Production code is unchanged.

The test runs in its own process because it intentionally replaces global fetch and mutates backend, settings, MemFS URL, and synthetic-agent mount state. It supplies and restores a synthetic API key so CI does not depend on developer authentication.

## Verification

- `bun test src/websocket/listener/turn-cleanup-shared-memory.e2e.test.ts --timeout 30000` — 1 pass, 0 fail on Windows 11 with the real `LETTA_API_KEY` removed from the test process.
- Adjacent lifecycle, coordinator, and Git synchronizer suites — 14 pass, 0 fail.
- Mutation check: removing `runPostTurnMemorySync` from finalized listener cleanup makes the new remote-SHA assertion fail.
- `bun run check` — all 12 repository checks passed with an isolated current-lockfile dependency install.
- Independent review found no blocker and confirmed disposable test-home protection prevents user-data deletion.

## Breadcrumbs

- Origin: #4103 added shared-memory auto-push and lower-level real-Git coverage.
- Gap: no prior test crossed finalized listener cleanup → post-turn coordinator → attachment discovery → remote push.
- Letta conversation: [`default`](https://chat.letta.com/chat/agent-03c143ce-b161-4a7b-93e8-6a0d570cf5f4?conversation=default)

## AI Disclosure

- [ ] This pull request was written entirely by a human
- [x] This pull request was written with AI assistance and reviewed and edited by a human
- [x] I have read the [AI Policy](https://github.com/letta-ai/letta-code/blob/main/AI_POLICY.md) and agree to its terms

Authorship selection remains pending human review while this PR is a draft.

## AI Tool(s) Used

Letta Code was used for freshness review, implementation, testing, mutation validation, and pull-request drafting. A separate Letta Code review independently checked lifecycle coverage and test safety.

## Human Verification

Pending Jibram's review before this draft is marked ready.