### PR TITLE
test(tools): cover shell completion notifications on Windows

### DIFF
--- a/src/tools/bash-background-notification.test.ts
+++ b/src/tools/bash-background-notification.test.ts
@@ -32,7 +32,7 @@ describe("Background bash completion notifications", () => {
     const script = join(fixtureDir, "command.cjs");
     writeFileSync(script, source);
     // Preserve the explicit shell exit status used by the old Unix fixtures.
-    return `node "${script}"${isWindows ? "; exit $LASTEXITCODE" : ""}`;
+    return `"${process.execPath}" "${script}"${isWindows ? "; exit $LASTEXITCODE" : ""}`;
   }
 
   const startBackground = async (args: {
@@ -148,6 +148,8 @@ describe("Background bash completion notifications", () => {
         "setTimeout(() => { console.error('automatic failure'); process.exitCode = 9; }, 100)",
       ),
       description: "Run failing automatic command",
+      // An otherwise empty PATH must not require a separate Node installation.
+      secretEnv: isWindows ? { PATH: fixtureDir } : undefined,
     });
 
     const notification = await waitForNotification(bashId);

--- a/src/tools/bash-background-notification.test.ts
+++ b/src/tools/bash-background-notification.test.ts
@@ -1,4 +1,7 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { bash } from "@/tools/impl/bash";
 import { kill_bash } from "@/tools/impl/kill-bash";
 import { backgroundProcesses } from "@/tools/impl/process_manager";
@@ -21,8 +24,16 @@ const isWindows = process.platform === "win32";
  * process registry and the queue bridge are module-level singletons, and a
  * shell torn down by a previous test can deliver its exit event here.
  */
-describe.skipIf(isWindows)("Background bash completion notifications", () => {
+describe("Background bash completion notifications", () => {
   let queued: QueuedMessage[] = [];
+  let fixtureDir: string;
+
+  function command(source: string): string {
+    const script = join(fixtureDir, "command.cjs");
+    writeFileSync(script, source);
+    // Preserve the explicit shell exit status used by the old Unix fixtures.
+    return `node "${script}"${isWindows ? "; exit $LASTEXITCODE" : ""}`;
+  }
 
   const startBackground = async (args: {
     command: string;
@@ -71,6 +82,7 @@ describe.skipIf(isWindows)("Background bash completion notifications", () => {
   };
 
   beforeEach(() => {
+    fixtureDir = mkdtempSync(join(tmpdir(), "bash notification-"));
     queued = [];
     clearPendingMessages();
     setMessageQueueAdder((message) => {
@@ -89,6 +101,7 @@ describe.skipIf(isWindows)("Background bash completion notifications", () => {
       }
     }
     backgroundProcesses.clear();
+    rmSync(fixtureDir, { recursive: true, force: true });
   });
 
   test("queues a task notification when a background command succeeds", async () => {
@@ -113,7 +126,9 @@ describe.skipIf(isWindows)("Background bash completion notifications", () => {
 
   test("routes one completion notification after an ordinary command yields", async () => {
     const bashId = await startAutomaticBackground({
-      command: "sleep 0.1; echo 'automatic finish'",
+      command: command(
+        "setTimeout(() => console.log('automatic finish'), 100)",
+      ),
       description: "Run automatic background command",
       parentScope: { agentId: "agent-auto", conversationId: "conv-auto" },
     });
@@ -129,7 +144,9 @@ describe.skipIf(isWindows)("Background bash completion notifications", () => {
 
   test("reports failure after an ordinary command yields", async () => {
     const bashId = await startAutomaticBackground({
-      command: "sleep 0.1; echo 'automatic failure' >&2; exit 9",
+      command: command(
+        "setTimeout(() => { console.error('automatic failure'); process.exitCode = 9; }, 100)",
+      ),
       description: "Run failing automatic command",
     });
 
@@ -142,8 +159,9 @@ describe.skipIf(isWindows)("Background bash completion notifications", () => {
   test("scrubs and bounds automatic completion output", async () => {
     const secret = "automatic-notification-secret";
     const bashId = await startAutomaticBackground({
-      command:
-        "sleep 0.1; node -e \"process.stdout.write('x'.repeat(50000) + (process.env.PASSWORD ?? ''))\"",
+      command: command(
+        "setTimeout(() => process.stdout.write('x'.repeat(50000) + (process.env.PASSWORD ?? '')), 100)",
+      ),
       description: "Print automatic output",
       secretEnv: { PASSWORD: secret },
     });
@@ -156,7 +174,7 @@ describe.skipIf(isWindows)("Background bash completion notifications", () => {
 
   test("reports a failing background command as failed with its exit code", async () => {
     const bashId = await startBackground({
-      command: "echo 'boom' >&2; exit 3",
+      command: command("console.error('boom'); process.exitCode = 3"),
       description: "Failing job",
     });
 
@@ -179,7 +197,7 @@ describe.skipIf(isWindows)("Background bash completion notifications", () => {
 
   test("notifies exactly once when a shell times out", async () => {
     const bashId = await startBackground({
-      command: "sleep 5",
+      command: isWindows ? "Start-Sleep -Seconds 5" : "sleep 5",
       description: "Slow job",
       timeout: 150,
     });
@@ -196,7 +214,7 @@ describe.skipIf(isWindows)("Background bash completion notifications", () => {
 
   test("stays silent when the agent deliberately kills the shell", async () => {
     const bashId = await startBackground({
-      command: "sleep 5",
+      command: isWindows ? "Start-Sleep -Seconds 5" : "sleep 5",
       description: "Cancelled job",
     });
 
@@ -208,7 +226,7 @@ describe.skipIf(isWindows)("Background bash completion notifications", () => {
 
   test("stays silent when an automatically yielded shell is stopped", async () => {
     const bashId = await startAutomaticBackground({
-      command: "sleep 5",
+      command: isWindows ? "Start-Sleep -Seconds 5" : "sleep 5",
       description: "Cancel automatic command",
     });
 

--- a/src/tools/exec-command-notification.test.ts
+++ b/src/tools/exec-command-notification.test.ts
@@ -24,7 +24,7 @@ describe("Exec command completion notifications", () => {
     const script = join(fixtureDir, "command.cjs");
     fs.writeFileSync(script, source);
     // Test notification routing, not PowerShell's default native-exit mapping.
-    return `node "${script}"${isWindows ? "; exit $LASTEXITCODE" : ""}`;
+    return `"${process.execPath}" "${script}"${isWindows ? "; exit $LASTEXITCODE" : ""}`;
   }
 
   function notificationsFor(sessionId: string): QueuedMessage[] {
@@ -116,6 +116,8 @@ describe("Exec command completion notifications", () => {
       ),
       description: "Run failing check",
       yield_time_ms: 250,
+      // An otherwise empty PATH must not require a separate Node installation.
+      secretEnv: isWindows ? { PATH: fixtureDir } : undefined,
     });
     const sessionId = sessionIdFrom(first.output);
     const notification = await waitForNotification(sessionId);

--- a/src/tools/exec-command-notification.test.ts
+++ b/src/tools/exec-command-notification.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import * as fs from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import {
   __clearExecSessionsForTests,
   exec_command,
@@ -14,8 +16,16 @@ import {
 
 const isWindows = process.platform === "win32";
 
-describe.skipIf(isWindows)("Exec command completion notifications", () => {
+describe("Exec command completion notifications", () => {
   let queued: QueuedMessage[] = [];
+  let fixtureDir: string;
+
+  function command(source: string): string {
+    const script = join(fixtureDir, "command.cjs");
+    fs.writeFileSync(script, source);
+    // Test notification routing, not PowerShell's default native-exit mapping.
+    return `node "${script}"${isWindows ? "; exit $LASTEXITCODE" : ""}`;
+  }
 
   function notificationsFor(sessionId: string): QueuedMessage[] {
     return queued.filter((message) =>
@@ -45,6 +55,7 @@ describe.skipIf(isWindows)("Exec command completion notifications", () => {
   }
 
   beforeEach(() => {
+    fixtureDir = fs.mkdtempSync(join(tmpdir(), "exec-notification-"));
     queued = [];
     clearPendingMessages();
     setMessageQueueAdder((message) => queued.push(message));
@@ -65,11 +76,14 @@ describe.skipIf(isWindows)("Exec command completion notifications", () => {
     }
     backgroundProcesses.clear();
     __clearExecSessionsForTests();
+    fs.rmSync(fixtureDir, { recursive: true, force: true });
   });
 
   test("notifies once when a yielded command succeeds", async () => {
     const first = await exec_command({
-      cmd: "printf start; sleep 0.4; printf done",
+      cmd: command(
+        "process.stdout.write('start'); setTimeout(() => process.stdout.write('done'), 400)",
+      ),
       description: "Run slow check",
       yield_time_ms: 250,
       parentScope: { agentId: "agent-1", conversationId: "conv-1" },
@@ -97,7 +111,9 @@ describe.skipIf(isWindows)("Exec command completion notifications", () => {
 
   test("notifies when a yielded command fails", async () => {
     const first = await exec_command({
-      cmd: "sleep 0.3; printf boom >&2; exit 7",
+      cmd: command(
+        "setTimeout(() => { process.stderr.write('boom'); process.exitCode = 7; }, 400)",
+      ),
       description: "Run failing check",
       yield_time_ms: 250,
     });
@@ -111,9 +127,11 @@ describe.skipIf(isWindows)("Exec command completion notifications", () => {
 
   test("does not notify for a command that finishes before yielding", async () => {
     const result = await exec_command({
-      cmd: "printf done",
+      cmd: command("process.stdout.write('done')"),
       description: "Run quick check",
-      yield_time_ms: 250,
+      // Windows PowerShell startup itself can exceed 250ms. This case tests
+      // completion before the chosen yield deadline, not shell startup speed.
+      yield_time_ms: isWindows ? 10_000 : 250,
     });
 
     expect(result.output).toContain("Process exited with code 0");
@@ -123,7 +141,7 @@ describe.skipIf(isWindows)("Exec command completion notifications", () => {
 
   test("write_stdin completion replaces the notification", async () => {
     const first = await exec_command({
-      cmd: "sleep 0.4; printf done",
+      cmd: command("setTimeout(() => process.stdout.write('done'), 400)"),
       description: "Wait for check",
       yield_time_ms: 250,
     });
@@ -132,7 +150,7 @@ describe.skipIf(isWindows)("Exec command completion notifications", () => {
     const result = await write_stdin({
       session_id: sessionId,
       chars: "",
-      yield_time_ms: 1_000,
+      yield_time_ms: isWindows ? 10_000 : 1_000,
     });
     expect(result.output).toContain("Process exited with code 0");
     expect(result.output).toContain("done");
@@ -144,7 +162,9 @@ describe.skipIf(isWindows)("Exec command completion notifications", () => {
   test("scrubs secrets and bounds notification output", async () => {
     const secret = "notification-secret";
     const first = await exec_command({
-      cmd: "sleep 0.3; node -e \"process.stdout.write((process.env.PASSWORD ?? '') + 'x'.repeat(50000))\"",
+      cmd: command(
+        "setTimeout(() => process.stdout.write((process.env.PASSWORD ?? '') + 'x'.repeat(50000)), 400)",
+      ),
       description: "Print bounded output",
       yield_time_ms: 250,
       secretEnv: { PASSWORD: secret },


### PR DESCRIPTION
## Summary

**Type: Test/CI.** Background shell commands should notify the owning agent and conversation when they finish. Both existing notification suites skipped Windows entirely, leaving their delivery, cancellation, and secret-redaction assertions without a Windows gate.

This enables the same 14 scenarios on Windows by replacing Unix-only fixtures with temporary JavaScript scripts launched with the running test executable and native PowerShell sleep commands. Each test owns its fixture directory. Explicit PowerShell exit propagation preserves the fixtures' chosen shell exit codes; it does not change the shell tools' default exit behavior. Windows completion deadlines allow for PowerShell startup.

Only two test files change. No production behavior changes or new live-provider tests.

## Review notes

- Start with the fixture commands and the removal of `describe.skipIf(isWindows)` in both notification suites. The existing delivery, routing, timeout, cancellation, duplicate-suppression, and output-scrubbing assertions remain.
- CI already discovers both files in the `tools` family and runs that family in its Windows, macOS, and Linux jobs. No workflow change is needed.
- Merge after current-head platform checks pass and the human-verification section is completed. Main risk: shell startup or fixture cleanup behaving differently under CI load.

## Verification

- `bun test src/tools/exec-command-notification.test.ts src/tools/bash-background-notification.test.ts --timeout 15000`: **14 passed, 72 assertions**, Windows 11 / Windows PowerShell 5.1 / Bun 1.3.14 (CI pin). The current revision also passes with Node absent from PATH.
- `bun run check`: **12/12 passed**, including TypeScript and Biome.
- Mutation checks: independently suppressing Windows Bash completion delivery and Windows exec completion delivery made the corresponding tests fail with missing-notification errors. Both production mutations were restored.
- The real CI impact selector includes both changed suites (`tools`, 90 selected tests).
- [Current-head CI](https://github.com/letta-ai/letta-code/actions/runs/34655314379) at `94732640`: **23 successful checks, none pending or failed**, including Windows x64, macOS arm64, Linux x64 and Linux arm64. Focused rereview requested from amelia-letta.
- Review correction: both fixtures use quoted `process.execPath`; each Windows failure case restricts PATH to its fixture directory. Reintroducing `node` makes both cases fail. Both inline review threads have commit/proof replies and are resolved.
- Scope ends at the real notification queue; no claim about a model consuming the notification or OS toast delivery. Follow-up review remains pending.

## Breadcrumbs

- Origin: the existing Bash and exec notification suites were introduced with Windows skips in [#3741](https://github.com/letta-ai/letta-code/pull/3741) and [#4219](https://github.com/letta-ai/letta-code/pull/4219). This closes a coverage gap, not a demonstrated production regression.
- Follow-up to: [#4220](https://github.com/letta-ai/letta-code/pull/4220), which added automatic Bash backgrounding scenarios to the existing suite.

## AI Disclosure

- [ ] This pull request was written entirely by a human
- [x] This pull request was written with AI assistance and reviewed and edited by a human
- [x] I have read the [AI Policy](https://github.com/letta-ai/letta-code/blob/main/AI_POLICY.md) and agree to its terms

AI-assisted; the exact human-verification statement below remains pending.

## AI Tool(s) Used

Letta Code (Hadron): source/history investigation, test changes, local validation, mutation checks, and PR preparation.

## Human Verification

Pending human review and the repository's required verification statement.
