### PR TITLE
fix(slack): preserve activity through startup and queued input [LET-12454]

### DIFF
--- a/src/channels/gateway-core.test.ts
+++ b/src/channels/gateway-core.test.ts
@@ -285,6 +285,7 @@ test("removed queued input emits cancellation while another turn is active", asy
     type: "finished",
     batchId: "channel-cm-queued",
     sources: [queuedSource],
+    remainingSources: [activeSource],
     outcome: "cancelled",
     stopReason: "cancelled",
   });

--- a/src/channels/gateway-core.ts
+++ b/src/channels/gateway-core.ts
@@ -19,6 +19,12 @@ import type {
   WsProtocolMessage,
 } from "@/types/app-server-protocol";
 import {
+  sourceLifecycleKey,
+  sourceRouteKey,
+  uniqueLifecycleSources,
+  uniqueRoutedSources,
+} from "./gateway-sources";
+import {
   createMessageChannelIdempotencyScope,
   type MessageChannelIdempotencyScope,
 } from "./message-channel-idempotency";
@@ -138,45 +144,6 @@ function hasAgentRuntime<
   return !!value.runtime?.agent_id;
 }
 
-function sourceRouteKey(source: ChannelTurnSource): string {
-  return [
-    source.channel,
-    source.accountId ?? "",
-    source.chatId,
-    source.threadId ?? "",
-  ].join(":");
-}
-
-function sourceLifecycleKey(source: ChannelTurnSource): string {
-  return [
-    sourceRouteKey(source),
-    source.messageId ?? "",
-    source.agentId,
-    source.conversationId,
-  ].join(":");
-}
-
-function uniqueSourcesBy(
-  sources: ChannelTurnSource[],
-  getKey: (source: ChannelTurnSource) => string,
-): ChannelTurnSource[] {
-  const byKey = new Map<string, ChannelTurnSource>();
-  for (const source of sources) byKey.set(getKey(source), source);
-  return [...byKey.values()];
-}
-
-function uniqueRoutedSources(
-  sources: ChannelTurnSource[],
-): ChannelTurnSource[] {
-  return uniqueSourcesBy(sources, sourceRouteKey);
-}
-
-function uniqueLifecycleSources(
-  sources: ChannelTurnSource[],
-): ChannelTurnSource[] {
-  return uniqueSourcesBy(sources, sourceLifecycleKey);
-}
-
 function channelTagsForSources(sources: ChannelTurnSource[]): string[] {
   return [...new Set(sources.map((source) => `channel:${source.channel}`))];
 }
@@ -269,6 +236,8 @@ export class ChannelGateway {
       state.acceptedClientMessageIds.add(delivery.clientMessageId);
       return true;
     }
