### PR TITLE
fix(skills): correct missed-fire claim in scheduling-tasks

### DIFF
--- a/src/skills/builtin/scheduling-tasks/SKILL.md
+++ b/src/skills/builtin/scheduling-tasks/SKILL.md
@@ -206,7 +206,7 @@ Include context about what the user originally asked for, so you can give a help
 - **Recurring tasks**: No longer auto-expire. They remain active until explicitly cancelled.
 - **One-shot cleanup (local runner)**: One-shot local tasks are garbage-collected 24 hours after firing.
 - **Default binding**: `letta cron add` uses `--agent` first, then `LETTA_AGENT_ID`. Omit `--conversation` for a fresh conversation per fire; use `--conversation self` to capture `LETTA_CONVERSATION_ID` explicitly.
-- **Local scheduler requirement**: Local schedules only fire while a Letta session is running on their computer; fires while no session runs are marked as missed. Cloud schedules fire from the cloud regardless.
+- **Local scheduler requirement**: Local schedules only fire while a Letta session is running on their computer. One-shot fires missed while no session runs are marked as missed; recurring fires during that time are silently skipped. Cloud schedules fire from the cloud regardless.
 - **`--at` for specific times**: `--at "3:00pm"` schedules a one-shot. If the time has already passed today, it schedules for tomorrow.
 - **Cloud schedule creation failures are loud**: if creating a cloud schedule fails, no schedule is created — a failed create never silently becomes a local schedule. (The local placement for computers the cloud scheduler can't reach is decided before creation and reported in the output.)
 


### PR DESCRIPTION
## Summary
- Fix stale claim: skill stated local "fires while no session runs are marked as missed" without distinguishing one-shot vs recurring
- Current source: `handleMissedOneShot` in `src/cron/scheduler.ts` only marks **one-shot** tasks missed (returns false for recurring); recurring fires while no session runs are silently skipped — no code path writes `outcome: "missed"` for recurring tasks

Builtin-skill-watch: scheduling-tasks@9ead5f0480b2-6c195a67f099d5e5

## Selected skill
`src/skills/builtin/scheduling-tasks`

## Stale claim
- **Claim**: "Local schedules only fire while a Letta session is running on their computer; fires while no session runs are marked as missed."
- **Current owning source**: `src/cron/scheduler.ts` `handleMissedOneShot` (line ~394): `if (task.recurring || !task.scheduled_for) return false;` — only one-shots are marked missed. Recurring tasks keep `status: "active"` and accumulate no missed records when the scheduler is not running; the tick loop only evaluates the current minute, so past minutes are never recorded.
- **Fix**: One-shot fires missed while no session runs are marked as missed; recurring fires during that time are silently skipped.

## Focused validation
- Traced every writer of `outcome: "missed"` / `missed_count` in `src/` (only `handleMissedOneShot` and its test)
- Verified all other skill claims against `src/cli/subcommands/cron.ts`, `cron-runner.ts`, `cron-scope.ts`, `src/cron/parse-interval.ts`, `cron-file.ts`, `scheduler.ts` (flags, conversation binding, runner defaults, UTC/local timezone rules, granularity, no auto-expiry, 24h GC, loud cloud failures, cron dialect)
- `bun run check` — all 12 checks pass

👾 Generated with [Letta Code](https://letta.com)