### PR TITLE
feat(channels): add host-provided Slack conversation binding actions

### DIFF
--- a/src/channels/message-channel-bindings.test.ts
+++ b/src/channels/message-channel-bindings.test.ts
@@ -1,0 +1,260 @@
+import { describe, expect, mock, test } from "bun:test";
+import {
+  type ChannelBindingLookup,
+  formatSlackBindingNotice,
+} from "./message-channel-bindings";
+import {
+  type ExecuteMessageChannelOptions,
+  executeMessageChannel,
+} from "./message-channel-executor";
+import { buildMessageChannelExternalToolDefinition } from "./message-channel-tool-definition";
+import { createSlackMessageActionAdapter } from "./slack/message-action-contract";
+
+const scope = { agentId: "agent-a", conversationId: "conv-a" };
+const binding: ChannelBindingLookup = {
+  channel: "slack",
+  accountId: "app-a",
+  chatId: "C123",
+  threadId: "100.1",
+  binding: {
+    conversationId: "conv-b",
+    enabled: true,
+    outboundEnabled: true,
+    detached: false,
+  },
+};
+
+function fixture() {
+  const get = mock(async () => binding);
+  const update = mock(async () => ({
+    ...binding,
+    status: "updated" as const,
+    previousConversationId: "conv-a",
+  }));
+  const resolveRoutedContext = mock(async () => null);
+  const options: ExecuteMessageChannelOptions = {
+    scope,
+    bindings: { get, update },
+    resolver: { isSupportedChannel: () => true, resolveRoutedContext },
+  };
+  return { options, get, update, resolveRoutedContext };
+}
+
+const getInput = {
+  action: "get-binding",
+  channel: "slack",
+  chat_id: "C123",
+  threadId: "100.1",
+};
+
+describe("host-owned MessageChannel bindings", () => {
+  test("reads another conversation's binding without resolving a send route", async () => {
+    const f = fixture();
+    const result = await executeMessageChannel(getInput, f.options);
+    expect(JSON.parse(result)).toEqual(binding);
+    expect(f.get).toHaveBeenCalledWith(
+      {
+        channel: "slack",
+        chatId: "C123",
+        accountId: undefined,
+        threadId: "100.1",
+      },
+      scope,
+    );
+    expect(f.resolveRoutedContext).not.toHaveBeenCalled();
+  });
+
+  test.each([undefined, "", "__root__", "not-a-timestamp"])(
+    "rejects missing or ambiguous thread identity %s",
+    async (threadId) => {
+      const f = fixture();
+      expect(
+        await executeMessageChannel({ ...getInput, threadId }, f.options),
+      ).toContain("require an exact threadId");
+      expect(f.get).not.toHaveBeenCalled();
+    },
+  );
+
+  test("preserves explicit null for an unthreaded DM", async () => {
+    const f = fixture();
+    await executeMessageChannel(
+      { ...getInput, chat_id: "D123", threadId: null },
+      f.options,
+    );
+    expect(f.get).toHaveBeenCalledWith(
+      expect.objectContaining({ chatId: "D123", threadId: null }),
+      scope,
+    );
+  });
+
+  test("requires both expected and destination conversations for writes", async () => {
+    const f = fixture();
+    const input = {
+      ...getInput,
+      action: "update-binding",
+      conversationId: "default",
+    };
+    expect(await executeMessageChannel(input, f.options)).toContain(
+      "requires conversationId and expectedConversationId",
+    );
+    await executeMessageChannel(
+      { ...input, expectedConversationId: "conv-b" },
+      f.options,
+    );
+    expect(f.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        conversationId: "default",
+        expectedConversationId: "conv-b",
+      }),
+      scope,
+    );
+    expect(f.resolveRoutedContext).not.toHaveBeenCalled();
+  });
+
+  test("unimplemented hosts and outbound targets cannot mutate bindings", async () => {
+    const f = fixture();
+    expect(
+      await executeMessageChannel(getInput, {
+        ...f.options,
+        bindings: undefined,
+      }),
+    ).toStartWith("Error:");
+    expect(
+      await executeMessageChannel(
+        { ...getInput, chat_id: undefined, target: "C123" },
+        f.options,
+      ),
+    ).toContain("target is for outbound sends");
+    expect(f.get).not.toHaveBeenCalled();
+  });
+
+  test("advertises only host-supported operations and fields", () => {
+    for (const supported of [false, true]) {
+      const tool = buildMessageChannelExternalToolDefinition({
+        scoped: false,
+        channels: [
+          {
+            channelId: "slack",
+            displayName: "Slack",
+            accountId: "app-a",
+            messageActions: createSlackMessageActionAdapter({
+              bindings: supported,
+            }),
+          },
+        ],
+      });
+      const properties = tool.parameters.properties as Record<
+        string,
+        { enum?: string[] }
+      >;
+      expect(properties.action?.enum?.includes("get-binding")).toBe(supported);
+      expect(Boolean(properties.expectedConversationId)).toBe(supported);
+      expect(tool.description.includes('action="update-binding"')).toBe(
+        supported,
+      );
+    }
+  });
+
+  test("passes an exact thread selector to routed lookup before sending", async () => {
+    const sendMessage = mock(async () => ({ messageId: "100.3" }));
+    const resolveRoutedContext = mock(
+      async (params: { threadId?: string | null }) => ({
+        route: {
+          ...scope,
+          accountId: "app-a",
+          chatId: "C123",
+          threadId: params.threadId,
+        },
+        transport: { sendMessage },
+        messageActions: createSlackMessageActionAdapter(),
+      }),
+    );
+    const result = await executeMessageChannel(
+      { ...getInput, action: "send", message: "hello", threadId: "200.1" },
+      {
+        scope,
+        resolver: { isSupportedChannel: () => true, resolveRoutedContext },
+      },
+    );
+    expect(result).toContain("Message sent");
+    expect(resolveRoutedContext).toHaveBeenCalledWith(
+      expect.objectContaining({ threadId: "200.1" }),
+    );
+    expect(sendMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ threadId: "200.1" }),
+    );
+  });
+
+  test("conflicts remain tool errors with the authorized current binding", async () => {
+    const f = fixture();
+    f.options.bindings = {
+      get: f.get,
+      update: async () => ({
+        ...binding,
+        status: "conflict",
+        previousConversationId: "conv-b",
+      }),
+    };
+    const result = await executeMessageChannel(
+      {
+        ...getInput,
+        action: "update-binding",
+        conversationId: "conv-c",
+        expectedConversationId: "conv-a",
+      },
+      f.options,
+    );
+    expect(result).toStartWith("Error:");
+    expect(result).toContain('"conversationId":"conv-b"');
+  });
+});
+
+test("send warnings include a usable conditional update and preserve delivery success", async () => {
+  const actions = createSlackMessageActionAdapter();
+  const result = await actions.handleAction({
+    request: {
+      action: "send",
+      channel: "slack",
+      chatId: "C123",
+      message: "hello",
+      threadId: "100.1",
+    },
+    route: { ...scope, accountId: "app-a", chatId: "C123", threadId: "100.1" },
+    adapter: {
+      sendMessage: async () => ({ messageId: "100.2", bindingInfo: binding }),
+    },
+    formatText: (text) => ({ text }),
+  });
+  expect(result).toStartWith("Message sent to slack (message_id: 100.2)");
+  expect(result).toContain(
+    "currently go to conv-b; this conversation is conv-a",
+  );
+  expect(result).toContain('"expectedConversationId":"conv-b"');
+  expect(result).toContain('"conversationId":"conv-a"');
+});
+
+test("matching, unbound, paused, detached, and unavailable notices are distinct", () => {
+  expect(formatSlackBindingNotice(binding, "conv-b")).toContain(
+    "go to this conversation",
+  );
+  expect(
+    formatSlackBindingNotice({ ...binding, binding: null }, "conv-a"),
+  ).toContain("no incoming-message binding");
+  expect(formatSlackBindingNotice({ unavailable: true }, "conv-a")).toContain(
+    "could not be checked",
+  );
+  const row = binding.binding;
+  if (!row) throw new Error("Missing fixture binding");
+  expect(
+    formatSlackBindingNotice(
+      { ...binding, binding: { ...row, enabled: false } },
+      "conv-a",
+    ),
+  ).toContain("paused");
+  expect(
+    formatSlackBindingNotice(
+      { ...binding, binding: { ...row, detached: true } },
+      "conv-a",
+    ),
+  ).toContain("detached");
+});

