### PR TITLE
fix(skills): use real --output-format flag in messaging-agents

### DIFF
--- a/src/skills/builtin/messaging-agents/SKILL.md
+++ b/src/skills/builtin/messaging-agents/SKILL.md
@@ -102,7 +102,7 @@ letta -p --from-agent $LETTA_AGENT_ID \
   "What do you know about the authentication system?"
 ```
 
-**Response (JSON format with `--output json`):**
+**Response (JSON format with `--output-format json`):**
 ```json
 {
   "type": "result",
@@ -170,7 +170,7 @@ letta -p --from-agent $LETTA_AGENT_ID \
 - Text-mode scripts return only the **final assistant message** (not tool calls, reasoning, or metadata)
 - JSON and stream-json responses include `agent_id`, `conversation_id`, and `environment.source` so you can continue the same conversation/runtime. Environment-routed turns also include `environment.id`, `connection_id`, `device_id`, and `name`.
 - The target agent may use tools, think, and reason - but you only see their final response
-- To see the full conversation transcript (including tool calls), use `letta messages list --agent <id>` targeting the other agent
+- To see the full conversation transcript (including tool calls), use `letta messages transcript --conversation <id>` (or `letta messages list --agent <id>`) targeting the other agent
 
 ## How It Works
 

--- a/src/skills/messaging-agents.test.ts
+++ b/src/skills/messaging-agents.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { CLI_FLAG_CATALOG } from "@/cli/args";
+
+const skill = readFileSync(
+  join(
+    process.cwd(),
+    "src",
+    "skills",
+    "builtin",
+    "messaging-agents",
+    "SKILL.md",
+  ),
+  "utf8",
+);
+
+// Headless flags the skill documents for `letta -p` messaging. Subcommand
+// flags (agents/messages/computers) are parsed by their own subcommand
+// parsers and are not part of the main CLI flag catalog.
+const HEADLESS_FLAGS_DOCUMENTED = [
+  "from-agent",
+  "agent",
+  "conversation",
+  "computer",
+  "output-format",
+] as const;
+
+describe("messaging-agents skill", () => {
+  test("documents headless flags the CLI parser accepts", () => {
+    for (const flag of HEADLESS_FLAGS_DOCUMENTED) {
+      expect(flag in CLI_FLAG_CATALOG).toBe(true);
+      expect(skill).toContain(`--${flag}`);
+    }
+  });
+
+  test("uses the real headless JSON output flag", () => {
+    expect(skill).toContain("--output-format json");
+    expect(skill).not.toContain("--output json");
+  });
+});


### PR DESCRIPTION
## Summary
- The `messaging-agents` skill told agents to run `letta -p ... --output json`, but the CLI flag catalog only defines `--output-format`; strict parsing rejects `--output` with `Unknown option`
- The full-transcript pointer referenced `letta messages list`, but `messages transcript` is the command that renders tool calls; `messages list` returns raw JSON messages
- Added `src/skills/messaging-agents.test.ts` locking the documented headless flags to the CLI flag catalog so a stale flag reference fails CI

Builtin-skill-watch: messaging-agents@aa3e294d006b-a29c6f40c6ffdc12

## Selected skill
`src/skills/builtin/messaging-agents`

## Stale claim and current owning source
- `--output json` (SKILL.md line 105) vs `src/cli/args.ts` `CLI_FLAG_CATALOG` (`output-format`, no `output` alias) and `src/index.ts` strict `parseCliArgs(processedArgs, true)`
- `letta messages list --agent <id>` for "full transcript (including tool calls)" vs `src/cli/subcommands/messages.ts` (`transcript` action renders tool calls; `list` returns raw JSON messages)

## Focused validation
- Parser probe: `parseCliArgs(["-p","--from-agent","agent-x","--agent","agent-y","--output","json","hi"], strict)` fails with `Unknown option '--output'`; `--output-format json` parses
- `bun test src/skills/messaging-agents.test.ts` (2 pass), `bun test src/skills/dispatching-coding-agents.test.ts src/agent/skills-discovery.test.ts` (18 pass), `bun run check` (12/12 pass)

## Test plan
- [x] `bun run check` passes
- [x] New skill test locks `--output-format` and rejects `--output json`
- [ ] Reviewer confirms the JSON example matches actual `letta -p --from-agent ... --output-format json` output

👾 Generated with [Letta Code](https://letta.com)

Co-Authored-By: Letta Code <noreply@letta.com>