+    const workAtSubmit =
+      state.active || state.pendingSourcesByClientMessageId.size > 0;
     state.pendingSourcesByClientMessageId.set(delivery.clientMessageId, {
       sources: uniqueLifecycleSources(delivery.sources),
       disposition: "submitting",
@@ -297,6 +266,8 @@ export class ChannelGateway {
       });
       if (!response.accepted) {
         state.pendingSourcesByClientMessageId.delete(delivery.clientMessageId);
+        if (workAtSubmit && !state.active)
+          this.finishRejectedDelivery(state, delivery);
         return false;
       }
       this.rememberAcceptedClientMessageId(state, delivery.clientMessageId);
@@ -320,8 +291,36 @@ export class ChannelGateway {
       return true;
     } catch (error) {
       state.pendingSourcesByClientMessageId.delete(delivery.clientMessageId);
+      if (workAtSubmit && !state.active)
+        this.finishRejectedDelivery(state, delivery);
       throw error;
     }
+  }
+
+  private remainingSources(state: GatewayRuntimeState): ChannelTurnSource[] {
+    return uniqueLifecycleSources([
+      ...(state.active?.lifecycleSources ?? []),
+      ...Array.from(state.pendingSourcesByClientMessageId.values()).flatMap(
+        (pending) => pending.sources,
+      ),
+    ]);
+  }
+
+  private finishRejectedDelivery(
+    state: GatewayRuntimeState,
+    delivery: ChannelGatewayDelivery,
+  ): void {
+    const remainingSources = this.remainingSources(state);
+    void this.enqueueHook(state, () =>
+      this.hooks.onLifecycle({
+        type: "finished",
+        batchId: `channel-${delivery.clientMessageId}`,
+        sources: delivery.sources,
+        stopReason: "cancelled",
+        outcome: "cancelled",
+        remainingSources,
+      }),
+    );
   }
 
   adoptQueuedDelivery(delivery: ChannelGatewayHandoffDelivery): void {
@@ -828,6 +827,7 @@ export class ChannelGateway {
       );
     }
     for (const entry of cancelled) {
+      const remainingSources = this.remainingSources(state);
       void this.enqueueHook(state, () =>
         this.hooks.onLifecycle({
           type: "finished",
@@ -835,6 +835,7 @@ export class ChannelGateway {
           sources: entry.sources,
           outcome: "cancelled",
           stopReason: "cancelled",
+          ...(remainingSources.length ? { remainingSources } : {}),
         }),
       );
     }
@@ -937,6 +938,10 @@ export class ChannelGateway {
     if (!active) return;
     state.active = null;
     active.richDraft?.dispose();
+    const remainingSources =
+      lifecycleOutcome(terminal.stopReason) === "completed"
+        ? this.remainingSources(state)
+        : [];
     void this.enqueueHook(state, () =>
       this.hooks.onLifecycle({
         type: "finished",
@@ -944,6 +949,7 @@ export class ChannelGateway {
         sources: active.lifecycleSources,
         outcome: lifecycleOutcome(terminal.stopReason),
         stopReason: terminal.stopReason,
+        ...(remainingSources.length ? { remainingSources } : {}),
         ...((terminal.runId ?? active.runId)
           ? { runId: terminal.runId ?? active.runId }
           : {}),

--- a/src/channels/gateway-sources.test.ts
+++ b/src/channels/gateway-sources.test.ts
@@ -1,0 +1,32 @@
+import { expect, test } from "bun:test";
+import {
+  sourceLifecycleKey,
+  sourceRouteKey,
+  uniqueLifecycleSources,
+  uniqueRoutedSources,
+} from "./gateway-sources";
+import { makeSource } from "./gateway-test-support";
+
+test("one route retains distinct input ownership and the latest source metadata", () => {
+  const first = makeSource({ threadId: "thread", messageId: "first" });
+  const next = { ...first, messageId: "next" };
+  const enriched = { ...first, showStartupStatus: true };
+  expect(sourceRouteKey(first)).toBe(sourceRouteKey(next));
+  expect(sourceLifecycleKey(first)).not.toBe(sourceLifecycleKey(next));
+  expect(uniqueRoutedSources([first, next, enriched])).toEqual([enriched]);
+  expect(uniqueLifecycleSources([first, next, enriched])).toEqual([
+    enriched,
+    next,
+  ]);
+});
+
+test("different accounts, threads, and agents retain separate sources", () => {
+  const first = makeSource({ accountId: "one", threadId: "one" });
+  const account = { ...first, accountId: "two" };
+  const thread = { ...first, threadId: "two" };
+  const agent = { ...first, agentId: "two" };
+  expect(uniqueRoutedSources([first, account, thread])).toHaveLength(3);
+  expect(uniqueLifecycleSources([first, account, thread, agent])).toHaveLength(
+    4,
+  );
+});

--- a/src/channels/gateway-sources.ts
+++ b/src/channels/gateway-sources.ts
@@ -1,0 +1,40 @@
+import type { ChannelTurnSource } from "./types";
+
+export function sourceRouteKey(source: ChannelTurnSource): string {
+  return [
+    source.channel,
+    source.accountId ?? "",
+    source.chatId,
+    source.threadId ?? "",
+  ].join(":");
+}
+
+export function sourceLifecycleKey(source: ChannelTurnSource): string {
+  return [
+    sourceRouteKey(source),
+    source.messageId ?? "",
+    source.agentId,
+    source.conversationId,
+  ].join(":");
+}
+
+function uniqueSourcesBy(
+  sources: ChannelTurnSource[],
+  getKey: (source: ChannelTurnSource) => string,
+): ChannelTurnSource[] {
+  const byKey = new Map<string, ChannelTurnSource>();
+  for (const source of sources) byKey.set(getKey(source), source);
+  return [...byKey.values()];
+}
+
+export function uniqueRoutedSources(
+  sources: ChannelTurnSource[],
+): ChannelTurnSource[] {
+  return uniqueSourcesBy(sources, sourceRouteKey);
+}
+
+export function uniqueLifecycleSources(
+  sources: ChannelTurnSource[],
+): ChannelTurnSource[] {
+  return uniqueSourcesBy(sources, sourceLifecycleKey);
+}

--- a/src/channels/slack/AGENTS.md
+++ b/src/channels/slack/AGENTS.md
@@ -31,7 +31,13 @@ state render only through `assistant.threads.setStatus`.
   not overwrite the last concrete title.
 - Messages deactivate local status state because Slack clears status on post.
 - Reactions do not deactivate status.
-- `end_turn` and `cancelled` clear status and post nothing.
+- The status controller owns lifecycle visibility. Warm existing-thread inputs
+  stay quiet until concrete non-MessageChannel tool activity; top-level mentions
+  and inputs whose host already showed startup status begin with thinking.
+- Once visible, activity is refreshed on new input without replacing its title.
+  A host's waking status must transition to thinking without an empty write.
+- `end_turn` and `cancelled` post nothing. Clear status only for sources with no
+  remaining work; cancelling queued input must not clear a still-active turn.
 - `requires_approval` is a continuation boundary, not a terminal event.
 - `tool_rule` is quiet completion. Fatal stop reasons get one plain error line.
 - Do not use `chat.startStream`, `chat.appendStream`, or `chat.stopStream` for

--- a/src/channels/slack/adapter.ts
+++ b/src/channels/slack/adapter.ts
@@ -33,7 +33,6 @@ import {
   formatSlackControlRequestBlocks,
   formatSlackLifecycleErrorMessage,
   resolveSlackConcreteActivity,
-  SLACK_ASSISTANT_STARTUP_STATUS,
   SLACK_ASSISTANT_WORKING_STATUS,
   shouldPostSlackTerminalError,
 } from "./presentation";
@@ -207,28 +206,23 @@ export function createSlackAdapter(
   ): Promise<void> {
     if (!running) return;
     if (event.type === "queued") {
-      if (
-        isSlackFlatChannelThreadOpener(event.source) &&
-        isNonEmptyString(event.source.messageId) &&
-        !agentThreadTracker.has(event.source.chatId, event.source.messageId)
-      ) {
-        await status.activate(
-          event.source,
-          SLACK_ASSISTANT_STARTUP_STATUS,
-          SLACK_ASSISTANT_STARTUP_STATUS,
-        );
-      }
+      const showStartupStatus =
+        event.source.showStartupStatus ||
+        (isSlackFlatChannelThreadOpener(event.source) &&
+          isNonEmptyString(event.source.messageId) &&
+          !agentThreadTracker.has(event.source.chatId, event.source.messageId));
+      await status.handleLifecycle({
+        ...event,
+        source: { ...event.source, showStartupStatus },
+      });
       return;
     }
 
     const sources = status.getUniqueSources(event.sources);
-    if (event.type === "processing") {
-      await Promise.all(sources.map(status.clearStale));
-      return;
-    }
+    await status.handleLifecycle(event);
+    if (event.type === "processing") return;
     if (event.stopReason === "requires_approval") return;
 
-    await Promise.all(sources.map(status.deactivate));
     if (!shouldPostSlackTerminalError(event.stopReason)) return;
     const errorText = event.error?.trim() ?? "";
     trackBoundaryError({

--- a/src/channels/slack/status-controller.test.ts
+++ b/src/channels/slack/status-controller.test.ts
@@ -209,7 +209,7 @@ test("slack status event table: concurrent title swaps are sent in event order",
   expect(sentTitles).toEqual(["Reading the adapter", "Running the tests"]);
 });
 
-test("slack status event table: queued mid-turn input does not clear live status", async () => {
+test("slack status event table: queued mid-turn input refreshes live status", async () => {
   const adapter = await createStartedSlackAdapter();
   const source = createSlackTurnSource();
   await adapter.handleTurnProgressEvent?.({
@@ -228,7 +228,10 @@ test("slack status event table: queued mid-turn input does not clear live status
     source: { ...source, messageId: "1712800000.000300" },
   });
 
-  expect(client.assistant.threads.setStatus).toHaveBeenCalledTimes(1);
+  expect(client.assistant.threads.setStatus).toHaveBeenCalledTimes(2);
+  expect(client.assistant.threads.setStatus.mock.calls[1]).toEqual(
+    client.assistant.threads.setStatus.mock.calls[0],
+  );
   expect(client.chat.postMessage).not.toHaveBeenCalled();
 });
 

--- a/src/channels/slack/status-controller.ts
+++ b/src/channels/slack/status-controller.ts
@@ -1,7 +1,9 @@
 import type {
+  ChannelTurnLifecycleEvent,
   ChannelTurnSource,
   OutboundChannelMessage,
 } from "@/channels/types";
+import { SLACK_ASSISTANT_STARTUP_STATUS } from "./progress";
 import {
   firstNonEmptyString,
   isNonEmptyString,
@@ -32,6 +34,7 @@ export type AgentConvSlackState = {
 };
 
 export type SlackStatusController = {
+  handleLifecycle: (event: ChannelTurnLifecycleEvent) => Promise<void>;
   getUniqueSources: (sources: ChannelTurnSource[]) => ChannelTurnSource[];
   getLifecycleErrorReplyKey: (source: ChannelTurnSource) => string | null;
   activate: (
@@ -146,6 +149,13 @@ export function createSlackStatusController(params: {
     const previous =
       writePromiseByConversation.get(stateKey) ?? Promise.resolve();
     const operation = previous.then(async () => {
+      // A reply or completion may have cleared activity while this write waited.
+      if (footerText && !stateByConversation.get(stateKey)?.isThinkingActive) {
+        if (signatureByConversation.get(stateKey) === signature) {
+          signatureByConversation.delete(stateKey);
+        }
+        return false;
+      }
       try {
         await setStatus.call(slackClient.assistant?.threads, {
           channel_id: source.chatId,
@@ -153,6 +163,18 @@ export function createSlackStatusController(params: {
           status: footerText,
           ...(footerText ? { loading_messages: [loadingText] } : {}),
         });
+        // The request may have applied after a reply auto-cleared Slack. Keep
+        // this correction in the same write queue, ahead of any new activity.
+        const state = stateByConversation.get(stateKey);
+        if (footerText && state && !state.isThinkingActive) {
+          await setStatus.call(slackClient.assistant?.threads, {
+            channel_id: source.chatId,
+            thread_ts: threadTs,
+            status: "",
+          });
+          clearedStaleReplyKeys.add(replyKey);
+          return true;
+        }
         if (footerText) clearedStaleReplyKeys.delete(replyKey);
         else clearedStaleReplyKeys.add(replyKey);
         return true;
@@ -261,7 +283,50 @@ export function createSlackStatusController(params: {
     signatureByConversation.delete(key);
   }
 
+  async function refresh(source: ChannelTurnSource): Promise<boolean> {
+    const key = getConversationKey(source);
+    const state = key ? stateByConversation.get(key) : undefined;
+    if (!key || !state?.isThinkingActive) return false;
+    await writeStatus(source, state.typingFooterText, state.thinkingText, {
+      force: true,
+    });
+    if (stateByConversation.get(key) === state && state.isThinkingActive) {
+      scheduleKeepalive(key);
+    }
+    return true;
+  }
+
+  async function handleLifecycle(
+    event: ChannelTurnLifecycleEvent,
+  ): Promise<void> {
+    if (event.type === "queued") {
+      if (await refresh(event.source)) return;
+      if (event.source.showStartupStatus) {
+        await activate(
+          event.source,
+          SLACK_ASSISTANT_STARTUP_STATUS,
+          SLACK_ASSISTANT_STARTUP_STATUS,
+        );
+      }
+      return;
+    }
+    for (const source of getUniqueSources(event.sources)) {
+      if (event.type === "processing") {
+        await clearStale(source);
+      } else if (event.stopReason !== "requires_approval") {
+        const remaining = event.remainingSources?.some(
+          (other) =>
+            other.accountId === source.accountId &&
+            getConversationKey(other) === getConversationKey(source) &&
+            getLifecycleReplyKey(other) === getLifecycleReplyKey(source),
+        );
+        if (!remaining) await deactivate(source);
+      }
+    }
+  }
+
   return {
+    handleLifecycle,
     getUniqueSources,
     getLifecycleErrorReplyKey,
     activate,

--- a/src/channels/slack/status-lifecycle.test.ts
+++ b/src/channels/slack/status-lifecycle.test.ts
@@ -1,0 +1,360 @@
+import { expect, test } from "bun:test";
+import {
+  ChannelGateway,
+  type ChannelGatewayDelivery,
+} from "@/channels/gateway-core";
+import {
+  FakeClient,
+  makeDelivery,
+  makeHooks,
+  makeQueueUpdate,
+  makeStreamDelta,
+  makeTurnFinished,
+  TEST_RUNTIME,
+} from "@/channels/gateway-test-support";
+import {
+  createSlackTurnSource,
+  createStartedSlackAdapter,
+  getSlackWriteClient,
+  installSlackAdapterTestHooks,
+} from "./adapter-test-harness";
+
+installSlackAdapterTestHooks();
+
+async function setup() {
+  const adapter = await createStartedSlackAdapter();
+  const client = new FakeClient();
+  const { hooks } = makeHooks({
+    onLifecycle: (event) => adapter.handleTurnLifecycleEvent?.(event),
+    onProgress: (event) => adapter.handleTurnProgressEvent?.(event),
+  });
+  const gateway = new ChannelGateway(client, hooks);
+  const source = createSlackTurnSource();
+  const delivery = makeDelivery({
+    sources: [source],
+    clientMessageId: "first",
+  });
+  const submit = async (options: Partial<ChannelGatewayDelivery> = {}) => {
+    await gateway.submit({ ...delivery, ...options });
+    await Bun.sleep(0);
+  };
+  const tool = async (name = "Bash") => {
+    client.emit(
+      makeStreamDelta({
+        message_type: "tool_call_message",
+        id: `message-${name}`,
+        tool_calls: [
+          {
+            name,
+            tool_call_id: `call-${name}`,
+            arguments: JSON.stringify({
+              command: "pwd",
+              description: "Inspect the workspace",
+            }),
+          },
+        ],
+      }),
+    );
+    await Bun.sleep(0);
+  };
+  const statuses = () =>
+    getSlackWriteClient().assistant.threads.setStatus.mock.calls.map(
+      ([args]) => args.status,
+    );
+  const followup = () => ({
+    ...delivery,
+    clientMessageId: "followup",
+    sources: [{ ...source, messageId: "1712800000.000300" }],
+  });
+  return { adapter, client, gateway, source, submit, tool, statuses, followup };
+}
+
+test("cold existing thread continues the host's waking status through reasoning and MessageChannel", async () => {
+  const h = await setup();
+  // The external host already wrote waking before it could reach the gateway.
+  const slack = getSlackWriteClient();
+  await slack.assistant.threads.setStatus({
+    channel_id: h.source.chatId,
+    thread_ts: h.source.threadId,
+    status: "is waking up...",
+    loading_messages: ["is waking up..."],
+  });
+  await h.submit({ sources: [{ ...h.source, showStartupStatus: true }] });
+  h.client.emit(
+    makeStreamDelta({
+      message_type: "reasoning_message",
+      reasoning: "Reply directly",
+    }),
+  );
+  await h.tool("MessageChannel");
+  expect(h.statuses()).toEqual(["is waking up...", "is thinking..."]);
+  await h.adapter.sendMessage({
+    channel: "slack",
+    chatId: h.source.chatId,
+    threadId: h.source.threadId,
+    agentId: h.source.agentId,
+    conversationId: h.source.conversationId,
+    text: "Hello",
+  });
+  h.client.emit(makeTurnFinished("end_turn"));
+  await Bun.sleep(0);
+  expect(h.statuses().at(-1)).toBe("");
+  expect(slack.chat.postMessage).toHaveBeenCalledTimes(1);
+  h.gateway.close();
+});
+
+test("warm existing thread stays quiet through reasoning and MessageChannel", async () => {
+  const h = await setup();
+  await h.submit();
+  h.client.emit(
+    makeStreamDelta({
+      message_type: "reasoning_message",
+      reasoning: "Nothing to do",
+    }),
+  );
+  await h.tool("MessageChannel");
+  h.client.emit(makeTurnFinished("end_turn"));
+  await Bun.sleep(0);
+  expect(h.statuses().every((status) => status === "")).toBe(true);
+  h.gateway.close();
+});
+
+test("steering reasserts the current tool title even when it has not changed", async () => {
+  const h = await setup();
+  await h.submit();
+  await h.tool();
+  const slack = getSlackWriteClient();
+  const last = slack.assistant.threads.setStatus.mock.calls.at(-1)?.[0];
+  expect(last?.status).toBe("is working...");
+  const count = h.statuses().length;
+  h.client.inputResponse.disposition = "queued";
+  await h.submit(h.followup());
+  expect(h.statuses().length).toBe(count + 1);
+  expect(slack.assistant.threads.setStatus.mock.calls.at(-1)?.[0]).toEqual(
+    last,
+  );
+  h.client.emit(
+    makeQueueUpdate([], TEST_RUNTIME, [
+      { client_message_id: "followup", disposition: "dequeued" },
+    ]),
+  );
+  await Bun.sleep(0);
+  expect(h.statuses().slice(count)).not.toContain("");
+  h.gateway.close();
+});
+
+test("already-visible work continues across a turn boundary into queued input", async () => {
+  const h = await setup();
+  await h.submit();
+  await h.tool();
+  h.client.inputResponse.disposition = "queued";
+  await h.submit(h.followup());
+  const count = h.statuses().length;
+  h.client.emit(makeTurnFinished("end_turn"));
+  await Bun.sleep(0);
+  h.client.emit(
+    makeQueueUpdate([], TEST_RUNTIME, [
+      { client_message_id: "followup", disposition: "dequeued" },
+    ]),
+  );
+  await Bun.sleep(0);
+  expect(h.statuses().slice(count)).not.toContain("");
+  h.client.emit(makeTurnFinished("end_turn"));
+  await Bun.sleep(0);
+  expect(h.statuses().at(-1)).toBe("");
+  h.gateway.close();
+});
+
+test("cancelling queued input does not clear the tool still running", async () => {
+  const h = await setup();
+  await h.submit();
+  await h.tool();
+  h.client.inputResponse.disposition = "queued";
+  await h.submit(h.followup());
+  const count = h.statuses().length;
+  h.client.emit(
+    makeQueueUpdate([], TEST_RUNTIME, [
+      { client_message_id: "followup", disposition: "cancelled" },
+    ]),
+  );
+  await Bun.sleep(0);
+  expect(h.statuses().slice(count)).not.toContain("");
+  h.client.emit(makeTurnFinished("cancelled"));
+  await Bun.sleep(0);
+  expect(h.statuses().at(-1)).toBe("");
+  h.gateway.close();
+});
+
+for (const failure of ["rejected", "throw"] as const) {
+  test(`steering ${failure} after the active turn ends clears carried activity`, async () => {
+    const h = await setup();
+    await h.submit();
+    await h.tool();
+    const entered = Promise.withResolvers<void>();
+    const release = Promise.withResolvers<void>();
+    const submitInput = h.client.submitInput.bind(h.client);
+    h.client.submitInput = async (command) => {
+      entered.resolve();
+      await release.promise;
+      if (failure === "throw") throw new Error("Transport closed");
+      h.client.inputResponse.accepted = false;
+      return submitInput(command);
+    };
+    const pending = h.gateway.submit(h.followup()).then(
+      (accepted) => accepted,
+      () => false,
+    );
+    await entered.promise;
+    const count = h.statuses().length;
+    h.client.emit(makeTurnFinished("end_turn"));
+    await Bun.sleep(0);
+    expect(h.statuses().slice(count)).not.toContain("");
+    release.resolve();
+    expect(await pending).toBe(false);
+    await Bun.sleep(0);
+    expect(h.statuses().at(-1)).toBe("");
+    h.gateway.close();
+  });
+}
+
+test("a reply closes the visibility gate even with another input queued", async () => {
+  const h = await setup();
+  await h.submit();
+  await h.tool();
+  await h.adapter.sendMessage({
+    channel: "slack",
+    chatId: h.source.chatId,
+    threadId: h.source.threadId,
+    agentId: h.source.agentId,
+    conversationId: h.source.conversationId,
+    text: "Done with that part",
+  });
+  const count = h.statuses().length;
+  h.client.inputResponse.disposition = "queued";
+  await h.submit(h.followup());
+  h.client.emit(makeTurnFinished("end_turn"));
+  h.client.emit(
+    makeQueueUpdate([], TEST_RUNTIME, [
+      { client_message_id: "followup", disposition: "dequeued" },
+    ]),
+  );
+  await h.tool("MessageChannel");
+  expect(
+    h
+      .statuses()
+      .slice(count)
+      .every((status) => status === ""),
+  ).toBe(true);
+  h.gateway.close();
+});
+
+test("cancelling the last queued input after a completed turn clears carried activity", async () => {
+  const h = await setup();
+  await h.submit();
+  await h.tool();
+  h.client.inputResponse.disposition = "queued";
+  await h.submit(h.followup());
+  h.client.emit(makeTurnFinished("end_turn"));
+  await Bun.sleep(0);
+  expect(h.statuses().at(-1)).toBe("is working...");
+  h.client.emit(
+    makeQueueUpdate([], TEST_RUNTIME, [
+      { client_message_id: "followup", disposition: "cancelled" },
+    ]),
+  );
+  await Bun.sleep(0);
+  expect(h.statuses().at(-1)).toBe("");
+  h.gateway.close();
+});
+
+for (const stopReason of ["cancelled", "error", "tool_rule", "end_turn"]) {
+  test(`${stopReason} clears activity when no input remains`, async () => {
+    const h = await setup();
+    await h.submit();
+    await h.tool();
+    h.client.emit(makeTurnFinished(stopReason));
+    await Bun.sleep(0);
+    expect(h.statuses().at(-1)).toBe("");
+    const count = h.statuses().length;
+    await h.submit({ ...h.followup(), clientMessageId: "later" });
+    expect(
+      h
+        .statuses()
+        .slice(count)
+        .every((status) => status === ""),
+    ).toBe(true);
+    h.gateway.close();
+  });
+}
+
+test("approval continuation retains activity until a reply or terminal event", async () => {
+  const h = await setup();
+  await h.submit();
+  await h.tool();
+  const count = h.statuses().length;
+  h.client.emit(
+    makeStreamDelta({
+      message_type: "stop_reason",
+      stop_reason: "requires_approval",
+    }),
+  );
+  await Bun.sleep(0);
+  expect(h.statuses().slice(count)).not.toContain("");
+  h.client.emit(makeTurnFinished("end_turn"));
+  await Bun.sleep(0);
+  expect(h.statuses().at(-1)).toBe("");
+  h.gateway.close();
+});
+
+test("retrying accepted cold input does not restart thinking after a reply", async () => {
+  const h = await setup();
+  const cold = { sources: [{ ...h.source, showStartupStatus: true }] };
+  await h.submit(cold);
+  await h.adapter.sendMessage({
+    channel: "slack",
+    chatId: h.source.chatId,
+    threadId: h.source.threadId,
+    agentId: h.source.agentId,
+    conversationId: h.source.conversationId,
+    text: "Hello",
+  });
+  h.client.emit(makeTurnFinished("end_turn"));
+  await Bun.sleep(0);
+  const count = h.statuses().length;
+  await h.submit(cold);
+  expect(h.statuses()).toHaveLength(count);
+  h.gateway.close();
+});
+
+test("rejected input between turns clears status when the previously queued input was cancelled", async () => {
+  const h = await setup();
+  await h.submit();
+  await h.tool();
+  h.client.inputResponse.disposition = "queued";
+  await h.submit(h.followup());
+  h.client.emit(makeTurnFinished("end_turn"));
+  await Bun.sleep(0);
+  const entered = Promise.withResolvers<void>();
+  const release = Promise.withResolvers<void>();
+  const submitInput = h.client.submitInput.bind(h.client);
+  h.client.submitInput = async (command) => {
+    entered.resolve();
+    await release.promise;
+    h.client.inputResponse.accepted = false;
+    return submitInput(command);
+  };
+  const last = h.gateway.submit({ ...h.followup(), clientMessageId: "third" });
+  await entered.promise;
+  h.client.emit(
+    makeQueueUpdate([], TEST_RUNTIME, [
+      { client_message_id: "followup", disposition: "cancelled" },
+    ]),
+  );
+  await Bun.sleep(0);
+  expect(h.statuses().at(-1)).toBe("is working...");
+  release.resolve();
+  expect(await last).toBe(false);
+  await Bun.sleep(0);
+  expect(h.statuses().at(-1)).toBe("");
+  h.gateway.close();
+});

--- a/src/channels/slack/status-refresh.test.ts
+++ b/src/channels/slack/status-refresh.test.ts
@@ -1,0 +1,117 @@
+import { afterEach, expect, mock, test } from "bun:test";
+import { makeSource } from "@/channels/gateway-test-support";
+import {
+  createSlackStatusController,
+  type SlackStatusController,
+} from "./status-controller";
+
+const controllers: SlackStatusController[] = [];
+afterEach(() => {
+  for (const controller of controllers.splice(0)) controller.clear();
+});
+
+function setup() {
+  const writes: string[] = [];
+  const setStatus = mock(async (args: { status: string }) => {
+    writes.push(args.status);
+  });
+  const controller = createSlackStatusController({
+    ensureApp: async () => undefined,
+    ensureWriteClient: async () => ({ assistant: { threads: { setStatus } } }),
+    resolveKnownThreadRoot: (id) => id,
+  });
+  controllers.push(controller);
+  const source = makeSource({
+    channel: "slack",
+    accountId: "account",
+    chatId: "C123",
+    threadId: "100.1",
+    messageId: "100.2",
+  });
+  return { controller, source, setStatus, writes };
+}
+
+test("a failed refresh keeps active ownership and retries the current title on next input", async () => {
+  const h = setup();
+  await h.controller.activate(h.source, "is working...", "Inspect files");
+  h.setStatus.mockRejectedValueOnce(new Error("rate_limited"));
+  await h.controller.handleLifecycle({ type: "queued", source: h.source });
+  expect(h.controller.activeSources()).toEqual([h.source]);
+  await h.controller.handleLifecycle({ type: "queued", source: h.source });
+  expect(h.setStatus).toHaveBeenCalledTimes(3);
+  expect(h.setStatus).toHaveBeenLastCalledWith(
+    expect.objectContaining({
+      status: "is working...",
+      loading_messages: ["Inspect files"],
+    }),
+  );
+});
+
+test("in-flight and queued refreshes cannot leave activity visible after a reply", async () => {
+  const h = setup();
+  await h.controller.activate(h.source, "is working...", "Inspect files");
+  const started = Promise.withResolvers<void>();
+  const release = Promise.withResolvers<void>();
+  let visible = "is working...";
+  h.setStatus.mockImplementation(async (args) => {
+    visible = args.status;
+  });
+  h.setStatus.mockImplementationOnce(async () => {
+    started.resolve();
+    await release.promise;
+    visible = "is working...";
+  });
+  const firstRefresh = h.controller.handleLifecycle({
+    type: "queued",
+    source: h.source,
+  });
+  await started.promise;
+  const secondRefresh = h.controller.handleLifecycle({
+    type: "queued",
+    source: h.source,
+  });
+  await Bun.sleep(0);
+  visible = ""; // Slack auto-clears when the reply is posted.
+  h.controller.markAutoClearedForMessage({ ...h.source });
+  release.resolve();
+  await Promise.all([firstRefresh, secondRefresh]);
+  expect(visible).toBe("");
+  expect(h.setStatus).toHaveBeenCalledTimes(3);
+  expect(h.controller.activeSources()).toEqual([]);
+  await h.controller.handleLifecycle({ type: "queued", source: h.source });
+  expect(h.setStatus).toHaveBeenCalledTimes(3);
+});
+
+test("remaining work for another thread, account or conversation cannot retain this status", async () => {
+  const h = setup();
+  for (const other of [
+    { ...h.source, threadId: "200.1" },
+    { ...h.source, accountId: "other" },
+    { ...h.source, conversationId: "other" },
+    { ...h.source, agentId: "other" },
+  ]) {
+    await h.controller.activate(h.source, "is working...", "Inspect files");
+    await h.controller.handleLifecycle({
+      type: "finished",
+      batchId: "batch",
+      sources: [h.source],
+      remainingSources: [other],
+      outcome: "completed",
+      stopReason: "end_turn",
+    });
+    expect(h.writes.at(-1)).toBe("");
+    expect(h.controller.activeSources()).toEqual([]);
+  }
+});
+
+test("closing the controller prevents a queued refresh from writing", async () => {
+  const h = setup();
+  await h.controller.activate(h.source, "is working...", "Inspect files");
+  const refresh = h.controller.handleLifecycle({
+    type: "queued",
+    source: h.source,
+  });
+  h.controller.clear();
+  await refresh;
+  expect(h.setStatus).toHaveBeenCalledTimes(1);
+});

--- a/src/channels/types.ts
+++ b/src/channels/types.ts
@@ -159,6 +159,8 @@ export interface ChannelTurnSource {
   senderId?: string;
   /** Platform team/workspace for the triggering user, when known. */
   senderTeamId?: string;
+  /** The host already showed startup activity before delivering this input. */
+  showStartupStatus?: boolean;
   messageId?: string;
   threadId?: string | null;
   agentId: string;
@@ -217,6 +219,8 @@ export type ChannelTurnLifecycleEvent =
       sources: ChannelTurnSource[];
       outcome: ChannelTurnOutcome;
       stopReason: StopReasonType;
+      /** Other inputs still queued or running when this delivery finishes. */
+      remainingSources?: ChannelTurnSource[];
       error?: string;
       runId?: string;
     };


### PR DESCRIPTION
## Summary

Slack activity should stay visible once work starts, without flashing on every no-op thread notification. This puts lifecycle visibility in the shared Slack status controller. New input refreshes the current description, and finishing one delivery does not clear activity when another input in the same thread is still queued or running.

Hosts can mark an input with `source.showStartupStatus` when startup activity was already shown. The controller then continues with thinking instead of clearing that status at processing start. Warm existing threads still wait for concrete non-`MessageChannel` tool activity; top-level mentions still show thinking immediately.

## Before and after

| Sequence | Before | After |
| --- | --- | --- |
| Host showed waking before delivering in-thread input | Waking → empty status → first concrete tool or reply | Waking → thinking → tools if any → reply |
| New input during visible tool work | No refresh of the current status | Reassert the current description, even when unchanged |
| Turn finishes with another input queued | Clear, then wait for the next concrete tool | Retain activity until that work finishes or a reply is posted |
| Queued input is cancelled while a tool runs | Clear the running tool's activity | Keep the active turn's status |

Replies and terminal cleanup still end activity. A late status request cannot leave the indicator active after a reply. Failed submissions also clear carried activity when no input remains. The gateway reports remaining sources on completion; it does not change execution or implement a second queue.

## Verification

Red-first tests exercise the real gateway, progress builder, Slack adapter, and status controller with in-memory listener transport and fake Slack API writes. The baseline fails the cold handoff, missing steering refresh, queued continuation, and queued cancellation cases. Additional tests cover rejected input between turns, a status request completing after a reply, source isolation, approval continuation, and final cleanup.

- 78 focused gateway and Slack tests passed.
- `bun run check`: all 12 checks passed.

These tests verify outgoing status requests, not Slack's rendered UI. Live Slack-client visual verification is still unperformed. The immediate disappearance reported on new input is not attributed to a particular upstream event by this PR.

## Breadcrumbs

- Linear: LET-12454, including the settled decision tree and internal provenance.
- Letta conversation: [`conv-74cd8112-8595-4a61-9170-dee90f4bf684`](https://chat.letta.com/chat/agent-b86b0d3a-c425-4c88-86b9-44171f178713?conversation=conv-74cd8112-8595-4a61-9170-dee90f4bf684).
- Origin: [the assistant-status implementation](https://github.com/letta-ai/letta-code/pull/3279), later [exported for remote hosts](https://github.com/letta-ai/letta-code/pull/3374). No single introducing change was established for the immediate disappearance on steering.
