### PR TITLE
fix(skills): correct image generation error format and provider options

### DIFF
--- a/src/skills/builtin/image-generation/SKILL.md
+++ b/src/skills/builtin/image-generation/SKILL.md
@@ -73,7 +73,8 @@ embed each on its own line. Also tell the user the `credits_charged`.
 | `prompt` | string | Required, 1–32000 chars. |
 | `model` | string | Optional; defaults per provider (below). |
 | `n` | int 1–4 | Optional, default 1. Request variations in one call. |
-| `size` | string | Optional, e.g. `"1024x1024"` (OpenAI). |
+| `size` | string | Optional, e.g. `"1024x1024"` (OpenAI and Flux). |
+| `aspect_ratio` | string | Optional (Gemini). |
 | `quality` | `low`\|`medium`\|`high`\|`auto` | Optional (OpenAI; higher = more credits). |
 | `output_format` | `png`\|`jpeg`\|`webp` | Optional (OpenAI). |
 | `input_images` | string[] (max 14) | Optional. Base64 **data URLs** for edit/remix. |
@@ -119,6 +120,7 @@ DATA_URL="data:image/png;base64,$(base64 < input.png | tr -d '\n')"
 
 - **Billing**: every success charges credits; don't loop needlessly, and report
   `credits_charged`.
-- **Errors**: `402` = insufficient credits (`credits_required` in body); `400`/`500`
-  return `{ "message": "..." }` — surface it to the user.
+- **Errors**: `402` = insufficient credits (`credits_required` in body); `400`
+  validation errors return `{ "issues": [...], "name": "ZodError" }`; `500`
+  errors return `{ "message": "..." }`. Surface any error to the user.
 - Only `flux`, `gemini`, and `openai` are supported here.


### PR DESCRIPTION
## Summary

- Builtin-skill-watch: image-generation@9ead5f0480b2-5493aa96fe388894
- Selected skill: `image-generation`

## Stale claims and current owning source

1. The skill claimed `400`/`500` errors both return `{ "message": "..." }`. In reality, `400` validation errors return a ZodError shape `{"issues":[...],"name":"ZodError"}` while `500` errors return `{"message":"..."}`. An agent following the skill literally would read `response.message` on a 400 validation error and get `undefined`.
2. `size` was annotated "(OpenAI)" but the server also uses it for Flux (parsed into width/height sent to bfl.ai), and Gemini supports an `aspect_ratio` option that the skill omitted.

Owning source: `letta-ai/letta-cloud` `libs/sdk-cloud-api/src/lib/imagesContract.ts` (generateImageBodySchema: prompt 1–32000, n int 1–4, input_images max 14, aspect_ratio) and `libs/tmp-cloud-api-router/src/lib/images/imagesRouter.ts` (parseSize → Flux width/height, aspect_ratio → Gemini responseFormat, 402 credits_required, 500 message body).

## Focused validation

- Live probes of `POST /v1/images/generations`: invalid provider → 400 ZodError listing `["openai","gemini","flux"]`; `n=5` → 400 ZodError "must be less than or equal to 4"; missing prompt → 400 ZodError "Required"; valid gemini request → 200 with `b64_json` image and `billing.credits_charged`
- Source inspection of imagesContract.ts and imagesRouter.ts in letta-cloud
- `bun run check` — all 12 checks passed

## Test plan

- [ ] Review that the error format description matches actual API behavior
- [ ] Verify size/aspect_ratio provider annotations match the contract