### PR TITLE
fix(slack): keep parallel tool status titles steady

### DIFF
--- a/src/channels/progress-builder.ts
+++ b/src/channels/progress-builder.ts
@@ -11,7 +11,7 @@ import {
   type ToolCallSummary,
   type ToolReturnSummary,
 } from "./progress-formatting";
-import type { ChannelTurnProgressUpdate } from "./types";
+import type { ChannelTurnProgressUpdate } from "./progress-types";
 
 function getMessageType(delta: Record<string, unknown>): string | null {
   return firstNonEmptyString(delta.message_type, delta.messageType) ?? null;
@@ -105,6 +105,47 @@ export function createChannelTurnProgressBuilder(
   // the whole builder is dropped with the turn.
   const argumentsByToolCallId = new Map<string, string>();
   const namesByToolCallId = new Map<string, string>();
+  // A model step can stream its parallel calls separately, with different
+  // message ids for server tools and approval requests. Keep one title across
+  // those calls and their later client start/end events (which omit step_id).
+  // Like the builder itself, these maps live only for the current turn.
+  const batchesByStep = new Map<string, { title: string | null }>();
+  const batchesByToolCallId = new Map<string, { title: string | null }>();
+
+  function addToolBatchTitles(
+    delta: unknown,
+    updates: ChannelTurnProgressUpdate[],
+  ): ChannelTurnProgressUpdate[] {
+    const record = asRecord(delta);
+    if (!record) return updates;
+    const messageType = getMessageType(record);
+    const isToolRequest =
+      messageType === "tool_call_message" ||
+      messageType === "approval_request_message";
+    // Older streams may lack step_id but still group calls in one message.
+    const stepKey = isToolRequest
+      ? firstNonEmptyString(record.step_id, record.id)
+      : undefined;
+    let requestBatch = stepKey ? batchesByStep.get(stepKey) : undefined;
+    if (stepKey && !requestBatch) {
+      requestBatch = { title: null };
+      batchesByStep.set(stepKey, requestBatch);
+    }
+    return updates.map((update) => {
+      if (update.kind !== "tool") return update;
+      const batch =
+        (update.toolCallId
+          ? batchesByToolCallId.get(update.toolCallId)
+          : undefined) ?? requestBatch;
+      if (!batch) return update;
+      if (update.toolCallId) batchesByToolCallId.set(update.toolCallId, batch);
+      if (batch.title === null && update.state === "started") {
+        batch.title =
+          firstNonEmptyString(update.toolTitle, update.toolDetails) ?? null;
+      }
+      return { ...update, toolBatchTitle: batch.title };
+    });
+  }
 
   // Wire shapes (see ToolCall / ToolCallDelta in @letta-ai/letta-client and
   // the local backend projections): flat `tool_call_id` / `name` /
@@ -578,5 +619,7 @@ export function createChannelTurnProgressBuilder(
     }
   }
 
-  return { buildUpdates };
+  return {
+    buildUpdates: (delta) => addToolBatchTitles(delta, buildUpdates(delta)),
+  };
 }

--- a/src/channels/progress-types.ts
+++ b/src/channels/progress-types.ts
@@ -1,0 +1,42 @@
+export type ChannelTurnProgressKind =
+  | "thinking"
+  | "responding"
+  | "tool"
+  | "approval"
+  | "command"
+  | "status"
+  | "retry"
+  | "error";
+
+export type ChannelTurnProgressState =
+  | "started"
+  | "updated"
+  | "completed"
+  | "error"
+  | "waiting";
+
+export interface ChannelTurnProgressUpdate {
+  kind: ChannelTurnProgressKind;
+  state: ChannelTurnProgressState;
+  /** Sanitized, user-facing status text. Never include tool args or output. */
+  message: string;
+  toolCallId?: string;
+  toolName?: string;
+  /** Optional sanitized argument summary for expanded tool progress details. */
+  toolDetails?: string;
+  /**
+   * Optional sanitized error-output preview for failed tool calls. Kept
+   * separate from toolDetails so surfaces can render it as secondary detail
+   * text; it must never be used as a row title/header (LET-9509).
+   */
+  errorDetails?: string;
+  /** Optional sanitized row title for native/rich progress surfaces. */
+  toolTitle?: string;
+  /**
+   * First useful tool title in the model step, for single-line status surfaces.
+   * Null means the step has no title yet. Individual tool titles stay unchanged.
+   */
+  toolBatchTitle?: string | null;
+  command?: string;
+  runId?: string;
+}

