### PR TITLE
fix(teleport): reject local channel moves at the source listener [LET-12240]

### DIFF
--- a/src/channels/routing.ts
+++ b/src/channels/routing.ts
@@ -47,6 +47,24 @@ function routeKey(
 
 // ── Load/save ─────────────────────────────────────────────────────
 
+/** Read the current persisted routes without merging into the process cache. */
+export function readRoutes(channelId: string): ChannelRoute[] {
+  if (loadRoutesOverride) {
+    return loadRoutesOverride(channelId) ?? getRoutesForChannel(channelId);
+  }
+  try {
+    const text = readFileSync(getChannelRoutingPath(channelId), "utf-8");
+    const parsed = JSON.parse(text) as { routes?: ChannelRoute[] };
+    return Array.isArray(parsed.routes)
+      ? parsed.routes.filter(
+          (route) => route?.chatId && route.agentId && route.conversationId,
+        )
+      : [];
+  } catch {
+    return [];
+  }
+}
+
 /**
  * Load routing table from disk for a given channel.
  */
@@ -92,9 +110,7 @@ export function loadRoutes(channelId: string): void {
   if (!existsSync(path)) return;
 
   try {
-    const text = readFileSync(path, "utf-8");
-    const parsed = JSON.parse(text) as { routes?: ChannelRoute[] };
-    const routes = parsed.routes ?? [];
+    const routes = readRoutes(channelId);
 
     for (const route of routes) {
       if (route.chatId && route.agentId && route.conversationId) {

--- a/src/channels/teleport-guard.ts
+++ b/src/channels/teleport-guard.ts
@@ -1,0 +1,20 @@
+import { getSupportedChannelIds } from "./plugin-registry";
+import { readRoutes } from "./routing";
+
+/** Only device-owned routes live here; Cloud-managed channels do not. */
+export function getLocalChannelTeleportError(scope: {
+  agentId: string;
+  conversationId: string;
+}): string | null {
+  const channels = getSupportedChannelIds().filter((channelId) => {
+    return readRoutes(channelId).some(
+      (route) =>
+        route.agentId === scope.agentId &&
+        route.conversationId === scope.conversationId &&
+        route.enabled !== false &&
+        route.outboundEnabled !== false,
+    );
+  });
+  if (channels.length === 0) return null;
+  return `This conversation is bound to ${channels.join(", ")} on this computer. Teleport is blocked because MessageChannel cannot follow the conversation to another computer yet. Remove the channel route or continue locally.`;
+}

--- a/src/cli/subcommands/teleport.ts
+++ b/src/cli/subcommands/teleport.ts
@@ -10,8 +10,7 @@ import {
   teleportToEnvironment,
 } from "@/backend/api/environments";
 import { ApiRequestError } from "@/backend/api/request";
-import { getSupportedChannelIds } from "@/channels/plugin-registry";
-import { listChannelRouteSnapshots } from "@/channels/service-routes";
+import { getLocalChannelTeleportError } from "@/channels/teleport-guard";
 import { type SessionRef, settingsManager } from "@/settings-manager";
 
 interface TeleportSubcommandDeps {
@@ -158,16 +157,6 @@ async function initializeTeleportSettings(): Promise<void> {
   await settingsManager.loadLocalProjectSettings();
 }
 
-function listActiveChannelRouteNames(session: SessionRef): string[] {
-  return getSupportedChannelIds().filter((channelId) =>
-    listChannelRouteSnapshots({
-      channelId,
-      agentId: session.agentId,
-      conversationId: session.conversationId,
-    }).some((route) => route.enabled && route.outboundEnabled !== false),
-  );
-}
-
 export async function runTeleportSubcommand(
   argv: string[],
   deps: TeleportSubcommandDeps = {},
@@ -212,12 +201,8 @@ export async function runTeleportSubcommand(
       )(),
     );
 
-    const activeChannelRoutes = listActiveChannelRouteNames(session);
-    if (activeChannelRoutes.length > 0) {
-      throw new Error(
-        `This conversation is bound to ${activeChannelRoutes.join(", ")} on this computer. Teleport is blocked because MessageChannel cannot follow the conversation to another computer yet. Remove the channel route or continue locally.`,
-      );
-    }
+    const channelError = getLocalChannelTeleportError(session);
+    if (channelError) throw new Error(channelError);
 
     let targetConnectionId: string;
 

--- a/src/integration-tests/teleport-backend.integration.test.ts
+++ b/src/integration-tests/teleport-backend.integration.test.ts
@@ -86,7 +86,11 @@ async function stop(child: ChildProcess) {
 }
 
 const testWithAPI = apiKey ? test : test.skip;
-testWithAPI.each(["destination lookup", "active handoff"])(
+testWithAPI.each([
+  "destination lookup",
+  "active handoff",
+  "local channel rejection",
+])(
   "Cloud teleport with saved local backend: %s",
   async (scenario) => {
     const root = await mkdtemp(join(tmpdir(), "letta-teleport-backend-"));
@@ -115,6 +119,25 @@ testWithAPI.each(["destination lookup", "active handoff"])(
             preferredBackendMode: role === "source" ? "api" : "local",
           }),
         );
+        if (role === "source" && scenario === "local channel rejection") {
+          const channelDir = join(home, ".letta", "channels", "telegram");
+          await mkdir(channelDir, { recursive: true });
+          await writeFile(
+            join(channelDir, "routing.yaml"),
+            JSON.stringify({
+              routes: [
+                {
+                  chatId: "teleport-test-chat",
+                  agentId,
+                  conversationId,
+                  enabled: true,
+                  outboundEnabled: true,
+                  createdAt: new Date().toISOString(),
+                },
+              ],
+            }),
+          );
+        }
         const env = createAuthenticatedCliTestEnv({
           HOME: home,
           LETTA_BASE_URL: baseURL,
@@ -239,6 +262,8 @@ testWithAPI.each(["destination lookup", "active handoff"])(
       } else {
         stage = "source runtime_start";
         const started = await source.client.runtimeStart(runtimeStart);
+        if (!started.success)
+          throw new Error(started.error ?? "Source runtime_start failed");
         expect(started.success).toBe(true);
         expect(started.runtime).toMatchObject(scope);
 
@@ -286,6 +311,11 @@ testWithAPI.each(["destination lookup", "active handoff"])(
           const result = await request<TeleportResponse>(
             `${runtimePath}/teleports/${encodeURIComponent(teleport.id)}`,
           );
+          if (scenario === "local channel rejection") {
+            return result.status === "failed" || result.status === "completed"
+              ? result
+              : undefined;
+          }
           if (result.status === "failed") {
             // On pre-fix code this produces the concrete local lookup failure,
             // rather than merely asserting that a backend flag has the wrong value.
@@ -297,16 +327,39 @@ testWithAPI.each(["destination lookup", "active handoff"])(
           }
           return result.status === "completed" ? result : undefined;
         });
-        expect(completed.agentId).toBe(agent.id);
-        expect(completed.conversationId).toBe(conversation.id);
-        expect(completed.targetConnectionId).toBe(destination.connectionId);
-        stage = "destination runtime_start";
-        const resumed = await destination.client.runtimeStart(runtimeStart);
-        expect(resumed.success).toBe(true);
-        expect(resumed.runtime).toMatchObject(scope);
-        expect(resumed.agent?.id).toBe(agent.id);
-        expect(resumed.conversation?.id).toBe(conversation.id);
-        expect(resumed.created).toEqual({ agent: false, conversation: false });
+        if (scenario === "local channel rejection") {
+          expect(completed.status).toBe("failed");
+          expect(completed.error).toContain("bound to telegram");
+          expect(completed.error).toContain("MessageChannel cannot follow");
+          stage = "source input after rejection";
+          const accepted = await source.client.submitInput({
+            runtime: scope,
+            payload: {
+              kind: "create_message",
+              messages: [
+                {
+                  role: "user",
+                  content: "Reply again after the rejected teleport.",
+                },
+              ],
+            },
+          });
+          expect(accepted.accepted).toBe(true);
+        } else {
+          expect(completed.agentId).toBe(agent.id);
+          expect(completed.conversationId).toBe(conversation.id);
+          expect(completed.targetConnectionId).toBe(destination.connectionId);
+          stage = "destination runtime_start";
+          const resumed = await destination.client.runtimeStart(runtimeStart);
+          expect(resumed.success).toBe(true);
+          expect(resumed.runtime).toMatchObject(scope);
+          expect(resumed.agent?.id).toBe(agent.id);
+          expect(resumed.conversation?.id).toBe(conversation.id);
+          expect(resumed.created).toEqual({
+            agent: false,
+            conversation: false,
+          });
+        }
       }
     } catch (error) {
       const httpStatus =
@@ -349,12 +402,16 @@ testWithAPI.each(["destination lookup", "active handoff"])(
         }
       }
       if (conversationId)
-        await sdk.conversations.delete(conversationId).catch(() => {
-          failures.push("conversation deletion");
+        await sdk.conversations.delete(conversationId).catch((error) => {
+          failures.push(
+            `conversation deletion ${conversationId}: ${error instanceof Letta.APIError ? error.status : "unknown"}`,
+          );
         });
       if (agentId)
-        await sdk.agents.delete(agentId).catch(() => {
-          failures.push("agent deletion");
+        await sdk.agents.delete(agentId).catch((error) => {
+          failures.push(
+            `agent deletion ${agentId}: ${error instanceof Letta.APIError ? error.status : "unknown"}`,
+          );
         });
       for (const id of environmentIds) {
         await request(

--- a/src/websocket/listener/teleport-channels.test.ts
+++ b/src/websocket/listener/teleport-channels.test.ts
@@ -1,0 +1,252 @@
+import { afterEach, beforeEach, expect, mock, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import WebSocket from "ws";
+import { __testOverrideChannelsRoot } from "@/channels/config";
+import { clearAllRoutes } from "@/channels/routing";
+import type { ChannelRoute } from "@/channels/types";
+import type { WsProtocolCommand } from "@/types/protocol_v2";
+import { openListenerConnection } from "./connection";
+import { getOrCreateScopedRuntime } from "./conversation-runtime";
+import {
+  registerRuntimeExternalTools,
+  rejectPendingExternalToolCalls,
+} from "./external-tools";
+import { createRuntime } from "./lifecycle";
+import { createListenerMessageHandler } from "./message-router";
+import { setActiveRuntime } from "./runtime";
+import {
+  claimPendingTeleportAtBoundary,
+  isRuntimeTeleportPending,
+} from "./teleport";
+import type { StartListenerOptions } from "./types";
+
+const scope = { agent_id: "agent-1", conversation_id: "conversation-1" };
+let channelsRoot: string;
+
+beforeEach(() => {
+  channelsRoot = mkdtempSync(join(tmpdir(), "teleport-channels-"));
+  __testOverrideChannelsRoot(channelsRoot);
+  clearAllRoutes();
+});
+
+afterEach(() => {
+  setActiveRuntime(null);
+  clearAllRoutes();
+  __testOverrideChannelsRoot(null);
+  rmSync(channelsRoot, { recursive: true, force: true });
+});
+
+function persistRoute(channel: string, overrides: Partial<ChannelRoute> = {}) {
+  const dir = join(channelsRoot, channel);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(
+    join(dir, "routing.yaml"),
+    JSON.stringify({
+      routes: [
+        {
+          chatId: "chat-1",
+          agentId: scope.agent_id,
+          conversationId: scope.conversation_id,
+          enabled: true,
+          outboundEnabled: true,
+          createdAt: "2026-09-04T00:00:00.000Z",
+          ...overrides,
+        },
+      ],
+    }),
+  );
+}
+
+function fixture() {
+  const listener = createRuntime();
+  const runtime = getOrCreateScopedRuntime(
+    listener,
+    scope.agent_id,
+    scope.conversation_id,
+  );
+  const sent: unknown[] = [];
+  const socket = {
+    readyState: WebSocket.OPEN,
+    bufferedAmount: 0,
+    isOpen: () => true,
+    send: (data: string) => sent.push(JSON.parse(data)),
+  };
+  const options: StartListenerOptions = {
+    connectionId: "source",
+    wsUrl: "ws://app-server.test",
+    deviceId: "source-device",
+    connectionName: "Source",
+    onConnected: () => {},
+    onDisconnected: () => {},
+    onError: () => {},
+  };
+  openListenerConnection({
+    runtime: listener,
+    connectionId: "source",
+    writer: socket as unknown as WebSocket,
+    options,
+  });
+  setActiveRuntime(listener);
+  const processIncomingMessage = mock(async () => {});
+  const runDetachedListenerTask = mock(() => {});
+  const handle = createListenerMessageHandler({
+    runtime: listener,
+    socket: socket as unknown as WebSocket,
+    opts: options,
+    processQueuedTurn: async () => {},
+    fileCommandSession: { handle: () => false },
+    getParsedRuntimeScope: () => null,
+    replaySyncStateForRuntime: async () => {},
+    getOrCreateScopedRuntime: () => runtime,
+    handleApprovalResponseInput: async () => false,
+    handleChangeDeviceStateInput: async () => false,
+    handleAbortMessageInput: async () => false,
+    stampInboundUserMessageOtids: (incoming) => incoming,
+    safeSocketSend: (_target, payload) => {
+      sent.push(payload);
+      return true;
+    },
+    runDetachedListenerTask,
+    trackListenerError: () => {},
+    processIncomingMessage,
+  });
+  const deliver = (command: WsProtocolCommand) =>
+    handle(Buffer.from(JSON.stringify(command)));
+  const request = (teleportId = "teleport-1") =>
+    deliver({
+      type: "teleport_request",
+      request_id: teleportId,
+      teleport_id: teleportId,
+      runtime: scope,
+      target: {
+        connection_id: "target",
+        device_id: "target-device",
+        connection_name: "Target",
+      },
+    });
+  return {
+    listener,
+    runtime,
+    sent,
+    deliver,
+    request,
+    processIncomingMessage,
+    runDetachedListenerTask,
+  };
+}
+
+test.each(["telegram", "slack", "discord"])(
+  "rejects a wire request for a local %s route without yielding or restarting the source",
+  async (channel) => {
+    persistRoute(channel);
+    const f = fixture();
+    const lease = f.runtime.turnLifecycle.begin({
+      origin: "message",
+      workingDirectory: process.cwd(),
+    });
+
+    await f.request();
+    await f.request(); // A repeated rejection must not become a pending handoff.
+    expect(f.sent).toContainEqual(
+      expect.objectContaining({
+        type: "teleport_ready",
+        success: false,
+        active_turn: false,
+        error: expect.stringContaining(`bound to ${channel}`),
+      }),
+    );
+    expect(
+      isRuntimeTeleportPending(
+        f.listener,
+        scope.agent_id,
+        scope.conversation_id,
+      ),
+    ).toBe(false);
+    expect(
+      claimPendingTeleportAtBoundary({
+        listener: f.listener,
+        agentId: scope.agent_id,
+        conversationId: scope.conversation_id,
+        activeTurn: true,
+      }),
+    ).toBeNull();
+    expect(f.runtime.turnLifecycle.isCurrent(lease)).toBe(true);
+    expect(f.runtime.isProcessing).toBe(true);
+
+    await f.deliver({
+      type: "teleport_failed",
+      teleport_id: "teleport-1",
+      runtime: scope,
+      error: "Local channel teleport is blocked",
+    });
+    expect(f.runDetachedListenerTask).not.toHaveBeenCalled();
+    expect(f.processIncomingMessage).not.toHaveBeenCalled();
+    expect(f.runtime.turnLifecycle.isCurrent(lease)).toBe(true);
+    f.runtime.turnLifecycle.finish(lease, "end_turn");
+  },
+);
+
+test.each([
+  { enabled: false },
+  { outboundEnabled: false },
+  { agentId: "another-agent" },
+  { conversationId: "another-conversation" },
+])("ignores an unrelated or inactive local route: %j", async (overrides) => {
+  persistRoute("telegram", overrides);
+  const f = fixture();
+  await f.request();
+  expect(f.sent).toContainEqual(
+    expect.objectContaining({ type: "teleport_ready", success: true }),
+  );
+});
+
+test("a Cloud-managed MessageChannel registration alone does not block teleport", async () => {
+  const f = fixture();
+  registerRuntimeExternalTools(f.listener, "source", scope, [
+    {
+      tools: [
+        {
+          name: "MessageChannel",
+          description: "Cloud channel replies",
+          parameters: { type: "object", properties: {} },
+        },
+      ],
+    },
+  ]);
+  try {
+    await f.request();
+    expect(f.sent).toContainEqual(
+      expect.objectContaining({ type: "teleport_ready", success: true }),
+    );
+  } finally {
+    rejectPendingExternalToolCalls(f.listener, "test cleanup");
+  }
+});
+
+test("removing a route in the gateway process unblocks the next request", async () => {
+  persistRoute("telegram");
+  const f = fixture();
+  await f.request();
+  expect(f.sent).toContainEqual(
+    expect.objectContaining({ type: "teleport_ready", success: false }),
+  );
+
+  // The gateway writes the file in a different process, so it cannot clear
+  // any routes cached in this listener.
+  writeFileSync(
+    join(channelsRoot, "telegram", "routing.yaml"),
+    JSON.stringify({ routes: [] }),
+  );
+  f.sent.length = 0;
+  await f.request();
+  expect(f.sent).toContainEqual(
+    expect.objectContaining({ type: "teleport_ready", success: false }),
+  );
+  f.sent.length = 0;
+  await f.request("teleport-2");
+  expect(f.sent).toContainEqual(
+    expect.objectContaining({ type: "teleport_ready", success: true }),
+  );
+});

--- a/src/websocket/listener/teleport.ts
+++ b/src/websocket/listener/teleport.ts
@@ -1,5 +1,6 @@
 import type WebSocket from "ws";
 import { resolveBackendMode } from "@/backend/backend-mode";
+import { getLocalChannelTeleportError } from "@/channels/teleport-guard";
 import type {
   TeleportContinuation,
   TeleportFailedCommand,
@@ -253,6 +254,18 @@ export function handleTeleportRequest(params: {
     drainAcceptedInputs: false,
     activeTurn: false,
   };
+  const channelError = getLocalChannelTeleportError(pending);
+  if (channelError) {
+    pending.readyAt = Date.now();
+    pending.error = channelError;
+    pendingTeleports.set(pending.teleportId, pending);
+    sendTeleportReady(listener, pending, {
+      success: false,
+      error: channelError,
+    });
+    retainTeleportForRecovery(listener, pending);
+    return;
+  }
   const conflicting = findPendingTeleportForRuntime(
     listener,
     pending.agentId,
@@ -411,7 +424,8 @@ export function handleTeleportFailure(params: {
     agentId: params.command.runtime.agent_id,
     conversationId: params.command.runtime.conversation_id,
   });
-  if (!pending) return;
+  // Rejected requests never yielded, so their source turn needs no recovery.
+  if (!pending || pending.error) return;
 
   const runtime = params.getOrCreateScopedRuntime(
     params.listener,


### PR DESCRIPTION
## Summary

Conversations using locally hosted channels must not teleport and lose `MessageChannel`. The CLI already rejects these moves, but requests from Desktop or the API could still make the source listener yield. The listener now applies the same route check before handing off the conversation. Cloud-managed channels remain supported because they do not use the local routing files.

The check reads the current routing file each time, so removing a route in the separate gateway process takes effect without restarting the listener. Repeated requests receive the same rejection, and the coordinator's failure reply does not start a recovery turn because the source never yielded.

## Before and after

Previously, `teleport_request` could make a locally bound conversation yield and report `teleport_ready` with `success: true`. The destination then ran without the original gateway's tool.

It now immediately returns the existing failure response. For a Telegram route:

```json
{
  "type": "teleport_ready",
  "teleport_id": "<request teleport ID>",
  "runtime": { "agent_id": "<agent>", "conversation_id": "<conversation>" },
  "success": false,
  "active_turn": false,
  "mode": "<current permission mode>",
  "error": "This conversation is bound to telegram on this computer. Teleport is blocked because MessageChannel cannot follow the conversation to another computer yet. Remove the channel route or continue locally."
}
```

The error lists all matching channel names. Disabled routes, routes with outbound delivery disabled, and routes belonging to another agent or conversation do not block the move.

## Verification

- `bun run check`: all 12 checks passed. The focused teleport, routing, and turn-lifecycle suites passed (58 tests).
- Red-first regression: persisted local routing files and `teleport_request` frames pass through the listener parser and handler. The three local-channel cases fail on the base commit and pass with the guard. The tests preserve an active turn through rejection and the subsequent `teleport_failed` reply, and cover route removal and a Cloud-style external-tool registration without local routes.
- Built the Node artifact and started `letta server --listen` in an isolated home directory. A real WebSocket client received the explicit rejection twice for the bound conversation, then `success: true` for an unbound conversation. The server remained responsive.
- Added a case to the existing Cloud/two-listener integration suite. The local attempt stopped before teleport: fixture creation succeeded, but source `runtime_start` and fixture deletion returned `404 Agent not found`. Full Cloud round-trip verification and Desktop rendering remain unverified; this PR does not change frontend rendering.

## Breadcrumbs

- Requested in: LET-12240. Related: LET-12038.
- Follow-up to [the CLI-only guard](https://github.com/letta-ai/letta-code/pull/4223), whose description explicitly left direct API and other-client requests uncovered.
- Origin: [conversation teleport](https://github.com/letta-ai/letta-code/pull/3813) and [gateway turn handoff](https://github.com/letta-ai/letta-code/pull/3846) did not reject local routes at the source listener. This completes missing enforcement rather than repairing a later regression.
- Letta conversation: [`conv-2e0377a0-0cdd-48d0-8344-78e9078362b1`](https://chat.letta.com/chat/agent-b86b0d3a-c425-4c88-86b9-44171f178713?conversation=conv-2e0377a0-0cdd-48d0-8344-78e9078362b1).
