### PR TITLE
docs(skill): correct schedule firing claim in self-configuration skill

### DIFF
--- a/src/skills/builtin/self-configuration/SKILL.md
+++ b/src/skills/builtin/self-configuration/SKILL.md
@@ -421,7 +421,7 @@ letta cron list
 letta cron add --name "weekly-review" --description "Weekly project review" --prompt "Ask the user for the weekly project review." --cron "0 9 * * 1" --agent "$AGENT_ID" --conversation "$CONVERSATION_ID"
 ```
 
-Scheduled tasks fire only while a Letta session/listener is running. Cron bindings can target other agents/conversations visible to the account; verify agent and conversation IDs explicitly when exact routing matters.
+Where schedules run depends on the runner. Local-runner schedules (stored in `~/.letta/crons.json`) fire only while a Letta session/listener is running on their computer; cloud schedules fire from the cloud regardless. Load `scheduling-tasks` for the placement rules. Cron bindings can target other agents/conversations visible to the account; verify agent and conversation IDs explicitly when exact routing matters.
 
 ## CLI startup flags
 


### PR DESCRIPTION
Builtin-skill-watch: self-configuration@9ead5f0480b2-d0e37ab61fdb329d

**Selected skill:** `self-configuration` (`src/skills/builtin/self-configuration`)

**Stale claim:** SKILL.md said "Scheduled tasks fire only while a Letta session/listener is running." Since LET-9692, `letta cron` has two runners: local schedules (`~/.letta/crons.json`, executed by the WS listener on this device) and durable cloud schedules fired by a cloud worker, which are the default for cloud agents. The sibling `scheduling-tasks` skill already documents the distinction.

**Current owning source:** `src/cli/subcommands/cron-runner.ts` (runner resolution, cloud default for cloud agents) and `src/cli/subcommands/cron.ts` (runner docs); `src/skills/builtin/scheduling-tasks/SKILL.md` states "Local schedules only fire while a Letta session is running on their computer ... Cloud schedules fire from the cloud regardless."

**Change:** one sentence in the Schedules section now distinguishes local-runner schedules (session-bound) from cloud schedules and defers placement rules to `scheduling-tasks`.

**Validation:** `bun run check` (12/12 pass) on the branch; no tests assert the old prose.

*Generated with [Letta Code](https://letta.com)*