### PR TITLE
fix(skills): correct SDK field casing in self-configuration api examples

### DIFF
--- a/src/skills/builtin/self-configuration/references/api-patch-examples.md
+++ b/src/skills/builtin/self-configuration/references/api-patch-examples.md
@@ -81,7 +81,7 @@ curl -sS -X PATCH "$base_url/v1/agents/$AGENT_ID" \
 
 ## TypeScript SDK
 
-SDK calls use the same account token authority as raw API calls. Check IDs before update calls; do not hard-code provider keys or other secrets in the patch body.
+SDK calls use the same account token authority as raw API calls. Check IDs before update calls; do not hard-code provider keys or other secrets in the patch body. SDK request fields are snake_case, matching the raw API.
 
 ```typescript
 import Letta from "@letta-ai/letta-client";
@@ -93,11 +93,11 @@ const client = new Letta({
 
 await client.agents.update(process.env.AGENT_ID!, {
   model: "openai/gpt-5.2",
-  contextWindowLimit: 64000,
-  modelSettings: {
-    providerType: "openai",
-    parallelToolCalls: true,
-    reasoning: { reasoningEffort: "medium" },
+  context_window_limit: 64000,
+  model_settings: {
+    provider_type: "openai",
+    parallel_tool_calls: true,
+    reasoning: { reasoning_effort: "medium" },
   },
 });
 ```
@@ -125,9 +125,11 @@ client.agents.update(
     },
 )
 
+# The Python SDK's conversations.update does not expose context_window_limit
+# as a keyword argument; pass it through extra_body, which the server accepts.
 client.conversations.update(
     conversation_id=os.environ["CONVERSATION_ID"],
-    context_window_limit=64000,
+    extra_body={"context_window_limit": 64000},
 )
 ```
 


### PR DESCRIPTION
Builtin-skill-watch: self-configuration@aa3e294d006b-fbdf1e92d9d75d41

**Selected skill:** `self-configuration` (`src/skills/builtin/self-configuration`)

**Stale claim:** `references/api-patch-examples.md` shipped SDK examples that do not work against the pinned clients:

- The TypeScript SDK example used camelCase request fields (`contextWindowLimit`, `modelSettings`, `providerType`, `parallelToolCalls`, `reasoningEffort`). `@letta-ai/letta-client@1.10.2` request params are snake_case with no case transform, so the example failed typecheck (`TS2561: contextWindowLimit does not exist in AgentUpdateParams`) and at runtime the unknown keys would be sent verbatim and silently ignored.
- The Python example called `client.conversations.update(..., context_window_limit=64000)`. The pinned Python SDK `conversations.update` has no such keyword (only `archived`, `last_message_at`, `model`, `model_settings`, `summary`), so the call raises `TypeError`. The server does accept the field on conversation PATCH (the repo itself sends it in `src/agent/max-context.ts`), so the correct mechanism is `extra_body`, which merges into the request JSON.

**Current owning source:** `node_modules/@letta-ai/letta-client/src/resources/agents/agents.ts` (`AgentUpdateParams` snake_case fields), `node_modules/@letta-ai/letta-client/src/resources/conversations/conversations.ts` (`ConversationUpdateParams` without `context_window_limit`), Python `letta_client==1.10.2` `resources/conversations/conversations.py` (`extra_body` kwarg, merged in `_base_client.make_request_options`), and `src/agent/max-context.ts` (server accepts `context_window_limit` on conversation PATCH).

**Change:** the TS example now uses the snake_case fields the SDK actually accepts, and the Python conversation example routes `context_window_limit` through `extra_body` with a one-line explanation. No other files touched.

**Focused validation performed:**

- `tsc --noEmit --strict` probe of the old TS example against the installed SDK fails with `TS2561`; the corrected example typechecks clean.
- Python SDK wheel `letta_client==1.10.2` inspected: `conversations.update` signature has `extra_body`, and `_base_client` merges `extra_body` into the request JSON.
- `bun run check` (12/12 pass) on the branch.

*Generated with [Letta Code](https://letta.com)*