--- a/src/channels/slack/parallel-progress.test.ts
+++ b/src/channels/slack/parallel-progress.test.ts
@@ -1,0 +1,298 @@
+import { expect, test } from "bun:test";
+import { ChannelGateway } from "@/channels/gateway-core";
+import {
+  FakeClient,
+  makeDelivery,
+  makeHooks,
+  makeStreamDelta,
+  makeTurnFinished,
+} from "@/channels/gateway-test-support";
+import { createChannelTurnProgressBuilder } from "@/channels/progress-builder";
+import type { ChannelTurnSource } from "@/channels/types";
+import { resolveSlackConcreteActivity } from "./progress";
+import { createSlackStatusController } from "./status-controller";
+
+function createProgressHarness() {
+  const titles: string[] = [];
+  const builder = createChannelTurnProgressBuilder();
+  const source: ChannelTurnSource = {
+    channel: "slack",
+    chatId: "C123",
+    threadId: "1712800000.000100",
+    agentId: "agent-1",
+    conversationId: "conv-1",
+  };
+  const status = createSlackStatusController({
+    ensureApp: async () => ({}),
+    ensureWriteClient: async () => ({
+      assistant: {
+        threads: {
+          setStatus: async (args) => {
+            titles.push(args.loading_messages?.[0] ?? "");
+          },
+        },
+      },
+    }),
+    resolveKnownThreadRoot: (id) => id,
+  });
+  return {
+    titles,
+    status,
+    source,
+    async feed(delta: unknown) {
+      const updates = builder.buildUpdates(delta);
+      for (const update of updates) {
+        const activity = resolveSlackConcreteActivity({
+          ...update,
+          type: "progress",
+          sources: [source],
+        });
+        if (activity) await status.activate(source, "is working...", activity);
+      }
+      return updates;
+    },
+  };
+}
+
+function tool(id: string, description: string) {
+  return {
+    tool_call_id: id,
+    name: "exec_command",
+    arguments: JSON.stringify({ cmd: "true", description }),
+  };
+}
+
+test("one model step keeps its first title through parallel starts and returns", async () => {
+  const h = createProgressHarness();
+  try {
+    const tools = [
+      tool("a", "Read source"),
+      tool("b", "Run tests"),
+      tool("c", "Inspect git history"),
+    ];
+    const updates = await h.feed({
+      id: "message-1",
+      step_id: "step-1",
+      run_id: "run-1",
+      message_type: "approval_request_message",
+      tool_calls: tools,
+    });
+    // Other consumers still receive every tool's own details.
+    expect(updates.map((update) => update.toolDetails)).toEqual([
+      "Read source",
+      "Run tests",
+      "Inspect git history",
+    ]);
+    expect(h.titles).toEqual(["Read source"]);
+    for (const tc of tools) {
+      await h.feed({
+        id: "message-1",
+        message_type: "client_tool_start",
+        tool_call_id: tc.tool_call_id,
+        tool_name: tc.name,
+        tool_args: tc.arguments,
+      });
+      expect(h.titles).toEqual(["Read source"]);
+    }
+    for (const tc of [...tools].reverse()) {
+      await h.feed({
+        message_type: "client_tool_end",
+        tool_call_id: tc.tool_call_id,
+        status: tc.tool_call_id === "b" ? "error" : "success",
+      });
+      expect(h.titles).toEqual(["Read source"]);
+    }
+    await h.feed({
+      id: "message-2",
+      step_id: "step-2",
+      run_id: "run-1",
+      message_type: "tool_call_message",
+      tool_calls: [tool("d", "Check the result")],
+    });
+    expect(h.titles).toEqual(["Read source", "Check the result"]);
+    await h.status.deactivate(h.source);
+    expect(h.titles).toEqual(["Read source", "Check the result", ""]);
+  } finally {
+    h.status.clear();
+  }
+});
+
+test("fragmented and mixed approval/server calls share the first useful step title", async () => {
+  const h = createProgressHarness();
+  try {
+    await h.feed({
+      id: "message-1",
+      step_id: "step-1",
+      message_type: "tool_call_message",
+      tool_calls: {
+        tool_call_id: "a",
+        name: "exec_command",
+        arguments: '{"cmd":"true","description":"Read',
+      },
+    });
+    expect(h.titles).toEqual([]);
+    await h.feed({
+      id: "approval-1",
+      step_id: "step-1",
+      message_type: "approval_request_message",
+      tool_calls: tool("b", "Run tests"),
+    });
+    expect(h.titles).toEqual(["Run tests"]);
+    await h.feed({
+      id: "message-1",
+      step_id: "step-1",
+      message_type: "tool_call_message",
+      tool_calls: { tool_call_id: "a", arguments: ' source"}' },
+    });
+    expect(h.titles).toEqual(["Run tests"]);
+    await h.feed({
+      message_type: "tool_return_message",
+      tool_returns: [
+        { tool_call_id: "a", status: "success", tool_return: "done" },
+        { tool_call_id: "b", status: "success", tool_return: "done" },
+      ],
+    });
+    expect(h.titles).toEqual(["Run tests"]);
+  } finally {
+    h.status.clear();
+  }
+});
+
+test("message-id batches preserve file titles through duplicate completions", async () => {
+  const h = createProgressHarness();
+  try {
+    await h.feed({
+      id: "message-1",
+      message_type: "tool_call_message",
+      tool_calls: [
+        {
+          tool_call_id: "a",
+          name: "Read",
+          arguments: JSON.stringify({ file_path: "/src/first.ts" }),
+        },
+        tool("b", "Run tests"),
+      ],
+    });
+    const firstTitle = h.titles[0];
+    if (!firstTitle) throw new Error("Expected a file progress title");
+    expect(firstTitle).toContain("first.ts");
+    expect(h.titles).toHaveLength(1);
+    for (const messageType of ["client_tool_end", "tool_return_message"]) {
+      await h.feed({
+        message_type: messageType,
+        tool_call_id: "a",
+        status: "success",
+      });
+      expect(h.titles).toEqual([firstTitle]);
+    }
+    // A following step with no intervening reasoning can change the title.
+    await h.feed({
+      id: "message-2",
+      message_type: "tool_call_message",
+      tool_calls: [tool("c", "Check results")],
+    });
+    expect(h.titles).toEqual([firstTitle, "Check results"]);
+  } finally {
+    h.status.clear();
+  }
+});
+
+test("untitled and MessageChannel calls cannot pin an empty or private status", async () => {
+  const h = createProgressHarness();
+  try {
+    await h.feed({
+      step_id: "step-1",
+      message_type: "tool_call_message",
+      tool_calls: [
+        {
+          tool_call_id: "message",
+          name: "MessageChannel",
+          arguments: JSON.stringify({ message: "Private reply text" }),
+        },
+        { tool_call_id: "unknown", name: "unknown", arguments: "{}" },
+      ],
+    });
+    expect(h.titles).toEqual([]);
+    await h.feed({
+      step_id: "step-1",
+      message_type: "tool_call_message",
+      tool_calls: [tool("a", `Inspect <source> ${"x".repeat(70)}`)],
+    });
+    expect(h.titles).toHaveLength(1);
+    expect(h.titles[0]).not.toContain("<");
+    expect(h.titles[0]?.length).toBeLessThanOrEqual(50);
+  } finally {
+    h.status.clear();
+  }
+});
+
+test("separate turns do not share the pinned title", async () => {
+  const first = createProgressHarness();
+  const second = createProgressHarness();
+  try {
+    for (const [h, description] of [
+      [first, "First conversation"],
+      [second, "Second conversation"],
+    ] as const) {
+      await h.feed({
+        step_id: "step-1",
+        message_type: "tool_call_message",
+        tool_calls: [tool("a", description)],
+      });
+      expect(h.titles).toEqual([description]);
+    }
+  } finally {
+    first.status.clear();
+    second.status.clear();
+  }
+});
+
+test("the gateway carries the batch title through queued hooks before cancellation", async () => {
+  const h = createProgressHarness();
+  const client = new FakeClient();
+  let finish!: () => void;
+  const finished = new Promise<void>((resolve) => {
+    finish = resolve;
+  });
+  const events: string[] = [];
+  const { hooks } = makeHooks({
+    onProgress: async (event) => {
+      events.push(event.toolCallId ?? "");
+      const activity = resolveSlackConcreteActivity(event);
+      if (activity)
+        await h.status.activate(h.source, "is working...", activity);
+    },
+    onLifecycle: async (event) => {
+      if (event.type === "finished") {
+        await h.status.deactivate(h.source);
+        finish();
+      }
+    },
+  });
+  const gateway = new ChannelGateway(client, hooks);
+  try {
+    await gateway.submit(makeDelivery({ sources: [h.source] }));
+    client.emit(
+      makeStreamDelta({
+        id: "message-1",
+        step_id: "step-1",
+        message_type: "tool_call_message",
+        tool_calls: [tool("a", "Read source"), tool("b", "Run tests")],
+      }),
+    );
+    client.emit(
+      makeStreamDelta({
+        message_type: "client_tool_start",
+        tool_call_id: "b",
+        tool_name: "exec_command",
+      }),
+    );
+    client.emit(makeTurnFinished("cancelled"));
+    await finished;
+    expect(events).toEqual(["a", "b", "b"]);
+    expect(h.titles).toEqual(["Read source", ""]);
+  } finally {
+    gateway.close();
+    h.status.clear();
+  }
+});

