### PR TITLE
refactor(memory): share frontmatter checks outside Git hooks [LET-12266]

### DIFF
--- a/src/agent/memory-git-hooks.ts
+++ b/src/agent/memory-git-hooks.ts
@@ -9,6 +9,7 @@
 
 import { chmodSync, existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
+import { validateMemoryFileFrontmatter } from "@/memory-frontmatter";
 import { debugLog } from "@/utils/debug";
 import {
   MEMORY_CONSTRAINTS_CONFIG_PATH,
@@ -37,9 +38,6 @@ export const PRE_COMMIT_HOOK_SCRIPT = `#!/usr/bin/env bash
 # Validate frontmatter in staged memory .md files
 # Installed by Letta Code CLI
 
-AGENT_EDITABLE_KEYS="description"
-PROTECTED_KEYS="read_only"
-ALL_KNOWN_KEYS="description read_only limit"
 errors=""
 
 memory_layout_policy_file="$(git rev-parse --git-common-dir 2>/dev/null)/${MEMORY_LAYOUT_POLICY}"
@@ -55,63 +53,30 @@ validate_memory_constraints() {
   fi
 }
 
-validate_v2_file() {
-  local file="$1" staged first_line closing_line frontmatter line key value
-  local has_name=false has_description=false
-  staged=$(git show ":$file")
-
-  if [ "\${file##*/}" = "MEMORY.md" ]; then
-    first_line=$(echo "$staged" | head -1)
-    if [ "$first_line" = "---" ]; then
-      errors="$errors\\n  $file: MEMORY.md must not have frontmatter"
-    fi
-    return
-  fi
-
-  first_line=$(echo "$staged" | head -1)
-  if [ "$first_line" != "---" ]; then
-    errors="$errors\\n  $file: missing frontmatter (must start with ---)"
-    return
-  fi
-  closing_line=$(echo "$staged" | tail -n +2 | grep -n '^---$' | head -1 | cut -d: -f1)
-  if [ -z "$closing_line" ]; then
-    errors="$errors\\n  $file: frontmatter opened but never closed (missing closing ---)"
-    return
-  fi
-  frontmatter=$(echo "$staged" | tail -n +2 | head -n $((closing_line - 1)))
-
-  while IFS= read -r line; do
-    [ -z "$line" ] && continue
-    key=$(echo "$line" | cut -d: -f1 | sed 's/^ *//;s/ *$//')
-    value=$(echo "$line" | cut -d: -f2- | sed 's/^ *//;s/ *$//')
-    case "$key" in
-      name)
-        if [ "$has_name" = "true" ]; then
-          errors="$errors\\n  $file: duplicate frontmatter key 'name'"
-        fi
-        has_name=true
-        ;;
-      description)
-        if [ "$has_description" = "true" ]; then
-          errors="$errors\\n  $file: duplicate frontmatter key 'description'"
-        fi
-        has_description=true
-        ;;
-      *)
-        errors="$errors\\n  $file: unknown frontmatter key '$key' (allowed: name description)"
-        continue
-        ;;
-    esac
-    if [ -z "$value" ] || [ "$value" = '""' ] || [ "$value" = "''" ]; then
-      errors="$errors\\n  $file: '$key' must not be empty"
-    fi
-  done <<< "$frontmatter"
-
-  if [ "$has_name" = "false" ]; then
-    errors="$errors\\n  $file: missing required field 'name'"
-  fi
-  if [ "$has_description" = "false" ]; then
-    errors="$errors\\n  $file: missing required field 'description'"
+validate_memory_file() {
+  local result
+  result=$(node - "$1" "$2" <<'LETTA_MEMORY_FRONTMATTER'
+const { execFileSync, spawnSync } = require("node:child_process");
+const validateMemoryFileFrontmatter = ${validateMemoryFileFrontmatter.toString()};
+const [path, format] = process.argv.slice(2);
+try {
+  const content = execFileSync("git", ["show", ":" + path], { encoding: "utf8", maxBuffer: Infinity, stdio: ["ignore", "pipe", "pipe"] });
+  let previousContent = null;
+  if (format === "legacy") {
+    const previous = spawnSync("git", ["show", "HEAD:" + path], { encoding: "utf8", maxBuffer: Infinity, stdio: ["ignore", "pipe", "pipe"] });
+    if (previous.error) throw previous.error;
+    if (previous.status === 0) previousContent = previous.stdout;
+  }
+  const errors = validateMemoryFileFrontmatter({ path, content, previousContent, format });
+  for (const error of errors) console.log("  " + error);
+} catch {
+  console.error("Memory validation could not read Git contents. No files were committed.");
+  process.exit(1);
+}
+LETTA_MEMORY_FRONTMATTER
+  ) || exit $?
+  if [ -n "$result" ]; then
+    errors="$errors\\n$result"
   fi
 }
 
@@ -154,7 +119,7 @@ if [ "$use_v2_validation" = "true" ]; then
           ;;
       esac
     fi
-    [ "$projected" = "true" ] && validate_v2_file "$file"
+    [ "$projected" = "true" ] && validate_memory_file "$file" "memfs-v2"
   done < <(git ls-files '*.md')
 
   if [ -n "$errors" ]; then
@@ -172,121 +137,10 @@ for file in $(git diff --cached --name-only --diff-filter=ACMR | grep -E '^(memo
   errors="$errors\\n  $file: invalid skill path (skills must be folders). Use skills/<name>/SKILL.md"
 done
 
-# Helper: extract a frontmatter value from content
-get_fm_value() {
-  local content="$1" key="$2"
-  local closing_line
-  closing_line=$(echo "$content" | tail -n +2 | grep -n '^---$' | head -1 | cut -d: -f1)
-  [ -z "$closing_line" ] && return
-  echo "$content" | tail -n +2 | head -n $((closing_line - 1)) | grep "^$key:" | cut -d: -f2- | sed 's/^ *//;s/ *$//'
-}
-
 # Match .md files under system/ or reference/ (with optional memory/ prefix).
 # Skip skill SKILL.md files — they use a different frontmatter format.
 for file in $(git diff --cached --name-only --diff-filter=ACM | grep -E '^(memory/)?(system|reference)/.*\\.md$'); do
-  staged=$(git show ":$file")
-
-  # Frontmatter is required
-  first_line=$(echo "$staged" | head -1)
-  if [ "$first_line" != "---" ]; then
-    errors="$errors\\n  $file: missing frontmatter (must start with ---)"
-    continue
-  fi
-
-  # Check frontmatter is properly closed
-  closing_line=$(echo "$staged" | tail -n +2 | grep -n '^---$' | head -1 | cut -d: -f1)
-  if [ -z "$closing_line" ]; then
-    errors="$errors\\n  $file: frontmatter opened but never closed (missing closing ---)"
-    continue
-  fi
-
-  # Check read_only protection against HEAD version
-  head_content=$(git show "HEAD:$file" 2>/dev/null || true)
-  if [ -n "$head_content" ]; then
-    head_ro=$(get_fm_value "$head_content" "read_only")
-    if [ "$head_ro" = "true" ]; then
-      errors="$errors\\n  $file: file is read_only and cannot be modified"
-      continue
-    fi
-  fi
-
-  # Extract frontmatter lines
-  frontmatter=$(echo "$staged" | tail -n +2 | head -n $((closing_line - 1)))
-
-  # Track required fields
-  has_description=false
-
-  # Validate each line
-  while IFS= read -r line; do
-    [ -z "$line" ] && continue
-    # Skip YAML multiline continuation lines (indented lines that continue a previous value)
-    case "$line" in
-      " "*|$'\t'*) continue ;;
-    esac
-
-    key=$(echo "$line" | cut -d: -f1 | tr -d ' ')
-    value=$(echo "$line" | cut -d: -f2- | sed 's/^ *//;s/ *$//')
-
-    # Check key is known
-    known=false
-    for k in $ALL_KNOWN_KEYS; do
-      if [ "$key" = "$k" ]; then
-        known=true
-        break
-      fi
-    done
-    if [ "$known" = "false" ]; then
-      errors="$errors\\n  $file: unknown frontmatter key '$key' (allowed: $ALL_KNOWN_KEYS)"
-      continue
-    fi
-
-    # Check if agent is trying to modify a protected key
-    for k in $PROTECTED_KEYS; do
-      if [ "$key" = "$k" ]; then
-        # Compare against HEAD — if value changed (or key was added), reject
-        if [ -n "$head_content" ]; then
-          head_val=$(get_fm_value "$head_content" "$key")
-          if [ "$value" != "$head_val" ]; then
-            errors="$errors\\n  $file: '$key' is a protected field and cannot be changed by the agent"
-          fi
-        else
-          # New file with read_only — agent shouldn't set this
-          errors="$errors\\n  $file: '$key' is a protected field and cannot be set by the agent"
-        fi
-      fi
-    done
-
-    # Validate value types
-    case "$key" in
-      limit)
-        # Legacy field accepted for backward compatibility.
-        ;;
-      description)
-        has_description=true
-        if [ -z "$value" ]; then
-          errors="$errors\\n  $file: 'description' must not be empty"
-        fi
-        ;;
-    esac
-  done <<< "$frontmatter"
-
-  # Check required fields
-  if [ "$has_description" = "false" ]; then
-    errors="$errors\\n  $file: missing required field 'description'"
-  fi
-
-  # Check if protected keys were removed (existed in HEAD but not in staged)
-  if [ -n "$head_content" ]; then
-    for k in $PROTECTED_KEYS; do
-      head_val=$(get_fm_value "$head_content" "$k")
-      if [ -n "$head_val" ]; then
-        staged_val=$(get_fm_value "$staged" "$k")
-        if [ -z "$staged_val" ]; then
-          errors="$errors\\n  $file: '$k' is a protected field and cannot be removed by the agent"
-        fi
-      fi
-    done
-  fi
+  validate_memory_file "$file" "legacy"
 done
 
 if [ -n "$errors" ]; then

--- a/src/agent/memory-git-hooks.ts
+++ b/src/agent/memory-git-hooks.ts
@@ -39,6 +39,7 @@ export const PRE_COMMIT_HOOK_SCRIPT = `#!/usr/bin/env bash
 # Installed by Letta Code CLI
 
 errors=""
+memory_files=()
 
 memory_layout_policy_file="$(git rev-parse --git-common-dir 2>/dev/null)/${MEMORY_LAYOUT_POLICY}"
 memory_layout_policy=$(cat "$memory_layout_policy_file" 2>/dev/null || true)
@@ -53,22 +54,25 @@ validate_memory_constraints() {
   fi
 }
 
-validate_memory_file() {
+validate_memory_files() {
+  [ "\${#memory_files[@]}" -eq 0 ] && return
   local result
-  result=$(node - "$1" "$2" <<'LETTA_MEMORY_FRONTMATTER'
+  result=$(node - "$1" "\${memory_files[@]}" <<'LETTA_MEMORY_FRONTMATTER'
 const { execFileSync, spawnSync } = require("node:child_process");
 const validateMemoryFileFrontmatter = ${validateMemoryFileFrontmatter.toString()};
-const [path, format] = process.argv.slice(2);
+const [format, ...paths] = process.argv.slice(2);
 try {
-  const content = execFileSync("git", ["show", ":" + path], { encoding: "utf8", maxBuffer: Infinity, stdio: ["ignore", "pipe", "pipe"] });
-  let previousContent = null;
-  if (format === "legacy") {
-    const previous = spawnSync("git", ["show", "HEAD:" + path], { encoding: "utf8", maxBuffer: Infinity, stdio: ["ignore", "pipe", "pipe"] });
-    if (previous.error) throw previous.error;
-    if (previous.status === 0) previousContent = previous.stdout;
+  for (const path of paths) {
+    const content = execFileSync("git", ["show", ":" + path], { encoding: "utf8", maxBuffer: Infinity, stdio: ["ignore", "pipe", "pipe"] });
+    let previousContent = null;
+    if (format === "legacy") {
+      const previous = spawnSync("git", ["show", "HEAD:" + path], { encoding: "utf8", maxBuffer: Infinity, stdio: ["ignore", "pipe", "pipe"] });
+      if (previous.error) throw previous.error;
+      if (previous.status === 0) previousContent = previous.stdout;
+    }
+    const errors = validateMemoryFileFrontmatter({ path, content, previousContent, format });
+    for (const error of errors) console.log("  " + error);
   }
-  const errors = validateMemoryFileFrontmatter({ path, content, previousContent, format });
-  for (const error of errors) console.log("  " + error);
 } catch {
   console.error("Memory validation could not read Git contents. No files were committed.");
   process.exit(1);
@@ -119,8 +123,9 @@ if [ "$use_v2_validation" = "true" ]; then
           ;;
       esac
     fi
-    [ "$projected" = "true" ] && validate_memory_file "$file" "memfs-v2"
+    [ "$projected" = "true" ] && memory_files+=("$file")
   done < <(git ls-files '*.md')
+  validate_memory_files "memfs-v2"
 
   if [ -n "$errors" ]; then
     echo "Memory validation failed:"
@@ -140,8 +145,9 @@ done
 # Match .md files under system/ or reference/ (with optional memory/ prefix).
 # Skip skill SKILL.md files — they use a different frontmatter format.
 for file in $(git diff --cached --name-only --diff-filter=ACM | grep -E '^(memory/)?(system|reference)/.*\\.md$'); do
-  validate_memory_file "$file" "legacy"
+  memory_files+=("$file")
 done
+validate_memory_files "legacy"
 
 if [ -n "$errors" ]; then
   echo "Frontmatter validation failed:"

--- a/src/memory-constraints.ts
+++ b/src/memory-constraints.ts
@@ -1,3 +1,8 @@
+export {
+  type MemoryFileFrontmatterInput,
+  validateMemoryFileFrontmatter,
+} from "./memory-frontmatter";
+
 export interface MemoryFileCharacterLimit {
   pattern: string;
   maxCharacters: number | null;

--- a/src/memory-frontmatter.test.ts
+++ b/src/memory-frontmatter.test.ts
@@ -1,6 +1,12 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { execFileSync, spawnSync } from "node:child_process";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
@@ -265,3 +271,69 @@ test("Node bundle exports the validator and installs a self-contained hook", asy
     "missing required field 'name'",
   );
 });
+
+test("one Node process validates a hundred projected files and reports both ends of the batch", () => {
+  root = mkdtempSync(join(tmpdir(), "memfs-frontmatter-batch-"));
+  const env = {
+    PATH: process.env.PATH,
+    HOME: root,
+    GIT_CONFIG_NOSYSTEM: "1",
+    GIT_CONFIG_GLOBAL: "/dev/null",
+    GIT_AUTHOR_NAME: "Test",
+    GIT_AUTHOR_EMAIL: "test@example.com",
+    GIT_COMMITTER_NAME: "Test",
+    GIT_COMMITTER_EMAIL: "test@example.com",
+  };
+  const git = (...args: string[]) =>
+    execFileSync("git", args, { cwd: root, env, stdio: "pipe" });
+  git("init", "--quiet");
+  for (let index = 0; index < 100; index++) {
+    writeFileSync(join(root, `notes-${String(index).padStart(3, "0")}.md`), v2);
+  }
+  git("add", "--", "*.md");
+  git("-c", "core.hooksPath=/dev/null", "commit", "--quiet", "-m", "accepted");
+  writeFileSync(
+    join(root, ".git/letta-memory-layout-policy"),
+    "shared-memory\n",
+  );
+  writeFileSync(join(root, ".git/hooks/pre-commit"), PRE_COMMIT_HOOK_SCRIPT, {
+    mode: 0o755,
+  });
+
+  // Observe launches, then execute the real Node binary and the real hook.
+  const node = execFileSync("node", ["-p", "process.execPath"], {
+    encoding: "utf8",
+  }).trim();
+  const bin = join(root, "bin");
+  mkdirSync(bin);
+  const launches = join(root, "node-launches");
+  writeFileSync(
+    join(bin, "node"),
+    `#!/usr/bin/env bash\nprintf 'node\\n' >> ${JSON.stringify(launches)}\nexec ${JSON.stringify(node)} "$@"\n`,
+    { mode: 0o755 },
+  );
+  const observedEnv = { ...env, PATH: `${bin}:${env.PATH}` };
+  const commit = () =>
+    spawnSync(
+      "git",
+      ["commit", "--allow-empty", "--quiet", "-m", "candidate"],
+      { cwd: root, env: observedEnv, encoding: "utf8", timeout: 15_000 },
+    );
+  const accepted = commit();
+  expect(accepted.status).toBe(0);
+  expect(readFileSync(launches, "utf8").trim().split("\n")).toHaveLength(1);
+
+  writeFileSync(launches, "");
+  writeFileSync(join(root, "notes-000.md"), legacy);
+  writeFileSync(join(root, "notes-099.md"), legacy);
+  git("add", "--", "*.md");
+  const rejected = commit();
+  expect(rejected.status).not.toBe(0);
+  expect(rejected.stdout + rejected.stderr).toContain(
+    "notes-000.md: missing required field 'name'",
+  );
+  expect(rejected.stdout + rejected.stderr).toContain(
+    "notes-099.md: missing required field 'name'",
+  );
+  expect(readFileSync(launches, "utf8").trim().split("\n")).toHaveLength(1);
+}, 30_000);

--- a/src/memory-frontmatter.test.ts
+++ b/src/memory-frontmatter.test.ts
@@ -1,0 +1,267 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { execFileSync, spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import { PRE_COMMIT_HOOK_SCRIPT } from "@/agent/memory-git-hooks";
+import {
+  type MemoryFileFrontmatterInput,
+  validateMemoryFileFrontmatter,
+} from "@/memory-constraints";
+
+const v2 = "---\nname: Notes\ndescription: Notes\n---\nbody\n";
+const legacy = "---\ndescription: Notes\n---\nbody\n";
+const locked = "---\ndescription: Notes\nread_only: true\n---\nbody\n";
+const unlocked = "---\ndescription: Notes\nread_only: false\n---\nbody\n";
+let root: string | undefined;
+
+afterEach(() => {
+  if (root) rmSync(root, { recursive: true, force: true });
+  root = undefined;
+});
+
+// This table runs against both the public function and a real installed hook.
+// It was also run against the pre-extraction Bash hook to preserve its policy.
+describe.each(["memfs-v2", "legacy"] as const)("%s frontmatter", (format) => {
+  const valid = format === "memfs-v2" ? v2 : legacy;
+  const cases: Array<[string, string, string | null, string | null]> = [
+    ["valid content", valid, null, null],
+    ["missing header", "plain text\n", null, "missing frontmatter"],
+    ["unclosed header", "---\ndescription: Notes\n", null, "never closed"],
+    ["empty header", "---\n---\nbody\n", null, "missing required field"],
+    [
+      "empty description",
+      valid.replace("description: Notes", "description:"),
+      null,
+      "must not be empty",
+    ],
+    [
+      "unknown field",
+      valid.replace("---\nbody", "extra: true\n---\nbody"),
+      null,
+      "unknown frontmatter key",
+    ],
+    [
+      "protected field on new file",
+      unlocked,
+      null,
+      format === "memfs-v2" ? "unknown frontmatter key" : "cannot be set",
+    ],
+  ];
+  if (format === "memfs-v2") {
+    cases.push(
+      ["missing name", legacy, null, "missing required field 'name'"],
+      [
+        "quoted empty name",
+        v2.replace("name: Notes", 'name: ""'),
+        null,
+        "must not be empty",
+      ],
+      [
+        "quoted empty description",
+        v2.replace("description: Notes", "description: ''"),
+        null,
+        "must not be empty",
+      ],
+      [
+        "duplicate name",
+        v2.replace("name: Notes", "name: Notes\nname: Again"),
+        null,
+        "duplicate frontmatter key",
+      ],
+      [
+        "duplicate description",
+        v2.replace(
+          "description: Notes",
+          "description: Notes\ndescription: Again",
+        ),
+        null,
+        "duplicate frontmatter key",
+      ],
+      ["indented fields", v2.replace("name:", "  name:"), null, null],
+    );
+  } else {
+    cases.push(
+      [
+        "legacy limit",
+        legacy.replace("---\nbody", "limit: old\n---\nbody"),
+        null,
+        null,
+      ],
+      [
+        "multiline description",
+        legacy.replace("description: Notes", "description: |\n  Notes"),
+        null,
+        null,
+      ],
+      [
+        "locked edit",
+        locked.replace("body", "changed"),
+        locked,
+        "read_only and cannot be modified",
+      ],
+      [
+        "protected value retained",
+        unlocked.replace("body", "changed"),
+        unlocked,
+        null,
+      ],
+      ["protected value changed", locked, unlocked, "cannot be changed"],
+      ["protected value removed", legacy, unlocked, "cannot be removed"],
+      [
+        "protected field spelling changed",
+        unlocked.replace("read_only:", "read_only :"),
+        unlocked,
+        "cannot be removed",
+      ],
+    );
+  }
+  test.each(cases)("%s", (_label, content, previousContent, expectedError) => {
+    const input: MemoryFileFrontmatterInput = {
+      path: format === "memfs-v2" ? "notes.md" : "system/notes.md",
+      content,
+      previousContent,
+      format,
+    };
+    const errors = validateMemoryFileFrontmatter(input);
+    if (expectedError) expect(errors.join("\n")).toContain(expectedError);
+    else expect(errors).toEqual([]);
+
+    root = mkdtempSync(join(tmpdir(), "memfs-frontmatter-parity-"));
+    const env = {
+      PATH: process.env.PATH,
+      HOME: root,
+      GIT_CONFIG_NOSYSTEM: "1",
+      GIT_CONFIG_GLOBAL: "/dev/null",
+      GIT_AUTHOR_NAME: "Test",
+      GIT_AUTHOR_EMAIL: "test@example.com",
+      GIT_COMMITTER_NAME: "Test",
+      GIT_COMMITTER_EMAIL: "test@example.com",
+    };
+    const git = (...args: string[]) =>
+      execFileSync("git", args, { cwd: root, env, stdio: "pipe" });
+    git("init", "--quiet");
+    const file = join(root, input.path);
+    mkdirSync(dirname(file), { recursive: true });
+    if (previousContent !== null) {
+      writeFileSync(file, previousContent);
+      git("add", input.path);
+    }
+    git(
+      "-c",
+      "core.hooksPath=/dev/null",
+      "commit",
+      "--quiet",
+      "--allow-empty",
+      "-m",
+      "accepted base",
+    );
+    writeFileSync(
+      join(root, ".git/letta-memory-layout-policy"),
+      format === "memfs-v2" ? "shared-memory\n" : "legacy-only\n",
+    );
+    writeFileSync(join(root, ".git/hooks/pre-commit"), PRE_COMMIT_HOOK_SCRIPT, {
+      mode: 0o755,
+    });
+    writeFileSync(file, content);
+    git("add", input.path);
+    const result = spawnSync("git", ["commit", "--quiet", "-m", "candidate"], {
+      cwd: root,
+      env,
+      encoding: "utf8",
+    });
+    expect(result.status === 0).toBe(errors.length === 0);
+    for (const error of errors)
+      expect(result.stdout + result.stderr).toContain(error);
+  });
+});
+
+test.each(["MEMORY.md", "reference/MEMORY.md"])(
+  "index %s is frontmatter-free",
+  (path) => {
+    expect(
+      validateMemoryFileFrontmatter({
+        path,
+        content: "# Index\n",
+        previousContent: null,
+        format: "memfs-v2",
+      }),
+    ).toEqual([]);
+    expect(
+      validateMemoryFileFrontmatter({
+        path,
+        content: v2,
+        previousContent: null,
+        format: "memfs-v2",
+      }),
+    ).toEqual([`${path}: MEMORY.md must not have frontmatter`]);
+  },
+);
+
+test("Node bundle exports the validator and installs a self-contained hook", async () => {
+  root = mkdtempSync(join(tmpdir(), "memfs-frontmatter-node-"));
+  const result = await Bun.build({
+    entrypoints: [
+      resolve("src/memory-constraints.ts"),
+      resolve("src/agent/memory-git-hooks.ts"),
+    ],
+    outdir: root,
+    target: "node",
+    format: "esm",
+    naming: "[name].mjs",
+  });
+  expect(result.success).toBe(true);
+  const publicEntry = pathToFileURL(join(root, "memory-constraints.mjs")).href;
+  const hookEntry = pathToFileURL(join(root, "memory-git-hooks.mjs")).href;
+  const env = {
+    PATH: process.env.PATH,
+    HOME: root,
+    GIT_CONFIG_NOSYSTEM: "1",
+    GIT_CONFIG_GLOBAL: "/dev/null",
+    GIT_AUTHOR_NAME: "Test",
+    GIT_AUTHOR_EMAIL: "test@example.com",
+    GIT_COMMITTER_NAME: "Test",
+    GIT_COMMITTER_EMAIL: "test@example.com",
+  };
+  execFileSync("git", ["init", "--quiet"], { cwd: root, env });
+  execFileSync(
+    "node",
+    [
+      "--input-type=module",
+      "-e",
+      `
+    import assert from 'node:assert/strict';
+    import { writeFileSync } from 'node:fs';
+    import { validateMemoryFileFrontmatter } from ${JSON.stringify(publicEntry)};
+    import { PRE_COMMIT_HOOK_SCRIPT } from ${JSON.stringify(hookEntry)};
+    assert.deepEqual(validateMemoryFileFrontmatter({ path: 'notes.md', content: ${JSON.stringify(v2)}, previousContent: null, format: 'memfs-v2' }), []);
+    assert.match(validateMemoryFileFrontmatter({ path: 'system/notes.md', content: ${JSON.stringify(legacy)}, previousContent: ${JSON.stringify(unlocked)}, format: 'legacy' }).join('\\n'), /cannot be removed/);
+    writeFileSync('.git/hooks/pre-commit', PRE_COMMIT_HOOK_SCRIPT, { mode: 0o755 });
+  `,
+    ],
+    { cwd: root, env, stdio: "pipe" },
+  );
+  writeFileSync(
+    join(root, ".git/letta-memory-layout-policy"),
+    "shared-memory\n",
+  );
+  writeFileSync(join(root, "notes.md"), v2);
+  execFileSync("git", ["add", "notes.md"], { cwd: root, env });
+  execFileSync("git", ["commit", "--quiet", "-m", "valid"], {
+    cwd: root,
+    env,
+    stdio: "pipe",
+  });
+  writeFileSync(join(root, "notes.md"), legacy);
+  execFileSync("git", ["add", "notes.md"], { cwd: root, env });
+  const rejected = spawnSync("git", ["commit", "--quiet", "-m", "invalid"], {
+    cwd: root,
+    env,
+    encoding: "utf8",
+  });
+  expect(rejected.status).not.toBe(0);
+  expect(rejected.stdout + rejected.stderr).toContain(
+    "missing required field 'name'",
+  );
+});

--- a/src/memory-frontmatter.ts
+++ b/src/memory-frontmatter.ts
@@ -1,0 +1,122 @@
+export interface MemoryFileFrontmatterInput {
+  path: string;
+  content: string;
+  /** Accepted contents of this path, never contents supplied by the change. */
+  previousContent: string | null;
+  format: "memfs-v2" | "legacy";
+}
+
+/**
+ * Canonical content checks used by the installed hook and external tree readers.
+ * The caller selects projected paths and supplies the trusted layout/base.
+ * Legacy callers select added/modified files; v2 callers select the whole tree.
+ * Ref operations, deletion/rename protection and policy authorization remain
+ * caller responsibilities, not decisions made from the proposed file contents.
+ * This is deliberately self-contained: the Git hook embeds its source so it
+ * does not depend on a package installation in the memory repository.
+ */
+export function validateMemoryFileFrontmatter({
+  path,
+  content,
+  previousContent,
+  format,
+}: MemoryFileFrontmatterInput): string[] {
+  const errors: string[] = [];
+  const v2 = format === "memfs-v2";
+  const lines = content.split("\n");
+  if (v2 && path.split("/").at(-1) === "MEMORY.md") {
+    return lines[0] === "---"
+      ? [`${path}: MEMORY.md must not have frontmatter`]
+      : [];
+  }
+  if (lines[0] !== "---") {
+    return [`${path}: missing frontmatter (must start with ---)`];
+  }
+  const closing = lines.indexOf("---", 1);
+  if (closing < 0) {
+    return [
+      `${path}: frontmatter opened but never closed (missing closing ---)`,
+    ];
+  }
+
+  // Match the legacy hook's scalar protected field lookup. Do not interpret
+  // YAML or turn a quoted value into a different authorization decision.
+  function legacyValue(text: string | null, key: string): string {
+    const previousLines = text?.split("\n") ?? [];
+    const end = previousLines.indexOf("---", 1);
+    if (end < 0) return "";
+    return previousLines
+      .slice(1, end)
+      .filter((line) => line.startsWith(`${key}:`))
+      .map((line) => line.slice(key.length + 1).replace(/^ +| +$/g, ""))
+      .join("\n");
+  }
+
+  if (
+    !v2 &&
+    previousContent &&
+    legacyValue(previousContent, "read_only") === "true"
+  ) {
+    return [`${path}: file is read_only and cannot be modified`];
+  }
+
+  const seen = new Set<string>();
+  const allowed = v2
+    ? ["name", "description"]
+    : ["description", "read_only", "limit"];
+  for (const line of lines.slice(1, closing)) {
+    if (!line) continue;
+    // Legacy descriptions permit YAML continuation lines. V2 uses two scalar
+    // fields, as in the existing hook, and rejects extra lines/keys.
+    if (!v2 && /^[ \t]/.test(line)) continue;
+    const separator = line.indexOf(":");
+    const rawKey = separator < 0 ? line : line.slice(0, separator);
+    const key = v2
+      ? rawKey.replace(/^ +| +$/g, "")
+      : rawKey.replaceAll(" ", "");
+    const value = (separator < 0 ? line : line.slice(separator + 1)).replace(
+      /^ +| +$/g,
+      "",
+    );
+    if (!allowed.includes(key)) {
+      errors.push(
+        `${path}: unknown frontmatter key '${key}' (allowed: ${allowed.join(" ")})`,
+      );
+      continue;
+    }
+    if (v2 && seen.has(key)) {
+      errors.push(`${path}: duplicate frontmatter key '${key}'`);
+    }
+    seen.add(key);
+    if (key === "read_only") {
+      if (!previousContent) {
+        errors.push(
+          `${path}: 'read_only' is a protected field and cannot be set by the agent`,
+        );
+      } else if (value !== legacyValue(previousContent, key)) {
+        errors.push(
+          `${path}: 'read_only' is a protected field and cannot be changed by the agent`,
+        );
+      }
+    }
+    if (
+      (v2 || key === "description") &&
+      (!value || (v2 && (value === '""' || value === "''")))
+    ) {
+      errors.push(`${path}: '${key}' must not be empty`);
+    }
+  }
+  for (const key of v2 ? ["name", "description"] : ["description"]) {
+    if (!seen.has(key)) errors.push(`${path}: missing required field '${key}'`);
+  }
+  if (
+    !v2 &&
+    legacyValue(previousContent, "read_only") &&
+    !legacyValue(content, "read_only")
+  ) {
+    errors.push(
+      `${path}: 'read_only' is a protected field and cannot be removed by the agent`,
+    );
+  }
+  return errors;
+}


### PR DESCRIPTION
## Summary

Memory validators need to apply the same frontmatter rules as the local Git hook. The existing package entrypoint exposes budgets and tree checks, but the frontmatter and legacy `read_only` checks still lived only in Bash.

Export `validateMemoryFileFrontmatter` through `@letta-ai/letta-code/memory-constraints` and make both local hook branches embed that same function. Callers supply the file contents, accepted contents, and trusted format. The hook keeps its existing path selection: the whole projected tree for v2, changed memory files for legacy. It validates frontmatter in one Node process, then runs the existing budget checks.

This preserves the current content rules. It does not add a read-only approval command, change deletion/rename handling, choose Git revisions, or enable hosted enforcement by itself.

## Verification

The parity tests exercise the public function and real Git commits for legacy and v2 files, including missing/unknown/duplicate fields, empty quoted values, and protected-field changes against an accepted base. The initial 28-case matrix passed against the pre-extraction Bash hook at `9ead5f04`; it passed again after extraction. No Git behavior is mocked.

The Node test bundles the public entrypoint and hook, imports them under Node, installs the resulting hook into a fresh repository, accepts valid v2 memory, and rejects a file missing its name.

The first extraction launched Node once per projected file. A real 100-file repository reproduced that regression with 100 launches at `ec489697`. The new test observes the real Node executable and requires one frontmatter-validation launch per commit, including an otherwise-empty commit and a rejected commit reporting invalid files at both ends of the batch. File contents and Git operations are not mocked.

- `bun test src/memory-frontmatter.test.ts src/agent/memory-git.precommit.test.ts src/agent/memory-git-v2-precommit.test.ts src/memory-constraints.test.ts src/agent/memory-constraints-audit.test.ts`: 84 passed.
- `bun run check`: all 12 checks passed.

## Breadcrumbs

- Requested in: LET-12266.
- Origin: existing content checks in [shared-memory validation](https://github.com/letta-ai/letta-code/pull/4102). This is an extraction, not a newly attributed regression.
- Follow-up to: [shared memory-constraints entrypoint](https://github.com/letta-ai/letta-code/pull/4318), which explicitly left frontmatter and read-only checks in the hook.
- Related, separate work: [read-only file controls](https://github.com/letta-ai/letta-code/pull/3616). This extraction does not adopt its approval command or deletion/rename behavior.
- Review follow-up: [batch Node startup across projected files](https://github.com/letta-ai/letta-code/pull/4353#discussion_r3978274709).

## AI Disclosure

This pull request was written by Letta Integration, an organization maintainer.

## AI Tool(s) Used

Letta Code, for implementation and verification.
