### PR TITLE
fix(listener): keep queued senders out of active continuations [LET-12455]

### DIFF
--- a/src/websocket/listener/queue-acting-user.test.ts
+++ b/src/websocket/listener/queue-acting-user.test.ts
@@ -35,6 +35,35 @@ function enqueueNotification(
 }
 
 describe("listener queue acting-user attribution", () => {
+  test.each([
+    ["cloud-user-a", "cloud-user-b"],
+    [undefined, "cloud-user-b"],
+    ["cloud-user-a", undefined],
+  ])(
+    "continuation stops before a different sender after a matching prefix",
+    (activeUser, otherUser) => {
+      const runtime = getOrCreateScopedRuntime(
+        createRuntime(),
+        "agent-parent",
+        "conv-parent",
+      );
+      enqueueNotification(runtime, "same sender", activeUser);
+      enqueueNotification(runtime, "different sender", otherUser);
+      enqueueNotification(runtime, "later same sender", activeUser);
+
+      const current = consumeQueuedTurn(runtime, { actingUserId: activeUser });
+      expect(current?.dequeuedBatch.items).toHaveLength(1);
+      expect(current?.queuedTurn.actingUserId).toBe(activeUser);
+      expect(runtime.queueRuntime.length).toBe(2);
+      expect(
+        consumeQueuedTurn(runtime, { actingUserId: activeUser }),
+      ).toBeNull();
+      expect(
+        runtime.queueRuntime.peekReady().map((item) => item.actingUserId),
+      ).toEqual([otherUser, activeUser]);
+    },
+  );
+
   test("delayed completions drain into separate requests for their initiating users", async () => {
     const listener = createRuntime();
     const runtime = getOrCreateScopedRuntime(

--- a/src/websocket/listener/queue.ts
+++ b/src/websocket/listener/queue.ts
@@ -281,7 +281,10 @@ export function shouldProcessInboundMessageDirectly(
   );
 }
 
-export function consumeQueuedTurn(runtime: ConversationRuntime): {
+export function consumeQueuedTurn(
+  runtime: ConversationRuntime,
+  continuation?: { actingUserId: string | undefined },
+): {
   dequeuedBatch: DequeuedBatch;
   queuedTurn: IncomingMessage;
 } | null {
@@ -302,6 +305,12 @@ export function consumeQueuedTurn(runtime: ConversationRuntime): {
   const isNoCoalesce = (candidate: (typeof queuedItems)[number]): boolean =>
     candidate.kind === "message" && candidate.noCoalesce === true;
   for (const item of queuedItems) {
+    // Tool results belong to the active request's sender. Leave a different
+    // sender's input queued for its own turn, including attributed/anonymous
+    // transitions. Idle queue drains do not have an active sender to preserve.
+    if (continuation && item.actingUserId !== continuation.actingUserId) {
+      break;
+    }
     if (
       !isCoalescable(item.kind) ||
       !hasSameQueueScope(firstQueuedItem, item)

--- a/src/websocket/listener/turn-approval.ts
+++ b/src/websocket/listener/turn-approval.ts
@@ -639,13 +639,14 @@ export async function handleApprovalStop(params: {
     },
   ]);
   let continuationBatchId = dequeuedBatchId;
-  let continuationActingUserId: string | undefined;
-  const consumedQueuedTurn = consumeQueuedTurn(runtime);
+  const sendOptions = buildSendOptions() ?? {};
+  const consumedQueuedTurn = consumeQueuedTurn(runtime, {
+    actingUserId: sendOptions.actingUserId,
+  });
   if (consumedQueuedTurn) {
     const { dequeuedBatch, queuedTurn } = consumedQueuedTurn;
     turnCorrelation?.appendDequeuedBatch(dequeuedBatch.batchId);
     continuationBatchId = dequeuedBatch.batchId;
-    continuationActingUserId = queuedTurn.actingUserId;
     nextTurnInput = appendQueuedTurnToInput(nextTurnInput, queuedTurn);
     emitDequeuedUserMessage(socket, runtime, queuedTurn, dequeuedBatch);
   }
@@ -669,7 +670,6 @@ export async function handleApprovalStop(params: {
   });
   let sendResult: ApprovalContinuationSendResult;
   try {
-    const sendOptions = buildSendOptions() ?? {};
     const imageFailureModesByMessageOtid = mergeImageFailureModesByMessageOtid(
       sendOptions.imageFailureModesByMessageOtid,
       nextTurnInput.imageFailureModesByMessageOtid,
@@ -679,9 +679,6 @@ export async function handleApprovalStop(params: {
       nextInputWithSkillContent,
       {
         ...sendOptions,
-        ...(continuationActingUserId
-          ? { actingUserId: continuationActingUserId }
-          : {}),
         ...(imageFailureModesByMessageOtid
           ? { imageFailureModesByMessageOtid }
           : {}),

--- a/src/websocket/listener/turn-lifecycle-integration.test.ts
+++ b/src/websocket/listener/turn-lifecycle-integration.test.ts
@@ -1,16 +1,27 @@
 import { afterEach, describe, expect, mock, test } from "bun:test";
+import { Letta } from "@letta-ai/letta-client";
+import { ACTING_USER_ID_HEADER } from "@/agent/acting-user";
 import {
   getConversationId,
   getCurrentAgentId,
   setConversationId,
   setCurrentAgentId,
 } from "@/agent/context";
+import { sendMessageStreamWithBackend } from "@/agent/message";
+import { APIBackend } from "@/backend";
+import {
+  prepareToolExecutionContextForSpecificTools,
+  releaseToolExecutionContext,
+} from "@/tools/manager";
 import { openListenerConnection } from "./connection";
 import { getOrCreateScopedRuntime } from "./conversation-runtime";
 import { enqueueInboundUserMessage } from "./inbound-queue";
 import { createRuntime } from "./lifecycle";
 import { getOrCreateConversationPermissionModeStateRef } from "./permission-mode";
-import { shouldProcessInboundMessageDirectly } from "./queue";
+import {
+  consumeQueuedTurn,
+  shouldProcessInboundMessageDirectly,
+} from "./queue";
 import { finalizeHandledRecoveryTurn } from "./recovery";
 import { clearConversationRuntimeState } from "./runtime";
 import { finishPendingTeleport, handleTeleportRequest } from "./teleport";
@@ -279,77 +290,167 @@ describe("listener turn lifecycle integration", () => {
     expect(executeApprovalBatch).toHaveBeenCalledTimes(1);
   });
 
-  test("a queued user's identity replaces the turn owner on an approval continuation", async () => {
-    const runtime = getOrCreateScopedRuntime(
-      createRuntime(),
-      "agent-1",
-      "conv-1",
-    );
-    const turnLease = runtime.turnLifecycle.begin({
-      origin: "message",
-      workingDirectory: process.cwd(),
-      initialStatus: "PROCESSING_API_RESPONSE",
-    });
-    enqueueInboundUserMessage(
-      runtime,
-      {
-        type: "message",
-        agentId: "agent-1",
-        conversationId: "conv-1",
-        messages: [{ role: "user", content: "message from Charles" }],
-      },
-      "cloud-user-charles",
-    );
-    const approval = {
-      toolCallId: "call-monitor",
-      toolName: "Bash",
-      toolArgs: '{"command":"pwd"}',
-    };
-    let sentActingUserId: string | undefined;
-
-    const result = await startQuestionApproval(runtime, turnLease, {
-      approvals: [approval],
-      processOwnedTurn: true,
-      buildSendOptions: () =>
-        ({
+  test.each([
+    ["user-a", "user-b"],
+    [undefined, "user-b"],
+    ["user-a", undefined],
+    ["user-a", "user-a"],
+    [undefined, undefined],
+  ])(
+    "continuation keeps actor %s with queued actor %s",
+    async (activeUser, queuedUser) => {
+      const runtime = getOrCreateScopedRuntime(
+        createRuntime(),
+        "agent-1",
+        "conv-1",
+      );
+      const turnLease = runtime.turnLifecycle.begin({
+        origin: "message",
+        workingDirectory: process.cwd(),
+        initialStatus: "PROCESSING_API_RESPONSE",
+      });
+      enqueueInboundUserMessage(
+        runtime,
+        {
+          type: "message",
           agentId: "agent-1",
-          streamTokens: true,
-          background: true,
-          workingDirectory: process.cwd(),
-          actingUserId: "cloud-user-monitor-owner",
-        }) as never,
-      dependencies: {
-        classifyApprovals: async () => ({
-          autoAllowed: [{ approval, parsedArgs: {}, context: null }],
-          autoDenied: [],
-          needsUserInput: [],
-        }),
-        executeApprovalBatch: async () => [
-          {
-            type: "tool" as const,
-            tool_call_id: approval.toolCallId,
-            status: "success" as const,
-            tool_return: "/workspace",
-          },
-        ],
-        ensureSecretsHydrated: async () => {},
-        sendApprovalContinuation: async (
-          _conversationId: string,
-          _messages: unknown[],
-          options: { actingUserId?: string },
-        ) => {
-          sentActingUserId = options.actingUserId;
-          return {
-            kind: "terminal" as const,
-            drainResult: { stopReason: "end_turn" as const, apiDurationMs: 0 },
-          };
+          conversationId: "conv-1",
+          messages: [{ role: "user", content: "queued input" }],
         },
-      } as never,
-    });
+        queuedUser,
+      );
+      const approval = {
+        toolCallId: "call-monitor",
+        toolName: "Bash",
+        toolArgs: '{"command":"pwd"}',
+      };
+      const requests: Array<{ actor: string | undefined; body: unknown }> = [];
+      const server = Bun.serve({
+        port: 0,
+        async fetch(request) {
+          const actor = request.headers.get(ACTING_USER_ID_HEADER) ?? undefined;
+          requests.push({ actor, body: await request.json() });
+          if (actor !== activeUser) {
+            return Response.json(
+              { message: "Conversation not found" },
+              { status: 404 },
+            );
+          }
+          return new Response(
+            'data: {"message_type":"stop_reason","stop_reason":"end_turn"}\n\n',
+            {
+              headers: { "Content-Type": "text/event-stream" },
+            },
+          );
+        },
+      });
+      const client = new Letta({
+        apiKey: "test-key",
+        baseURL: server.url.toString(),
+        maxRetries: 0,
+      });
+      const backend = new APIBackend({ getClient: async () => client });
+      const preparedToolContext =
+        await prepareToolExecutionContextForSpecificTools([]);
 
-    expect(result.kind).toBe("terminal");
-    expect(sentActingUserId).toBe("cloud-user-charles");
-  });
+      try {
+        const result = await startQuestionApproval(runtime, turnLease, {
+          approvals: [approval],
+          processOwnedTurn: true,
+          buildSendOptions: () =>
+            ({
+              agentId: "agent-1",
+              streamTokens: true,
+              background: true,
+              workingDirectory: process.cwd(),
+              actingUserId: activeUser,
+            }) as never,
+          dependencies: {
+            classifyApprovals: async () => ({
+              autoAllowed: [{ approval, parsedArgs: {}, context: null }],
+              autoDenied: [],
+              needsUserInput: [],
+            }),
+            executeApprovalBatch: async () => [
+              {
+                type: "tool" as const,
+                tool_call_id: approval.toolCallId,
+                status: "success" as const,
+                tool_return: "/workspace",
+              },
+            ],
+            ensureSecretsHydrated: async () => {},
+            sendApprovalContinuation: async (
+              conversationId: string,
+              messages: Parameters<typeof sendMessageStreamWithBackend>[2],
+              options: Parameters<typeof sendMessageStreamWithBackend>[3],
+            ) => {
+              const stream = await sendMessageStreamWithBackend(
+                backend,
+                conversationId,
+                messages,
+                {
+                  ...options,
+                  preparedToolContext,
+                  skillSources: [],
+                },
+              );
+              for await (const _event of stream) {
+                /* Drain the real SDK stream. */
+              }
+              return {
+                kind: "terminal" as const,
+                drainResult: {
+                  stopReason: "end_turn" as const,
+                  apiDurationMs: 0,
+                },
+              };
+            },
+          } as never,
+        });
+
+        expect(result.kind).toBe("terminal");
+        expect(requests).toHaveLength(1);
+        expect(requests[0]?.actor).toBe(activeUser);
+        expect(JSON.stringify(requests[0]?.body)).toContain("call-monitor");
+        const sameUser = activeUser === queuedUser;
+        expect(JSON.stringify(requests[0]?.body).includes("queued input")).toBe(
+          sameUser,
+        );
+        expect(runtime.queueRuntime.length).toBe(sameUser ? 0 : 1);
+        runtime.turnLifecycle.finish(turnLease, "end_turn");
+        if (!sameUser) {
+          const next = consumeQueuedTurn(runtime);
+          if (!next) throw new Error("Deferred input was lost");
+          expect(next?.queuedTurn.actingUserId).toBe(queuedUser);
+          expect(JSON.stringify(next?.queuedTurn.messages)).toContain(
+            "queued input",
+          );
+          expect(runtime.queueRuntime.length).toBe(0);
+          await expect(
+            sendMessageStreamWithBackend(
+              backend,
+              "conv-1",
+              next.queuedTurn.messages,
+              {
+                actingUserId: next.queuedTurn.actingUserId,
+                preparedToolContext,
+                skillSources: [],
+              },
+            ),
+          ).rejects.toThrow("Conversation not found");
+          expect(requests).toHaveLength(2);
+          expect(requests[1]?.actor).toBe(queuedUser);
+          expect(JSON.stringify(requests[1]?.body)).not.toContain(
+            "call-monitor",
+          );
+        }
+      } finally {
+        server.stop(true);
+        releaseToolExecutionContext(preparedToolContext.contextId);
+      }
+    },
+  );
 
   test("teleport yields after persisting the current tool result", async () => {
     const listener = createRuntime();


### PR DESCRIPTION
## Summary

Keep an active tool-result request under its original sender. Input from a different sender stays queued for a separate turn instead of being appended to the tool results and replacing the request's acting user. Same-sender input can still join the continuation, and queue order is preserved.

This changes normal active-tool continuations, not restart or stale-approval recovery. It does not grant a queued sender additional permissions.

## Verification

The existing lifecycle regression now sends through the real API backend and SDK to a loopback HTTP server. The server accepts the active sender and rejects the queued sender. On the base commit, the active continuation fails with 404. With this patch, it succeeds and only the later, separate request is rejected. Coverage includes same-sender and unattributed inputs, plus a compatible queue prefix followed by a different sender.

Tool classification/execution are stubbed in the existing fixture. This is local HTTP verification, not a production deployment or a live Cloud replay.

- `bun run check`: all 12 checks passed.
- `bun test src/websocket/listener/turn-lifecycle-integration.test.ts src/websocket/listener/queue-acting-user.test.ts src/websocket/listener/send-lease.test.ts src/websocket/listener/recovery-lease.test.ts src/agent/send-message-stream-acting-user.test.ts`: 35 tests passed.

## Breadcrumbs

- LET-12455
- Origin: [#3866](https://github.com/letta-ai/letta-code/pull/3866) introduced the queued-sender override. This preserves its sender-attribution goal by separating incompatible inputs rather than running them under the original sender.
- Overlaps the queue API touched by [#4296](https://github.com/letta-ai/letta-code/pull/4296), which adds a separate GitHub-authority restriction.
- Generating conversation: `conv-a1eda9ed-8ad0-46d2-9433-6c2e625b0278`

## AI Tool(s) Used

Letta Code. Authored at a maintainer's request, ready for human review.
