### PR TITLE
docs(skills): fix stale tool conversation handle claim in creating-mods

### DIFF
--- a/src/skills/builtin/creating-mods/references/architecture.md
+++ b/src/skills/builtin/creating-mods/references/architecture.md
@@ -141,7 +141,7 @@ A forked handle keeps the same agent/backend defaults and targets the forked con
 
 `updateLlmConfig({ model?, reasoningEffort?, contextWindow?, scope? })` changes the model, reasoning effort, and/or context window, and works across local and Letta Cloud backends. Only the fields you pass change; the rest are preserved, so `updateLlmConfig({ contextWindow })` adjusts just the context window without touching the model or reasoning effort. `scope` defaults to `"conversation"` (a conversation-scoped override that leaves the agent's default untouched); pass `scope: "agent"` to change the agent default. Changing reasoning effort without a model resolves the current model to rebuild provider-specific settings. The change takes effect on the next turn (the model is resolved per provider request).
 
-Tools currently receive `ctx.conversation.getHistory()` but not fork/send helpers. If a tool needs model-side follow-up, return information for the model to act on instead of starting a hidden run from the tool.
+Tools receive the same scoped `ctx.conversation` handle as commands and events, including `fork`, `sendMessageStream`, `updateTitle`, and `updateLlmConfig`. Still prefer returning information for the model to act on; only fork and send in the background when the tool genuinely needs independent model work.
 
 ## Error handling
 


### PR DESCRIPTION
## Summary

- Fix stale claim in `references/architecture.md` that mod tools "receive `ctx.conversation.getHistory()` but not fork/send helpers"

## Stale claim and current owning source

`src/tools/manager.ts` (~line 2172) builds the full `createModConversationHandle(...)` for mod tool run contexts, so tools receive the same scoped `ctx.conversation` handle as commands and events: `fork`, `getHistory`, `sendMessageStream`, `updateTitle`, and `updateLlmConfig` (`src/mods/conversation-handle.ts`, `ModToolRunContext.conversation: ModConversationHandle` in `src/mods/types.ts:579-586`).

## Scope note

This PR intentionally does not touch `turn_end`/`"reload"`/`alwaysAsk` drift: open watcher PR #4118 already covers those findings for this skill; no duplication per watcher rules.

## Focused validation

- `bun run check` passes (12/12 checks)
- Diff is documentation-only (1 markdown file in `src/skills/builtin/creating-mods/references/`)

Builtin-skill-watch: creating-mods@de54f4a461b6-34f18e9b25b017bd

## Test plan

- [x] `bun run check` passes
- [x] Diff is documentation-only

👾 Generated with [Letta Code](https://letta.com)

Co-Authored-By: Letta Code <noreply@letta.com>