### PR TITLE
fix(runtime): cancel conversation monitors on interrupt [LET-12443]

### DIFF
--- a/src/agent/prompts/interrupt_recovery_alert.txt
+++ b/src/agent/prompts/interrupt_recovery_alert.txt
@@ -1,1 +1,1 @@
-<system-reminder>The user interrupted the active stream.</system-reminder>
+<system-reminder>The user interrupted the active stream. Any pending monitors in this conversation were also cancelled because of the interruption. Do not restart them unless the user asks.</system-reminder>

--- a/src/cli/app/use-interrupt-handler.ts
+++ b/src/cli/app/use-interrupt-handler.ts
@@ -18,6 +18,7 @@ import { settleTuiInterrupt } from "@/cli/helpers/tui-turn-lifecycle";
 import { INTERRUPTED_BY_USER } from "@/constants";
 import type { ApprovalContext } from "@/permissions/analyzer";
 import type { QueueRuntime } from "@/queue/queue-runtime";
+import { stopMonitorsForScope } from "@/tools/impl/stop-monitor";
 
 import { EAGER_CANCEL, INTERRUPT_MESSAGE } from "./constants";
 import { extractErrorMeta } from "./errors";
@@ -140,6 +141,11 @@ export function useInterruptHandler(ctx: InterruptHandlerContext) {
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: refs are stable objects; .current is read dynamically when interrupt fires.
   const handleInterrupt = useCallback(async () => {
+    const stopMonitors = () =>
+      stopMonitorsForScope({
+        agentId: agentIdRef.current,
+        conversationId: conversationIdRef.current || "default",
+      });
     // If we're executing client-side tools, abort them AND the main stream
     const hasTrackedTools =
       executingToolCallIdsRef.current.length > 0 ||
@@ -150,6 +156,7 @@ export function useInterruptHandler(ctx: InterruptHandlerContext) {
       hasTrackedTools &&
       !toolResultsInFlightRef.current
     ) {
+      stopMonitors();
       toolAbortControllerRef.current.abort();
 
       // Mark any in-flight conversation as stale, consistent with EAGER_CANCEL.
@@ -241,6 +248,7 @@ export function useInterruptHandler(ctx: InterruptHandlerContext) {
     if (!streaming || interruptRequested) {
       return;
     }
+    stopMonitors();
 
     // If we're in the middle of queue cancel, set flag to restore instead of auto-send
     if (waitingForQueueCancelRef.current) {

--- a/src/cli/tui-interrupt-queue-lifecycle.test.tsx
+++ b/src/cli/tui-interrupt-queue-lifecycle.test.tsx
@@ -18,6 +18,7 @@ import { Readable, Writable } from "node:stream";
 import type { Stream } from "@letta-ai/letta-client/core/streaming";
 import type { LettaStreamingResponse } from "@letta-ai/letta-client/resources/agents/messages";
 import { type Instance, render } from "ink";
+import { WebSocketServer } from "ws";
 import { __testSetBackend } from "@/backend";
 import {
   type BackendMode,
@@ -32,6 +33,11 @@ import {
 } from "@/backend/dev/headless-turn-executor";
 import { App } from "@/cli/App";
 import { settingsManager } from "@/settings-manager";
+import { monitor } from "@/tools/impl/monitor";
+import {
+  backgroundProcesses,
+  clearBackgroundProcessCleanup,
+} from "@/tools/impl/process_manager";
 import {
   addToMessageQueue,
   clearPendingMessages,
@@ -138,6 +144,39 @@ class DelayedInterruptExecutor implements HeadlessTurnExecutor {
   }
 }
 
+const monitorSources = new Set<WebSocketServer>();
+const monitorIds = new Set<string>();
+
+async function startMonitor(scope: {
+  agentId: string;
+  conversationId: string;
+}) {
+  const server = new WebSocketServer({ host: "127.0.0.1", port: 0 });
+  monitorSources.add(server);
+  await new Promise<void>((resolve) => server.once("listening", resolve));
+  const address = server.address();
+  if (!address || typeof address === "string")
+    throw new Error("Missing socket address");
+  const connected = new Promise<import("ws").WebSocket>((resolve) =>
+    server.once("connection", resolve),
+  );
+  const result = await monitor({
+    description: "Watch interrupt fixture events",
+    ws: { url: `ws://127.0.0.1:${address.port}` },
+    persistent: true,
+    parentScope: scope,
+  });
+  monitorIds.add(result.taskId);
+  const socket = await connected;
+  const state = backgroundProcesses.get(result.taskId);
+  if (!state) throw new Error("Monitor was not registered");
+  let closed = false;
+  socket.once("close", () => {
+    closed = true;
+  });
+  return { socket, state, isClosed: () => closed };
+}
+
 const renderedInstances = new Set<Instance>();
 let previousBackendMode: BackendMode;
 let previousHome: string | undefined;
@@ -160,6 +199,21 @@ afterEach(async () => {
     instance.cleanup();
   }
   renderedInstances.clear();
+  for (const id of monitorIds) {
+    const state = backgroundProcesses.get(id);
+    if (state) {
+      state.completionNotificationSuppressed = true;
+      state.process.kill();
+    }
+    clearBackgroundProcessCleanup(id);
+    backgroundProcesses.delete(id);
+  }
+  monitorIds.clear();
+  for (const server of monitorSources) {
+    for (const socket of server.clients) socket.terminate();
+    server.close();
+  }
+  monitorSources.clear();
   setMessageQueueAdder(null);
   clearPendingMessages();
   __testSetBackend(null);
@@ -214,6 +268,38 @@ async function typePrompt(stdin: NodeJS.ReadStream, text: string) {
 }
 
 describe("TUI interrupt queue lifecycle", () => {
+  test("a real Monitor survives normal completion and idle Esc", async () => {
+    const inputs: HeadlessTurnExecutorInput[] = [];
+    const { stdin } = await renderTestApp({
+      async execute(input) {
+        inputs.push(input);
+        return createAssistantMessageStream();
+      },
+    });
+    await typePrompt(stdin, "complete normally");
+    await waitFor(() => inputs.length === 1, "the normal turn");
+    const input = inputs[0];
+    if (!input) throw new Error("Missing first turn");
+    const source = await startMonitor(input);
+    // An event drives another complete turn while the source stays connected.
+    source.socket.send("normal monitor event");
+    await waitFor(() => inputs.length === 2, "the Monitor notification turn");
+    await sleep(300);
+    expect(source.state.status).toBe("running");
+    stdin.push("\u001b");
+    await sleep(100);
+    expect(source.isClosed()).toBe(false);
+    source.socket.send("still watching after idle Esc");
+    await waitFor(() => inputs.length === 3, "the event after idle Esc");
+    expect(JSON.stringify(inputs[2]?.body)).toContain(
+      "still watching after idle Esc",
+    );
+    expect(JSON.stringify(inputs[2]?.body)).not.toContain(
+      "Any pending monitors",
+    );
+    expect(source.state.status).toBe("running");
+  }, 15_000);
+
   test("an idle Monitor notification starts an agent turn without user input", async () => {
     const executor = new DelayedInterruptExecutor();
     await renderTestApp(executor);
@@ -237,12 +323,20 @@ describe("TUI interrupt queue lifecycle", () => {
     await typePrompt(stdin, "start turn");
     await waitFor(() => executor.inputs.length === 1, "the typed initial turn");
 
-    addToMessageQueue({
-      kind: "task_notification",
-      text: monitorNotification("queued before Esc"),
-    });
+    const input = executor.inputs[0];
+    if (!input) throw new Error("Missing first turn");
+    const source = await startMonitor(input);
+    source.socket.send("queued before Esc");
+    await waitFor(
+      () => source.state.stdout.join("\n").includes("queued before Esc"),
+      "the real Monitor event to be received",
+    );
+    // Monitor batches events for 200ms before handing them to the TUI queue.
+    await sleep(300);
     stdin.push("\u001b");
     await executor.abortObserved;
+    await waitFor(source.isClosed, "the Monitor socket to close on Esc");
+    expect(source.state.status).not.toBe("running");
 
     // Cancellation has not settled yet: nothing may start a replacement turn.
     await sleep(100);
@@ -253,9 +347,12 @@ describe("TUI interrupt queue lifecycle", () => {
       () => executor.inputs.length === 2,
       "the queued notification turn after cancellation settled",
     );
-    expect(JSON.stringify(executor.inputs[1]?.body)).toContain(
-      "queued before Esc",
+    const nextTurn = JSON.stringify(executor.inputs[1]?.body);
+    expect(nextTurn).toContain("queued before Esc");
+    expect(nextTurn).toContain(
+      "Any pending monitors in this conversation were also cancelled",
     );
+    expect(nextTurn).toContain("Do not restart them unless the user asks.");
   }, 15_000);
 
   test("typed prompt, Esc, then a notification that arrives after cancellation settled", async () => {

--- a/src/headless-interrupt-recovery.test.ts
+++ b/src/headless-interrupt-recovery.test.ts
@@ -1,42 +1,197 @@
-import { describe, expect, test } from "bun:test";
-import { readFileSync } from "node:fs";
+import { expect, test } from "bun:test";
+import { spawn } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { type WebSocket, WebSocketServer } from "ws";
+import { createIsolatedCliTestEnv } from "@/test-utils/test-process-env";
 
-/**
- * Regression guard for the post-interrupt approval recovery (PR #2631).
- *
- * A turn cancelled mid-tool-call (while a tool awaited approval) leaves the
- * Letta agent in `requires_approval` with a dangling approval. Before this fix
- * the next in-session user turn was sent against that stale state and the run
- * errored — surfaced downstream (in the ACP adapter) as a bare "refusal" with
- * no visible output. The fix records that the prior turn was interrupted and
- * clears pending approvals (reusing resolveAllPendingApprovals) at the start of
- * the next turn, before sending.
- *
- * The behavior itself is backend-coupled and proven by scripts/cancel-tool-smoke.ts
- * (turn 2 recovers to end_turn instead of refusal). These assertions lock the
- * wiring so the recovery can't silently regress.
- */
-describe("headless post-interrupt approval recovery wiring", () => {
-  const source = readFileSync(
-    fileURLToPath(new URL("./headless.ts", import.meta.url)),
-    "utf-8",
-  );
-
-  test("tracks whether the prior turn was interrupted", () => {
-    expect(source).toContain("let priorTurnInterrupted = false;");
-    // The epilogue records the interrupted state from the abort controller.
-    expect(source).toContain(
-      "priorTurnInterrupted = currentAbortController?.signal.aborted === true;",
-    );
-  });
-
-  test("clears dangling approvals before the next turn when interrupted", () => {
-    expect(source).toContain("if (priorTurnInterrupted) {");
-    // It consumes the flag and runs the shared recovery primitive.
-    const idx = source.indexOf("if (priorTurnInterrupted) {");
-    const block = source.slice(idx, idx + 400);
-    expect(block).toContain("priorTurnInterrupted = false;");
-    expect(block).toContain("resolveAllPendingApprovals()");
-  });
+// Run the real bidirectional entrypoint in isolation: only the model/backend is
+// fake. Monitor, its socket, stdin control requests, and queue recovery are real.
+const fixture = `
+import { __testSetBackend } from "./src/backend";
+import { setConfiguredBackendMode } from "./src/backend/backend-mode";
+import { FakeHeadlessBackend } from "./src/backend/dev/fake-headless-backend";
+import { createAssistantMessageStream } from "./src/backend/dev/headless-turn-executor";
+import { parseCliArgs } from "./src/cli/args";
+import { handleHeadlessCommand } from "./src/headless";
+import { monitor } from "./src/tools/impl/monitor";
+import { settingsManager } from "./src/settings-manager";
+await settingsManager.initialize();
+let turns = 0;
+const backend = new FakeHeadlessBackend("agent-headless-interrupt", {
+  async execute(input) {
+    turns++;
+    console.log(JSON.stringify({ type: "fixture_input", turn: turns, body: input.body }));
+    if (turns === 1) {
+      await monitor({ description: "Watch headless interrupt events", persistent: true,
+        ws: { url: process.env.MONITOR_TEST_URL },
+        parentScope: { agentId: input.agentId, conversationId: input.conversationId } });
+    }
+    if (turns !== 2) return createAssistantMessageStream();
+    const controller = new AbortController();
+    return { controller, async *[Symbol.asyncIterator]() {
+      console.log(JSON.stringify({ type: "fixture_waiting" }));
+      if (!controller.signal.aborted) {
+        await new Promise(resolve => controller.signal.addEventListener("abort", resolve, { once: true }));
+      }
+    } };
+  }
 });
+setConfiguredBackendMode("local");
+__testSetBackend(backend);
+await handleHeadlessCommand(parseCliArgs([
+  "bun", "letta", "--agent", "agent-headless-interrupt", "--conversation", "default",
+  "--input-format", "stream-json", "--output-format", "stream-json",
+  "--memfs-startup", "skip", "--no-mods"
+], true), undefined, undefined, undefined, false);
+`;
+
+test("headless interrupt stops a real Monitor, preserves its queued event, and sends recovery on the next turn", async () => {
+  const home = mkdtempSync(join(tmpdir(), "letta-headless-monitor-interrupt-"));
+  const server = new WebSocketServer({ host: "127.0.0.1", port: 0 });
+  await new Promise<void>((resolve) => server.once("listening", resolve));
+  const address = server.address();
+  if (!address || typeof address === "string")
+    throw new Error("Missing socket address");
+  let socket: WebSocket | undefined;
+  let closed = false;
+  server.on("connection", (client) => {
+    socket = client;
+    client.once("close", () => {
+      closed = true;
+    });
+  });
+  const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+  const child = spawn(
+    process.execPath,
+    [
+      "--loader=.md:text",
+      "--loader=.mdx:text",
+      "--loader=.txt:text",
+      "--eval",
+      fixture,
+    ],
+    {
+      cwd: repoRoot,
+      env: createIsolatedCliTestEnv({
+        HOME: home,
+        LETTA_FS_SANDBOX: "0",
+        NO_COLOR: "1",
+        MONITOR_TEST_URL: `ws://127.0.0.1:${address.port}`,
+      }),
+      stdio: ["pipe", "pipe", "pipe"],
+    },
+  );
+  const events: Array<Record<string, unknown>> = [];
+  let stderr = "";
+  child.stderr.on("data", (chunk) => {
+    stderr += chunk.toString();
+  });
+  const send = (value: unknown) =>
+    child.stdin.write(`${JSON.stringify(value)}\n`);
+  const user = (content: string) =>
+    send({ type: "user", message: { content } });
+  const interrupt = (requestId: string) =>
+    send({
+      type: "control_request",
+      request_id: requestId,
+      request: { subtype: "interrupt" },
+    });
+  let survivedCompletion = false;
+  let survivedIdleInterrupt = false;
+  try {
+    await new Promise<void>((resolvePromise, reject) => {
+      let buffer = "";
+      let results = 0;
+      let waiting = false;
+      let interrupted = false;
+      const timeout = setTimeout(() => finish(new Error("Timed out")), 25_000);
+      let finished = false;
+      const finish = (error?: Error) => {
+        if (finished) return;
+        finished = true;
+        clearTimeout(timeout);
+        if (error)
+          reject(
+            new Error(
+              `${error.message}; events=${JSON.stringify(events)}; stderr=${stderr}`,
+            ),
+          );
+        else resolvePromise();
+      };
+      child.on("error", finish);
+      child.on("close", (code) => finish(new Error(`Fixture exited: ${code}`)));
+      child.stdout.on("data", (chunk) => {
+        buffer += chunk.toString();
+        while (buffer.includes("\n")) {
+          const end = buffer.indexOf("\n");
+          const line = buffer.slice(0, end);
+          buffer = buffer.slice(end + 1);
+          let event: Record<string, unknown>;
+          try {
+            event = JSON.parse(line);
+          } catch {
+            continue;
+          }
+          events.push(event);
+          if (event.type === "system" && event.subtype === "init")
+            user("complete normally");
+          if (event.type === "result") {
+            results++;
+            if (results === 1) {
+              // Result is emitted before the turn's finally block. Wait for
+              // that epilogue before testing an actually idle interrupt.
+              setTimeout(() => {
+                survivedCompletion = socket?.readyState === 1 && !closed;
+                interrupt("idle-interrupt");
+              }, 200);
+            } else if (results === 3) finish();
+          }
+          if (
+            event.type === "control_response" &&
+            (event.response as { request_id?: string })?.request_id ===
+              "idle-interrupt"
+          ) {
+            survivedIdleInterrupt = socket?.readyState === 1 && !closed;
+            user("wait until interrupted");
+          }
+          if (event.type === "fixture_waiting") {
+            waiting = true;
+            socket?.send("queued real Monitor event before interrupt");
+          }
+          if (waiting && !interrupted && event.type === "queue_blocked") {
+            interrupted = true;
+            interrupt("active-interrupt");
+          }
+        }
+      });
+    });
+    expect(survivedCompletion).toBe(true);
+    expect(survivedIdleInterrupt).toBe(true);
+    const deadline = Date.now() + 2000;
+    while (!closed && Date.now() < deadline) await Bun.sleep(10);
+    expect(closed).toBe(true);
+    expect(
+      events
+        .filter((event) => event.type === "result")
+        .map((event) => event.subtype),
+    ).toEqual(["success", "interrupted", "success"]);
+    const nextTurn = events.find(
+      (event) => event.type === "fixture_input" && event.turn === 3,
+    );
+    const body = JSON.stringify(nextTurn?.body);
+    expect(body).toContain("queued real Monitor event before interrupt");
+    expect(body).toContain(
+      "Any pending monitors in this conversation were also cancelled",
+    );
+    expect(body).toContain("Do not restart them unless the user asks.");
+  } finally {
+    child.stdin.end();
+    child.kill("SIGKILL");
+    for (const client of server.clients) client.terminate();
+    server.close();
+    rmSync(home, { recursive: true, force: true });
+  }
+}, 30_000);

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -61,7 +61,10 @@ import {
 import { updateAgentLLMConfig, updateAgentSystemPrompt } from "./agent/modify";
 import { buildCreateAgentOptionsForPersonality } from "./agent/personality";
 import { resolvePersonalityId } from "./agent/personality-presets";
-import type { MemoryPromptMode } from "./agent/prompt-assets";
+import {
+  INTERRUPT_RECOVERY_ALERT,
+  type MemoryPromptMode,
+} from "./agent/prompt-assets";
 import { resolveSkillSourcesSelection } from "./agent/skill-sources";
 import type { SkillSource } from "./agent/skills";
 import { SessionStats } from "./agent/stats";
@@ -166,6 +169,7 @@ import {
 import { getCurrentWorkingDirectory } from "./runtime-context";
 import { settingsManager, shouldPersistSessionState } from "./settings-manager";
 import { writeWireMessage, writeWireMessageAsync } from "./stream-json-writer";
+import { stopMonitorsForScope } from "./tools/impl/stop-monitor";
 import {
   INTERACTIVE_USER_INPUT_TOOL_NAMES,
   isInteractiveApprovalTool,
@@ -2248,6 +2252,11 @@ ${SYSTEM_REMINDER_CLOSE}
 
   // One-shot mode has no input loop, so wire SIGINT directly into the turn.
   const sigintSignal = createSigintAbortSignal();
+  sigintSignal.addEventListener(
+    "abort",
+    () => stopMonitorsForScope({ agentId: agent.id, conversationId }),
+    { once: true },
+  );
   const exitInterrupted = async (): Promise<never> => {
     if (outputFormat === "stream-json") {
       const errorMsg: ErrorMessage = {
@@ -3699,10 +3708,7 @@ async function runBidirectionalMode(
   // Feed lines into queue or resolver
   rl.on("line", (line) => {
     maybeNotifyBlocked(line);
-    // Fast path: handle control_request:interrupt synchronously so we can
-    // abort an in-flight drain without waiting for the main loop to dequeue.
-    // Without this, a runaway thinking turn never sees the interrupt because
-    // `getNextLine()` isn't called until the current drain returns.
+    // Interrupt before dequeue so an in-flight drain can unwind.
     let parsedLine: {
       type?: string;
       request?: { subtype?: string };
@@ -3724,10 +3730,7 @@ async function runBidirectionalMode(
         turnStarting,
       });
       if (action === "abort-active") {
-        // Abort the in-flight turn. Do NOT null the controller here — the
-        // turn's epilogue (line ~4275) reads currentAbortController?.signal.aborted
-        // to classify the result as "interrupted" vs "error". The `finally`
-        // block at the bottom of the user-message branch is what owns nulling.
+        // Preserve the controller until finally so the turn records interruption.
         (currentAbortController as AbortController).abort();
         if (lineResolver) {
           // If the turn is blocked waiting for a permission/external-tool
@@ -3738,10 +3741,7 @@ async function runBidirectionalMode(
           resolve(null);
         }
       } else if (action === "latch") {
-        // Narrow pre-controller race: a user message was just dispatched but
-        // its AbortController isn't created yet. Latch so the imminent turn
-        // aborts. An idle interrupt ("noop") must NOT latch — that would
-        // poison the next user turn.
+        // Latch only for the imminent turn, never for an idle interrupt.
         pendingInterrupt = true;
       }
       const interruptResponse: ControlResponse = {
@@ -3996,11 +3996,7 @@ async function runBidirectionalMode(
         };
         writeWireMessage(initResponse);
       } else if (subtype === "interrupt") {
-        // Abort current operation if any. Do NOT null the controller — the
-        // turn's epilogue (line ~4415) reads currentAbortController?.signal.aborted
-        // to classify the result as "interrupted" vs "error", and the
-        // user-message branch's `finally` is what owns nulling. Mirrors the
-        // fast path in rl.on("line", ...).
+        // Preserve the controller until finally so the turn records interruption.
         if (
           currentAbortController !== null &&
           decideInterruptAction({
@@ -4273,18 +4269,19 @@ async function runBidirectionalMode(
         continue;
       }
 
-      // Create abort controller for this operation.  Drain any latched
-      // interrupt that arrived before the controller existed (race between
-      // the readline 'line' event and the microtask that creates the
-      // controller — see rl.on("line", ...) above).
+      // Drain pre-controller interrupts after installing scoped monitor cleanup.
       currentAbortController = new AbortController();
+      currentAbortController.signal.addEventListener(
+        "abort",
+        () => stopMonitorsForScope({ agentId: agent.id, conversationId }),
+        { once: true },
+      );
       if (pendingInterrupt) {
         pendingInterrupt = false;
         currentAbortController.abort();
       }
       // Controller now exists — close the pre-controller race window.
       turnStarting = false;
-
       turnInProgress = true;
       try {
         const buffers = createBuffers(agent.id);
@@ -4354,14 +4351,14 @@ async function runBidirectionalMode(
         }
         currentInput = turnStartEmission.input;
 
-        // If the previous turn was interrupted mid-tool-call, the agent may be
-        // left in `requires_approval` with a dangling approval. Sending this
-        // fresh turn against that stale state makes the run error (a silent
-        // "refusal" downstream). Clear it first, reusing the same recovery the
-        // resume path uses. Best-effort: a recovery failure must not abort the
-        // new turn. (PR #2631 — handle interrupts.)
+        // Clear dangling approvals before sending fresh input after an interrupt.
         if (priorTurnInterrupted) {
           priorTurnInterrupted = false;
+          currentInput.unshift({
+            role: "user",
+            content: INTERRUPT_RECOVERY_ALERT,
+            otid: randomUUID(),
+          });
           try {
             await resolveAllPendingApprovals();
           } catch (recoveryError) {
@@ -4689,7 +4686,10 @@ async function runBidirectionalMode(
             const executedResults = await executeApprovalBatch(
               decisions,
               undefined,
-              { toolContextId: turnToolContextId ?? undefined },
+              {
+                toolContextId: turnToolContextId ?? undefined,
+                abortSignal: currentAbortController.signal,
+              },
             );
 
             emitLocalToolReturns(executedResults, sessionId);

--- a/src/tools/impl/kill-bash.ts
+++ b/src/tools/impl/kill-bash.ts
@@ -15,10 +15,13 @@ interface KillBashResult {
 
 export async function kill_bash(args: KillBashArgs): Promise<KillBashResult> {
   validateRequiredParams(args, ["shell_id"], "KillBash");
-  const { shell_id } = args;
+  return { killed: killBackgroundProcess(args.shell_id) };
+}
+
+export function killBackgroundProcess(shell_id: string): boolean {
   const proc = backgroundProcesses.get(shell_id);
   if (!proc || (proc.kind === "monitor" && proc.status !== "running")) {
-    return { killed: false };
+    return false;
   }
   const previousStatus = proc.status;
   const previousNotificationSuppression = proc.completionNotificationSuppressed;
@@ -37,10 +40,10 @@ export async function kill_bash(args: KillBashArgs): Promise<KillBashResult> {
     } else {
       backgroundProcesses.delete(shell_id);
     }
-    return { killed: true };
+    return true;
   } catch {
     proc.status = previousStatus;
     proc.completionNotificationSuppressed = previousNotificationSuppression;
-    return { killed: false };
+    return false;
   }
 }

--- a/src/tools/impl/monitor.test.ts
+++ b/src/tools/impl/monitor.test.ts
@@ -10,11 +10,15 @@ import {
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { WebSocketServer } from "ws";
+import { runWithRuntimeContext } from "@/runtime-context";
 import {
   ANTHROPIC_DEFAULT_TOOLS,
+  executeTool,
   GEMINI_DEFAULT_TOOLS,
   OPENAI_DEFAULT_TOOLS,
   OPENAI_PASCAL_TOOLS,
+  prepareToolExecutionContextForSpecificTools,
+  releaseToolExecutionContext,
 } from "@/tools/manager";
 import MonitorSchema from "@/tools/schemas/Monitor.json";
 import {
@@ -174,6 +178,105 @@ describe("Monitor", () => {
         command: "printf 'ok'\rprintf 'hidden'",
       }),
     ).rejects.toThrow("control characters");
+  });
+
+  test("does not start either source after its tool execution was interrupted", async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const size = backgroundProcesses.size;
+    for (const source of [
+      { command: nodeCommand("setInterval(() => {}, 1000)") },
+      { ws: { url: "ws://127.0.0.1:1" } },
+    ]) {
+      await expect(
+        monitor({
+          ...source,
+          description: "Interrupted before startup",
+          persistent: true,
+          signal: controller.signal,
+        }),
+      ).rejects.toMatchObject({ name: "AbortError" });
+    }
+    expect(backgroundProcesses.size).toBe(size);
+    expect(queuedMessages).toEqual([]);
+  });
+
+  test("a pending tool-start handler cannot launch a monitor after interruption", async () => {
+    const entered = Promise.withResolvers<void>();
+    const release = Promise.withResolvers<void>();
+    const controller = new AbortController();
+    const prepared = await prepareToolExecutionContextForSpecificTools(
+      ["Monitor"],
+      {
+        modEvents: {
+          async emit(name) {
+            if (name === "tool_start") {
+              entered.resolve();
+              await release.promise;
+            }
+            return { diagnostics: [], handlerCount: 1, name, results: [] };
+          },
+        },
+      },
+    );
+    const size = backgroundProcesses.size;
+    try {
+      const execution = executeTool(
+        "Monitor",
+        {
+          description: "Delayed startup",
+          command: nodeCommand("setInterval(() => {}, 1000)"),
+          persistent: true,
+        },
+        { toolContextId: prepared.contextId, signal: controller.signal },
+      );
+      await entered.promise;
+      controller.abort();
+      release.resolve();
+      expect((await execution).status).toBe("error");
+      expect(backgroundProcesses.size).toBe(size);
+      expect(queuedMessages).toEqual([]);
+    } finally {
+      release.resolve();
+      releaseToolExecutionContext(prepared.contextId);
+    }
+  });
+
+  test("manager-created monitors keep the captured conversation scope", async () => {
+    const scope = {
+      agentId: "agent-captured",
+      conversationId: "conv-captured",
+    };
+    const prepared = await prepareToolExecutionContextForSpecificTools(
+      ["Monitor"],
+      { runtimeContext: scope },
+    );
+    try {
+      const result = await runWithRuntimeContext(
+        { agentId: "agent-other", conversationId: "conv-other" },
+        () =>
+          executeTool(
+            "Monitor",
+            {
+              description: "Captured owner",
+              command: nodeCommand('console.log("captured event")'),
+              timeout_ms: 5000,
+            },
+            { toolContextId: prepared.contextId },
+          ),
+      );
+      expect(result.status).toBe("success");
+      await waitFor(() => queuedMessages.length > 0);
+      expect(
+        queuedMessages.every(
+          (message) =>
+            message.agentId === scope.agentId &&
+            message.conversationId === scope.conversationId,
+        ),
+      ).toBe(true);
+    } finally {
+      releaseToolExecutionContext(prepared.contextId);
+    }
   });
 
   test("accepts an empty ws placeholder and uses the reference defaults", async () => {

--- a/src/tools/impl/monitor.ts
+++ b/src/tools/impl/monitor.ts
@@ -52,6 +52,7 @@ interface MonitorArgs {
   ws?: MonitorWebSocketSource;
   secretEnv?: Record<string, string>;
   parentScope?: { agentId: string; conversationId: string };
+  signal?: AbortSignal;
 }
 
 type NormalizedMonitorArgs = MonitorArgs & {
@@ -746,6 +747,8 @@ function startWebSocketMonitor(args: NormalizedMonitorArgs): MonitorResult {
 }
 
 export async function monitor(args: MonitorArgs): Promise<MonitorResult> {
+  // Hooks may have yielded since approval execution checked cancellation.
+  args.signal?.throwIfAborted();
   const normalized = normalizeMonitorArgs(args);
   installMonitorProcessExitCleanup();
   return normalized.command !== undefined

--- a/src/tools/impl/stop-monitor.ts
+++ b/src/tools/impl/stop-monitor.ts
@@ -4,8 +4,25 @@ import type {
 } from "@/types/task-control-protocol";
 import { addToMessageQueue } from "@/utils/message-queue-bridge";
 import { formatMonitorEventNotification } from "@/utils/task-notifications";
-import { kill_bash } from "./kill-bash";
-import { backgroundProcesses } from "./process_manager";
+import { kill_bash, killBackgroundProcess } from "./kill-bash";
+import {
+  type BackgroundRuntimeScope,
+  backgroundProcesses,
+} from "./process_manager";
+
+/** Stop this conversation's monitors without queuing a turn that undoes the abort. */
+export function stopMonitorsForScope(scope: BackgroundRuntimeScope): void {
+  for (const [id, process] of backgroundProcesses) {
+    if (
+      process.kind === "monitor" &&
+      process.status === "running" &&
+      process.runtimeScope?.agentId === scope.agentId &&
+      process.runtimeScope.conversationId === scope.conversationId
+    ) {
+      killBackgroundProcess(id);
+    }
+  }
+}
 
 export async function stopMonitor(
   command: MonitorStopCommand,

--- a/src/tools/manager.ts
+++ b/src/tools/manager.ts
@@ -2562,19 +2562,16 @@ async function executeToolInner(
     if (options?.toolEndArgsRef) options.toolEndArgsRef.current = args;
 
     try {
-      // Inject options for tools that support them without altering schemas
       let enhancedArgs = args;
       let invocationSecrets: Record<string, string> = {};
 
-      // Every built-in may opt into turn cancellation without adding another
-      // manager-side allowlist entry. The signal remains outside tool schemas.
+      // Cancellation is internal, not part of model-facing tool schemas.
       if (options?.signal) {
         enhancedArgs = { ...enhancedArgs, signal: options.signal };
       }
 
       if (STREAMING_SHELL_TOOLS.has(internalName)) {
-        // Keep secret values out of shell interpolation and only redact values
-        // that this invocation can access.
+        // Redact only this invocation's secrets.
         const command = enhancedArgs.command ?? enhancedArgs.cmd;
         invocationSecrets =
           typeof command === "string" ||
@@ -2596,12 +2593,19 @@ async function executeToolInner(
         if (Object.keys(invocationSecrets).length > 0) {
           enhancedArgs = { ...enhancedArgs, secretEnv: invocationSecrets };
         }
-        if (options?.parentScope) {
-          enhancedArgs = { ...enhancedArgs, parentScope: options.parentScope };
+        const parentScope =
+          options?.parentScope ??
+          (internalName === "Monitor" && scopedAgentId
+            ? {
+                agentId: scopedAgentId,
+                conversationId: executionScope.conversationId ?? "default",
+              }
+            : undefined);
+        if (parentScope) {
+          enhancedArgs = { ...enhancedArgs, parentScope };
         }
       }
 
-      // Inject toolCallId, abort signal, and parent scope for Task tool
       if (internalName === "Task") {
         if (options?.toolCallId) {
           enhancedArgs = { ...enhancedArgs, toolCallId: options.toolCallId };
@@ -2611,9 +2615,7 @@ async function executeToolInner(
         }
       }
 
-      // Inject scoped metadata for Skill tool.
-      // In listener/desktop mode, relying on global agent context is unsafe
-      // because multiple agent/conversation scopes can overlap in one process.
+      // Skill metadata must not use process-global scope in listener mode.
       if (internalName === "Skill" && options?.toolCallId) {
         enhancedArgs = { ...enhancedArgs, toolCallId: options.toolCallId };
       }
@@ -2621,8 +2623,6 @@ async function executeToolInner(
         enhancedArgs = { ...enhancedArgs, parentScope: options.parentScope };
       }
 
-      // Inject worktree-only execution state and cancellation without exposing
-      // either internal field in the model-facing schema.
       if (WORKTREE_TOOL_NAMES.has(internalName as ToolName)) {
         enhancedArgs = {
           ...enhancedArgs,

--- a/src/websocket/listen-client-concurrency.test.ts
+++ b/src/websocket/listen-client-concurrency.test.ts
@@ -1318,7 +1318,7 @@ describe("listen-client multi-worker concurrency", () => {
       | Array<Record<string, unknown>>
       | undefined;
 
-    expect(firstSendMessages).toHaveLength(2);
+    expect(firstSendMessages).toHaveLength(3);
     expect(firstSendMessages?.[0]).toMatchObject({
       type: "approval",
       approvals: [
@@ -1329,7 +1329,7 @@ describe("listen-client multi-worker concurrency", () => {
         },
       ],
     });
-    expect(firstSendMessages?.[1]).toEqual({
+    expect(firstSendMessages?.[2]).toEqual({
       role: "user",
       content: [
         {

--- a/src/websocket/listener/control-inputs-interrupt.test.ts
+++ b/src/websocket/listener/control-inputs-interrupt.test.ts
@@ -1,13 +1,33 @@
 import { afterEach, describe, expect, mock, test } from "bun:test";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { type WebSocket, WebSocketServer } from "ws";
+import { bash } from "@/tools/impl/bash";
+import { monitor } from "@/tools/impl/monitor";
+import { MONITOR_EVENT_BATCH_MS } from "@/tools/impl/monitor-event-stream";
+import {
+  backgroundProcesses,
+  clearBackgroundProcessCleanup,
+} from "@/tools/impl/process_manager";
 import { handleAbortMessageInput } from "./control-inputs";
 import { getOrCreateScopedRuntime } from "./conversation-runtime";
 import { enqueueInboundUserMessage } from "./inbound-queue";
 import { createRuntime } from "./lifecycle";
+import {
+  clearProcessServices,
+  installProcessEventRouting,
+} from "./process-services";
 import { scheduleQueuePump } from "./queue";
 import { setActiveRuntime } from "./runtime";
 import type { ListenerTransport } from "./transport";
 import { finishListenerTurn } from "./turn-terminal";
 import type { IncomingMessage, StartListenerOptions } from "./types";
+
+function requireFixture<T>(value: T | undefined): T {
+  if (value === undefined) throw new Error("Missing interrupt test fixture");
+  return value;
+}
 
 function createOpenTransport(): ListenerTransport {
   return {
@@ -29,8 +49,12 @@ function createDeferred(): {
   return { promise, resolve };
 }
 
-async function waitFor(predicate: () => boolean): Promise<void> {
-  for (let attempt = 0; attempt < 100; attempt += 1) {
+async function waitFor(
+  predicate: () => boolean,
+  timeoutMs = 100,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
     if (predicate()) {
       return;
     }
@@ -41,6 +65,198 @@ async function waitFor(predicate: () => boolean): Promise<void> {
 
 describe("listener interrupt queue handoff", () => {
   afterEach(() => setActiveRuntime(null));
+
+  test("abort stops earlier-turn monitor sources only in the exact runtime scope", async () => {
+    const listener = createRuntime();
+    const socket = createOpenTransport();
+    const options = {} as StartListenerOptions;
+    const scopes = [
+      { agentId: "agent-monitor-a", conversationId: "shared" },
+      { agentId: "agent-monitor-a", conversationId: "other" },
+      { agentId: "agent-monitor-b", conversationId: "shared" },
+    ];
+    const runtimes = scopes.map((scope) =>
+      getOrCreateScopedRuntime(listener, scope.agentId, scope.conversationId),
+    );
+    const target = requireFixture(runtimes[0]);
+    const scratchpad = mkdtempSync(join(tmpdir(), "interrupt-monitors-"));
+    const previousScratchpad = process.env.LETTA_SCRATCHPAD;
+    process.env.LETTA_SCRATCHPAD = scratchpad;
+    const taskIds: string[] = [];
+    const peers: WebSocket[] = [];
+    const server = new WebSocketServer({ port: 0, host: "127.0.0.1" });
+    server.on("connection", (peer) => peers.push(peer));
+    const processQueuedTurn = mock(async (_incoming: IncomingMessage) => {});
+    setActiveRuntime(listener);
+    installProcessEventRouting({
+      runtime: listener,
+      processTransport: socket,
+      opts: options,
+      processQueuedTurn,
+    });
+    try {
+      await new Promise<void>((resolve) => server.once("listening", resolve));
+      const address = server.address();
+      if (!address || typeof address === "string")
+        throw new Error("No WS port");
+      // Start all sources in an earlier turn, not under the lease being aborted.
+      const earlier = target.turnLifecycle.begin({
+        origin: "message",
+        workingDirectory: process.cwd(),
+      });
+      const script = join(scratchpad, "source.js");
+      writeFileSync(
+        script,
+        "console.log(process.pid); setInterval(() => {}, 1000);",
+      );
+      const command = await monitor({
+        command: `${JSON.stringify(process.execPath)} ${JSON.stringify(script)}`,
+        description: "target command",
+        persistent: true,
+        parentScope: scopes[0],
+      });
+      taskIds.push(command.taskId);
+      for (const scope of scopes) {
+        const result = await monitor({
+          ws: { url: `ws://127.0.0.1:${address.port}` },
+          description: `socket ${scope.agentId}/${scope.conversationId}`,
+          persistent: true,
+          parentScope: scope,
+        });
+        taskIds.push(result.taskId);
+        await waitFor(() => peers.length === taskIds.length - 1, 4000);
+      }
+      const beforeBash = new Set(backgroundProcesses.keys());
+      await bash({
+        command: `${JSON.stringify(process.execPath)} ${JSON.stringify(script)}`,
+        description: "ordinary background task survives monitor cancellation",
+        run_in_background: true,
+        parentScope: scopes[0],
+      });
+      const bashId = requireFixture(
+        [...backgroundProcesses.keys()].find((id) => !beforeBash.has(id)),
+      );
+      taskIds.push(bashId);
+      const bashState = requireFixture(backgroundProcesses.get(bashId));
+      await waitFor(() => (bashState.totalStdoutLines ?? 0) > 0, 4000);
+      const bashPid = Number(
+        readFileSync(requireFixture(bashState.outputFile), "utf8").trim(),
+      );
+      expect(bashPid).toBeGreaterThan(0);
+      const commandState = requireFixture(
+        backgroundProcesses.get(command.taskId),
+      );
+      await waitFor(() => (commandState.totalStdoutLines ?? 0) > 0, 4000);
+      const pid = Number(
+        readFileSync(requireFixture(commandState.outputFile), "utf8").trim(),
+      );
+      expect(pid).toBeGreaterThan(0);
+      process.kill(pid, 0);
+      await waitFor(() => target.queueRuntime.length > 0, 4000);
+      finishListenerTurn(target, earlier, {
+        stopReason: "end_turn",
+        socket,
+        agentId: requireFixture(scopes[0]).agentId,
+        conversationId: requireFixture(scopes[0]).conversationId,
+      });
+      const later = target.turnLifecycle.begin({
+        origin: "message",
+        workingDirectory: process.cwd(),
+      });
+      target.turnLifecycle.setRunId(later, "run-later");
+      // Keep the control scopes busy so their real routed notifications remain inspectable.
+      for (const runtime of runtimes.slice(1)) {
+        runtime.turnLifecycle.begin({
+          origin: "message",
+          workingDirectory: process.cwd(),
+        });
+      }
+      const baseline = target.queueRuntime.peek().map((item) => item.id);
+      requireFixture(peers[0]).send("buffered-before-cancel");
+      const wsState = requireFixture(
+        backgroundProcesses.get(requireFixture(taskIds[1])),
+      );
+      await waitFor(() => (wsState.totalStdoutLines ?? 0) > 0, 4000);
+      // The frame reached the actual source but has not reached its batch timer.
+      expect(target.queueRuntime.peek().map((item) => item.id)).toEqual(
+        baseline,
+      );
+      const cancellation = createDeferred();
+      expect(
+        await handleAbortMessageInput(
+          listener,
+          {
+            command: {
+              type: "abort_message",
+              runtime: {
+                agent_id: requireFixture(scopes[0]).agentId,
+                conversation_id: requireFixture(scopes[0]).conversationId,
+              },
+              run_id: "run-later",
+            },
+            socket,
+            opts: options,
+            processQueuedTurn,
+          },
+          {
+            cancelRun: async () => cancellation.promise,
+            cancelConversation: async () => {},
+          },
+        ),
+      ).toBe(true);
+      // Cancellation must stop local sources without waiting for the backend.
+      expect(commandState.status).not.toBe("running");
+      expect(wsState.status).not.toBe("running");
+      await waitFor(() => requireFixture(peers[0]).readyState === 3, 4000);
+      await waitFor(() => {
+        try {
+          process.kill(pid, 0);
+          return false;
+        } catch {
+          return true;
+        }
+      }, 4000);
+      for (const peer of peers.slice(1))
+        peer.send("still-delivering-after-cancel");
+      await waitFor(
+        () =>
+          runtimes.slice(1).every((runtime) => runtime.queueRuntime.length > 0),
+        4000,
+      );
+      await Bun.sleep(MONITOR_EVENT_BATCH_MS * 2);
+      expect(target.queueRuntime.peek().map((item) => item.id)).toEqual(
+        baseline,
+      );
+      for (const id of taskIds.slice(2))
+        expect(backgroundProcesses.get(id)?.status).toBe("running");
+      for (const runtime of runtimes.slice(1)) {
+        expect(JSON.stringify(runtime.queueRuntime.peek())).toContain(
+          "still-delivering-after-cancel",
+        );
+      }
+      expect(bashState.status).toBe("running");
+      process.kill(bashPid, 0);
+      expect(processQueuedTurn).not.toHaveBeenCalled();
+      cancellation.resolve();
+    } finally {
+      for (const id of taskIds) {
+        const state = backgroundProcesses.get(id);
+        if (state) {
+          state.completionNotificationSuppressed = true;
+          state.status = "failed";
+          state.process.kill("SIGKILL");
+          clearBackgroundProcessCleanup(id);
+          backgroundProcesses.delete(id);
+        }
+      }
+      for (const peer of peers) peer.terminate();
+      server.close();
+      clearProcessServices(listener);
+      if (previousScratchpad === undefined) delete process.env.LETTA_SCRATCHPAD;
+      else process.env.LETTA_SCRATCHPAD = previousScratchpad;
+      rmSync(scratchpad, { recursive: true, force: true });
+    }
+  }, 15000);
 
   test("does not release the next turn before cancellation fallback settles", async () => {
     const listener = createRuntime();

--- a/src/websocket/listener/control-inputs-interrupt.test.ts
+++ b/src/websocket/listener/control-inputs-interrupt.test.ts
@@ -10,6 +10,7 @@ import {
   backgroundProcesses,
   clearBackgroundProcessCleanup,
 } from "@/tools/impl/process_manager";
+import { addToMessageQueue } from "@/utils/message-queue-bridge";
 import { handleAbortMessageInput } from "./control-inputs";
 import { getOrCreateScopedRuntime } from "./conversation-runtime";
 import { enqueueInboundUserMessage } from "./inbound-queue";
@@ -88,6 +89,13 @@ describe("listener interrupt queue handoff", () => {
     server.on("connection", (peer) => peers.push(peer));
     const processQueuedTurn = mock(async (_incoming: IncomingMessage) => {});
     setActiveRuntime(listener);
+    // Another test's background task can finish before this listener mounts.
+    addToMessageQueue({
+      kind: "task_notification",
+      text: "Unrelated background task completed",
+      agentId: "agent-unrelated-completion",
+      conversationId: "unrelated-completion",
+    });
     installProcessEventRouting({
       runtime: listener,
       processTransport: socket,
@@ -236,7 +244,15 @@ describe("listener interrupt queue handoff", () => {
       }
       expect(bashState.status).toBe("running");
       process.kill(bashPid, 0);
-      expect(processQueuedTurn).not.toHaveBeenCalled();
+      expect(
+        processQueuedTurn.mock.calls.filter(([incoming]) =>
+          scopes.some(
+            (scope) =>
+              incoming.agentId === scope.agentId &&
+              incoming.conversationId === scope.conversationId,
+          ),
+        ),
+      ).toEqual([]);
       cancellation.resolve();
     } finally {
       for (const id of taskIds) {

--- a/src/websocket/listener/control-inputs.ts
+++ b/src/websocket/listener/control-inputs.ts
@@ -5,6 +5,7 @@ import { getBackend } from "@/backend";
 import { INTERRUPTED_BY_USER } from "@/constants";
 import { migratePermissionMode } from "@/permissions/mode";
 import { trackBoundaryError } from "@/telemetry/error-reporting";
+import { stopMonitorsForScope } from "@/tools/impl/stop-monitor";
 import type {
   AbortMessageCommand,
   ApprovalResponseBody,
@@ -478,6 +479,12 @@ export async function handleAbortMessageInput(
     return false;
   }
 
+  if (scope.agent_id) {
+    stopMonitorsForScope({
+      agentId: scope.agent_id,
+      conversationId: scope.conversation_id,
+    });
+  }
   const cancellation = scopedRuntime.turnLifecycle.requestCancellation({
     waitForExternalSettlement: hasActiveTurn && Boolean(scopedRuntime.agentId),
   });

--- a/src/websocket/listener/turn-setup-interrupt.test.ts
+++ b/src/websocket/listener/turn-setup-interrupt.test.ts
@@ -1,0 +1,185 @@
+import { expect, test } from "bun:test";
+import {
+  setConversationId,
+  setCurrentAgentId,
+  setCurrentAgentName,
+} from "@/agent/context";
+import { INTERRUPT_RECOVERY_ALERT } from "@/agent/prompt-assets";
+import { __testSetBackend } from "@/backend";
+import { FakeHeadlessBackend } from "@/backend/dev/fake-headless-backend";
+import { DEFAULT_PERMISSION_MODE } from "@/permissions/mode";
+import { settingsManager } from "@/settings-manager";
+import { TestDirectory } from "@/test-utils/test-fs";
+import { isolateAmbientLettaTestEnv } from "@/test-utils/test-process-env";
+import { clearCapturedToolExecutionContexts } from "@/tools/manager";
+import { handleAbortMessageInput } from "./control-inputs";
+import { getOrCreateScopedRuntime } from "./conversation-runtime";
+import { createRuntime } from "./lifecycle";
+import {
+  __listenerModAdapterTestUtils,
+  createListenerModAdapter,
+  disposeListenerModAdapter,
+} from "./mod-adapter";
+import { setActiveRuntime } from "./runtime";
+import type { ListenerTransport } from "./transport";
+import { prepareListenerTurn } from "./turn-setup";
+import { finishListenerTurn } from "./turn-terminal";
+import type { StartListenerOptions } from "./types";
+import { __listenerWarmupTestUtils } from "./warmup";
+
+test("turn setup delivers the abort monitor notice once, only to the interrupted scope", async () => {
+  const directory = new TestDirectory();
+  const originalHome = process.env.HOME;
+  await settingsManager.reset();
+  const restoreEnv = isolateAmbientLettaTestEnv();
+  process.env.HOME = directory.path;
+  const listener = createRuntime();
+  const agentId = "agent-turn-setup-interrupt";
+  const conversationId = "default";
+  const socket: ListenerTransport = {
+    kind: "local",
+    bufferedAmount: 0,
+    isOpen: () => true,
+    send: () => {},
+  };
+  __testSetBackend(
+    new FakeHeadlessBackend(
+      agentId,
+      undefined,
+      {},
+      {
+        modelHandle: "anthropic/claude-sonnet-4-6",
+      },
+    ),
+  );
+  // Keep remote MemFS/secrets hydration outside this local turn-setup fixture.
+  __listenerWarmupTestUtils.setWarmupDepsForTests({
+    ensureMemfsSyncedForAgent: async () => false,
+    ensureSecretsHydratedForAgent: async () => {},
+  });
+  __listenerModAdapterTestUtils.setEnsureMemfsSyncedForAgentForTests(
+    async () => false,
+  );
+  listener.modAdapter = createListenerModAdapter({
+    globalModsDirectory: directory.createDir("mods"),
+    cacheDirectory: directory.createDir("cache"),
+  });
+  setActiveRuntime(listener);
+
+  async function prepareInput(
+    scopeAgentId: string,
+    scopeConversationId: string,
+  ) {
+    const runtime = getOrCreateScopedRuntime(
+      listener,
+      scopeAgentId,
+      scopeConversationId,
+    );
+    runtime.skillSources = [];
+    const lease = runtime.turnLifecycle.begin({
+      origin: "message",
+      workingDirectory: directory.path,
+    });
+    try {
+      const result = await prepareListenerTurn({
+        msg: {
+          type: "message",
+          agentId: scopeAgentId,
+          conversationId: scopeConversationId,
+          messages: [{ role: "user", content: "continue without monitors" }],
+          clientToolset: { base: "default" },
+        },
+        runtime,
+        agentId: scopeAgentId,
+        conversationId: scopeConversationId,
+        workingDirectory: directory.path,
+        permissionModeState: { mode: DEFAULT_PERMISSION_MODE },
+        turnLease: lease,
+      });
+      expect(result.kind).toBe("ready");
+      if (result.kind !== "ready") throw new Error("Turn setup was not ready");
+      return result.turnInput.messages;
+    } finally {
+      finishListenerTurn(runtime, lease, {
+        stopReason: "end_turn",
+        socket,
+        agentId: scopeAgentId,
+        conversationId: scopeConversationId,
+      });
+    }
+  }
+
+  try {
+    await settingsManager.initialize();
+    const runtime = getOrCreateScopedRuntime(listener, agentId, conversationId);
+    const lease = runtime.turnLifecycle.begin({
+      origin: "message",
+      workingDirectory: directory.path,
+    });
+    expect(
+      await handleAbortMessageInput(listener, {
+        command: {
+          type: "abort_message",
+          runtime: { agent_id: agentId, conversation_id: conversationId },
+        },
+        socket,
+        opts: {} as StartListenerOptions,
+        processQueuedTurn: async () => {},
+      }),
+    ).toBe(true);
+    expect(lease.signal.aborted).toBe(true);
+    finishListenerTurn(runtime, lease, {
+      stopReason: "cancelled",
+      socket,
+      agentId,
+      conversationId,
+    });
+    // Backend cancellation is intentionally fire-and-forget; let its fence settle.
+    await Bun.sleep(0);
+    expect(runtime.turnLifecycle.kind).toBe("idle");
+
+    for (const [otherAgent, otherConversation] of [
+      [agentId, "other-conversation"],
+      ["other-agent", conversationId],
+    ] as const) {
+      const messages = await prepareInput(otherAgent, otherConversation);
+      expect(JSON.stringify(messages)).not.toContain(
+        INTERRUPT_RECOVERY_ALERT.trim(),
+      );
+    }
+
+    const messages = await prepareInput(agentId, conversationId);
+    const serialized = JSON.stringify(messages);
+    expect(serialized.split(INTERRUPT_RECOVERY_ALERT.trim())).toHaveLength(2);
+    expect(serialized).toContain("Do not restart them unless the user asks.");
+    expect(messages).toHaveLength(2);
+    expect(messages[0]).toMatchObject({ role: "user" });
+    expect(JSON.stringify(messages[0])).toContain(
+      INTERRUPT_RECOVERY_ALERT.trim(),
+    );
+    expect(messages[1]).toMatchObject({
+      role: "user",
+      content: "continue without monitors",
+    });
+    const laterMessages = await prepareInput(agentId, conversationId);
+    expect(JSON.stringify(laterMessages)).not.toContain(
+      INTERRUPT_RECOVERY_ALERT.trim(),
+    );
+    expect(laterMessages).toHaveLength(1);
+  } finally {
+    disposeListenerModAdapter(listener);
+    __listenerWarmupTestUtils.resetWarmupDepsForTests();
+    __listenerModAdapterTestUtils.resetForTests();
+    clearCapturedToolExecutionContexts();
+    setActiveRuntime(null);
+    setCurrentAgentId(null);
+    setCurrentAgentName(null);
+    setConversationId(null);
+    __testSetBackend(null);
+    await settingsManager.reset();
+    restoreEnv();
+    if (originalHome === undefined) delete process.env.HOME;
+    else process.env.HOME = originalHome;
+    directory.cleanup();
+  }
+});

--- a/src/websocket/listener/turn-setup.ts
+++ b/src/websocket/listener/turn-setup.ts
@@ -9,6 +9,7 @@ import {
   setCurrentAgentId,
   setCurrentAgentName,
 } from "@/agent/context";
+import { INTERRUPT_RECOVERY_ALERT } from "@/agent/prompt-assets";
 import { getBackend } from "@/backend";
 import type { Line } from "@/cli/helpers/accumulator";
 import {
@@ -30,6 +31,7 @@ import {
   ensureListenerModAdaptersForAgent,
 } from "./mod-adapter";
 import type { ConversationPermissionModeState } from "./permission-mode";
+import { hasInterruptedCacheForScope } from "./runtime";
 import { emitListenerTurnStart } from "./turn-events";
 import {
   createTurnInputState,
@@ -117,12 +119,23 @@ export async function prepareListenerTurn(params: {
 
   const messagesToSend: Array<MessageCreate | ApprovalCreate> = [];
   let queuedInterruptedToolCallIds: string[] = [];
+  const wasInterrupted = hasInterruptedCacheForScope(runtime.listener, {
+    agent_id: agentId,
+    conversation_id: conversationId,
+  });
   const consumed = agentId
     ? consumeInterruptQueue(runtime, agentId, conversationId)
     : null;
   if (consumed) {
     messagesToSend.push(consumed.approvalMessage);
     queuedInterruptedToolCallIds = consumed.interruptedToolCallIds;
+  }
+  if (wasInterrupted) {
+    messagesToSend.push({
+      role: "user",
+      content: INTERRUPT_RECOVERY_ALERT,
+      otid: crypto.randomUUID(),
+    });
   }
   messagesToSend.push(...ensureTurnInputMessageOtids(msg.messages));
 


### PR DESCRIPTION
## Summary

Interrupt now stops running Monitors in that agent/conversation, including persistent monitors started by earlier turns. It uses the existing silent TaskStop cleanup, so stopping a monitor does not enqueue another notification that wakes the agent. Other conversations and ordinary background jobs are unaffected.

Append the cancellation note to the existing abort recovery text and send it with the next input in the listener and headless paths too. Reject Monitor startup if its tool call was interrupted while a pre-tool handler was pending.

Idle interrupts and notifications already in the queue retain their existing behavior. Buffered and future events from the stopped sources are discarded.

## Verification

Exercised real shell processes and local WebSocket sources on Linux through listener abort, TUI Escape, and headless stdin interruption. The listener regression failed before the change because the monitor remained running. Afterward, its process exits and socket closes while both neighboring conversation scopes and an ordinary background shell remain active. The next input receives the cancellation notice without a separate cancellation-triggered turn. Model inference uses the existing fake backend.

Ran `bun run check`, `bun run build`, and the focused monitor, background-process, listener, TUI, and headless interruption tests. The built Node CLI starts successfully. No production rollout performed.

## Breadcrumbs

- Requested change: LET-12443
- Origin: [Monitor implementation #3751](https://github.com/letta-ai/letta-code/pull/3751) did not cancel monitors on turn interruption. This adds that behavior rather than attributing the reported timing issue to a particular regression.
- Uses cleanup from: [per-Monitor cancellation #4280](https://github.com/letta-ai/letta-code/pull/4280)
- Letta conversation: [conv-27e69b41-3cf0-4ed9-8618-42d819b06f83](https://chat.letta.com/chat/agent-19babcc0-e958-41b0-81d8-00107f71deb7?conversation=conv-27e69b41-3cf0-4ed9-8618-42d819b06f83)

## AI Disclosure

AI-authored internal team change requested by a maintainer.

## AI Tool(s) Used

Letta Code (Titan) for investigation, implementation, and verification.

## Human Verification

Pending maintainer review.
