### PR TITLE
fix(listener): separate queued turns by acting user [LET-12319]

### DIFF
--- a/src/websocket/listener/queue-acting-user.test.ts
+++ b/src/websocket/listener/queue-acting-user.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, test } from "bun:test";
+import type { Stream } from "@letta-ai/letta-client/core/streaming";
+import type { LettaStreamingResponse } from "@letta-ai/letta-client/resources/agents/messages";
+import { ACTING_USER_ID_HEADER } from "@/agent/acting-user";
+import { sendMessageStreamWithBackend } from "@/agent/message";
+import type { Backend } from "@/backend";
+import type { TaskNotificationQueueItem } from "@/queue/queue-runtime";
+import { prepareToolExecutionContextForSpecificTools } from "@/tools/manager";
+import { getOrCreateScopedRuntime } from "./conversation-runtime";
+import { enqueueInboundUserMessage } from "./inbound-queue";
+import { createRuntime } from "./lifecycle";
+import { consumeQueuedTurn, scheduleQueuePump } from "./queue";
+import { getActiveRuntime, setActiveRuntime } from "./runtime";
+import { LocalListenerTransport } from "./transport";
+import type {
+  ConversationRuntime,
+  IncomingMessage,
+  StartListenerOptions,
+} from "./types";
+
+function enqueueNotification(
+  runtime: ConversationRuntime,
+  text: string,
+  actingUserId?: string,
+): void {
+  const item: Omit<TaskNotificationQueueItem, "id" | "enqueuedAt"> = {
+    kind: "task_notification",
+    source: "task_notification",
+    text,
+    agentId: "agent-parent",
+    conversationId: "conv-parent",
+    actingUserId,
+  };
+  runtime.queueRuntime.enqueue(item);
+}
+
+describe("listener queue acting-user attribution", () => {
+  test("delayed completions drain into separate requests for their initiating users", async () => {
+    const listener = createRuntime();
+    const runtime = getOrCreateScopedRuntime(
+      listener,
+      "agent-parent",
+      "conv-parent",
+    );
+    const previousRuntime = getActiveRuntime();
+    setActiveRuntime(listener);
+    const lease = runtime.turnLifecycle.begin({
+      origin: "message",
+      workingDirectory: process.cwd(),
+    });
+    const requests: Array<{ userId?: string; body: unknown }> = [];
+    const stream = {
+      async *[Symbol.asyncIterator]() {},
+    } as unknown as Stream<LettaStreamingResponse>;
+    const backend = {
+      createConversationMessageStream: async (
+        _conversationId: string,
+        body: unknown,
+        options?: { headers?: Record<string, string> },
+      ) => {
+        requests.push({
+          userId: options?.headers?.[ACTING_USER_ID_HEADER],
+          body,
+        });
+        return stream;
+      },
+    } as unknown as Backend;
+    const preparedToolContext =
+      await prepareToolExecutionContextForSpecificTools([], {
+        runtimeContext: { actingUserId: "cloud-user-current-turn" },
+      });
+    const sendQueuedTurn = async (queuedTurn: IncomingMessage) => {
+      await sendMessageStreamWithBackend(
+        backend,
+        "conv-parent",
+        queuedTurn.messages,
+        {
+          streamTokens: true,
+          background: true,
+          skillSources: [],
+          preparedToolContext,
+          actingUserId: queuedTurn.actingUserId,
+        },
+      );
+    };
+    const socket = new LocalListenerTransport();
+    const options: StartListenerOptions = {
+      connectionId: "conn-test",
+      wsUrl: "wss://example.test/ws",
+      deviceId: "device-test",
+      connectionName: "test-listener",
+      onConnected: () => {},
+      onDisconnected: () => {},
+      onError: () => {},
+    };
+
+    try {
+      enqueueNotification(runtime, "Agent A completed", "cloud-user-a");
+      enqueueNotification(runtime, "Agent B completed", "cloud-user-b");
+      scheduleQueuePump(runtime, socket, options, sendQueuedTurn);
+      await runtime.messageQueue;
+      expect(requests).toHaveLength(0);
+      expect(runtime.queueRuntime.length).toBe(2);
+
+      runtime.turnLifecycle.finish(lease, "end_turn");
+      scheduleQueuePump(runtime, socket, options, sendQueuedTurn);
+      await runtime.messageQueue;
+
+      expect(requests.map((request) => request.userId)).toEqual([
+        "cloud-user-a",
+        "cloud-user-b",
+      ]);
+      expect(JSON.stringify(requests[0]?.body)).toContain("Agent A completed");
+      expect(JSON.stringify(requests[0]?.body)).not.toContain(
+        "Agent B completed",
+      );
+      expect(JSON.stringify(requests[1]?.body)).toContain("Agent B completed");
+      expect(runtime.queueRuntime.length).toBe(0);
+    } finally {
+      setActiveRuntime(previousRuntime);
+    }
+  });
+
+  test("a queued user message cannot absorb another user's notification", () => {
+    const runtime = getOrCreateScopedRuntime(
+      createRuntime(),
+      "agent-parent",
+      "conv-parent",
+    );
+    enqueueInboundUserMessage(
+      runtime,
+      {
+        type: "message",
+        agentId: "agent-parent",
+        conversationId: "conv-parent",
+        messages: [{ role: "user", content: "Continue my work" }],
+      },
+      "cloud-user-b",
+    );
+    enqueueNotification(runtime, "Agent A completed", "cloud-user-a");
+
+    const first = consumeQueuedTurn(runtime);
+    expect(first?.dequeuedBatch.items).toHaveLength(1);
+    expect(first?.queuedTurn.actingUserId).toBe("cloud-user-b");
+    const second = consumeQueuedTurn(runtime);
+    expect(second?.dequeuedBatch.items).toHaveLength(1);
+    expect(second?.queuedTurn.actingUserId).toBe("cloud-user-a");
+    expect(consumeQueuedTurn(runtime)).toBeNull();
+  });
+
+  test.each([
+    ["same-user", ["cloud-user-a", "cloud-user-a"], "cloud-user-a"],
+    ["unattributed", [undefined, undefined], undefined],
+    [
+      "partly attributed",
+      [undefined, "cloud-user-a", undefined],
+      "cloud-user-a",
+    ],
+  ] as const)(
+    "preserves %s notification coalescing",
+    (_name, users, expectedUser) => {
+      const runtime = getOrCreateScopedRuntime(
+        createRuntime(),
+        "agent-parent",
+        "conv-parent",
+      );
+      for (const [index, user] of users.entries()) {
+        enqueueNotification(runtime, `completed ${index}`, user);
+      }
+      const batch = consumeQueuedTurn(runtime);
+      expect(batch?.dequeuedBatch.items).toHaveLength(users.length);
+      expect(batch?.queuedTurn.actingUserId).toBe(expectedUser);
+      expect(consumeQueuedTurn(runtime)).toBeNull();
+    },
+  );
+
+  test("unattributed items do not bridge different acting users", () => {
+    const runtime = getOrCreateScopedRuntime(
+      createRuntime(),
+      "agent-parent",
+      "conv-parent",
+    );
+    for (const user of [undefined, "cloud-user-a", undefined, "cloud-user-b"]) {
+      enqueueNotification(runtime, "completed", user);
+    }
+    const first = consumeQueuedTurn(runtime);
+    expect(first?.dequeuedBatch.items).toHaveLength(3);
+    expect(first?.queuedTurn.actingUserId).toBe("cloud-user-a");
+    const second = consumeQueuedTurn(runtime);
+    expect(second?.dequeuedBatch.items).toHaveLength(1);
+    expect(second?.queuedTurn.actingUserId).toBe("cloud-user-b");
+  });
+});

