### PR TITLE
feat(listener): mark the end of startup-only log capture

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@letta-ai/letta-code",
   "version": "0.32.1",
+  "lettaStartupLogProtocol": 1,
   "description": "Letta Code is a CLI tool for interacting with stateful Letta agents from the terminal.",
   "type": "module",
   "packageManager": "bun@1.3.14",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env bun
+import "@/utils/startup-log-boundary";
 import { hostname } from "node:os";
 import { APIError } from "@letta-ai/letta-client/core/error";
 import type { AgentState } from "@letta-ai/letta-client/resources/agents/agents";
@@ -95,7 +96,6 @@ import { markMilestone } from "./utils/timing";
 // Stable fallbacks avoid creating new arrays that retrigger effects on every render.
 const EMPTY_APPROVAL_ARRAY: ApprovalRequest[] = [];
 const EMPTY_MESSAGE_ARRAY: Message[] = [];
-
 function normalizeUpdateCommandAliases(args: string[]): string[] {
   const [command, ...rest] = args;
 

--- a/src/standalone-entry.ts
+++ b/src/standalone-entry.ts
@@ -1,3 +1,4 @@
+import "@/utils/startup-log-boundary";
 import { registerBunOAuthFlows } from "@earendil-works/pi-ai/bun-oauth";
 
 // pi-ai keeps Node-only OAuth implementations behind bundler-opaque imports.

--- a/src/startup-log-protocol.test.ts
+++ b/src/startup-log-protocol.test.ts
@@ -1,0 +1,182 @@
+import { beforeAll, expect, test } from "bun:test";
+import { spawn, spawnSync } from "node:child_process";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { createIsolatedCliTestEnv } from "@/test-utils/test-process-env";
+
+const root = process.cwd();
+const token = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee";
+const marker = `\n[letta-startup-end:${token}]\n`;
+const unixTest = process.platform === "win32" ? test.skip : test;
+
+beforeAll(() => {
+  if (process.platform === "win32") return;
+  // Exercise the published build pipeline, not a mocked or test-only entrypoint.
+  const result = spawnSync("bun", ["run", "build"], {
+    cwd: root,
+    encoding: "utf8",
+    timeout: 120_000,
+  });
+  if (result.status !== 0) {
+    throw new Error(`CLI build failed\n${result.stdout}\n${result.stderr}`);
+  }
+}, 130_000);
+
+for (const runtime of ["bun", "node"]) {
+  for (const enabled of [true, false]) {
+    unixTest(
+      `${runtime} CLI with ${enabled ? "Cloud marker" : "no marker"}: real registration and immediate legacy WebSocket input`,
+      async () => {
+        const home = await mkdtemp(join(root, ".startup-protocol-test-"));
+        const server = Bun.serve({
+          hostname: "127.0.0.1",
+          port: 0,
+          fetch(request, server) {
+            const url = new URL(request.url);
+            if (url.pathname === "/ws") {
+              if (server.upgrade(request)) return;
+              return new Response("Expected WebSocket", { status: 400 });
+            }
+            if (url.pathname === "/v1/environments/register") {
+              return Response.json({
+                connectionId: "startup-protocol-test",
+                wsUrl: `ws://127.0.0.1:${server.port}/ws`,
+                supportsSplitStatusChannels: false,
+              });
+            }
+            return Response.json({ error: "test endpoint" }, { status: 404 });
+          },
+          websocket: {
+            open(socket) {
+              // Send immediately, without waiting for any ready/Connected prose.
+              socket.send(
+                JSON.stringify({
+                  type: "input",
+                  request_id: "startup-early",
+                  runtime: {
+                    agent_id: "test-agent",
+                    conversation_id: "test-conv",
+                  },
+                  payload: {
+                    kind: "create_message",
+                    messages: [
+                      { role: "user", content: "REAL_WS_USER_PRIVATE" },
+                    ],
+                  },
+                }),
+              );
+            },
+            message() {},
+          },
+        });
+        const env = createIsolatedCliTestEnv({
+          HOME: home,
+          LETTA_BASE_URL: `http://127.0.0.1:${server.port}`,
+          LETTA_API_KEY: "test-key-not-a-secret",
+          IGNORE_SELF_HOSTED_LISTENER_ERROR: "1",
+          LETTA_STARTUP_LOG_MARKER: enabled ? token : undefined,
+          LETTA_STARTUP_LOG_OWNER_PID: undefined,
+          LETTA_DEBUG: "1",
+          LETTA_CODE_TELEM: "0",
+          DO_NOT_TRACK: "1",
+          LETTA_DISABLE_CRON_SCHEDULER: "1",
+          LETTA_DISABLE_MODS: "1",
+        });
+        const child = spawn(
+          "sh",
+          [
+            "-c",
+            (enabled ? "export LETTA_STARTUP_LOG_OWNER_PID=$$; " : "") +
+              'exec "$@" 2>&1',
+            "listener",
+            runtime,
+            ...(runtime === "bun"
+              ? [`--config=${join(root, "bunfig.toml")}`]
+              : []),
+            join(root, runtime === "bun" ? "src/index.ts" : "letta.js"),
+            "server",
+            "--debug",
+            "--computer-name",
+            "startup-protocol-test",
+          ],
+          { cwd: home, env, stdio: ["ignore", "pipe", "pipe"] },
+        );
+        let output = "";
+        try {
+          await new Promise<void>((resolve, reject) => {
+            const timeout = setTimeout(
+              () => reject(new Error(`Timed out\n${output}`)),
+              25_000,
+            );
+            const finish = () => {
+              if (
+                output.includes("REAL_WS_USER_PRIVATE") &&
+                output.includes("Connected. Awaiting instructions.")
+              ) {
+                clearTimeout(timeout);
+                resolve();
+              }
+            };
+            child.stdout.on("data", (data) => {
+              output += data.toString();
+              finish();
+            });
+            child.on("error", (error) => {
+              clearTimeout(timeout);
+              reject(error);
+            });
+            child.on("close", (code) => {
+              clearTimeout(timeout);
+              reject(new Error(`Listener exited ${code}\n${output}`));
+            });
+          });
+          if (enabled) {
+            expect(output.split(marker)).toHaveLength(2);
+            const [startup, content] = output.split(marker);
+            expect(startup).toContain("Registered successfully");
+            expect(startup).not.toContain("REAL_WS_USER_PRIVATE");
+            expect(startup).not.toContain("Connected. Awaiting instructions.");
+            expect(content).toContain("REAL_WS_USER_PRIVATE");
+          } else {
+            expect(output).not.toContain("[letta-startup-end:");
+            expect(output).toContain("REAL_WS_USER_PRIVATE");
+          }
+        } finally {
+          child.kill("SIGKILL");
+          await new Promise<void>((resolve) => {
+            if (child.exitCode !== null || child.signalCode !== null) resolve();
+            else child.once("close", () => resolve());
+          });
+          server.stop(true);
+          await rm(home, { recursive: true, force: true });
+        }
+      },
+      35_000,
+    );
+  }
+}
+
+unixTest(
+  "package capability remains readable when Node fails before importing the runtime",
+  async () => {
+    const pkg = JSON.parse(await readFile(join(root, "package.json"), "utf8"));
+    expect(pkg.lettaStartupLogProtocol).toBe(1);
+    const result = spawnSync(
+      "node",
+      [
+        "--import",
+        "file:///missing-letta-startup-import.mjs",
+        join(root, "letta.js"),
+        "--version",
+      ],
+      {
+        cwd: root,
+        encoding: "utf8",
+        env: createIsolatedCliTestEnv({ LETTA_STARTUP_LOG_MARKER: token }),
+      },
+    );
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("ERR_MODULE_NOT_FOUND");
+    expect(result.stdout + result.stderr).not.toContain(marker);
+  },
+);

--- a/src/test-utils/startup-log-boundary-scenario.ts
+++ b/src/test-utils/startup-log-boundary-scenario.ts
@@ -1,0 +1,169 @@
+import "@/utils/startup-log-boundary";
+import assert from "node:assert/strict";
+import { writeSync } from "node:fs";
+import WebSocket from "ws";
+import { openListenerConnection } from "@/websocket/listener/connection";
+import { getOrCreateScopedRuntime } from "@/websocket/listener/conversation-runtime";
+import {
+  createRuntime,
+  startConnectedListenerRuntime,
+  stopRuntime,
+} from "@/websocket/listener/lifecycle";
+import { createListenerMessageHandler } from "@/websocket/listener/message-router";
+import { setActiveRuntime } from "@/websocket/listener/runtime";
+import type { StartListenerOptions } from "@/websocket/listener/types";
+
+// Run in a fresh process: neither the marker singleton nor module mocks leak.
+const mode = process.argv[2];
+const listener = createRuntime();
+const runtime = getOrCreateScopedRuntime(listener, "agent-1", "conv-1");
+const log = (value: string) => writeSync(2, `${value}\n`);
+const socket = {
+  readyState: WebSocket.OPEN,
+  bufferedAmount: 0,
+  send: (data: string) => log(`SENT:${data}`),
+  removeAllListeners: () => {},
+  close: () => {},
+} as unknown as WebSocket;
+let connected = 0;
+let parsed = 0;
+let processed = 0;
+const opts: StartListenerOptions = {
+  connectionId: "startup-test",
+  wsUrl: "ws://localhost/unused",
+  deviceId: "device-test",
+  connectionName: "startup-test",
+  onConnected: () => {
+    connected += 1;
+    log("CONNECTED_PRIVATE");
+    // A gateway can synchronously receive input inside onConnected.
+    void handleMessage(input);
+  },
+  onDisconnected: () => {},
+  onError: (error) => {
+    throw error;
+  },
+  onLog: log,
+};
+listener.onWsEvent = (direction, source, payload) =>
+  log(`EVENT:${direction}:${source}:${JSON.stringify(payload)}`);
+listener.processServicesStarted = true;
+setActiveRuntime(listener);
+openListenerConnection({
+  runtime: listener,
+  connectionId: opts.connectionId,
+  writer: socket,
+  options: opts,
+});
+const handleMessage = createListenerMessageHandler({
+  runtime: listener,
+  socket,
+  opts,
+  processQueuedTurn: async () => {},
+  fileCommandSession: { handle: () => false },
+  getParsedRuntimeScope: () => {
+    parsed += 1;
+    return null;
+  },
+  replaySyncStateForRuntime: async () => {},
+  getOrCreateScopedRuntime: () => runtime,
+  handleApprovalResponseInput: async () => false,
+  handleChangeDeviceStateInput: async () => false,
+  handleAbortMessageInput: async () => false,
+  stampInboundUserMessageOtids: (incoming) => incoming,
+  safeSocketSend: (_socket, payload) => {
+    log(`SENT:${JSON.stringify(payload)}`);
+    return true;
+  },
+  runDetachedListenerTask: () => {},
+  trackListenerError: (type) => {
+    throw new Error(type);
+  },
+  processIncomingMessage: async () => {
+    processed += 1;
+    log("PROCESSED_PRIVATE");
+  },
+});
+const input = Buffer.from(
+  JSON.stringify({
+    type: "input",
+    request_id: "early-input",
+    runtime: { agent_id: "agent-1", conversation_id: "conv-1" },
+    payload: {
+      kind: "create_message",
+      messages: [
+        {
+          role: "user",
+          content: "EARLY_USER_PRIVATE",
+          client_message_id: "early-1",
+        },
+      ],
+    },
+  }),
+);
+function connect() {
+  return startConnectedListenerRuntime(listener, socket, opts, async () => {}, {
+    startHeartbeat: false,
+    startCronScheduler: false,
+    startProcessServices: false,
+    emitInitialState: false,
+  });
+}
+
+try {
+  assert.equal(process.env.LETTA_STARTUP_LOG_MARKER, undefined);
+  assert.equal(process.env.LETTA_STARTUP_LOG_OWNER_PID, undefined);
+  log("STARTUP_DIAGNOSTIC");
+  if (mode === "failure" || mode === "invalid-owner") {
+    await assert.rejects(handleMessage(input), /Failed to seal startup logs/);
+    await assert.rejects(connect(), /Failed to seal startup logs/);
+    await assert.rejects(handleMessage(input), /Failed to seal startup logs/);
+    assert.equal(connected, 0);
+    assert.equal(parsed, 0);
+    assert.equal(processed, 0);
+    log("BLOCKED_ALL_CONTENT");
+  } else if (mode === "connected") {
+    const first = connect();
+    log("CALLER_RETURNED");
+    await first;
+    await connect();
+    await runtime.messageQueue;
+    assert.equal(connected, 2);
+    assert.ok(parsed > 0);
+    log("DONE");
+  } else if (mode === "ready") {
+    await handleMessage(
+      Buffer.from(
+        JSON.stringify({
+          type: "listener_ready",
+          connection_generation: "test",
+          connection_attempt: 1,
+          extra: "READY_EXTRA_PRIVATE",
+        }),
+      ),
+    );
+    assert.equal(connected, 0);
+    log("BEFORE_CONNECTED");
+    await connect();
+    log("DONE");
+  } else {
+    await handleMessage(Buffer.from('{"type":"pong"}'));
+    assert.ok(listener.lastPongAt && listener.lastPongAt > 0);
+    log("AFTER_PONG_STARTUP");
+    // Deliver the first frame before the connected runtime has ever started.
+    await handleMessage(
+      mode === "malformed" ? Buffer.from("MALFORMED_PRIVATE") : input,
+    );
+    assert.equal(connected, 0);
+    log("BEFORE_CONNECTED");
+    await connect();
+    await runtime.messageQueue;
+    assert.ok(parsed > 0);
+    log("DONE");
+  }
+} finally {
+  stopRuntime(listener, true);
+  setActiveRuntime(null);
+}
+// Listener dependencies can own timers; all assertions above have completed.
+process.exit(0);

--- a/src/utils/startup-log-boundary.test.ts
+++ b/src/utils/startup-log-boundary.test.ts
@@ -1,0 +1,190 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
+const root = process.cwd();
+const unixDescribe = process.platform === "win32" ? describe.skip : describe;
+const token = "12345678-1234-4567-89ab-123456789abc";
+const marker = `\n[letta-startup-end:${token}]\n`;
+let directory: string;
+let source: string;
+let bundle: string;
+
+beforeAll(async () => {
+  directory = await mkdtemp(join(root, ".startup-boundary-test-"));
+  source = join(directory, "probe.ts");
+  bundle = join(directory, "probe.js");
+  await writeFile(
+    source,
+    `import { sealStartupLogs } from "@/utils/startup-log-boundary";
+import { writeSync } from "node:fs";
+import { spawn, spawnSync } from "node:child_process";
+import assert from "node:assert/strict";
+
+assert.equal(process.env.LETTA_STARTUP_LOG_MARKER, undefined);
+assert.equal(process.env.LETTA_STARTUP_LOG_OWNER_PID, undefined);
+if (process.argv[2] === "owned-child") {
+  // Intentionally omit env: Bun inherits both original env vars despite deletion.
+  const code = 'const raw = { marker: process.env.LETTA_STARTUP_LOG_MARKER, owner: process.env.LETTA_STARTUP_LOG_OWNER_PID }; import(' + JSON.stringify(process.argv[3]) + ').then(({ sealStartupLogs }) => { sealStartupLogs(); sealStartupLogs(); if (process.env.LETTA_STARTUP_LOG_MARKER !== undefined || process.env.LETTA_STARTUP_LOG_OWNER_PID !== undefined) throw new Error("env not consumed"); process.stdout.write(JSON.stringify(raw)); });';
+  const child = spawnSync(process.execPath, ["-e", code], { encoding: "utf8" });
+  assert.equal(child.status, 0, child.stderr);
+  // Any marker emitted by the child makes this JSON parse fail.
+  const raw = JSON.parse(child.stdout);
+  if (process.versions.bun) {
+    assert.equal(raw.marker, "${token}");
+    assert.equal(raw.owner, String(process.pid));
+  } else {
+    assert.deepEqual(raw, {});
+  }
+  writeSync(1, "child did not seal\\n");
+}
+const args = ["-e", 'process.stdout.write(JSON.stringify([process.env.LETTA_STARTUP_LOG_MARKER, process.env.LETTA_STARTUP_LOG_OWNER_PID]))'];
+// Explicit-env sync and default async children observe both env deletions.
+const child = spawnSync(process.execPath, args, { encoding: "utf8", env: process.env });
+assert.equal(child.stdout, "[null,null]");
+const asyncChild = spawn(process.execPath, args);
+let inherited = "";
+asyncChild.stdout.on("data", (data) => { inherited += data; });
+await new Promise((resolve) => asyncChild.on("close", resolve));
+assert.equal(inherited, "[null,null]");
+if (process.argv[2] !== "failure") writeSync(1, "startup stdout");
+writeSync(2, "\\nstartup stderr\\n");
+if (process.argv[2] === "failure" || process.argv[2] === "invalid") {
+  let first;
+  try { sealStartupLogs(); } catch (error) { first = error; }
+  assert.ok(first);
+  assert.throws(() => sealStartupLogs(), (error) => error === first);
+  writeSync(2, "blocked twice\\n");
+} else {
+  sealStartupLogs();
+  writeSync(2, "user stderr\\n");
+  process.env.LETTA_STARTUP_LOG_MARKER = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+  process.env.LETTA_STARTUP_LOG_OWNER_PID = String(process.pid);
+  sealStartupLogs();
+  writeSync(1, "user stdout\\n");
+}
+`,
+  );
+  const result = await Bun.build({
+    entrypoints: [source],
+    outdir: directory,
+    naming: "probe.js",
+    target: "node",
+    format: "esm",
+  });
+  expect(result.success).toBe(true);
+  const boundaryBuild = await Bun.build({
+    entrypoints: [join(root, "src/utils/startup-log-boundary.ts")],
+    outdir: directory,
+    naming: "boundary.js",
+    target: "node",
+    format: "esm",
+  });
+  expect(boundaryBuild.success).toBe(true);
+});
+
+afterAll(async () => {
+  if (directory) await rm(directory, { recursive: true, force: true });
+});
+
+for (const runtime of ["bun", "node"]) {
+  unixDescribe(`${runtime} process startup boundary`, () => {
+    function run(mode: string, value?: string, owner?: string) {
+      const env = { ...process.env };
+      delete env.LETTA_STARTUP_LOG_MARKER;
+      delete env.LETTA_STARTUP_LOG_OWNER_PID;
+      if (value !== undefined) env.LETTA_STARTUP_LOG_MARKER = value;
+      if (owner !== undefined && owner !== "self") {
+        env.LETTA_STARTUP_LOG_OWNER_PID = owner;
+      }
+      // Both descriptors point at the SAME pipe, as in a Cloud launch.
+      const result = spawnSync(
+        "sh",
+        [
+          "-c",
+          (owner === "self" ? "export LETTA_STARTUP_LOG_OWNER_PID=$$; " : "") +
+            (mode === "failure"
+              ? 'exec "$@" 2>&1 1</dev/null'
+              : 'exec "$@" 2>&1'),
+          "probe",
+          runtime,
+          runtime === "bun" ? source : bundle,
+          mode,
+          runtime === "bun"
+            ? join(root, "src/utils/startup-log-boundary.ts")
+            : join(directory, "boundary.js"),
+        ],
+        { cwd: directory, env, encoding: "utf8", timeout: 20_000 },
+      );
+      expect(result.error).toBeUndefined();
+      if (result.status !== 0) throw new Error(result.stdout);
+      return result.stdout;
+    }
+
+    test("writes exact one-shot marker synchronously ahead of either output stream", () => {
+      expect(run("normal", token)).toBe(
+        `startup stdout\nstartup stderr\n${marker}user stderr\nuser stdout\n`,
+      );
+    });
+
+    test("the exec owner's matching PID seals even after a default spawnSync child", () => {
+      expect(run("owned-child", token, "self")).toBe(
+        `child did not seal\nstartup stdout\nstartup stderr\n${marker}user stderr\nuser stdout\n`,
+      );
+    });
+
+    test.each([token, "invalid-uuid"])(
+      "a different owner ignores marker %j entirely",
+      (value) => {
+        expect(run("normal", value, "9007199254740991")).toBe(
+          "startup stdout\nstartup stderr\nuser stderr\nuser stdout\n",
+        );
+      },
+    );
+
+    test.each([
+      "",
+      "0",
+      "-1",
+      "01",
+      "1.5",
+      "1e2",
+      "1\n",
+      " 1",
+      "NaN",
+      "9007199254740992",
+    ])("malformed owner %j blocks content with a sticky failure", (owner) => {
+      expect(run("invalid", token, owner)).toBe(
+        "startup stdout\nstartup stderr\nblocked twice\n",
+      );
+    });
+
+    test("malformed owner without a marker still fails closed", () => {
+      expect(run("invalid", undefined, "invalid-owner")).toBe(
+        "startup stdout\nstartup stderr\nblocked twice\n",
+      );
+    });
+
+    test("does nothing without opt-in, including a late env assignment", () => {
+      expect(run("normal")).toBe(
+        "startup stdout\nstartup stderr\nuser stderr\nuser stdout\n",
+      );
+    });
+
+    test("a real unwritable output descriptor blocks content and stays failed", () => {
+      expect(run("failure", token, "self")).toBe(
+        "\nstartup stderr\nblocked twice\n",
+      );
+    });
+
+    test.each(["", "not-a-uuid", `${token}\nforged`])(
+      "invalid opt-in %j fails closed without reflecting its value",
+      (value) => {
+        expect(run("invalid", value, "self")).toBe(
+          "startup stdout\nstartup stderr\nblocked twice\n",
+        );
+      },
+    );
+  });
+}

--- a/src/utils/startup-log-boundary.ts
+++ b/src/utils/startup-log-boundary.ts
@@ -1,0 +1,57 @@
+import { writeSync } from "node:fs";
+
+// Cloud alone opts in. Capture at module load, before startup can spawn children.
+let marker = process.env.LETTA_STARTUP_LOG_MARKER;
+const ownerPid = process.env.LETTA_STARTUP_LOG_OWNER_PID;
+delete process.env.LETTA_STARTUP_LOG_MARKER;
+delete process.env.LETTA_STARTUP_LOG_OWNER_PID;
+let failure: Error | undefined;
+
+if (ownerPid !== undefined) {
+  if (
+    !/^[1-9][0-9]*$/.test(ownerPid) ||
+    !Number.isSafeInteger(Number(ownerPid))
+  ) {
+    // Reject malformed managed launches at the content boundary, not at import.
+    failure = new Error("Failed to seal startup logs", {
+      cause: new Error(
+        "LETTA_STARTUP_LOG_OWNER_PID must be a positive integer",
+      ),
+    });
+  } else if (Number(ownerPid) !== process.pid) {
+    // Bun spawnSync can inherit the original OS env despite process.env deletion.
+    // Only the shell's exec-replacement process may seal the parent's capture.
+    marker = undefined;
+  }
+}
+
+/** Seal the process's merged stdout/stderr startup capture before user content. */
+export function sealStartupLogs(): void {
+  if (failure) throw failure;
+  if (marker === undefined) return;
+
+  try {
+    if (
+      !/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(
+        marker,
+      )
+    ) {
+      throw new Error("LETTA_STARTUP_LOG_MARKER must be a UUID");
+    }
+    const bytes = Buffer.from(`\n[letta-startup-end:${marker}]\n`);
+    // Do not use stdout.write: Node pipes can buffer it past content on stderr.
+    // A short write must finish before any content-producing callback can run.
+    let offset = 0;
+    while (offset < bytes.length) {
+      const written = writeSync(1, bytes, offset, bytes.length - offset);
+      if (written === 0)
+        throw new Error("Startup marker write made no progress");
+      offset += written;
+    }
+    marker = undefined;
+  } catch (cause) {
+    // Sticky failure: a caught rejection/reconnect must not enable content later.
+    failure = new Error("Failed to seal startup logs", { cause });
+    throw failure;
+  }
+}

--- a/src/websocket/listener/lifecycle.ts
+++ b/src/websocket/listener/lifecycle.ts
@@ -12,6 +12,7 @@ import { trackBoundaryError } from "@/telemetry/error-reporting";
 import { loadTools } from "@/tools/manager";
 import type { RuntimeScope } from "@/types/protocol_v2";
 import { isDebugEnabled } from "@/utils/debug";
+import { sealStartupLogs } from "@/utils/startup-log-boundary";
 import { killAllTerminals } from "@/websocket/terminal-handler";
 import {
   rejectPendingApprovalResolvers,
@@ -389,11 +390,10 @@ export async function startConnectedListenerRuntime(
   } = {},
 ): Promise<void> {
   if (runtime !== getActiveRuntime() || runtime.intentionallyClosed) return;
+  sealStartupLogs();
   installExternalToolBridge(runtime);
-  // LETTA_DISABLE_CRON_SCHEDULER=1 lets users opt out entirely. Useful when
-  // running multiple letta-code instances against the same agent dir, since
-  // only one process can hold the lease and the others would otherwise log
-  // "scheduler lease held by PID ..." on every connect.
+  // Opt out when another process already holds the cron scheduler lease.
+  // LETTA_DISABLE_CRON_SCHEDULER=1 suppresses recurring lease-held messages.
   const shouldStartCronScheduler =
     options.startCronScheduler !== false &&
     process.env.LETTA_DISABLE_CRON_SCHEDULER !== "1";

--- a/src/websocket/listener/message-router.ts
+++ b/src/websocket/listener/message-router.ts
@@ -12,6 +12,7 @@ import type {
 } from "@/types/protocol_v2";
 import { debugLog, isDebugEnabled } from "@/utils/debug";
 import { getErrorMessage } from "@/utils/error";
+import { sealStartupLogs } from "@/utils/startup-log-boundary";
 import {
   handleTerminalInput,
   handleTerminalKill,
@@ -212,12 +213,16 @@ export function createListenerMessageHandler(
   const connectionId = explicitConnectionId ?? opts.connectionId;
 
   return async (data: WebSocket.RawData): Promise<void> => {
+    const lifecycleMessage =
+      parseListenerReadyMessage(data) ?? parseServerLifecycleMessage(data);
+    // Legacy relays can deliver input before onConnected. Fail outside the
+    // handler catch so no parsing, logging, or dispatch follows a failed seal.
+    // Only projected pongs are content-free; ready frames retain extra fields.
+    if (lifecycleMessage?.type !== "pong") sealStartupLogs();
     const raw = data.toString();
     let parsedScope: ParsedRuntimeScope = null;
 
     try {
-      const lifecycleMessage =
-        parseListenerReadyMessage(data) ?? parseServerLifecycleMessage(data);
       if (lifecycleMessage) {
         // Record relay pongs so the heartbeat watchdog can detect a half-open
         // socket (no pong within the timeout) and force a reconnect.

--- a/src/websocket/listener/startup-log-boundary.test.ts
+++ b/src/websocket/listener/startup-log-boundary.test.ts
@@ -1,0 +1,140 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { mkdtemp, rm } from "node:fs/promises";
+import { join } from "node:path";
+
+const root = process.cwd();
+const unixDescribe = process.platform === "win32" ? describe.skip : describe;
+const token = "87654321-1234-4567-89ab-123456789abc";
+const marker = `\n[letta-startup-end:${token}]\n`;
+const source = join(root, "src/test-utils/startup-log-boundary-scenario.ts");
+let directory: string;
+let bundle: string;
+
+beforeAll(async () => {
+  directory = await mkdtemp(join(root, ".listener-startup-test-"));
+  bundle = join(directory, "scenario.js");
+  const result = await Bun.build({
+    entrypoints: [source],
+    outdir: directory,
+    naming: "scenario.js",
+    target: "node",
+    format: "esm",
+    external: ["ws", "@vscode/ripgrep", "node-pty", "grammy"],
+    define: { __USE_MAGICK__: "false" },
+    loader: { ".md": "text", ".mdx": "text", ".txt": "text" },
+  });
+  expect(result.success).toBe(true);
+}, 60_000);
+
+afterAll(async () => {
+  if (directory) await rm(directory, { recursive: true, force: true });
+});
+
+for (const runtime of ["bun", "node"]) {
+  unixDescribe(`${runtime} real listener startup ordering`, () => {
+    function run(mode: string, enabled = true): string {
+      const env: NodeJS.ProcessEnv = {
+        ...process.env,
+        HOME: directory,
+        LETTA_DEBUG: "1",
+        LETTA_CODE_TELEM: "0",
+        DO_NOT_TRACK: "1",
+        LETTA_DISABLE_CRON_SCHEDULER: "1",
+      };
+      delete env.LETTA_STARTUP_LOG_MARKER;
+      delete env.LETTA_STARTUP_LOG_OWNER_PID;
+      if (enabled) env.LETTA_STARTUP_LOG_MARKER = token;
+      if (mode === "invalid-owner")
+        env.LETTA_STARTUP_LOG_OWNER_PID = "not-a-pid";
+      const result = spawnSync(
+        "sh",
+        [
+          "-c",
+          (enabled && mode !== "invalid-owner"
+            ? "export LETTA_STARTUP_LOG_OWNER_PID=$$; "
+            : "") +
+            (mode === "failure"
+              ? 'exec "$@" 2>&1 1</dev/null'
+              : 'exec "$@" 2>&1'),
+          "listener",
+          runtime,
+          ...(runtime === "bun"
+            ? [`--config=${join(root, "bunfig.toml")}`]
+            : []),
+          runtime === "bun" ? source : bundle,
+          mode,
+        ],
+        { cwd: directory, env, encoding: "utf8", timeout: 30_000 },
+      );
+      if (result.status !== 0) {
+        throw new Error(
+          `Listener scenario failed: ${result.error ?? result.status}\n${result.stdout}`,
+        );
+      }
+      return result.stdout;
+    }
+
+    function expectSealed(output: string): [string, string] {
+      expect(output.split(marker)).toHaveLength(2);
+      const [startup, content] = output.split(marker) as [string, string];
+      expect(startup).toContain("STARTUP_DIAGNOSTIC");
+      expect(startup).not.toContain("PRIVATE");
+      expect(content).toContain("CONNECTED_PRIVATE");
+      expect(content).toContain("EARLY_USER_PRIVATE");
+      expect(content).toContain("DONE");
+      return [startup, content];
+    }
+
+    test("seals synchronously before onConnected and immediate gateway ingress; reconnect emits no second marker", () => {
+      const [, content] = expectSealed(run("connected"));
+      expect(content.indexOf("CONNECTED_PRIVATE")).toBeLessThan(
+        content.indexOf("CALLER_RETURNED"),
+      );
+    });
+
+    test("legacy early user ingress seals before full-input debug/event logs, not at onConnected", () => {
+      const [startup, content] = expectSealed(run("early"));
+      expect(startup).toContain("AFTER_PONG_STARTUP");
+      expect(content.indexOf("EARLY_USER_PRIVATE")).toBeLessThan(
+        content.indexOf("BEFORE_CONNECTED"),
+      );
+      expect(content.indexOf("BEFORE_CONNECTED")).toBeLessThan(
+        content.indexOf("CONNECTED_PRIVATE"),
+      );
+    });
+
+    test("malformed early frames cannot enter startup capture through unparseable-frame logs", () => {
+      const [, content] = expectSealed(run("malformed"));
+      expect(content).toContain("MALFORMED_PRIVATE");
+      expect(content).toContain("_ws_unparseable");
+    });
+
+    test("ready frames with extra fields seal before their lifecycle event log", () => {
+      const [startup, content] = expectSealed(run("ready"));
+      expect(startup).not.toContain("READY_EXTRA_PRIVATE");
+      expect(content).toContain("READY_EXTRA_PRIVATE");
+    });
+
+    test("real marker IO failure blocks both ingress and connected callbacks, including retries", () => {
+      const output = run("failure");
+      expect(output).toContain("BLOCKED_ALL_CONTENT");
+      expect(output).not.toContain("PRIVATE");
+      expect(output).not.toContain("[letta-startup-end:");
+    });
+
+    test("malformed owner blocks ingress and connected callbacks before any content", () => {
+      const output = run("invalid-owner");
+      expect(output).toContain("BLOCKED_ALL_CONTENT");
+      expect(output).not.toContain("PRIVATE");
+      expect(output).not.toContain("[letta-startup-end:");
+    });
+
+    test("without Cloud opt-in the listener retains its existing content logging", () => {
+      const output = run("early", false);
+      expect(output).toContain("EARLY_USER_PRIVATE");
+      expect(output).toContain("CONNECTED_PRIVATE");
+      expect(output).not.toContain("[letta-startup-end:");
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Add an opt-in, synchronous marker that lets a supervisor separate startup diagnostics from later listener input. The marker is emitted before connected callbacks or early inbound-message logging, not after the human-readable connected message. Without the opt-in environment variable, logging is unchanged.

A launch can bind its marker to the PID of the shell that execs the runtime. This prevents an inherited child environment from ending its parent’s capture. Marker-write failures remain sticky and stop content processing rather than leaving an apparently open startup capture. Package metadata advertises the protocol so supervisors can safely skip older runtimes.

## Verification

`bun run check` passed. The focused boundary, CLI, and existing listener suites passed 78 tests across eight files. Tests built the actual package and exercised both Bun source and the bundled Node CLI against a local registration/WebSocket server that sends input immediately. Removing either boundary made its regression fail before restoring it.

Also exercised the built Node and Bun listeners through a detached shell, file collector, and structured logger. Startup diagnostics and blank lines were retained, a synthetic credential was redacted, and the immediate-input sentinel stayed outside the collected prefix.

## AI Disclosure

Internal Letta Code automation. No human review is claimed.

## AI Tool(s) Used

Letta Code.

## Human Verification

Pending maintainer review.

## Breadcrumbs

- LET-12360
- Generating conversation: [conv-8782425f-7f19-4b93-8a79-8ea6002be931](https://chat.letta.com/chat/agent-19babcc0-e958-41b0-81d8-00107f71deb7?conversation=conv-8782425f-7f19-4b93-8a79-8ea6002be931)

👾 Generated with [Letta Code](https://letta.com)