--- a/src/channels/slack/progress.ts
+++ b/src/channels/slack/progress.ts
@@ -55,7 +55,11 @@ export function resolveSlackConcreteActivity(
     return null;
   }
 
-  for (const description of [event.toolTitle, event.toolDetails]) {
+  const descriptions =
+    event.toolBatchTitle !== undefined
+      ? [event.toolBatchTitle]
+      : [event.toolTitle, event.toolDetails];
+  for (const description of descriptions) {
     if (!isNonEmptyString(description)) {
       continue;
     }

--- a/src/channels/types.ts
+++ b/src/channels/types.ts
@@ -14,8 +14,15 @@ import type {
   ListModelsResponseModelEntry,
   StopReasonType,
 } from "@/types/protocol_v2";
+import type { ChannelTurnProgressUpdate } from "./progress-types";
 import type { WhatsAppAttachmentPolicyConfig } from "./whatsapp/attachment-policy-types";
 import type { WhatsAppWaitingBehavior } from "./whatsapp/waiting-behavior-config-types";
+
+export type {
+  ChannelTurnProgressKind,
+  ChannelTurnProgressState,
+  ChannelTurnProgressUpdate,
+} from "./progress-types";
 /**
  * Vendor-neutral model-picker payload produced by the generic channel
  * `/model` handler. Adapters decide how (or whether) to render it.
@@ -159,44 +166,6 @@ export interface ChannelTurnSource {
 }
 
 export type ChannelTurnOutcome = "completed" | "error" | "cancelled";
-
-export type ChannelTurnProgressKind =
-  | "thinking"
-  | "responding"
-  | "tool"
-  | "approval"
-  | "command"
-  | "status"
-  | "retry"
-  | "error";
-
-export type ChannelTurnProgressState =
-  | "started"
-  | "updated"
-  | "completed"
-  | "error"
-  | "waiting";
-
-export interface ChannelTurnProgressUpdate {
-  kind: ChannelTurnProgressKind;
-  state: ChannelTurnProgressState;
-  /** Sanitized, user-facing status text. Never include tool args or output. */
-  message: string;
-  toolCallId?: string;
-  toolName?: string;
-  /** Optional sanitized argument summary for expanded tool progress details. */
-  toolDetails?: string;
-  /**
-   * Optional sanitized error-output preview for failed tool calls. Kept
-   * separate from toolDetails so surfaces can render it as secondary detail
-   * text; it must never be used as a row title/header (LET-9509).
-   */
-  errorDetails?: string;
-  /** Optional sanitized row title for native/rich progress surfaces. */
-  toolTitle?: string;
-  command?: string;
-  runId?: string;
-}
 
 export interface ChannelTurnProgressEvent extends ChannelTurnProgressUpdate {
   type: "progress";


### PR DESCRIPTION
## Summary

Slack should show a readable activity title while an agent runs parallel tools. Today, it cycles through each tool's description as calls stream in, start executing, and finish.

Keep the first useful tool title for each model step. The next step can replace it. Individual tool events, titles, details, and errors remain available to other consumers; only Slack selects the shared `toolBatchTitle`. The existing status controller still handles deduplication, keepalives, message clears, and cancellation.

## Before and after

For one step containing “Read source”, “Run tests”, and “Inspect git history”:

| Event | Before | After |
| --- | --- | --- |
| Tool calls arrive | Three successive titles | “Read source” |
| Client tools start | The same titles cycle again | Unchanged |
| Tools return out of order | Completion titles can replace the current title | Unchanged |
| Next model step | Its tool titles cycle | Its first useful title |
| Turn ends or is cancelled | Status clears | Status clears |

Calls use `step_id` to share a title, including separate server-tool and approval messages. Streams without `step_id` use the tool message's `id`. Client execution events recover the title through `tool_call_id`. Events with neither a known tool call nor a step/message identity retain their existing behavior.

## Verification

The red-first regression starts with tool-call and approval wire shapes, then runs the production progress builder, Slack selector, and status controller. Only the Slack API writer is replaced. It failed on the old code because both array and fragmented parallel calls replaced the first title. The gateway test also checks that queued hooks preserve the title and cancellation clears it after the pending progress events.

Validated the built `channels` and `channels/slack` package exports under Node with the same parallel start/completion sequence: one title, then a clear. The 84 focused channel/Slack tests, all 12 repository checks, and the package build passed locally.

Live Slack rendering remains unverified. No before/after recording is claimed.

## Breadcrumbs

- Linear: LET-12431
- Origin: follow-up to the [original Slack status-line implementation](https://github.com/letta-ai/letta-code/pull/3279), which deliberately serialized distinct per-tool titles but did not group parallel calls.
- Letta conversation: [conv-7bf232e9-be3b-48cf-89ee-78cb6b87d7f2](https://chat.letta.com/chat/agent-b86b0d3a-c425-4c88-86b9-44171f178713?conversation=conv-7bf232e9-be3b-48cf-89ee-78cb6b87d7f2)
