### PR TITLE
fix(cli): link agent-limit errors to Chat

### DIFF
--- a/src/cli/app-urls.test.ts
+++ b/src/cli/app-urls.test.ts
@@ -8,7 +8,6 @@ import {
   buildAgentTerminalLink,
   buildChatUrl,
   buildChatWebUrl,
-  buildPlatformUrl,
   isLocalAgentId,
   LETTA_CHAT_API_KEYS_URL,
 } from "@/cli/helpers/app-urls";
@@ -70,9 +69,6 @@ describe("app URL helpers", () => {
     );
     expect(LETTA_CHAT_API_KEYS_URL).toBe(
       "https://chat.letta.com/preferences/api-keys",
-    );
-    expect(buildPlatformUrl("/projects/default-project/agents")).toBe(
-      "https://platform.letta.com/projects/default-project/agents",
     );
   });
 });

--- a/src/cli/error-formatter.test.ts
+++ b/src/cli/error-formatter.test.ts
@@ -96,6 +96,49 @@ describe("formatErrorDetails", () => {
     });
   });
 
+  test.each([
+    {
+      billingTier: "free",
+      expectedMessage:
+        "You've reached the agent limit (3) for the Free Plan. Delete agents at: https://chat.letta.com/agents\n" +
+        "Or upgrade to Pro for unlimited agents at: https://chat.letta.com/preferences/usage",
+    },
+    {
+      billingTier: "pro",
+      expectedMessage:
+        "You've reached your agent limit. Delete agents at: https://chat.letta.com/agents\n" +
+        "Or check your plan at: https://chat.letta.com/preferences/usage",
+    },
+  ])(
+    "links $billingTier agent-limit recovery to Chat",
+    ({ billingTier, expectedMessage }) => {
+      setErrorContext({ billingTier });
+      const error = new APIError(
+        429,
+        { error: "Rate limited", reasons: ["agents-limit-exceeded"] },
+        undefined,
+        new Headers(),
+      );
+
+      expect(formatErrorDetails(error)).toBe(expectedMessage);
+    },
+  );
+
+  test("links resource-limit recovery to Chat while retaining the server explanation", () => {
+    const error = new APIError(
+      402,
+      { error: "You have reached your limit for agents (3)." },
+      undefined,
+      new Headers(),
+    );
+
+    expect(formatErrorDetails(error)).toBe(
+      "You have reached your limit for agents (3).\n" +
+        "Upgrade at: https://chat.letta.com/preferences/usage\n" +
+        "Delete agents at: https://chat.letta.com/agents",
+    );
+  });
+
   test("uses neutral credit exhaustion copy for free tier not-enough-credits", () => {
     setErrorContext({ billingTier: "free", modelDisplayName: "Kimi K2.5" });
 

--- a/src/cli/helpers/app-urls.ts
+++ b/src/cli/helpers/app-urls.ts
@@ -1,7 +1,6 @@
 import { isLocalAgentId as isLocalAgentIdShared } from "@/agent/agent-id";
 
 const CHAT_BASE = "https://chat.letta.com";
-const PLATFORM_BASE = "https://platform.letta.com";
 
 export const LETTA_CHAT_API_KEYS_URL = `${CHAT_BASE}/preferences/api-keys`;
 
@@ -74,11 +73,4 @@ export function buildAgentTerminalLink(
  */
 export function buildChatWebUrl(path: string): string {
   return `${CHAT_BASE}${path}`;
-}
-
-/**
- * Build a URL for developer and management pages on Letta Platform.
- */
-export function buildPlatformUrl(path: string): string {
-  return `${PLATFORM_BASE}${path}`;
 }

--- a/src/cli/helpers/error-formatter.ts
+++ b/src/cli/helpers/error-formatter.ts
@@ -3,16 +3,12 @@ import {
   formatConversationBusyErrorMessage,
   isConversationBusyErrorText,
 } from "@/utils/conversation-busy-error";
-import {
-  buildAgentTerminalLink,
-  buildChatWebUrl,
-  buildPlatformUrl,
-} from "./app-urls";
+import { buildAgentTerminalLink, buildChatWebUrl } from "./app-urls";
 import { getErrorContext } from "./error-context";
 import { checkZaiError } from "./zai-errors";
 
 const LETTA_USAGE_URL = buildChatWebUrl("/preferences/usage");
-const LETTA_AGENTS_URL = buildPlatformUrl("/projects/default-project/agents");
+const LETTA_AGENTS_URL = buildChatWebUrl("/agents");
 
 export type ErrorDisplaySurface = "plain" | "terminal";
 


### PR DESCRIPTION
## Summary

Agent and resource limit errors should send users to the current agent list. Their deletion links still pointed to the deprecated Platform page, while billing links already pointed to Chat.

Use https://chat.letta.com/agents for those recovery links and remove the unused Platform URL helper. Error classification, plan-specific explanations, and billing destinations are unchanged.

## Verification

- Added regression cases using SDK APIError inputs for free and paid agent limits (429), plus a resource limit (402). All three failed on the old destination and pass with the fix, without mocking the formatter or URL helpers.
- `bun test src/cli/error-formatter.test.ts src/cli/app-urls.test.ts`: 47 passed.
- `bun run check`: all 12 checks passed, including typecheck.
- `git diff --check`: passed.

## Breadcrumbs

- Requested in: LET-12364.
- Origin: Follow-up to [the earlier web-link update](https://github.com/letta-ai/letta-code/pull/3328), which retained Platform for agent-management links.
- Letta conversation: [`conv-1548278e-a534-4d4f-a5eb-24b6af34e0c9`](https://chat.letta.com/chat/agent-b86b0d3a-c425-4c88-86b9-44171f178713?conversation=conv-1548278e-a534-4d4f-a5eb-24b6af34e0c9).

## AI Tool(s) Used

Letta Code.

👾 Generated with [Letta Code](https://letta.com)