### PR TITLE
fix(skills): report image-generation credits only when asked

### DIFF
--- a/src/skills/builtin/image-generation/SKILL.md
+++ b/src/skills/builtin/image-generation/SKILL.md
@@ -37,7 +37,7 @@ else:
 with open("robot-mascot.png", "wb") as f:
     f.write(data)
 
-print("saved robot-mascot.png; credits:", response["billing"]["credits_charged"])
+print("saved robot-mascot.png")
 PY
 ```
 
@@ -63,7 +63,9 @@ The Letta Code UI renders local file paths in markdown image tags, so the image
 appears inline. **Always display generated images this way** — don't just report
 the path, and never paste the raw base64 / a `data:` URI. The markdown path must
 match where you saved the file. For `n > 1`, save each image to its own file and
-embed each on its own line. Also tell the user the `credits_charged`.
+embed each on its own line. Keep credit amounts and billing metadata out of
+user-facing replies and captions unless the user asks about cost. When asked,
+read `billing.credits_charged` from the saved response.
 
 ## Request body
 
@@ -117,8 +119,7 @@ DATA_URL="data:image/png;base64,$(base64 < input.png | tr -d '\n')"
 
 ## Notes
 
-- **Billing**: every success charges credits; don't loop needlessly, and report
-  `credits_charged`.
+- **Billing**: every success charges credits; don't loop needlessly.
 - **Errors**: `402` = insufficient credits (`credits_required` in body); `400`/`500`
   return `{ "message": "..." }` — surface it to the user.
 - Only `flux`, `gemini`, and `openai` are supported here.


### PR DESCRIPTION
## Summary

Image-generation replies should show the image without volunteering its credit cost. The bundled skill currently tells agents twice to report `credits_charged`, and its example prints the amount alongside the saved filename.

Remove those instructions and keep the saved response available for cost questions. The replacement agent-facing skill text is:

> Keep credit amounts and billing metadata out of user-facing replies and captions unless the user asks about cost. When asked, read `billing.credits_charged` from the saved response.

Billing and insufficient-credit error handling are unchanged.

## Verification

- `bun run check`: all 12 checks passed.
- Executed the skill's Python example against local base64 and URL fixtures. Both saved the image, printed only the filename, and retained the billing amount in the response JSON.
- Read the complete skill to check that no unconditional cost-reporting instruction remains. No paid generation or model-compliance evaluation was run for this prompt-only change.

## Breadcrumbs

- Origin: the unconditional reporting instructions were added in [the original image-generation skill](https://github.com/letta-ai/letta-code/pull/2788).
- Letta conversation: [`conv-c53a1b03-51d6-4ade-98cc-97023726a9e9`](https://chat.letta.com/chat/agent-b86b0d3a-c425-4c88-86b9-44171f178713?conversation=conv-c53a1b03-51d6-4ade-98cc-97023726a9e9).

## AI Tool(s) Used

Letta Code researched, edited, and verified this change.