--- a/src/channels/message-channel-bindings.ts
+++ b/src/channels/message-channel-bindings.ts
@@ -1,0 +1,72 @@
+/** Persisted inbound routing state, supplied by the host that owns the route. */
+export interface ChannelConversationBinding {
+  conversationId: string;
+  enabled: boolean;
+  outboundEnabled: boolean;
+  detached: boolean;
+}
+
+export interface ChannelBindingSelection {
+  channel: string;
+  accountId?: string;
+  chatId: string;
+  threadId: string | null;
+}
+
+export interface ChannelBindingLookup extends ChannelBindingSelection {
+  accountId: string;
+  binding: ChannelConversationBinding | null;
+}
+
+export interface ChannelBindingUpdate extends ChannelBindingLookup {
+  status: "updated" | "unchanged" | "conflict" | "not-found";
+  previousConversationId: string | null;
+}
+
+export interface MessageChannelBindingOperations {
+  get(
+    selection: ChannelBindingSelection,
+    scope: { agentId: string; conversationId: string },
+  ): Promise<ChannelBindingLookup>;
+  update(
+    selection: ChannelBindingSelection & {
+      conversationId: string;
+      expectedConversationId: string;
+    },
+    scope: { agentId: string; conversationId: string },
+  ): Promise<ChannelBindingUpdate>;
+}
+
+export type ChannelSendBindingInfo =
+  | ChannelBindingLookup
+  | { unavailable: true };
+
+export function formatSlackBindingNotice(
+  info: ChannelSendBindingInfo | undefined,
+  conversationId: string,
+): string {
+  if (!info) return "";
+  if ("unavailable" in info) {
+    return "\nThe message was delivered, but its thread binding could not be checked.";
+  }
+  if (!info.binding) return "\nThis thread has no incoming-message binding.";
+  const binding = info.binding;
+  const state = binding.detached
+    ? `This thread is detached (binding: ${binding.conversationId}).`
+    : !binding.enabled
+      ? `Incoming replies are paused for this thread (binding: ${binding.conversationId}).`
+      : binding.conversationId === conversationId
+        ? `Replies in this thread go to this conversation (${conversationId}).`
+        : `Replies in this thread currently go to ${binding.conversationId}; this conversation is ${conversationId}.`;
+  if (binding.conversationId === conversationId) return `\n${state}`;
+  const action = {
+    action: "update-binding",
+    channel: info.channel,
+    accountId: info.accountId,
+    chat_id: info.chatId,
+    threadId: info.threadId,
+    conversationId,
+    expectedConversationId: binding.conversationId,
+  };
+  return `\n${state}\nTo change this thread's destination to this conversation, call MessageChannel with ${JSON.stringify(action)}. Existing pause/detach settings are preserved.`;
+}

