### PR TITLE
fix(skills): correct finding-agents output fields for lean list responses

### DIFF
--- a/src/skills/builtin/finding-agents/SKILL.md
+++ b/src/skills/builtin/finding-agents/SKILL.md
@@ -90,8 +90,9 @@ Returns the raw API response with full agent details. Key fields:
 - `id` - Agent ID (e.g., `agent-abc123`)
 - `name` - Agent name
 - `description` - Agent description
-- `tags` - Agent tags
 - `blocks` - Memory blocks (if `--include-blocks` used)
+
+The `tags` field is returned empty: the server no longer includes tag relationships in list responses, and the CLI does not request them. `--tags` filtering still works server-side, but to see an agent's actual tags, retrieve the agent via the Letta API with `include: ["agent.tags"]`.
 
 ## Related Skills
 


### PR DESCRIPTION
Builtin-skill-watch: finding-agents@9ead5f0480b2-6d9469b78e7c1258

## Selected skill

`src/skills/builtin/finding-agents`

## Stale claim and current owning source

The skill's Output section listed `tags` as a key field of the `letta agents list` response. Since the server stopped implicitly loading relationships (see #4341 and the SDK contract "No relationships are included by default" in `@letta-ai/letta-client` `AgentListParams`), the list response returns `tags: []` even for tagged agents, and `runListAction` in `src/cli/subcommands/agents.ts` never requests `include: ["agent.tags"]`. Verified against the live API: default list returns `"tags": []` for agents whose real tags include `origin:letta-code`; adding `include: ["agent.tags"]` returns the real tags.

The update removes `tags` from the key-fields list and notes that `--tags` filtering still works server-side while the output field is empty, directing agents to retrieve with `include: ["agent.tags"]` via the API when they need actual tags.

All other claims verified current: options and defaults (`--name` exact match, `--query` fuzzy, `--match-all-tags` default ANY, `--limit` default 20) against `src/cli/subcommands/agents.ts` and live API probes; `origin:letta-code` tag against `src/agent/agent-tags.ts`; `letta messages search --query ... --all-agents` against `src/cli/subcommands/messages.ts`; `agent_id` presence in search results against the letta-client SDK types.

## Focused validation

- `bun run check`: all 12 checks passed
- Live read-only API probes: default list vs `include: ["agent.tags"]` (tags empty vs populated), `--tags` filter works server-side, `--name` exact match, `--query` fuzzy match, `--include-blocks` populates blocks