### PR TITLE
fix(skills): correct claude session path encoding in dispatching-coding-agents

### DIFF
--- a/src/skills/builtin/dispatching-coding-agents/SKILL.md
+++ b/src/skills/builtin/dispatching-coding-agents/SKILL.md
@@ -184,7 +184,7 @@ Both CLIs persist full session data (tool calls, reasoning, files read) to disk.
 ### Session storage paths
 
 **Claude Code:** `~/.claude/projects/<encoded-path>/<session-id>.jsonl`
-- `<encoded-path>` = working directory with `/` replaced by `-` (e.g. `/Users/foo/repos/bar` becomes `-Users-foo-repos-bar`)
+- `<encoded-path>` = working directory with every non-alphanumeric character replaced by `-` (e.g. `/Users/foo/repos/bar` becomes `-Users-foo-repos-bar`, `/Users/foo/my_repo` becomes `-Users-foo-my-repo`)
 - Use `--output-format json` to get the `session_id` in the response
 
 **Codex:** `~/.codex/sessions/<year>/<month>/<day>/rollout-*-<session-id>.jsonl`


### PR DESCRIPTION
## Summary

Builtin-skill-watch audit found the `dispatching-coding-agents` skill described the Claude Code session storage path encoding incorrectly: it claimed the encoded project path replaces only `/` with `-`. Verified against the installed claude binary (2.1.251), the actual sanitizer replaces every non-alphanumeric character with `-`:

```js
e.replace(/[^a-zA-Z0-9]/g, "-")
```

So a cwd like `/Users/foo/my_repo` encodes to `-Users-foo-my-repo`, not `-Users-foo-my_repo` as the old rule predicted. An agent following the old rule would compute the wrong `~/.claude/projects/` directory for any path containing `_`, `.`, or spaces.

## Changes

- `SKILL.md`: one line — encoding rule now says "every non-alphanumeric character replaced by `-`" with an added underscore example

## Verification

- `bun run check` — 12/12 checks pass
- Encoding confirmed from the claude binary transcript-path code path (`getProjectKey` → `sanitizePath` → `/[^a-zA-Z0-9]/g`)

## Provenance

- Builtin-skill-watch: dispatching-coding-agents@9ead5f0480b2-81b905d6fa44e4fc
- Workflow: https://github.com/letta-ai/letta-code/actions/runs/34581306041
- Tracker: #4065

👾 Generated with [Letta Code](https://letta.com)

Co-Authored-By: Letta Code <noreply@letta.com>