### PR TITLE
fix(agent): skip exhausted ChatGPT plans before rotation

### DIFF
--- a/src/agent/chatgpt-plan-rotation.test.ts
+++ b/src/agent/chatgpt-plan-rotation.test.ts
@@ -1,20 +1,203 @@
 import { describe, expect, test } from "bun:test";
+import Letta from "@letta-ai/letta-client";
 import { clearAvailableModelsCache } from "@/agent/available-models";
 import {
   formatPlanRotationNotice,
+  isChatGPTPlanExhausted,
   rotateChatGPTPlanOnQuotaLimit,
 } from "@/agent/chatgpt-plan-rotation";
 import {
   parseChatGPTUsageLimitDetail,
   selectChatGPTQuotaFailoverHandle,
 } from "@/agent/turn-recovery-policy";
-import { __testSetBackend } from "@/backend";
+import { __testSetBackend, APIBackend } from "@/backend";
+import type { ChatGPTUsageSnapshot } from "@/providers/chatgpt-usage-service";
 
 const FULL_DETAIL =
   'ChatGPT rate limit exceeded: {"error":{"type":"usage_limit_reached","message":"You have hit your usage limit.","plan_type":"plus","resets_at":1700000000,"resets_in_seconds":3600}}';
 
 const PRIMARY_HANDLE = "chatgpt-caren/gpt-5.2";
 const SIBLING_HANDLE = "chatgpt-jin/gpt-5.2";
