### PR TITLE
fix(context-doctor): remove incorrect persona.md and overlap claims

### DIFF
--- a/src/skills/builtin/context-doctor/ROOT_MEMORY.md
+++ b/src/skills/builtin/context-doctor/ROOT_MEMORY.md
@@ -65,9 +65,8 @@ The context in the memory filesystem should have a clear structure, with a well-
 
 #### Invalid context format
 Files in the memory filesystem must follow certain structural requirements: 
-- Must have root `MEMORY.md` and root `persona.md`
+- Must have root `MEMORY.md`
 - Root and child `MEMORY.md` files have no frontmatter; every other memory Markdown file has exactly `name` and `description` frontmatter
-- Must NOT have overlapping file and folder names (e.g. `human.md` and `human/identity.md`)
 - Must follow specification for skills (e.g. `skills/{skill_name}/`) with the format:
 ```
 skill-name/

--- a/src/skills/builtin/context-doctor/SKILL.md
+++ b/src/skills/builtin/context-doctor/SKILL.md
@@ -65,8 +65,6 @@ The context in the memory filesystem should have a clear structure, with a well-
 
 #### Invalid context format
 Files in the memory filesystem must follow certain structural requirements: 
-- Must have a `system/persona.md`
-- Must NOT have overlapping file and folder names (e.g. `system/human.md` and `system/human/identity.md`) 
 - Must follow specification for skills (e.g. `skills/{skill_name}/`) with the format:
 ```
 skill-name/


### PR DESCRIPTION
Builtin-skill-watch: context-doctor@9ead5f0480b2-aec3edebbc10e4e4

## Selected skill
`context-doctor` - Identify and repair degradation in system prompt, external memory, and skills preventing you from following instructions or remembering information as well as you should.

## Stale claims
1. The skill stated that `persona.md` is a required root file alongside `MEMORY.md`
2. The skill stated that overlapping file and folder names are prohibited

## Current owning source
`src/agent/memory-constraints.ts` and `src/memory-constraints.ts` - The memory constraints validator only requires `MEMORY.md` for MemFS v2 (API-backed memory). Neither `persona.md` nor overlap prohibition is enforced by the validator.

## Validation performed
- Checked `memory-constraints.ts` for persona validation: none found
- Checked `memory-git-hooks.ts` for overlap validation: none found
- Verified memory structure detection in `memory-format.ts`: only checks for `MEMORY.md` marker
- Ran `bun run check`: all 12 checks pass
- Ran focused tests: 44 tests pass

🏥