--- a/src/websocket/listener/queue.ts
+++ b/src/websocket/listener/queue.ts
@@ -129,7 +129,7 @@ function getPrimaryQueueMessageItem(items: QueueItem[]): QueueItem | null {
 
 /**
  * Picks an acting cloud user id to attribute the outbound
- * createMessage to. QueueRuntime keeps different non-empty acting users in
+ * createMessage to. Queue consumers keep different non-empty acting users in
  * separate batches; scanning from the end tolerates unattributed items around
  * the attributed work. Returns undefined when no item in the batch carries an
  * actingUserId (self-hosted / pre-channel-split flow).
@@ -297,6 +297,7 @@ export function consumeQueuedTurn(runtime: ConversationRuntime): {
   let hasCronPrompt = false;
   let hasModContinue = false;
   let batchConnectionId: string | undefined;
+  let batchActingUserId = firstQueuedItem.actingUserId;
   let batchImageFailureMode: "strict" | "drop" | null = null;
   const isNoCoalesce = (candidate: (typeof queuedItems)[number]): boolean =>
     candidate.kind === "message" && candidate.noCoalesce === true;
@@ -310,6 +311,13 @@ export function consumeQueuedTurn(runtime: ConversationRuntime): {
     // noCoalesce items run as single-item batches: one never joins an
     // existing batch, and nothing joins a batch it started.
     if (queueLen > 0 && (isNoCoalesce(item) || isNoCoalesce(firstQueuedItem))) {
+      break;
+    }
+    if (
+      batchActingUserId &&
+      item.actingUserId &&
+      batchActingUserId !== item.actingUserId
+    ) {
       break;
     }
 
@@ -337,6 +345,7 @@ export function consumeQueuedTurn(runtime: ConversationRuntime): {
       batchImageFailureMode = itemImageFailureMode;
     }
 
+    batchActingUserId ??= item.actingUserId;
     queueLen += 1;
     if (item.kind === "message") {
       hasMessage = true;


### PR DESCRIPTION
## Summary

Agent completion notifications should keep the user who started their work when they resume the parent conversation. The earlier attribution fix split different users in `QueueRuntime.tryDequeue()`, but the listener chooses its own batch in `consumeQueuedTurn()` and calls `consumeItems()` directly. Two users' notifications could therefore become one parent turn attributed to the last user.

The listener now stops its batch before a different non-empty `actingUserId`. Same-user and unattributed coalescing keep their existing behavior, as do conversation scope, connection, image-policy, and `noCoalesce` checks.

## Before and after

When completions for users A and B wait behind an active parent turn:

- Before: one parent request contains both completions with `X-Letta-Acting-User-Id: B`.
- After: the queue drains two parent requests, containing A's completion attributed to A, then B's completion attributed to B.

## Verification

The red-first regression queues both completions while a listener turn is active, confirms the queue stays blocked, finishes that turn, and drains the production queue pump. Its send callback calls the production message-request builder against a recording backend. Before the fix it produced only B's request; afterward it produces separate A and B request bodies and headers even when the prepared tool context belongs to another user. No live Cloud quota or billing request was made.

## Breadcrumbs

- Linear: LET-12319
- Origin: follow-up to [the subagent attribution fix](https://github.com/letta-ai/letta-code/pull/4334). This closes the listener batching path omitted by that fix; it is not a new regression introduced by the propagation change.
- Letta conversation: [`conv-7518093f-ddda-49d7-acc6-78a80dd123e2`](https://chat.letta.com/chat/agent-b86b0d3a-c425-4c88-86b9-44171f178713?conversation=conv-7518093f-ddda-49d7-acc6-78a80dd123e2)

👾 Generated with [Letta Code](https://letta.com)
