### PR TITLE
docs(skills): correct height-cap claim in customizing-statusline api reference

### DIFF
--- a/src/skills/builtin/customizing-statusline/references/api.md
+++ b/src/skills/builtin/customizing-statusline/references/api.md
@@ -75,7 +75,8 @@ render(ctx: {
 ```
 
 - `row`/`columns` measure visible width with ANSI stripped, so chalk-colored segments and links align correctly.
-- The host clips each line to `width` and caps total height; the mod owns layout within that.
+- The host clips each line to `width`; the mod owns layout within that.
+- Above/below panels (order ≠ 0) are height-capped at 8 lines total; order-0 panels render every returned line, so keep them to one line.
 
 ## Render rules
 


### PR DESCRIPTION
Builtin-skill-watch: customizing-statusline@9ead5f0480b2-d067869121d1b7b1

**Selected skill:** `customizing-statusline`

**Stale claim:** api.md render-context section said "The host clips each line to `width` and caps total height" for all panels.

**Current owning source:** `src/cli/components/ModPanelRow.tsx` caps above/below panels (order ≠ 0) at 8 lines total (`MAX_MOD_PANEL_LINES`); `src/cli/components/InputRich.tsx` `StatuslineSlot` renders every returned line for order-0 panels with per-line `truncateToWidth` clipping only, no height cap. The claim has been inaccurate since the skill was authored in #3104, not drift from a later change.

**Focused validation:** Read both render paths at commit 9ead5f0480b2. `ModPanelRow` slices to `MAX_MOD_PANEL_LINES = 8` before rendering; `StatuslineSlot` maps all lines through `truncateToWidth` with no slice. Pre-commit checks (filename casing, layer boundaries, module ownership, tsc) passed on the commit.

**Changes:**
- Split the claim: per-line width clipping applies to all panels; the 8-line height cap applies only to above/below panels; order-0 panels render every returned line, so keep them to one line