### PR TITLE
fix(skill): add zoomLevel to desktop preferences skill

### DIFF
--- a/src/skills/builtin/editing-letta-code-desktop-preferences/SKILL.md
+++ b/src/skills/builtin/editing-letta-code-desktop-preferences/SKILL.md
@@ -25,6 +25,7 @@ User-editable preference keys:
 - `remoteEnvName`: environment name shown in the Letta Cloud environment picker for the cloud listener.
 - `localBackendDirectory`: directory containing local backend agents, conversations, and memory.
 - `allowLocalAgentsWhenSignedIn`: boolean for whether signed-in Desktop sessions can see local/offline agents.
+- `zoomLevel`: number for the Desktop window zoom level (Chromium zoom), normally set through Desktop's View menu zoom controls.
 
 System-managed keys (do not edit directly):
 - `artifactsByAgent`: per-agent artifacts panel state, written by Desktop UI.


### PR DESCRIPTION
Builtin-skill-watch: editing-letta-code-desktop-preferences@aa3e294d006b-042b685854ad9825

**Selected skill:** `editing-letta-code-desktop-preferences`

**Stale claim:** The skill lists all Desktop preference keys but is missing `zoomLevel`, added to the Desktop preferences schema in letta-cloud #15865 (`fix(desktop): preserve window zoom across resize`, 2026-09-09), after the skill was last updated.

**Current owning source:** letta-cloud `apps/code-desktop/electron/src/preferencesStorage.ts` defines `zoomLevel: number` on `DesktopPreferences`, persisted via `savePreferences({ zoomLevel })` from the View menu zoom controls (`main.ts`), normalized by `desktopZoom.ts` (`normalizeDesktopZoomLevel`), and applied live by the preferences file watcher through `applyDesktopPreferences` → `applyDesktopZoomLevel`.

**Focused validation:** Traced every skill claim against letta-cloud main (`preferencesStorage.ts`, `main.ts`, `listenerManager.ts`, `Preferences.tsx`, `DebugPanelSidebar.tsx`, `useRemoteAppServerSettings.ts`): file path, user-editable keys, theme enum, system-managed keys, remoteAppServer startup semantics, and the 100ms watcher debounce (`schedulePreferencesReload`) all match. The only other stale claim (`debugPanelEnabled` "controlled via app menus") is already covered by open watcher PRs #4322 / #4263 / #4122 and is intentionally not duplicated here. `bun run check` passes 12/12.

**Change:** added `zoomLevel` to the user-editable keys list with its View-menu provenance.

👾 Generated with [Letta Code](https://letta.com)

Co-Authored-By: Letta Code <noreply@letta.com>