--- a/src/channels/message-channel-executor.ts
+++ b/src/channels/message-channel-executor.ts
@@ -1,4 +1,5 @@
 import type { ExternalToolCallResult } from "@/types/app-server-protocol";
+import type { MessageChannelBindingOperations } from "./message-channel-bindings";
 import { formatOutboundChannelMessage } from "./message-channel-formatting";
 import {
   MessageChannelDuplicateActionError,
@@ -41,6 +42,7 @@ export interface MessageChannelExecutionResolver {
     channel: SupportedChannelId;
     chatId: string;
     accountId?: string;
+    threadId?: string | null;
     scope: MessageChannelExecutionScope;
   }):
     | Promise<ResolvedMessageChannelContext | string | null>
@@ -63,6 +65,8 @@ export interface ExecuteMessageChannelOptions {
   resolver: MessageChannelExecutionResolver;
   channelTurnSources?: ChannelTurnSource[];
   idempotencyScope?: MessageChannelIdempotencyScope | null;
+  /** Available only when this host implements persisted binding operations. */
+  bindings?: MessageChannelBindingOperations;
 }
 
 export function createMessageChannelExternalToolResult(
@@ -375,6 +379,54 @@ export async function executeMessageChannel(
   const normalized = normalizeMessageChannelInput(input, options.resolver);
   if (typeof normalized === "string") return normalized;
   if (
+    normalized.action === "get-binding" ||
+    normalized.action === "update-binding"
+  ) {
+    if (normalized.channel !== "slack" || !options.bindings) {
+      return "Error: Binding operations are not supported by this channel host.";
+    }
+    if (!normalized.chatId || normalized.target) {
+      return "Error: Binding operations require chat_id; target is for outbound sends.";
+    }
+    if (
+      input.threadId !== null &&
+      (typeof input.threadId !== "string" || !/^\d+\.\d+$/.test(input.threadId))
+    ) {
+      return "Error: Binding operations require an exact threadId timestamp, or explicit null for an unthreaded DM.";
+    }
+    const selection = {
+      channel: normalized.channel,
+      accountId: normalized.accountId,
+      chatId: normalized.chatId,
+      threadId: input.threadId,
+    };
+    try {
+      if (normalized.action === "get-binding") {
+        return JSON.stringify(
+          await options.bindings.get(selection, options.scope),
+        );
+      }
+      const conversationId = firstNonEmptyString(input.conversationId);
+      const expectedConversationId = firstNonEmptyString(
+        input.expectedConversationId,
+      );
+      if (!conversationId || !expectedConversationId) {
+        return "Error: update-binding requires conversationId and expectedConversationId.";
+      }
+      const result = await options.bindings.update(
+        { ...selection, conversationId, expectedConversationId },
+        options.scope,
+      );
+      const prefix =
+        result.status === "conflict" || result.status === "not-found"
+          ? "Error: "
+          : "";
+      return `${prefix}${JSON.stringify(result)}`;
+    } catch (error) {
+      return `Error: Binding operation failed: ${error instanceof Error ? error.message : "unknown error"}`;
+    }
+  }
+  if (
     normalized.channel === "slack" &&
     normalized.action === "download-file" &&
     normalized.target
@@ -395,6 +447,9 @@ export async function executeMessageChannel(
         channel: normalized.channel,
         chatId: normalized.chatId,
         accountId,
+        ...(normalized.threadId !== null
+          ? { threadId: normalized.threadId }
+          : {}),
         scope: options.scope,
       });
       if (typeof context === "string") return context;

--- a/src/channels/message-channel-tool-definition.ts
+++ b/src/channels/message-channel-tool-definition.ts
@@ -257,6 +257,12 @@ export function buildMessageChannelDescriptionFromDiscovery(
         hasAction("download-file")
           ? 'action="download-file" with attachmentId + messageId'
           : "",
+        hasAction("get-binding")
+          ? 'action="get-binding" with chat_id and an explicit threadId (null for an unthreaded DM) to inspect the persisted incoming-message destination without sending'
+          : "",
+        hasAction("update-binding")
+          ? 'action="update-binding" with the same exact thread, conversationId, and expectedConversationId to reassign an existing binding within this agent. It does not send a message, copy history, move queued inputs, change computers, or alter pause/detach settings. Outbound sends never take over an existing binding'
+          : "",
       ].filter(Boolean)
     : [];
   const slackCapabilityGuidance =

--- a/src/channels/message-channel-types.ts
+++ b/src/channels/message-channel-types.ts
@@ -9,7 +9,9 @@ export interface MessageChannelInput {
   accountId?: string;
   message?: string;
   replyTo?: string;
-  threadId?: string;
+  threadId?: string | null;
+  conversationId?: string;
+  expectedConversationId?: string;
   messageId?: string;
   attachmentId?: string;
   emoji?: string;

--- a/src/channels/plugin-types.ts
+++ b/src/channels/plugin-types.ts
@@ -1,3 +1,4 @@
+import type { ChannelSendBindingInfo } from "./message-channel-bindings";
 import type {
   ChannelAccount,
   ChannelAdapter,
@@ -223,6 +224,12 @@ export interface ChannelAccountConfigAdapter<TAccount extends ChannelAccount> {
 
 export type ChannelMessageActionName = string;
 
+export interface ChannelMessageActionResult {
+  messageId: string;
+  /** Optional persisted inbound binding, read independently by the host. */
+  bindingInfo?: ChannelSendBindingInfo;
+}
+
 export interface ChannelMessageToolSchemaContribution {
   properties: Record<string, unknown>;
   visibility?: "all-configured";
@@ -268,8 +275,12 @@ export interface ChannelResolvedMessageTarget {
 /** Minimal outbound surface consumed by channel-owned MessageChannel actions. */
 export type ChannelMessageActionTransport = Pick<
   ChannelAdapter,
-  "sendMessage" | "downloadAttachment" | "listCustomEmojis"
->;
+  "downloadAttachment" | "listCustomEmojis"
+> & {
+  sendMessage(
+    message: OutboundChannelMessage,
+  ): Promise<ChannelMessageActionResult>;
+};
 
 /** Route identity required by MessageChannel action implementations. */
 export type ChannelMessageActionRoute = Pick<

--- a/src/channels/slack/message-action-contract.ts
+++ b/src/channels/slack/message-action-contract.ts
@@ -1,3 +1,4 @@
+import { formatSlackBindingNotice } from "@/channels/message-channel-bindings";
 import type {
   ChannelMessageActionAdapter,
   ChannelMessageActionContext,
@@ -14,6 +15,8 @@ export interface CreateSlackMessageActionAdapterOptions {
   resolveMessageTarget?: ChannelMessageActionAdapter["resolveMessageTarget"];
   /** Host-owned attachment materialization, when download-file is supported. */
   downloadFile?: (context: ChannelMessageActionContext) => Promise<string>;
+  /** Advertise binding actions only when the executor's host provides them. */
+  bindings?: boolean;
 }
 
 async function sendSlackMessage(
@@ -46,9 +49,13 @@ async function sendSlackMessage(
     agentId: route.agentId,
     conversationId: route.conversationId,
   });
-  return request.mediaPath
+  const confirmation = request.mediaPath
     ? `Attachment sent to slack (message_id: ${result.messageId})`
     : `Message sent to slack (message_id: ${result.messageId})`;
+  return (
+    confirmation +
+    formatSlackBindingNotice(result.bindingInfo, route.conversationId)
+  );
 }
 
 async function reactInSlack(
@@ -108,10 +115,28 @@ export function createSlackMessageActionAdapter(
     ...(options.listCustomEmojis ? ["list-custom-emojis"] : []),
     ...(options.uploadFile ? ["upload-file"] : []),
     ...(options.downloadFile ? ["download-file"] : []),
+    ...(options.bindings ? ["get-binding", "update-binding"] : []),
   ];
   return {
     describeMessageTool() {
       const properties: Record<string, unknown> = {};
+      if (options.bindings) {
+        properties.threadId = {
+          type: ["string", "null"],
+          description:
+            "Thread identifier. Binding actions require an exact Slack thread timestamp, or explicit null for an unthreaded DM.",
+        };
+        properties.conversationId = {
+          type: "string",
+          description:
+            "Destination conversation for update-binding. Must belong to this agent; default selects this agent's default conversation.",
+        };
+        properties.expectedConversationId = {
+          type: "string",
+          description:
+            "Expected current destination for update-binding, from get-binding. A different current binding returns a conflict; an already-matching destination is a no-op.",
+        };
+      }
       if (options.downloadFile) {
         properties.attachmentId = {
           type: "string",

--- a/src/gateway-core.ts
+++ b/src/gateway-core.ts
@@ -16,6 +16,14 @@ export type {
 export { ChannelGateway } from "./channels/gateway-core";
 export { formatChannelControlRequestPrompt } from "./channels/interactive";
 export type {
+  ChannelBindingLookup,
+  ChannelBindingSelection,
+  ChannelBindingUpdate,
+  ChannelConversationBinding,
+  ChannelSendBindingInfo,
+  MessageChannelBindingOperations,
+} from "./channels/message-channel-bindings";
+export type {
   ExecuteMessageChannelOptions,
   MessageChannelExecutionResolver,
   MessageChannelExecutionScope,


### PR DESCRIPTION
## Summary

An agent should be able to inspect which conversation receives a Slack thread's replies and explicitly change that destination. `MessageChannel` currently supports outbound actions but has no host-provided binding operations or way to report a different incoming-message destination after sending.

Add optional `get-binding` and `update-binding` callbacks to the shared executor, require an exact thread selector for them, and let Slack sends include independently read binding information. Hosts opt into the actions and own storage, authorization, and conditional updates. This PR does not enable the feature in any host or change local route storage. Ordinary sends keep their existing behavior when binding information is absent.

Routed lookup also receives an explicit `threadId` when supplied, so hosts can select one thread before deciding whether a channel has ambiguous routes.

## Model-facing contract

These additions are part of the `MessageChannel` **tool definition**, only when the Slack host opts into bindings. Other configured actions remain available.

<details>
<summary>Exact new field definitions and tool guidance</summary>

```json
{
  "threadId": {
    "type": ["string", "null"],
    "description": "Thread identifier. Binding actions require an exact Slack thread timestamp, or explicit null for an unthreaded DM."
  },
  "conversationId": {
    "type": "string",
    "description": "Destination conversation for update-binding. Must belong to this agent; default selects this agent's default conversation."
  },
  "expectedConversationId": {
    "type": "string",
    "description": "Expected current destination for update-binding, from get-binding. A different current binding returns a conflict; an already-matching destination is a no-op."
  }
}
```

The Slack capability list adds these exact entries:

```text
action="get-binding" with chat_id and an explicit threadId (null for an unthreaded DM) to inspect the persisted incoming-message destination without sending

action="update-binding" with the same exact thread, conversationId, and expectedConversationId to reassign an existing binding within this agent. It does not send a message, copy history, move queued inputs, change computers, or alter pause/detach settings. Outbound sends never take over an existing binding
```

Hosts without binding support do not advertise either action or the destination fields. Binding calls require `chat_id`; `target` remains an outbound-send mode.

</details>

<details>
<summary>Exact tool-result examples and conditional send notices</summary>

A binding read returns the host's authorized lookup as a JSON **tool result**:

```json
{"channel":"slack","accountId":"app-a","chatId":"C123","threadId":"100.1","binding":{"conversationId":"conv-b","enabled":true,"outboundEnabled":true,"detached":false}}
```

A conflicting update returns `is_error: true` with this text:

```text
Error: {"channel":"slack","accountId":"app-a","chatId":"C123","threadId":"100.1","binding":{"conversationId":"conv-b","enabled":true,"outboundEnabled":true,"detached":false},"status":"conflict","previousConversationId":"conv-b"}
```

An accepted send from `conv-a` to a thread bound to `conv-b` returns `is_error: false`:

```text
Message sent to slack (message_id: 100.2)
Replies in this thread currently go to conv-b; this conversation is conv-a.
To change this thread's destination to this conversation, call MessageChannel with {"action":"update-binding","channel":"slack","accountId":"app-a","chat_id":"C123","threadId":"100.1","conversationId":"conv-a","expectedConversationId":"conv-b"}. Existing pause/detach settings are preserved.
```

The line after the existing send confirmation varies with the host's lookup:

```text
Replies in this thread go to this conversation (conv-a).
This thread has no incoming-message binding.
The message was delivered, but its thread binding could not be checked.
Incoming replies are paused for this thread (binding: conv-b).
This thread is detached (binding: conv-b).
```

Paused or detached bindings to another conversation still include the conditional update example above. Matching bindings do not. Hosts that omit binding information retain the original send confirmation with no additional text. Reactions have no binding notice.

</details>

## Verification

- `bun run check`: all 12 checks passed.
- 65 focused tests passed across the new contract tests and existing gateway, Slack, Telegram, WhatsApp, and schema suites. Existing module-mocking suites ran in separate processes.
- Built the published gateway/channel subpaths and declarations, then exercised the Node artifacts: binding read, conflict error, and accepted send with a different stored destination. Storage and Slack transport were test doubles.
- Exercised the branch-built executor through a host gateway's external-tool handler, including successful send followed by a failed binding lookup. One post remained successful and returned the unavailable notice.
- No live Slack binding was changed. End-to-end host reassignment and queued-input behavior are separate host implementation work; this PR only supplies the shared contract.

## Breadcrumbs

- Requested in: LET-12384.
- Letta conversation: [`conv-939ab058-4adb-4b64-9364-0fb996f87722`](https://chat.letta.com/chat/agent-b86b0d3a-c425-4c88-86b9-44171f178713?conversation=conv-939ab058-4adb-4b64-9364-0fb996f87722).

## AI Tool(s) Used

Letta Code.