+
+describe("quota-aware plan rotation over HTTP", () => {
+  for (const outcome of [
+    "available",
+    "all exhausted",
+    "unavailable",
+    "cancelled",
+    "cancelled during update",
+  ] as const) {
+    test(`${outcome}: checks quota before updating only the active conversation`, async () => {
+      const conversations = new Map([
+        ["conv-first", PRIMARY_HANDLE],
+        ["conv-second", PRIMARY_HANDLE],
+      ]);
+      const checked: string[] = [];
+      const updates: string[] = [];
+      const controller = new AbortController();
+      const server = Bun.serve({
+        port: 0,
+        fetch(req) {
+          const url = new URL(req.url);
+          const path = url.pathname.replace(/\/$/, "");
+          if (path === "/v1/models") {
+            if (outcome === "cancelled during update" && checked.length > 0)
+              controller.abort();
+            return Response.json(
+              [PRIMARY_HANDLE, SIBLING_HANDLE, "chatgpt-third/gpt-5.2"].map(
+                (handle) => ({
+                  handle,
+                  provider_type: "chatgpt_oauth",
+                  provider_category: "byok",
+                  max_context_window: 128_000,
+                }),
+              ),
+            );
+          }
+          if (path === "/v1/providers/chatgpt-usage") {
+            const provider = url.searchParams.get("provider_name") ?? "";
+            checked.push(provider);
+            if (outcome === "cancelled") controller.abort();
+            if (outcome === "cancelled during update")
+              clearAvailableModelsCache();
+            if (outcome === "unavailable")
+              return new Response("unavailable", { status: 503 });
+            return Response.json({
+              providerName: provider,
+              fetchedAt: new Date().toISOString(),
+              limitReached:
+                outcome === "all exhausted" ||
+                (outcome === "available" && checked.length === 1),
+            });
+          }
+          const id = path.split("/").at(-1) ?? "";
+          if (path.startsWith("/v1/conversations/") && conversations.has(id)) {
+            if (req.method === "PATCH") {
+              return req.json().then((body) => {
+                const model = (body as { model: string }).model;
+                updates.push(model);
+                conversations.set(id, model);
+                return Response.json({ id, model });
+              });
+            }
+            return Response.json({ id, model: conversations.get(id) });
+          }
+          return new Response("unexpected route", { status: 404 });
+        },
+      });
+      const client = new Letta({
+        apiKey: "test-key",
+        baseURL: server.url.toString(),
+        maxRetries: 0,
+      });
+      __testSetBackend(new APIBackend({ getClient: async () => client }));
+      clearAvailableModelsCache();
+      try {
+        const result = await rotateChatGPTPlanOnQuotaLimit({
+          agentId: "agent-rotation",
+          conversationId: "conv-first",
+          currentHandle: PRIMARY_HANDLE,
+          error: { error_code: "usage_limit_reached" },
+          exhaustedProviders: new Set(),
+          signal: controller.signal,
+        });
+        if (outcome === "available") {
+          expect(checked).toHaveLength(2);
+          expect(result?.toProvider).toBe(checked[1]);
+          expect(updates).toEqual([`${checked[1]}/gpt-5.2`]);
+        } else if (outcome === "unavailable") {
+          expect(checked).toHaveLength(1);
+          expect(result?.toProvider).toBe(checked[0]);
+          expect(updates).toHaveLength(1);
+        } else {
+          expect(checked).toHaveLength(outcome.startsWith("cancelled") ? 1 : 2);
+          expect(result).toBeNull();
+          expect(updates).toEqual([]);
+          expect(conversations.get("conv-first")).toBe(PRIMARY_HANDLE);
+        }
+        expect(conversations.get("conv-second")).toBe(PRIMARY_HANDLE);
+      } finally {
+        server.stop(true);
+        clearAvailableModelsCache();
+        __testSetBackend(null);
+      }
+    });
+  }
+});
+
+describe("plan-wide quota evidence", () => {
+  const now = Date.now();
+  const usage: ChatGPTUsageSnapshot = {
+    providerName: "plan",
+    fetchedAt: new Date(now).toISOString(),
+    summary: "",
+    primary: null,
+    secondary: null,
+    additional: [],
+  };
+  const fullWindow = {
+    label: "primary",
+    usedPercent: 100,
+    windowDurationMins: 300,
+    resetsAt: now / 1000 + 100,
+  };
+
+  test("uses the explicit limit verdict, including usable credits", () => {
+    expect(isChatGPTPlanExhausted({ ...usage, limitReached: true }, now)).toBe(
+      true,
+    );
+    expect(
+      isChatGPTPlanExhausted(
+        { ...usage, limitReached: false, primary: fullWindow },
+        now,
+      ),
+    ).toBe(false);
+    expect(
+      isChatGPTPlanExhausted(
+        { ...usage, primary: fullWindow, credits: { hasCredits: true } },
+        now,
+      ),
+    ).toBe(false);
+    expect(
+      isChatGPTPlanExhausted(
+        { ...usage, limitReached: true, credits: { hasCredits: true } },
+        now,
+      ),
+    ).toBe(false);
+  });
+
+  test("uses unexpired primary/secondary windows, not unrelated model limits", () => {
+    expect(isChatGPTPlanExhausted({ ...usage, primary: fullWindow }, now)).toBe(
+      true,
+    );
+    expect(
+      isChatGPTPlanExhausted({ ...usage, secondary: fullWindow }, now),
+    ).toBe(true);
+    expect(
+      isChatGPTPlanExhausted(
+        { ...usage, primary: { ...fullWindow, resetsAt: now / 1000 - 1 } },
+        now,
+      ),
+    ).toBe(false);
+    expect(
+      isChatGPTPlanExhausted({ ...usage, additional: [fullWindow] }, now),
+    ).toBe(false);
+    expect(isChatGPTPlanExhausted(usage, now)).toBe(false);
+  });
+
+  test("does not exclude a plan from stale quota data", () => {
+    expect(
+      isChatGPTPlanExhausted(
+        {
+          ...usage,
+          fetchedAt: new Date(now - 31_000).toISOString(),
+          limitReached: true,
+        },
+        now,
+      ),
+    ).toBe(false);
+  });
+});
 
 describe("rotateChatGPTPlanOnQuotaLimit", () => {
   test("updates only the active conversation and keeps exhausted plans turn-local", async () => {

--- a/src/agent/chatgpt-plan-rotation.ts
+++ b/src/agent/chatgpt-plan-rotation.ts
@@ -22,9 +22,30 @@ import {
   selectChatGPTQuotaFailoverHandle,
 } from "@/agent/turn-recovery-policy";
 import { getBackend } from "@/backend";
+import type { ChatGPTUsageSnapshot } from "@/providers/chatgpt-usage-service";
 
 /** Maximum plan swaps per turn, enforced by each consumer. */
 export const CHATGPT_PLAN_ROTATION_MAX_SWAPS_PER_TURN = 3;
+
+/** Only account-wide limits apply to every model exposed by a plan. */
+export function isChatGPTPlanExhausted(
+  usage: ChatGPTUsageSnapshot,
+  now = Date.now(),
+): boolean {
+  const fetchedAt = Date.parse(usage.fetchedAt);
+  if (!Number.isFinite(fetchedAt) || now - fetchedAt > 30_000) return false;
+  // Subscription windows can be full while the account still has credits.
+  const hasCredits =
+    usage.credits?.unlimited === true || usage.credits?.hasCredits === true;
+  if (hasCredits) return false;
+  if (usage.limitReached != null) return usage.limitReached;
+  return [usage.primary, usage.secondary].some(
+    (window) =>
+      window?.usedPercent != null &&
+      window.usedPercent >= 100 &&
+      (window.resetsAt === null || window.resetsAt * 1000 > now),
+  );
+}
 
 export interface ChatGPTPlanRotationResult {
   fromProvider: string;
@@ -104,8 +125,9 @@ export async function rotateChatGPTPlanOnQuotaLimit(params: {
   currentHandle: string | null;
   error: unknown;
   exhaustedProviders: Set<string>;
+  signal?: AbortSignal;
 }): Promise<ChatGPTPlanRotationResult | null> {
-  const { agentId, conversationId, error, exhaustedProviders } = params;
+  const { agentId, conversationId, error, exhaustedProviders, signal } = params;
 
   const parsedDetail = parseChatGPTUsageLimitDetail(error);
   if (!parsedDetail) return null;
@@ -138,11 +160,38 @@ export async function rotateChatGPTPlanOnQuotaLimit(params: {
   // The current plan is out of quota regardless of whether a sibling exists.
   exhaustedProviders.add(fromProvider);
 
-  const toHandle = selectChatGPTQuotaFailoverHandle({
-    currentHandle,
-    models,
-    exhaustedProviders,
-  });
+  // Check candidates before changing the model, not by spending a swap/run on
+  // each exhausted plan. Failed usage reads leave the old fallback available.
+  const excludedProviders = new Set(exhaustedProviders);
+  const timeout = AbortSignal.timeout(3_000);
+  const usageSignal = signal ? AbortSignal.any([signal, timeout]) : timeout;
+  let toHandle: string | null = null;
+  while (!signal?.aborted) {
+    toHandle = selectChatGPTQuotaFailoverHandle({
+      currentHandle,
+      models,
+      exhaustedProviders: excludedProviders,
+    });
+    if (!toHandle) return null;
+    const provider = providerFromHandle(toHandle);
+    if (!provider) return null;
+    let usage: ChatGPTUsageSnapshot | null = null;
+    try {
+      usage =
+        (await getBackend().readChatGPTUsage?.(provider, usageSignal)) ?? null;
+    } catch {
+      // Unsupported servers and unavailable usage are not proof of exhaustion.
+    }
+    if (signal?.aborted) return null;
+    if (
+      !usage ||
+      usage.providerName !== provider ||
+      !isChatGPTPlanExhausted(usage)
+    )
+      break;
+    excludedProviders.add(provider);
+  }
+  if (signal?.aborted) return null;
   if (!toHandle) return null;
 
   const toProvider = providerFromHandle(toHandle);
@@ -150,13 +199,19 @@ export async function rotateChatGPTPlanOnQuotaLimit(params: {
 
   try {
     if (conversationId === "default") {
-      await updateAgentLLMConfig(agentId, toHandle, {
-        provider_type: "chatgpt_oauth",
-      });
+      await updateAgentLLMConfig(
+        agentId,
+        toHandle,
+        { provider_type: "chatgpt_oauth" },
+        { signal },
+      );
     } else {
-      await updateConversationLLMConfig(conversationId, toHandle, {
-        provider_type: "chatgpt_oauth",
-      });
+      await updateConversationLLMConfig(
+        conversationId,
+        toHandle,
+        { provider_type: "chatgpt_oauth" },
+        { signal },
+      );
     }
   } catch {
     return null;

--- a/src/agent/modify.ts
+++ b/src/agent/modify.ts
@@ -344,6 +344,7 @@ function maxTokensForUpdatePayload(
  * @returns The updated agent state from the server (includes llm_config and model_settings)
  */
 export interface UpdateLLMConfigOptions {
+  signal?: AbortSignal;
   /**
    * Context window to send explicitly. Wins over updateArgs.context_window
    * and catalog derivation on EVERY backend — including local backends, where
@@ -447,12 +448,17 @@ export async function updateAgentLLMConfig(
     useBackendModelCatalog,
   });
 
-  await backend.updateAgent(agentId, {
-    model: modelHandle,
-    ...(hasModelSettings && { model_settings: modelSettings }),
-    ...(contextWindow && { context_window_limit: contextWindow }),
-    ...(maxTokens !== undefined && { max_tokens: maxTokens }),
-  });
+  options?.signal?.throwIfAborted();
+  await backend.updateAgent(
+    agentId,
+    {
+      model: modelHandle,
+      ...(hasModelSettings && { model_settings: modelSettings }),
+      ...(contextWindow && { context_window_limit: contextWindow }),
+      ...(maxTokens !== undefined && { max_tokens: maxTokens }),
+    },
+    ...(options?.signal ? [{ signal: options.signal }] : []),
+  );
 
   const finalAgent = await backend.retrieveAgent(agentId, {
     include: ["agent.tools", "agent.tags"],
@@ -522,7 +528,12 @@ export async function updateConversationLLMConfig(
     ...(maxTokens !== undefined && { max_tokens: maxTokens }),
   } as Parameters<typeof backend.updateConversation>[1];
 
-  return backend.updateConversation(conversationId, payload);
+  options?.signal?.throwIfAborted();
+  return backend.updateConversation(
+    conversationId,
+    payload,
+    ...(options?.signal ? [{ signal: options.signal }] : []),
+  );
 }
 
 export interface ModelConfigUpdate {

--- a/src/backend/backend.ts
+++ b/src/backend/backend.ts
@@ -2,6 +2,10 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import type { Message } from "@letta-ai/letta-client/resources/agents/messages";
+import {
+  type ChatGPTUsageSnapshot,
+  normalizeCloudChatGPTUsageResponse,
+} from "@/providers/chatgpt-usage-service";
 import type { getClient } from "./api/client";
 import type {
   ForkConversationOptions,
@@ -272,6 +276,11 @@ export interface Backend {
     options?: ModelsListOptions,
   ): Promise<Awaited<ReturnType<APIClient["models"]["list"]>>>;
 
+  readChatGPTUsage?(
+    providerName: string,
+    signal?: AbortSignal,
+  ): Promise<ChatGPTUsageSnapshot | null>;
+
   createConversationMessageStream(
     conversationId: string,
     body: ConversationMessageCreateBody,
@@ -527,6 +536,19 @@ export class APIBackend implements Backend {
   async listModels(options?: ModelsListOptions) {
     const client = await this.getClient();
     return client.models.list(options);
+  }
+
+  async readChatGPTUsage(providerName: string, signal?: AbortSignal) {
+    const client = await this.getClient();
+    // Use the same credentials/server as model selection. Do not reuse the
+    // provider selector's name-only cache across authenticated projects.
+    const raw = await client.get<unknown>("/v1/providers/chatgpt-usage", {
+      query: { provider_name: providerName },
+      signal,
+      timeout: 3_000,
+      maxRetries: 0,
+    });
+    return normalizeCloudChatGPTUsageResponse({ raw, providerName });
   }
 
   async createConversationMessageStream(

--- a/src/cli/app/use-conversation-loop.ts
+++ b/src/cli/app/use-conversation-loop.ts
@@ -2384,10 +2384,10 @@ export function useConversationLoop(ctx: ConversationLoopContext) {
               currentHandle: currentModelId,
               error: streamErrorInfo ?? runErrorInfo ?? fallbackError,
               exhaustedProviders: chatgptExhaustedProvidersRef.current,
+              signal: turnAbortController.signal,
             });
             if (rotation) {
               chatgptPlanSwapsRef.current += 1;
-
               const statusId = uid("status");
               buffersRef.current.byId.set(statusId, {
                 kind: "status",

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -2884,11 +2884,11 @@ ${SYSTEM_REMINDER_CLOSE}
           currentHandle: null,
           error: result.errorInfo ?? runErrorInfo ?? latestErrorText,
           exhaustedProviders: chatgptExhaustedProviders,
+          signal: sigintSignal,
         });
         if (rotation) {
           chatgptPlanSwaps += 1;
           const rotationMessage = formatPlanRotationNotice(rotation);
-
           if (outputFormat === "stream-json") {
             const retryMsg: RetryMessage = {
               type: "retry",

--- a/src/websocket/listener/turn.ts
+++ b/src/websocket/listener/turn.ts
@@ -661,6 +661,7 @@ async function handleIncomingMessageInner(
             currentHandle: null,
             error: quotaError,
             exhaustedProviders: chatgptExhaustedProviders,
+            signal: turnAbortSignal,
           });
           if (rotation) {
             chatgptPlanSwaps += 1;
@@ -675,7 +676,6 @@ async function handleIncomingMessageInner(
               agentId,
               conversationId,
             });
-
             if (turnAbortSignal.aborted) {
               throw new Error("Cancelled by user");
             }


### PR DESCRIPTION
## Summary

Check a candidate ChatGPT plan's quota before switching the conversation to it. Known-exhausted candidates are skipped without consuming a model swap. This runs in the shared rotation helper used by TUI, headless, and listener turns.

Usage reads use the same authenticated client as model updates, with a three-second check budget and no shared quota cache. Unavailable or stale usage preserves the previous fallback behavior. Usable credits keep a plan eligible. Additional model-specific quota buckets are not treated as account-wide exhaustion.

Cancellation now reaches the model-update request, including cancellation while preparing its context-window settings.

## Verification

`bun run check`, `bun run build`, `node letta.js --version`, and `bun test src/agent/chatgpt-plan-rotation.test.ts` passed (20 tests in the focused suite).

The HTTP tests use the real SDK and assert the model PATCH, including no PATCH when all candidates are exhausted or the turn is cancelled. An isolated live check skipped an exhausted candidate and persisted the selected model only in the target conversation. The control conversation stayed unchanged. That check exercised quota lookup and model mutation, not a complete LLM turn or rendered UI.

## Breadcrumbs

- Requested by @cpacker.
- Origin: [ChatGPT plan rotation #3911](https://github.com/letta-ai/letta-code/pull/3911) selected sibling plans without checking their quota. This adds that missing check, rather than restoring a regressed behavior.
- Follow-up to [streamed quota error preservation #4317](https://github.com/letta-ai/letta-code/pull/4317). Error classification and the three-swap limit are unchanged.

## AI Tool(s) Used

Letta Code for implementation, tests, and review. Human review pending.
