### PR TITLE
feat(cli): enqueue Cloud messages and support --no-wait [LET-12149]

### DIFF
--- a/scripts/source-file-size-baseline.json
+++ b/scripts/source-file-size-baseline.json
@@ -21,7 +21,7 @@
   "src/cli/mods/local-mod-loader.test.ts": 1043,
   "src/cli/reflection-transcript.test.ts": 1084,
   "src/cli/subcommands/skills.ts": 1264,
-  "src/headless.ts": 4888,
+  "src/headless.ts": 4884,
   "src/hooks/integration.test.ts": 1147,
   "src/index.ts": 2616,
   "src/mods/learning-harness.ts": 2434,

--- a/src/agent/subagent-env-composition.test.ts
+++ b/src/agent/subagent-env-composition.test.ts
@@ -51,6 +51,7 @@ describe("composeSubagentChildEnv", () => {
 
     expect(env[LETTA_DISABLE_MODS_ENV]).toBeUndefined();
     expect(env[LETTA_MOD_CAPABILITY_PROFILE_ENV]).toBeUndefined();
+    expect(env.LETTA_SUBAGENT_LAUNCH).toBe("1");
   });
 
   test("normal subagent records parent identity without overriding memory dir", () => {

--- a/src/agent/subagents/subagent-launcher.ts
+++ b/src/agent/subagents/subagent-launcher.ts
@@ -18,6 +18,7 @@ import {
   resolveEntryScriptPath,
   resolveLettaInvocation,
 } from "@/tools/impl/shell-env";
+import { SUBAGENT_LAUNCH_ENV } from "@/utils/subagent-launch-marker";
 import type { SubagentLaunchProfile, SubagentMemoryScope } from ".";
 
 interface ResolveSubagentLauncherOptions {
@@ -197,6 +198,7 @@ export function composeSubagentChildEnv(
     ...(inheritedBaseUrl && { LETTA_BASE_URL: inheritedBaseUrl }),
     ...(actingUserId && { [ACTING_USER_ID_ENV]: actingUserId }),
     LETTA_CODE_AGENT_ROLE: "subagent",
+    [SUBAGENT_LAUNCH_ENV]: "1",
     ...(subagentType === "reflection" && {
       [LETTA_MOD_CAPABILITY_PROFILE_ENV]: PROVIDERS_ONLY_MOD_CAPABILITY_PROFILE,
     }),

--- a/src/backend/api/conversation-enqueue.test.ts
+++ b/src/backend/api/conversation-enqueue.test.ts
@@ -1,0 +1,93 @@
+import { expect, test } from "bun:test";
+import { enqueueConversationMessage } from "./conversation-enqueue";
+import { ApiRequestError, type apiRequest } from "./request";
+
+test.each([undefined, "My laptop", "cloud"])(
+  "enqueue passes the selector and stable message ID: %s",
+  async (computer) => {
+    let body: Record<string, unknown> | undefined;
+    const request: typeof apiRequest = async <T>(
+      method: string,
+      path: string,
+      value?: Record<string, unknown>,
+    ) => {
+      expect(method).toBe("POST");
+      expect(path).toBe("/v1/conversations/conv-target/messages/enqueue");
+      body = value;
+      return {
+        client_message_id: "cm-1",
+        workflow_id: "wf-1",
+        super_run_id: "sr-1",
+      } as T;
+    };
+    const receipt = await enqueueConversationMessage(
+      {
+        agentId: "agent-target",
+        conversationId: "conv-target",
+        clientMessageId: "cm-1",
+        content: "hello",
+        computer,
+      },
+      undefined,
+      request,
+    );
+    expect(body?.computer).toBe(computer);
+    expect(body?.messages).toEqual([
+      { role: "user", content: "hello", client_message_id: "cm-1" },
+    ]);
+    expect(receipt).toEqual({
+      status: "queued",
+      agent_id: "agent-target",
+      conversation_id: "conv-target",
+      client_message_id: "cm-1",
+      workflow_id: "wf-1",
+      super_run_id: "sr-1",
+    });
+    expect(receipt).not.toHaveProperty("run_id");
+  },
+);
+
+test.each([400, 404, 409, 503])(
+  "HTTP %s never falls back to local execution or retries",
+  async (status) => {
+    let calls = 0;
+    const request: typeof apiRequest = async () => {
+      calls++;
+      throw new ApiRequestError("rejected", status, "");
+    };
+    await expect(
+      enqueueConversationMessage(
+        {
+          agentId: "agent-1",
+          conversationId: "conv-1",
+          clientMessageId: "cm-1",
+          content: "hello",
+        },
+        undefined,
+        request,
+      ),
+    ).rejects.toMatchObject({ status });
+    expect(calls).toBe(1);
+  },
+);
+
+test("a mismatched receipt does not confirm the requested send", async () => {
+  const request: typeof apiRequest = async <T>() =>
+    ({
+      client_message_id: "another-send",
+      workflow_id: "wf",
+      super_run_id: "sr",
+    }) as T;
+  await expect(
+    enqueueConversationMessage(
+      {
+        agentId: "agent-1",
+        conversationId: "conv-1",
+        clientMessageId: "cm-1",
+        content: "hi",
+      },
+      undefined,
+      request,
+    ),
+  ).rejects.toThrow("acceptance is unknown");
+});

--- a/src/backend/api/conversation-enqueue.ts
+++ b/src/backend/api/conversation-enqueue.ts
@@ -1,0 +1,142 @@
+import { Stream } from "@letta-ai/letta-client/core/streaming";
+import type { MessageCreate } from "@letta-ai/letta-client/resources/agents/agents";
+import type { Message } from "@letta-ai/letta-client/resources/agents/messages";
+import { getClient } from "./client";
+import { ApiRequestError, apiFetch, apiRequest } from "./request";
+
+export interface EnqueueReceipt {
+  status: "queued";
+  agent_id: string;
+  conversation_id: string;
+  client_message_id: string;
+  workflow_id: string;
+  super_run_id: string;
+}
+
+export interface EnqueueConversationInput {
+  agentId: string;
+  conversationId: string;
+  clientMessageId: string;
+  content: MessageCreate["content"];
+  computer?: string;
+}
+
+/** Cloud owns delivery after this request returns 202. Never retry by executing locally. */
+export async function enqueueConversationMessage(
+  input: EnqueueConversationInput,
+  signal?: AbortSignal,
+  request = apiRequest,
+): Promise<EnqueueReceipt> {
+  const accepted = await request<
+    Pick<EnqueueReceipt, "client_message_id" | "workflow_id" | "super_run_id">
+  >(
+    "POST",
+    `/v1/conversations/${encodeURIComponent(input.conversationId)}/messages/enqueue`,
+    {
+      agent_id: input.agentId,
+      client_message_id: input.clientMessageId,
+      ...(input.computer !== undefined ? { computer: input.computer } : {}),
+      messages: [
+        {
+          role: "user",
+          content: input.content,
+          client_message_id: input.clientMessageId,
+        },
+      ],
+    },
+    { signal },
+  );
+  if (
+    accepted.client_message_id !== input.clientMessageId ||
+    !accepted.workflow_id ||
+    !accepted.super_run_id
+  ) {
+    throw new Error(
+      "Enqueue returned an invalid receipt; acceptance is unknown. Do not resend automatically.",
+    );
+  }
+  return {
+    ...accepted,
+    status: "queued",
+    agent_id: input.agentId,
+    conversation_id: input.conversationId,
+  };
+}
+
+/** Relevant fields from the existing Cloud conversation Super Run feed. */
+export interface ConversationSendStatus {
+  conversation_id: string;
+  active_super_runs: Array<{ id: string; status: string }>;
+  runtime_status: {
+    state: string;
+    loop_state: {
+      status: string;
+      client_message_ids_by_run_id?: Record<string, string[]>;
+    } | null;
+  } | null;
+}
+
+export type ConversationStatusEvent =
+  | {
+      type: "conversation_super_run_snapshot";
+      statuses: ConversationSendStatus[];
+    }
+  | {
+      type: "conversation_super_run_update";
+      conversation_id: string;
+      status: ConversationSendStatus | null;
+    };
+
+export async function openConversationStatusStream(
+  agentId: string,
+  controller: AbortController,
+): Promise<AsyncIterable<ConversationStatusEvent>> {
+  const response = await apiFetch(
+    `/v1/agents/${encodeURIComponent(agentId)}/super-runs/stream`,
+    { signal: controller.signal, headers: { Accept: "text/event-stream" } },
+  );
+  if (!response.ok) {
+    throw new ApiRequestError(
+      "Could not subscribe to conversation status",
+      response.status,
+      await response.text(),
+    );
+  }
+  return Stream.fromSSEResponse<ConversationStatusEvent>(response, controller);
+}
+
+export async function listEnqueuedRunMessages(
+  runId: string,
+  signal?: AbortSignal,
+): Promise<Message[]> {
+  const client = await getClient();
+  const result: Message[] = [];
+  for await (const message of client.runs.messages.list(
+    runId,
+    { limit: 100 },
+    { signal },
+  )) {
+    result.push(message);
+  }
+  return result;
+}
+
+export interface LatestConversationSuperRun {
+  id: string;
+  status: string;
+  completed_at: string | null;
+  cancelled_at: string | null;
+  errored_at: string | null;
+}
+
+export async function getLatestConversationSuperRun(
+  conversationId: string,
+  signal?: AbortSignal,
+): Promise<LatestConversationSuperRun> {
+  return apiRequest(
+    "GET",
+    `/v1/conversations/${encodeURIComponent(conversationId)}/super-run`,
+    undefined,
+    { signal },
+  );
+}

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -156,6 +156,17 @@ export const CLI_FLAG_CATALOG = {
       continuationLines: ["Default: text"],
     },
   },
+  "no-wait": {
+    parser: { type: "boolean" },
+    mode: "headless",
+    help: {
+      description:
+        "Submit a Cloud message and return its acceptance receipt without waiting for an answer",
+      continuationLines: [
+        "Use --conversation or --agent to select the destination.",
+      ],
+    },
+  },
   "input-format": {
     parser: { type: "string" },
     mode: "headless",

--- a/src/cli/subcommands/message-status.test.ts
+++ b/src/cli/subcommands/message-status.test.ts
@@ -1,0 +1,39 @@
+import { expect, test } from "bun:test";
+import type { Backend } from "@/backend";
+import { readMessageStatus } from "./message-status";
+
+test("status works without a local task and does not equate idle with successful delivery", async () => {
+  const backend = {
+    capabilities: { environmentRouting: true },
+    retrieveConversation: async () => ({ agent_id: "agent-target" }),
+  } as unknown as Backend;
+  const result = await readMessageStatus("conv-target", undefined, backend, {
+    getAgentRuntimeStatus: async () => ({
+      agent_id: "agent-target",
+      snapshot_at: 0,
+      statuses: [
+        {
+          conversation_id: "conv-target",
+          state: "IDLE",
+          active_run_ids: [],
+          loop_state: null,
+          last_activity_at: 0,
+        },
+      ],
+    }),
+    getLatestConversationSuperRun: async () => ({
+      id: "sr-newer",
+      status: "COM",
+      completed_at: "now",
+      errored_at: null,
+      cancelled_at: null,
+    }),
+  });
+  expect(result).toMatchObject({
+    agent_id: "agent-target",
+    latest_super_run: { id: "sr-newer" },
+  });
+  expect(JSON.stringify(result)).toContain(
+    "not confirmation that a particular message completed",
+  );
+});

--- a/src/cli/subcommands/message-status.ts
+++ b/src/cli/subcommands/message-status.ts
@@ -1,0 +1,44 @@
+import type { Backend } from "@/backend";
+import { getAgentRuntimeStatus } from "@/backend/api/agents";
+import { getLatestConversationSuperRun } from "@/backend/api/conversation-enqueue";
+import { ApiRequestError } from "@/backend/api/request";
+
+/** Inspection works for any readable conversation, without a local Task ID. */
+export async function readMessageStatus(
+  conversationId: string,
+  agentId: string | undefined,
+  backend: Pick<Backend, "capabilities" | "retrieveConversation">,
+  deps = { getAgentRuntimeStatus, getLatestConversationSuperRun },
+): Promise<object> {
+  if (!backend.capabilities.environmentRouting)
+    throw new Error(
+      "Message status is only available for Cloud conversations.",
+    );
+  if (conversationId !== "default") {
+    const conversation = await backend.retrieveConversation(conversationId);
+    if (agentId && conversation.agent_id !== agentId)
+      throw new Error("The conversation does not belong to that agent.");
+    agentId = conversation.agent_id ?? undefined;
+  }
+  if (!agentId) throw new Error("--conversation default requires --agent.");
+  const runtime = await deps.getAgentRuntimeStatus(agentId, [conversationId]);
+  let latest = null;
+  if (conversationId !== "default") {
+    try {
+      latest = await deps.getLatestConversationSuperRun(conversationId);
+    } catch (error) {
+      if (!(error instanceof ApiRequestError && error.status === 404))
+        throw error;
+    }
+  }
+  return {
+    agent_id: agentId,
+    conversation_id: conversationId,
+    runtime_status:
+      runtime.statuses.find(
+        (status) => status.conversation_id === conversationId,
+      ) ?? null,
+    latest_super_run: latest,
+    note: "This is the conversation's current state, not confirmation that a particular message completed. Compare latest_super_run.id with your receipt; a different ID belongs to a different send. Use messages list to inspect the conversation.",
+  };
+}

--- a/src/cli/subcommands/messages.ts
+++ b/src/cli/subcommands/messages.ts
@@ -4,6 +4,7 @@ import { parseArgs } from "node:util";
 import { getBackend } from "@/backend";
 import { searchMessagesForBackend } from "@/backend/message-search";
 import { settingsManager } from "@/settings-manager";
+import { readMessageStatus } from "./message-status";
 
 type SearchMode = "vector" | "fts" | "hybrid";
 type ListOrder = "asc" | "desc";
@@ -12,6 +13,7 @@ type MessagesSubcommandDeps = {
   initializeSettings?: () => Promise<void>;
   getBackend?: typeof getBackend;
   searchMessagesForBackend?: typeof searchMessagesForBackend;
+  readMessageStatus?: typeof readMessageStatus;
 };
 
 type TranscriptMessage = {
@@ -49,6 +51,7 @@ Usage:
   letta messages search --query <text> [options]
   letta messages list [options]
   letta messages transcript --conversation <id> [options]
+  letta messages status --conversation <id> [--agent <id>]
 
 Search options:
   --query <text>        Search query (required)
@@ -186,6 +189,24 @@ export async function runMessagesSubcommand(
   try {
     await (deps.initializeSettings ?? (() => settingsManager.initialize()))();
     const backend = (deps.getBackend ?? getBackend)();
+    if (action === "status") {
+      const conversationId =
+        parsed.values.conversation || parsed.values["conversation-id"];
+      if (!conversationId)
+        throw new Error("Pass --conversation <id> to inspect message status.");
+      console.log(
+        JSON.stringify(
+          await (deps.readMessageStatus ?? readMessageStatus)(
+            conversationId,
+            parsed.values.agent || parsed.values["agent-id"],
+            backend,
+          ),
+          null,
+          2,
+        ),
+      );
+      return 0;
+    }
     const searchMessages =
       deps.searchMessagesForBackend ?? searchMessagesForBackend;
 

--- a/src/headless-cloud-send.test.ts
+++ b/src/headless-cloud-send.test.ts
@@ -1,0 +1,444 @@
+import { expect, test } from "bun:test";
+import type { Backend } from "@/backend";
+import type {
+  ConversationStatusEvent,
+  EnqueueConversationInput,
+} from "@/backend/api/conversation-enqueue";
+import { ApiRequestError } from "@/backend/api/request";
+import { parseCliArgs } from "@/cli/args";
+import {
+  buildAgentSendReminder,
+  shouldEnqueueCloudSend,
+  tryCloudHeadlessSend,
+} from "./headless-cloud-send";
+
+const flags = (...args: string[]) => parseCliArgs(args, true).values;
+function fixture() {
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  const submissions: EnqueueConversationInput[] = [];
+  const backend = {
+    capabilities: { environmentRouting: true },
+    retrieveConversation: async () => ({
+      id: "conv-target",
+      agent_id: "agent-target",
+    }),
+    retrieveAgent: async (id: string) => ({
+      id,
+      llm_config: { model: "test-model" },
+    }),
+    createConversation: async () => ({ id: "conv-new" }),
+    retrieveRun: async () => ({
+      id: "run-1",
+      status: "completed",
+      stop_reason: "end_turn",
+    }),
+  } as unknown as Backend;
+  const deps = {
+    env: { AGENT_ID: "agent-parent", CONVERSATION_ID: "conv-parent" },
+    writeStdout: async (text: string) => {
+      stdout.push(text);
+    },
+    writeStderr: (text: string) => {
+      stderr.push(text);
+    },
+    enqueue: async (input: EnqueueConversationInput) => {
+      submissions.push(input);
+      return {
+        status: "queued" as const,
+        agent_id: input.agentId,
+        conversation_id: input.conversationId,
+        client_message_id: input.clientMessageId,
+        workflow_id: "wf-1",
+        super_run_id: "sr-1",
+      };
+    },
+    openStatusStream: async () => {
+      throw new Error("no-wait must not subscribe");
+    },
+  };
+  return { backend, deps, stdout, stderr, submissions };
+}
+
+test.each(["text", "json", "stream-json"])(
+  "no-wait %s exits on HTTP acceptance with a receipt and recovery commands",
+  async (format) => {
+    const f = fixture();
+    const result = await tryCloudHeadlessSend(
+      flags(
+        "--conversation",
+        "conv-target",
+        "--no-wait",
+        "--output-format",
+        format,
+      ),
+      "hello",
+      f.backend,
+      false,
+      f.deps,
+    );
+    expect(result).toBe(0);
+    expect(f.submissions).toHaveLength(1);
+    const receipt = JSON.parse(f.stdout.join(""));
+    expect(receipt).toMatchObject({
+      status: "queued",
+      agent_id: "agent-target",
+      conversation_id: "conv-target",
+      workflow_id: "wf-1",
+      super_run_id: "sr-1",
+    });
+    expect(receipt.status_command).toContain("letta messages status");
+    expect(receipt).not.toHaveProperty("run_id");
+    expect(f.submissions[0]?.content).toContain(
+      "agent-parent, conversation conv-parent",
+    );
+    expect(f.submissions[0]?.content).toContain(
+      "use SendAgentMessage if available",
+    );
+    expect(f.submissions[0]?.content).toContain(
+      "Ordinary assistant output is not forwarded",
+    );
+    expect(f.deps.env.CONVERSATION_ID).toBe("conv-parent");
+  },
+);
+
+test("computer is forwarded to enqueue without a direct environment send", async () => {
+  const f = fixture();
+  await tryCloudHeadlessSend(
+    flags(
+      "--conversation",
+      "conv-target",
+      "--computer",
+      "My laptop",
+      "--no-wait",
+    ),
+    "hello",
+    f.backend,
+    false,
+    f.deps,
+  );
+  expect(f.submissions[0]?.computer).toBe("My laptop");
+});
+
+test("empty computer never falls through to local execution, and cloud-sandbox remains an alias", async () => {
+  const f = fixture();
+  expect(shouldEnqueueCloudSend(flags("--computer", ""), true, false)).toBe(
+    true,
+  );
+  expect(
+    await tryCloudHeadlessSend(
+      flags("--conversation", "conv-target", "--computer", "", "--no-wait"),
+      "hi",
+      f.backend,
+      false,
+      f.deps,
+    ),
+  ).toBe(1);
+  expect(f.submissions).toHaveLength(0);
+  await tryCloudHeadlessSend(
+    flags(
+      "--conversation",
+      "conv-target",
+      "--environment",
+      "cloud-sandbox",
+      "--no-wait",
+    ),
+    "hi",
+    f.backend,
+    false,
+    f.deps,
+  );
+  expect(f.submissions[0]?.computer).toBe("cloud");
+});
+
+test("non-waiting output waits for HTTP acceptance, not merely the start of the request", async () => {
+  const f = fixture();
+  let accept = () => {};
+  let observed = () => {};
+  const accepted = new Promise<void>((resolve) => {
+    accept = resolve;
+  });
+  const started = new Promise<void>((resolve) => {
+    observed = resolve;
+  });
+  const result = tryCloudHeadlessSend(
+    flags("--conversation", "conv-target", "--no-wait"),
+    "hi",
+    f.backend,
+    false,
+    {
+      ...f.deps,
+      enqueue: async (input) => {
+        observed();
+        await accepted;
+        return f.deps.enqueue(input);
+      },
+    },
+  );
+  await started;
+  expect(f.stdout).toHaveLength(0);
+  accept();
+  expect(await result).toBe(0);
+  expect(JSON.parse(f.stdout.join("")).status).toBe("queued");
+});
+
+test("a network failure cannot claim the server rejected the send", async () => {
+  const f = fixture();
+  await tryCloudHeadlessSend(
+    flags(
+      "--conversation",
+      "conv-target",
+      "--no-wait",
+      "--output-format",
+      "json",
+    ),
+    "hi",
+    f.backend,
+    false,
+    {
+      ...f.deps,
+      enqueue: async () => {
+        throw new Error("connection reset");
+      },
+    },
+  );
+  expect(JSON.parse(f.stdout.join(""))).toMatchObject({
+    status: "acceptance_unknown",
+    conversation_id: "conv-target",
+  });
+});
+
+test.each([400, 404, 409, 503])(
+  "HTTP %s is returned without executing locally",
+  async (status) => {
+    const f = fixture();
+    const result = await tryCloudHeadlessSend(
+      flags(
+        "--conversation",
+        "conv-target",
+        "--no-wait",
+        "--output-format",
+        "json",
+      ),
+      "hello",
+      f.backend,
+      false,
+      {
+        ...f.deps,
+        enqueue: async () => {
+          throw new ApiRequestError("rejected", status, "{}");
+        },
+      },
+    );
+    expect(result).toBe(1);
+    expect(JSON.parse(f.stdout.join(""))).toMatchObject({
+      http_status: status,
+      is_error: true,
+    });
+  },
+);
+
+test("explicit sender keeps its identity but cannot borrow another sender's return conversation", async () => {
+  const f = fixture();
+  await tryCloudHeadlessSend(
+    flags(
+      "--conversation",
+      "conv-target",
+      "--from-agent",
+      "agent-other",
+      "--no-wait",
+    ),
+    "hello",
+    f.backend,
+    false,
+    f.deps,
+  );
+  expect(f.submissions[0]?.content).toContain("agent-other");
+  expect(f.submissions[0]?.content).not.toContain("conv-parent");
+  expect(f.submissions[0]?.content).toContain("No return conversation");
+});
+
+test("missing sender context adds no fabricated return address", () => {
+  expect(buildAgentSendReminder({}, true)).toBe("");
+  expect(buildAgentSendReminder({ agentId: "agent-a" }, true)).toContain(
+    "No return conversation",
+  );
+  expect(
+    buildAgentSendReminder(
+      { agentId: "agent-a", conversationId: "conv-a" },
+      false,
+    ),
+  ).toContain("only see the final message");
+});
+
+test("unsafe IDs cannot enter a reply command", async () => {
+  const f = fixture();
+  const result = await tryCloudHeadlessSend(
+    flags("--conversation", "conv-target", "--no-wait"),
+    "hi",
+    f.backend,
+    false,
+    {
+      ...f.deps,
+      env: {
+        AGENT_ID: "agent-parent",
+        CONVERSATION_ID: "conv-a; curl attacker",
+      },
+    },
+  );
+  expect(result).toBe(1);
+  expect(f.submissions).toHaveLength(0);
+});
+
+test("two concurrent callers retain independent return addresses and message IDs", async () => {
+  const a = fixture();
+  const b = fixture();
+  b.deps.env = { AGENT_ID: "agent-second", CONVERSATION_ID: "conv-second" };
+  await Promise.all(
+    [a, b].map((f) =>
+      tryCloudHeadlessSend(
+        flags("--conversation", "conv-target", "--no-wait"),
+        "hello",
+        f.backend,
+        false,
+        f.deps,
+      ),
+    ),
+  );
+  expect(a.submissions[0]?.content).toContain("conv-parent");
+  expect(b.submissions[0]?.content).toContain("conv-second");
+  expect(a.submissions[0]?.clientMessageId).not.toBe(
+    b.submissions[0]?.clientMessageId,
+  );
+});
+
+test("Agent fresh, resume, and fork process entrypoints are not silently rerouted", async () => {
+  for (const args of [
+    ["--new-agent"],
+    ["--conversation", "conv-resumed"],
+    ["--conversation", "conv-fork"],
+    ["--agent", "agent-child", "--new"],
+    ["--conversation", "conv-child", "--computer", "cloud"],
+  ]) {
+    const f = fixture();
+    expect(
+      await tryCloudHeadlessSend(
+        flags(...args),
+        "hello",
+        f.backend,
+        true,
+        f.deps,
+      ),
+    ).toBeUndefined();
+    expect(f.submissions).toHaveLength(0);
+  }
+});
+
+test("Bash sends from a child use enqueue after its one-shot launch marker is consumed", () => {
+  expect(
+    shouldEnqueueCloudSend(flags("--conversation", "conv-parent"), true, false),
+  ).toBe(true);
+});
+
+test("fresh local and App Server paths remain execution paths", () => {
+  expect(
+    shouldEnqueueCloudSend(flags("--conversation", "conv-local"), false, false),
+  ).toBe(false);
+  expect(shouldEnqueueCloudSend(flags("--new-agent"), true, false)).toBe(false);
+  expect(shouldEnqueueCloudSend(flags("--agent", "agent-1"), true, false)).toBe(
+    false,
+  );
+});
+
+test("request-scoped tool restrictions are rejected rather than lost at enqueue", async () => {
+  const f = fixture();
+  expect(
+    await tryCloudHeadlessSend(
+      flags("--conversation", "conv-target", "--tools", "Read", "--no-wait"),
+      "hi",
+      f.backend,
+      false,
+      f.deps,
+    ),
+  ).toBe(1);
+  expect(f.submissions).toHaveLength(0);
+});
+
+test.each(["text", "json", "stream-json"])(
+  "waiting %s subscribes before submission and preserves the stdout format",
+  async (format) => {
+    const f = fixture();
+    const order: string[] = [];
+    let submitted: EnqueueConversationInput | undefined;
+    const result = await tryCloudHeadlessSend(
+      flags("--conversation", "conv-target", "--output-format", format),
+      "hi",
+      f.backend,
+      false,
+      {
+        ...f.deps,
+        openStatusStream: async () => ({
+          async *[Symbol.asyncIterator](): AsyncGenerator<ConversationStatusEvent> {
+            order.push("subscribed");
+            yield { type: "conversation_super_run_snapshot", statuses: [] };
+            if (!submitted)
+              throw new Error("must submit before reading run updates");
+            yield {
+              type: "conversation_super_run_update",
+              conversation_id: "conv-target",
+              status: {
+                conversation_id: "conv-target",
+                active_super_runs: [],
+                runtime_status: {
+                  state: "ACTIVE",
+                  loop_state: {
+                    status: "WAITING_ON_INPUT",
+                    client_message_ids_by_run_id: {
+                      "run-1": [submitted.clientMessageId],
+                    },
+                  },
+                },
+              },
+            };
+            await new Promise(() => {});
+          },
+        }),
+        enqueue: async (input) => {
+          order.push("submitted");
+          submitted = input;
+          return f.deps.enqueue(input);
+        },
+        latestSuperRun: async () => ({
+          id: "sr-1",
+          status: "QUE",
+          completed_at: null,
+          cancelled_at: null,
+          errored_at: null,
+        }),
+        listRunMessages: async () => [
+          {
+            id: "answer",
+            message_type: "assistant_message",
+            content: "done",
+            date: "2026-09-01T00:00:00Z",
+          },
+        ],
+      },
+    );
+    expect(result).toBe(0);
+    expect(order).toEqual(["subscribed", "submitted"]);
+    if (format === "text") expect(f.stdout.join("")).toBe("done\n");
+    else if (format === "json")
+      expect(JSON.parse(f.stdout.join("")).result).toBe("done");
+    else {
+      const events = f.stdout.map((line) => JSON.parse(line));
+      expect(events.map(({ type, subtype }) => [type, subtype])).toEqual([
+        ["system", "init"],
+        ["result", "success"],
+      ]);
+      expect(events.at(-1).result).toBe("done");
+    }
+    expect(f.stderr.join("")).toContain('"status":"queued"');
+    expect(submitted?.content).toContain("only see the final message");
+  },
+);

--- a/src/headless-cloud-send.ts
+++ b/src/headless-cloud-send.ts
@@ -1,0 +1,403 @@
+import { randomUUID } from "node:crypto";
+import type { Backend } from "@/backend";
+import {
+  type EnqueueReceipt,
+  enqueueConversationMessage,
+  getLatestConversationSuperRun,
+  listEnqueuedRunMessages,
+  openConversationStatusStream,
+} from "@/backend/api/conversation-enqueue";
+import { ApiRequestError } from "@/backend/api/request";
+import type { ParsedCliArgs } from "@/cli/args";
+import { normalizeConversationShorthandFlags } from "@/cli/flag-utils";
+import type { SystemInitMessage } from "@/types/protocol";
+import {
+  EnqueuedWaitError,
+  waitForEnqueuedReply,
+} from "./headless-enqueue-wait";
+import {
+  isCloudEnvironmentSelector,
+  resolveEnvironmentMaxWaitMs,
+} from "./headless-environment-response";
+
+type SendValues = ParsedCliArgs["values"];
+type SendBackend = Pick<
+  Backend,
+  "capabilities" | "retrieveConversation" | "createConversation" | "retrieveRun"
+>;
+
+export function shouldEnqueueCloudSend(
+  values: SendValues,
+  cloud: boolean,
+  isAgentLaunch: boolean,
+): boolean {
+  if (!cloud || isAgentLaunch || values["new-agent"] || values.ephemeral)
+    return false;
+  return Boolean(
+    values.conversation ||
+      values["from-agent"] ||
+      values["no-wait"] ||
+      values.computer !== undefined ||
+      values.environment !== undefined ||
+      values.env !== undefined,
+  );
+}
+
+export function buildAgentSendReminder(
+  sender: { agentId?: string; conversationId?: string },
+  noWait: boolean,
+): string {
+  if (!sender.agentId) return "";
+  const address = sender.conversationId
+    ? `, conversation ${sender.conversationId}`
+    : "";
+  const instruction = !noWait
+    ? "The sender will only see the final message you generate (not tool calls or reasoning). Include your answer in your final response."
+    : sender.conversationId
+      ? `To reply to agent ${sender.agentId}${address}, use SendAgentMessage if available. Otherwise run letta -p --agent ${sender.agentId} --conversation ${sender.conversationId} --no-wait "your reply". Ordinary assistant output is not forwarded to the sender.`
+      : "Ordinary assistant output is not forwarded to the sender. No return conversation was supplied.";
+  return `<system-reminder>\nThis message is from agent ${sender.agentId}${address}.\n${instruction}\n</system-reminder>\n\n`;
+}
+
+function validateAddress(
+  value: string | undefined,
+  kind: "agent" | "conversation",
+): string | undefined {
+  if (!value) return undefined;
+  if (kind === "conversation" && value === "default") return value;
+  const prefix = kind === "agent" ? "agent" : "conv";
+  if (!new RegExp(`^${prefix}-[a-zA-Z0-9-]+$`).test(value)) {
+    throw new Error(`Invalid ${kind} ID: ${JSON.stringify(value)}`);
+  }
+  return value;
+}
+
+function validateSendOptions(values: SendValues): void {
+  if (values.resume)
+    throw new Error(
+      "--resume is interactive-only; use --conversation <id> in headless mode.",
+    );
+  const computer = values.computer ?? values.environment ?? values.env;
+  if (computer !== undefined && !computer.trim())
+    throw new Error("Computer selector must not be empty.");
+  if (values["input-format"])
+    throw new Error(
+      "Cloud message delivery does not support --input-format stream-json.",
+    );
+  if (values.new && values.conversation)
+    throw new Error("--new cannot be combined with --conversation.");
+  // Enqueue runs with the receiving listener's configuration. These flags
+  // cannot silently change that configuration or weaken its restrictions.
+  for (const flag of [
+    "tools",
+    "allowedTools",
+    "disallowedTools",
+    "permission-mode",
+    "yolo",
+    "model",
+    "system",
+    "system-custom",
+    "pre-load-skills",
+    "max-turns",
+    "memfs",
+    "stateless",
+    "personality",
+    "base-tools",
+    "no-skills",
+    "no-bundled-skills",
+    "skill-sources",
+    "skills",
+    "toolset",
+  ] as const) {
+    if (values[flag] !== undefined && values[flag] !== false) {
+      throw new Error(
+        `--${flag} configures local execution and is not supported when sending to an existing Cloud harness.`,
+      );
+    }
+  }
+}
+
+export interface CloudSendDeps {
+  enqueue?: typeof enqueueConversationMessage;
+  openStatusStream?: typeof openConversationStatusStream;
+  listRunMessages?: typeof listEnqueuedRunMessages;
+  latestSuperRun?: typeof getLatestConversationSuperRun;
+  writeStdout: (text: string) => Promise<void>;
+  writeStderr?: (text: string) => void;
+  env?: NodeJS.ProcessEnv;
+  timeoutMs?: number;
+}
+
+/** Return undefined for execution paths this PR intentionally leaves unchanged. */
+export async function tryCloudHeadlessSend(
+  values: SendValues,
+  prompt: string,
+  backend: SendBackend,
+  isAgentLaunch: boolean,
+  deps: CloudSendDeps,
+): Promise<number | undefined> {
+  if (
+    !shouldEnqueueCloudSend(
+      values,
+      backend.capabilities.environmentRouting,
+      isAgentLaunch,
+    )
+  ) {
+    if (values["no-wait"])
+      throw new Error(
+        "--no-wait requires a Cloud message destination; it is not supported for local execution or Agent process launches.",
+      );
+    return undefined;
+  }
+  const env = deps.env ?? process.env;
+  const format = values["output-format"] ?? "text";
+  const noWait = Boolean(values["no-wait"]);
+  const started = Date.now();
+  const clientMessageId = randomUUID();
+  const controller = new AbortController();
+  const submissionTimeout = setTimeout(
+    () =>
+      controller.abort(
+        new Error(
+          "Cloud submission timed out; inspect the conversation before resending.",
+        ),
+      ),
+    30_000,
+  );
+  const timeout = setTimeout(
+    () =>
+      controller.abort(
+        new Error("Stopped waiting; remote execution was not cancelled."),
+      ),
+    deps.timeoutMs ?? resolveEnvironmentMaxWaitMs(),
+  );
+  const interrupt = () =>
+    controller.abort(
+      new Error("Interrupted waiting; remote execution was not cancelled."),
+    );
+  process.once("SIGINT", interrupt);
+  let receipt: EnqueueReceipt | undefined;
+  let submissionAttempted = false;
+  let agentId: string | undefined;
+  let conversationId: string | undefined;
+  const stderr = deps.writeStderr ?? ((text) => process.stderr.write(text));
+  const writeObject = (value: object) =>
+    deps.writeStdout(
+      `${JSON.stringify(value, null, format === "stream-json" ? undefined : 2)}\n`,
+    );
+  try {
+    if (!["text", "json", "stream-json"].includes(format))
+      throw new Error(`Invalid output format: ${format}`);
+    validateSendOptions(values);
+    const explicitSender = values["from-agent"];
+    const ambientSender = env.AGENT_ID || env.LETTA_AGENT_ID;
+    const sender = {
+      agentId: validateAddress(explicitSender || ambientSender, "agent"),
+      // An explicit different sender cannot inherit this process's return conversation.
+      conversationId: validateAddress(
+        !explicitSender || explicitSender === ambientSender
+          ? env.CONVERSATION_ID || env.LETTA_CONVERSATION_ID
+          : undefined,
+        "conversation",
+      ),
+    };
+    const normalized = normalizeConversationShorthandFlags({
+      specifiedConversationId: values.conversation,
+      specifiedAgentId: values.agent,
+    });
+    agentId = validateAddress(
+      normalized.specifiedAgentId ?? undefined,
+      "agent",
+    );
+    conversationId = validateAddress(
+      normalized.specifiedConversationId ?? undefined,
+      "conversation",
+    );
+    if (
+      !agentId &&
+      !conversationId &&
+      !values.name &&
+      !explicitSender &&
+      !noWait &&
+      (values.computer || values.environment || values.env)
+    ) {
+      // Preserve the existing `--computer` shorthand for the ambient agent.
+      agentId = validateAddress(ambientSender, "agent");
+    }
+    if (!agentId && !conversationId)
+      throw new Error(
+        "Choose a destination with --agent or --conversation. Ambient AGENT_ID identifies the sender.",
+      );
+    if (conversationId && conversationId !== "default") {
+      const conversation = await backend.retrieveConversation(conversationId, {
+        signal: controller.signal,
+      });
+      if (agentId && agentId !== conversation.agent_id)
+        throw new Error(
+          "The conversation does not belong to the requested agent.",
+        );
+      agentId = conversation.agent_id ?? undefined;
+    }
+    if (!agentId) throw new Error("--conversation default requires --agent.");
+    if (!conversationId) {
+      const conversation = await backend.createConversation(
+        { agent_id: agentId, ...(sender.agentId ? { hidden: true } : {}) },
+        { signal: controller.signal },
+      );
+      conversationId = conversation.id;
+    }
+    const recovery = {
+      status_command: `letta messages status --agent ${agentId} --conversation ${conversationId}`,
+      messages_command: `letta messages list --agent ${agentId} --conversation ${conversationId}`,
+    };
+    // Subscribe and receive the initial snapshot BEFORE submitting. A status
+    // stream opened only after 202 can miss a fast run's exact send mapping.
+    const events = noWait
+      ? undefined
+      : (
+          await (deps.openStatusStream ?? openConversationStatusStream)(
+            agentId,
+            controller,
+          )
+        )[Symbol.asyncIterator]();
+    const initial = events ? await events.next() : undefined;
+    if (initial?.done)
+      throw new Error(
+        "Conversation status stream closed before submission; nothing was sent.",
+      );
+    submissionAttempted = true;
+    receipt = await (deps.enqueue ?? enqueueConversationMessage)(
+      {
+        agentId,
+        conversationId,
+        clientMessageId,
+        content: `${buildAgentSendReminder(sender, noWait)}${prompt}`,
+        computer: isCloudEnvironmentSelector(
+          values.computer ?? values.environment ?? values.env,
+        )
+          ? "cloud"
+          : (values.computer ?? values.environment ?? values.env),
+      },
+      AbortSignal.any([controller.signal, AbortSignal.timeout(30_000)]),
+    );
+    clearTimeout(submissionTimeout);
+    if (noWait) {
+      await writeObject({ ...receipt, ...recovery });
+      return 0;
+    }
+    if (!events || !initial || initial.done)
+      throw new Error("Missing conversation status subscription.");
+    if (format === "stream-json") {
+      const init: SystemInitMessage = {
+        type: "system",
+        subtype: "init",
+        session_id: agentId,
+        agent_id: agentId,
+        conversation_id: conversationId,
+        model: "",
+        tools: [],
+        cwd: "",
+        mcp_servers: [],
+        permission_mode: "",
+        slash_commands: [],
+        uuid: randomUUID(),
+      };
+      await writeObject(init);
+    }
+    stderr(`${JSON.stringify({ ...receipt, ...recovery })}\n`);
+    const reply = await waitForEnqueuedReply({
+      receipt,
+      events,
+      firstEvent: initial.value,
+      signal: controller.signal,
+      retrieveRun: (id) =>
+        backend.retrieveRun(id, { signal: controller.signal }),
+      listRunMessages: (id) =>
+        (deps.listRunMessages ?? listEnqueuedRunMessages)(
+          id,
+          controller.signal,
+        ),
+      latestSuperRun: async () => {
+        if (!conversationId || conversationId === "default") return null;
+        try {
+          return await (deps.latestSuperRun ?? getLatestConversationSuperRun)(
+            conversationId,
+            controller.signal,
+          );
+        } catch (error) {
+          if (error instanceof ApiRequestError && error.status === 404)
+            return null;
+          throw error;
+        }
+      },
+    });
+    if (format === "text") await deps.writeStdout(`${reply.text}\n`);
+    else
+      await writeObject({
+        type: "result",
+        subtype: "success",
+        is_error: false,
+        result: reply.text,
+        session_id: agentId,
+        ...receipt,
+        status: "completed",
+        run_ids: reply.runIds,
+        ...(reply.stopReason ? { stop_reason: reply.stopReason } : {}),
+        duration_ms: Date.now() - started,
+        duration_api_ms: 0,
+        num_turns: 1,
+        usage: null,
+        uuid: randomUUID(),
+        ...recovery,
+      });
+    return 0;
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    const result = {
+      type: "result",
+      subtype: "error",
+      is_error: true,
+      error: detail,
+      result: null,
+      session_id: agentId ?? "",
+      duration_ms: Date.now() - started,
+      duration_api_ms: 0,
+      num_turns: receipt ? 1 : 0,
+      run_ids: error instanceof EnqueuedWaitError ? error.runIds : [],
+      usage: null,
+      stop_reason: "error",
+      uuid: randomUUID(),
+      status: receipt
+        ? "wait_failed"
+        : submissionAttempted &&
+            !(
+              error instanceof ApiRequestError &&
+              error.status >= 400 &&
+              error.status < 500
+            )
+          ? "acceptance_unknown"
+          : "submission_failed",
+      agent_id: agentId ?? null,
+      conversation_id: conversationId ?? "",
+      client_message_id: clientMessageId,
+      ...(receipt ? { receipt } : {}),
+      ...(agentId && conversationId
+        ? {
+            status_command: `letta messages status --agent ${agentId} --conversation ${conversationId}`,
+            messages_command: `letta messages list --agent ${agentId} --conversation ${conversationId}`,
+          }
+        : {}),
+      ...(error instanceof ApiRequestError
+        ? { http_status: error.status }
+        : {}),
+    };
+    if (format === "text") stderr(`${JSON.stringify(result)}\n`);
+    else await writeObject(result);
+    return 1;
+  } finally {
+    clearTimeout(timeout);
+    clearTimeout(submissionTimeout);
+    process.removeListener("SIGINT", interrupt);
+    controller.abort();
+  }
+}

--- a/src/headless-cloud-startup.test.ts
+++ b/src/headless-cloud-startup.test.ts
@@ -1,0 +1,175 @@
+import { expect, test } from "bun:test";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { createIsolatedCliTestEnv } from "@/test-utils/test-process-env";
+
+async function runStartup(args: string[]) {
+  const home = await mkdtemp(join(tmpdir(), "letta-cloud-startup-"));
+  const requestLog = join(home, "requests.jsonl");
+  try {
+    await mkdir(join(home, ".letta"));
+    await writeFile(
+      join(home, ".letta", "settings.json"),
+      JSON.stringify({
+        agents: [{ agentId: "agent-named-target", pinned: true }],
+      }),
+    );
+    await writeFile(requestLog, "");
+    const child = Bun.spawn(
+      [
+        process.execPath,
+        `--config=${resolve(import.meta.dir, "..", "bunfig.toml")}`,
+        "--preload",
+        resolve(import.meta.dir, "test-utils/fixtures/cloud-send-startup.ts"),
+        resolve(import.meta.dir, "index.ts"),
+        "-p",
+        "startup target check",
+        "--backend",
+        "api",
+        ...args,
+      ],
+      {
+        cwd: home,
+        env: createIsolatedCliTestEnv({
+          HOME: home,
+          LETTA_MODEL_CATALOG_CACHE_DIR: join(home, "cache"),
+          LETTA_SKIP_KEYCHAIN_CHECK: "1",
+          LETTA_API_KEY: "test-only-no-network",
+          LETTA_BASE_URL: "https://api.letta.com",
+          CLI_STARTUP_REQUEST_LOG: requestLog,
+          LETTA_SUBAGENT_LAUNCH: undefined,
+        }),
+        stdin: "ignore",
+        stdout: "pipe",
+        stderr: "pipe",
+      },
+    );
+    const deadline = setTimeout(() => child.kill(), 20_000);
+    try {
+      const [code, stdout, stderr] = await Promise.all([
+        child.exited,
+        new Response(child.stdout).text(),
+        new Response(child.stderr).text(),
+      ]);
+      const requests = (await readFile(requestLog, "utf8"))
+        .trim()
+        .split("\n")
+        .filter(Boolean)
+        .map(
+          (line) =>
+            JSON.parse(line) as { method: string; path: string; body?: string },
+        );
+      return { code, stdout, stderr, requests };
+    } finally {
+      clearTimeout(deadline);
+    }
+  } finally {
+    await rm(home, { recursive: true, force: true });
+  }
+}
+
+test.each(
+  ["--computer", "--environment", "--env"].flatMap((selector) =>
+    ["--name", "-n"].map((nameFlag) => ({ selector, nameFlag })),
+  ),
+)(
+  "startup resolves the named recipient before Cloud delivery: %j",
+  async ({ selector, nameFlag }) => {
+    const result = await runStartup([
+      nameFlag,
+      "nAmEd ReCiPiEnT",
+      selector,
+      "My laptop",
+      "--no-wait",
+      "--output-format",
+      "json",
+    ]);
+    expect(result.stderr).not.toContain("Choose a destination");
+    expect(result.code, result.stderr).toBe(0);
+    const receipt = JSON.parse(result.stdout);
+    expect(receipt.agent_id).toBe("agent-named-target");
+    const send = result.requests.find((request) =>
+      request.path.endsWith("/messages/enqueue"),
+    );
+    expect(JSON.parse(send?.body ?? "{}")).toMatchObject({
+      agent_id: "agent-named-target",
+      computer: "My laptop",
+    });
+    expect(
+      result.requests.some(
+        (request) => request.path === "/v1/agents/agent-named-target",
+      ),
+    ).toBe(true);
+  },
+  25_000,
+);
+
+test.each([
+  { flag: "--model", value: "test-model" },
+  { flag: "--tools", value: "Read" },
+  { flag: "--allowedTools", value: "Read" },
+  { flag: "--disallowedTools", value: "Bash" },
+  { flag: "--permission-mode", value: "strict" },
+])(
+  "startup rejects unsupported recipient restrictions before submission: %j",
+  async ({ flag, value }) => {
+    const result = await runStartup([
+      "--name",
+      "Named Recipient",
+      "--computer",
+      "My laptop",
+      "--no-wait",
+      "--output-format",
+      "json",
+      flag,
+      value,
+    ]);
+    expect(result.code, result.stderr).toBe(1);
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      status: "submission_failed",
+    });
+    expect(JSON.parse(result.stdout).error).toContain(
+      `${flag} configures local execution`,
+    );
+    expect(
+      result.requests.filter(
+        (request) =>
+          request.method === "POST" && request.path.includes("/conversations"),
+      ),
+    ).toEqual([]);
+  },
+  25_000,
+);
+
+test.each([
+  {
+    destination: [],
+    error: "--from-agent requires --agent <id> or --conversation <id>",
+  },
+  {
+    destination: ["--conversation", "default"],
+    error: "--from-agent cannot be used with --new-agent",
+  },
+])(
+  "startup still rejects --new-agent plus --from-agent after skipping enqueue: %j",
+  async ({ destination, error }) => {
+    const result = await runStartup([
+      "--new-agent",
+      "--from-agent",
+      "agent-sender",
+      ...destination,
+    ]);
+    expect(result.code).toBe(1);
+    expect(result.stderr).toContain(error);
+    expect(
+      result.requests.filter(
+        (request) =>
+          request.method === "POST" &&
+          (request.path.replace(/\/$/, "") === "/v1/agents" ||
+            request.path.includes("/conversations")),
+      ),
+    ).toEqual([]);
+  },
+  25_000,
+);

--- a/src/headless-enqueue-wait.test.ts
+++ b/src/headless-enqueue-wait.test.ts
@@ -1,0 +1,216 @@
+import { expect, test } from "bun:test";
+import type {
+  Message,
+  Run,
+} from "@letta-ai/letta-client/resources/agents/messages";
+import type {
+  ConversationStatusEvent,
+  EnqueueReceipt,
+} from "@/backend/api/conversation-enqueue";
+import { waitForEnqueuedReply } from "./headless-enqueue-wait";
+
+const receipt: EnqueueReceipt = {
+  status: "queued",
+  agent_id: "agent-1",
+  conversation_id: "conv-1",
+  client_message_id: "cm-1",
+  workflow_id: "wf-1",
+  super_run_id: "sr-1",
+};
+function event(
+  correlations: Record<string, string[]>,
+): ConversationStatusEvent {
+  return {
+    type: "conversation_super_run_update",
+    conversation_id: "conv-1",
+    status: {
+      conversation_id: "conv-1",
+      active_super_runs: [],
+      runtime_status: {
+        state: "ACTIVE",
+        loop_state: {
+          status: "WAITING_ON_INPUT",
+          client_message_ids_by_run_id: correlations,
+        },
+      },
+    },
+  };
+}
+function assistant(text: string, runId: string): Message {
+  return {
+    id: `msg-${runId}`,
+    date: "2026-09-01T02:33:43Z",
+    message_type: "assistant_message",
+    content: [{ type: "text", text }],
+    run_id: runId,
+    seq_id: 10,
+  };
+}
+const neverEnds: AsyncIterator<ConversationStatusEvent> = {
+  next: () => new Promise(() => {}),
+};
+const base = {
+  receipt,
+  events: neverEnds,
+  signal: new AbortController().signal,
+  latestSuperRun: async () => null,
+  pollMs: 1,
+};
+
+test("Skill and approval continuation followed by an answer belongs to the original send", async () => {
+  let checks = 0;
+  let reads = 0;
+  const events: AsyncIterator<ConversationStatusEvent> = {
+    next: async () => {
+      if (reads++ === 0)
+        return {
+          done: false,
+          value: event({
+            "run-approval": ["cm-1"],
+            "run-final": ["cm-1"],
+            "run-next-human": ["cm-2"],
+          }),
+        };
+      return new Promise(() => {});
+    },
+  };
+  const reply = await waitForEnqueuedReply({
+    ...base,
+    events,
+    firstEvent: event({ "run-approval": ["cm-1"] }),
+    retrieveRun: async (id): Promise<Run> => {
+      checks++;
+      return {
+        id,
+        agent_id: "agent-1",
+        status: "completed",
+        stop_reason: id === "run-approval" ? "requires_approval" : "end_turn",
+      };
+    },
+    listRunMessages: async (id) => {
+      expect(id).toBe("run-final");
+      return [
+        {
+          id: "skill",
+          date: "2026-09-01T02:33:40Z",
+          message_type: "user_message",
+          content:
+            '<skill_content name="acquiring-skills">instructions</skill_content>',
+          run_id: id,
+        },
+        {
+          id: "task",
+          date: "2026-09-01T02:33:41Z",
+          message_type: "user_message",
+          content: "<task-notification>done</task-notification>",
+          run_id: id,
+        },
+        assistant("the requested answer", id),
+      ];
+    },
+  });
+  expect(checks).toBe(2);
+  expect(reply.text).toBe("the requested answer");
+  expect(reply.runIds).toEqual(["run-approval", "run-final"]);
+});
+
+test("a real subsequent human turn cannot supply the earlier answer", async () => {
+  const reply = await waitForEnqueuedReply({
+    ...base,
+    firstEvent: event({ "run-1": ["cm-1"], "run-2": ["cm-2"] }),
+    retrieveRun: async (id) => {
+      expect(id).toBe("run-1");
+      return {
+        id,
+        agent_id: "agent-1",
+        status: "completed",
+        stop_reason: "end_turn",
+      };
+    },
+    listRunMessages: async (id) => [assistant("first answer", id)],
+  });
+  expect(reply.text).toBe("first answer");
+  expect(reply.runIds).toEqual(["run-1"]);
+});
+
+test.each(["failed", "cancelled"] as const)(
+  "remote %s terminates informatively",
+  async (status) => {
+    await expect(
+      waitForEnqueuedReply({
+        ...base,
+        firstEvent: event({ "run-1": ["cm-1"] }),
+        retrieveRun: async () => ({ id: "run-1", agent_id: "agent-1", status }),
+        listRunMessages: async () => [],
+      }),
+    ).rejects.toThrow(`run-1 ${status}`);
+  },
+);
+
+test("idle without a message mapping is not completion", async () => {
+  const controller = new AbortController();
+  let reads = 0;
+  await expect(
+    waitForEnqueuedReply({
+      ...base,
+      signal: controller.signal,
+      firstEvent: event({}),
+      retrieveRun: async () => {
+        throw new Error("must not guess a run");
+      },
+      listRunMessages: async () => [],
+      latestSuperRun: async () => {
+        if (++reads === 2) controller.abort(new Error("wait deadline"));
+        return null;
+      },
+    }),
+  ).rejects.toThrow("wait deadline");
+});
+
+test("delivery failure before any run is a failure, not an empty successful answer", async () => {
+  await expect(
+    waitForEnqueuedReply({
+      ...base,
+      firstEvent: event({}),
+      retrieveRun: async () => ({ id: "run-unexpected", agent_id: "agent-1" }),
+      listRunMessages: async () => [],
+      latestSuperRun: async () => ({
+        id: "sr-1",
+        status: "CAN",
+        cancelled_at: "now",
+        errored_at: "now",
+        completed_at: null,
+      }),
+    }),
+  ).rejects.toThrow("failed before a run");
+});
+
+test("closed status stream does not resend or infer completion", async () => {
+  await expect(
+    waitForEnqueuedReply({
+      ...base,
+      firstEvent: event({}),
+      events: { next: async () => ({ done: true, value: undefined }) },
+      retrieveRun: async () => ({ id: "run-unexpected", agent_id: "agent-1" }),
+      listRunMessages: async () => [],
+    }),
+  ).rejects.toThrow("connection closed");
+});
+
+test("completed run allows the final message to become visible on a later read", async () => {
+  let reads = 0;
+  const reply = await waitForEnqueuedReply({
+    ...base,
+    firstEvent: event({ "run-1": ["cm-1"] }),
+    retrieveRun: async () => ({
+      id: "run-1",
+      agent_id: "agent-1",
+      status: "completed",
+      stop_reason: "end_turn",
+    }),
+    listRunMessages: async () =>
+      ++reads === 1 ? [] : [assistant("visible now", "run-1")],
+  });
+  expect(reply.text).toBe("visible now");
+  expect(reads).toBe(2);
+});

--- a/src/headless-enqueue-wait.ts
+++ b/src/headless-enqueue-wait.ts
@@ -1,0 +1,163 @@
+import type {
+  Message,
+  Run,
+} from "@letta-ai/letta-client/resources/agents/messages";
+import type { StopReasonType } from "@letta-ai/letta-client/resources/runs/runs";
+import type {
+  ConversationSendStatus,
+  ConversationStatusEvent,
+  EnqueueReceipt,
+  LatestConversationSuperRun,
+} from "@/backend/api/conversation-enqueue";
+
+/** A send may span approval continuations. Only listener-published run IDs belong to it. */
+export function getSendRunIds(
+  status: ConversationSendStatus | null,
+  clientMessageId: string,
+): string[] {
+  return Object.entries(
+    status?.runtime_status?.loop_state?.client_message_ids_by_run_id ?? {},
+  )
+    .filter(([, ids]) => ids.includes(clientMessageId))
+    .map(([runId]) => runId);
+}
+
+export function getConversationStatus(
+  event: ConversationStatusEvent,
+  conversationId: string,
+): ConversationSendStatus | null | undefined {
+  if (event.type === "conversation_super_run_snapshot") {
+    return (
+      event.statuses.find(
+        (status) => status.conversation_id === conversationId,
+      ) ?? null
+    );
+  }
+  return event.conversation_id === conversationId ? event.status : undefined;
+}
+
+export interface EnqueuedReply {
+  text: string;
+  runIds: string[];
+  stopReason: StopReasonType | null;
+}
+
+export class EnqueuedWaitError extends Error {
+  constructor(
+    error: unknown,
+    readonly runIds: string[],
+  ) {
+    super(error instanceof Error ? error.message : String(error), {
+      cause: error,
+    });
+    this.name = "EnqueuedWaitError";
+  }
+}
+
+/**
+ * Subscribe before enqueue so even a fast recipient cannot finish before we
+ * see its run-to-message mapping. Stream loss is a waiting error, never a resend.
+ */
+export async function waitForEnqueuedReply(params: {
+  receipt: EnqueueReceipt;
+  events: AsyncIterator<ConversationStatusEvent>;
+  firstEvent: ConversationStatusEvent;
+  retrieveRun: (runId: string) => Promise<Run>;
+  listRunMessages: (runId: string) => Promise<Message[]>;
+  latestSuperRun: () => Promise<LatestConversationSuperRun | null>;
+  signal: AbortSignal;
+  pollMs?: number;
+  now?: () => number;
+}): Promise<EnqueuedReply> {
+  const runIds = new Set<string>();
+  const now = params.now ?? Date.now;
+  let completedWithoutText: { runId: string; at: number } | undefined;
+  let next: Promise<IteratorResult<ConversationStatusEvent>> = Promise.resolve({
+    done: false,
+    value: params.firstEvent,
+  });
+  try {
+    while (true) {
+      params.signal.throwIfAborted();
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      const event = await Promise.race([
+        next,
+        new Promise<null>((resolve) => {
+          timer = setTimeout(() => resolve(null), params.pollMs ?? 1_000);
+        }),
+      ]).finally(() => clearTimeout(timer));
+      if (event) {
+        if (event.done)
+          throw new Error(
+            "Conversation status connection closed; remote execution may still be running.",
+          );
+        const status = getConversationStatus(
+          event.value,
+          params.receipt.conversation_id,
+        );
+        if (status !== undefined) {
+          for (const runId of getSendRunIds(
+            status,
+            params.receipt.client_message_id,
+          ))
+            runIds.add(runId);
+        }
+        next = params.events.next();
+        // Keep a rejected read handled while the run/message HTTP requests run.
+        void next.catch(() => {});
+      }
+
+      // Newest mapped run is the current approval continuation, never another
+      // human turn selected by transcript position or role.
+      const runId = [...runIds].at(-1);
+      if (!runId) {
+        const latest = await params.latestSuperRun();
+        if (
+          latest?.id === params.receipt.super_run_id &&
+          (latest.errored_at || latest.cancelled_at)
+        ) {
+          throw new Error(
+            `Accepted send ${latest.id} ${latest.errored_at ? "failed" : "was cancelled"} before a run was observed.`,
+          );
+        }
+        continue;
+      }
+      const run = await params.retrieveRun(runId);
+      if (run.status === "failed" || run.status === "cancelled") {
+        throw new Error(
+          `Remote run ${runId} ${run.status}${run.stop_reason ? ` (${run.stop_reason})` : ""}`,
+        );
+      }
+      if (run.status !== "completed" || run.stop_reason === "requires_approval")
+        continue;
+      const messages = await params.listRunMessages(runId);
+      const assistant = messages
+        .filter((message) => message.message_type === "assistant_message")
+        .sort((a, b) => (b.seq_id ?? 0) - (a.seq_id ?? 0))[0];
+      if (assistant?.message_type === "assistant_message") {
+        const text =
+          typeof assistant.content === "string"
+            ? assistant.content
+            : assistant.content
+                .filter((part) => part.type === "text")
+                .map((part) => part.text)
+                .join("\n");
+        if (text.trim())
+          return {
+            text,
+            runIds: [...runIds],
+            stopReason: run.stop_reason ?? null,
+          };
+      }
+      if (completedWithoutText?.runId !== runId)
+        completedWithoutText = { runId, at: now() };
+      // Run status and messages can become visible on different reads.
+      if (now() - completedWithoutText.at < 15_000) continue;
+      throw new Error(
+        `Remote run ${runId} completed without an assistant reply (${run.stop_reason ?? "unknown stop reason"})`,
+      );
+    }
+  } catch (error) {
+    throw new EnqueuedWaitError(error, [...runIds]);
+  }
+}

--- a/src/headless-environment-response.ts
+++ b/src/headless-environment-response.ts
@@ -17,6 +17,24 @@ import {
 import { ApiRequestError } from "@/backend/api/request";
 import { toolFilter } from "@/tools/filter";
 
+export function isCloudEnvironmentSelector(
+  selector: string | boolean | undefined,
+): boolean {
+  if (typeof selector !== "string") return false;
+  const normalized = selector.trim().toLowerCase();
+  return normalized === "cloud" || normalized === "cloud-sandbox";
+}
+
+export function getEnvironmentRoutedMessagingUnsupportedReason(
+  environment: EnvironmentConnection,
+): string | null {
+  if (environment.metadata?.environmentMessageProtocol === "v2-input")
+    return null;
+  return `Computer ${environment.connectionName} (${environment.deviceId}) is running Letta Code ${
+    environment.metadata?.lettaCodeVersion ?? "unknown"
+  } and does not advertise computer-routed headless messaging support. Update that runtime or omit --computer to use same-computer messaging.`;
+}
+
 /**
  * Build the POST body for an environment-routed turn.
  *

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -22,6 +22,7 @@ import {
 } from "@/utils/message-queue-bridge";
 import { detectShellContext } from "@/utils/shell-context";
 import { createSigintAbortSignal } from "@/utils/sigint-abort";
+import { consumeSubagentLaunch } from "@/utils/subagent-launch-marker";
 import { reportSubagentStdoutLoss } from "@/utils/subagent-stdout-failure";
 import { isAgentIdCompatibleWithBackend } from "./agent/agent-id";
 import type { ApprovalResult } from "./agent/approval-execution";
@@ -113,8 +114,11 @@ import {
   validatePrimaryStartupFlagConflicts,
 } from "./cli/startup-flag-validation";
 import { SYSTEM_REMINDER_CLOSE, SYSTEM_REMINDER_OPEN } from "./constants";
+import { tryCloudHeadlessSend } from "./headless-cloud-send";
 import {
   buildEnvironmentCreateMessageBody,
+  getEnvironmentRoutedMessagingUnsupportedReason,
+  isCloudEnvironmentSelector,
   waitForEnvironmentAssistantMessage,
 } from "./headless-environment-response";
 import {
@@ -687,25 +691,6 @@ function formatAgentReplyMetadata(params: {
   });
 }
 
-function isCloudEnvironmentSelector(
-  selector: string | boolean | undefined,
-): boolean {
-  if (typeof selector !== "string") return false;
-  const normalized = selector.trim().toLowerCase();
-  return normalized === "cloud" || normalized === "cloud-sandbox";
-}
-
-function getEnvironmentRoutedMessagingUnsupportedReason(
-  environment: EnvironmentConnection,
-): string | null {
-  if (environment.metadata?.environmentMessageProtocol === "v2-input") {
-    return null;
-  }
-  return `Computer ${environment.connectionName} (${environment.deviceId}) is running Letta Code ${
-    environment.metadata?.lettaCodeVersion ?? "unknown"
-  } and does not advertise computer-routed headless messaging support. Update that runtime or omit --computer to use same-computer messaging.`;
-}
-
 export async function handleHeadlessCommand(
   parsedArgs: ParsedCliArgs,
   model?: string,
@@ -715,6 +700,7 @@ export async function handleHeadlessCommand(
   startupOptions: { requestedBackendMode?: BackendMode } = {},
 ) {
   const { values, positionals } = parsedArgs;
+  const isAgentLaunch = consumeSubagentLaunch(process.env);
   telemetry.setSurface(getTerminalTelemetrySurface(true));
   const modsDisabled = shouldDisableMods({
     cliFlag: values["no-mods"],
@@ -806,6 +792,16 @@ export async function handleHeadlessCommand(
   prepareHeadlessEphemeralBackend(Boolean(values.ephemeral));
   const backend = getBackend();
   markMilestone("HEADLESS_CLIENT_READY");
+  const sendExitCode = await tryCloudHeadlessSend(
+    values,
+    prompt,
+    backend,
+    isAgentLaunch,
+    {
+      writeStdout: writeFinalHeadlessStdout,
+    },
+  );
+  if (sendExitCode !== undefined) return flushAndExit(sendExitCode);
   // Check for --resume flag (interactive only)
   if (values.resume) {
     trackHeadlessBoundaryError(

--- a/src/integration-tests/startup-flow.integration.test.ts
+++ b/src/integration-tests/startup-flow.integration.test.ts
@@ -230,7 +230,7 @@ describe("Startup Flow - Invalid Inputs", () => {
       const result = await runCli(
         [
           "--conversation",
-          "conversation-definitely-does-not-exist-12345",
+          "conv-00000000-0000-0000-0000-000000000000",
           "-p",
           "test",
         ],
@@ -447,8 +447,7 @@ describe("Startup Flow - Integration", () => {
         [
           "--conversation",
           realConversationId,
-          "-m",
-          "sonnet-4.6-low",
+          // The recipient was configured above; enqueue does not reconfigure it.
           "-p",
           "Say OK",
           "--output-format",
@@ -493,8 +492,7 @@ describe("Startup Flow - Integration", () => {
           agentIdForTest,
           "--conversation",
           "default",
-          "-m",
-          "sonnet-4.6-low",
+          // Keep the model set during agent creation.
           "-p",
           "Say OK",
           "--output-format",

--- a/src/skills/builtin/messaging-agents/SKILL.md
+++ b/src/skills/builtin/messaging-agents/SKILL.md
@@ -60,14 +60,43 @@ Results include `agent_id` for each matching message.
 
 ## CLI Usage (agent-to-agent)
 
+### Send without waiting for the answer (Cloud)
+
+```bash
+letta -p --conversation <target-conversation-id> --no-wait --output-format json "message text"
+```
+
+Keep the returned receipt. `queued` confirms Cloud accepted the message, not that
+the recipient has read it or finished. The CLI uses your `AGENT_ID` and
+`CONVERSATION_ID` as the return address. Reply explicitly to the supplied address;
+ordinary assistant output is not forwarded for a non-waiting send.
+
+To inspect progress without a local task ID, use the receipt's `status_command`
+or `messages_command`:
+
+```bash
+letta messages status --agent <target-agent-id> --conversation <target-conversation-id>
+letta messages list --agent <target-agent-id> --conversation <target-conversation-id>
+```
+
+Compare `latest_super_run.id` with the receipt's `super_run_id`. A different ID
+belongs to another send; an idle conversation alone does not prove completion.
+If waiting fails or times out, inspect before resending. The CLI does not cancel
+remote work when it stops waiting.
+
+Omit `--no-wait` to wait for the final answer instead. Configure execution tools
+and permissions on the recipient; Cloud sends do not accept local execution
+flags such as `--tools` or `--permission-mode`.
+
 ### Starting a New Conversation
 
 ```bash
 letta -p --from-agent $LETTA_AGENT_ID --agent <id> "message text"
 ```
 
-When no `--computer` is specified, the target agent will run on the same
-computer as the caller agent.
+For Cloud agents, omitting `--computer` lets Cloud select the conversation's
+active or saved computer, or start a Cloud sandbox when needed. Local/App Server
+execution and Agent-launched child processes keep their existing behavior.
 
 To route the target agent turn through a specific remote/local computer:
 
@@ -91,7 +120,7 @@ letta -p --from-agent $LETTA_AGENT_ID \
 | Arg | Required | Description |
 |-----|----------|-------------|
 | `--agent <id>` | Yes | Target agent ID to message |
-| `--from-agent <id>` | Yes | Sender agent ID (injects agent-to-agent system reminder) |
+| `--from-agent <id>` | Yes, unless using `--no-wait` | Select agent-to-agent delivery when starting a conversation |
 | `--computer <selector>` | No | Route through `cloud` (target agent's cloud sandbox) or an online computer by connection name, device ID, or connection ID |
 | `"message text"` | Yes | Message body (positional after flags) |
 
@@ -102,7 +131,7 @@ letta -p --from-agent $LETTA_AGENT_ID \
   "What do you know about the authentication system?"
 ```
 
-**Response (JSON format with `--output json`):**
+**Response (JSON format with `--output-format json`, relevant fields):**
 ```json
 {
   "type": "result",
@@ -110,9 +139,9 @@ letta -p --from-agent $LETTA_AGENT_ID \
   "is_error": false,
   "result": "The authentication system uses JWT tokens...",
   "agent_id": "agent-abc123",
-  "conversation_id": "conversation-xyz789",
-  "environment": { "source": "same-environment" },
-  "usage": { "prompt_tokens": 120, "completion_tokens": 80, "total_tokens": 200, "step_count": 1 }
+  "conversation_id": "conv-xyz789",
+  "status": "completed",
+  "usage": null
 }
 ```
 
@@ -148,14 +177,15 @@ letta -p --from-agent $LETTA_AGENT_ID \
   "Run on my same computer."
 ```
 
-Omit `--computer` when you want the target agent to run on the same computer as
-the caller agent.
+Use `--computer` only when that computer is needed. If the conversation is active
+on another computer, Cloud returns 409 rather than silently moving it. An offline
+computer returns 503. Inspect the error; do not bypass enqueue with a direct send.
 
 **Arguments:**
 | Arg | Required | Description |
 |-----|----------|-------------|
 | `--conversation <id>` | Yes | Existing conversation ID |
-| `--from-agent <id>` | Yes | Sender agent ID (injects agent-to-agent system reminder) |
+| `--from-agent <id>` | No | Override the sender agent ID; otherwise use the calling agent's environment |
 | `"message text"` | Yes | Follow-up message (positional after flags) |
 
 **Example:**
@@ -168,7 +198,7 @@ letta -p --from-agent $LETTA_AGENT_ID \
 ## Understanding the Response
 
 - Text-mode scripts return only the **final assistant message** (not tool calls, reasoning, or metadata)
-- JSON and stream-json responses include `agent_id`, `conversation_id`, and `environment.source` so you can continue the same conversation/runtime. Environment-routed turns also include `environment.id`, `connection_id`, `device_id`, and `name`.
+- Cloud enqueue receipts include `agent_id`, `conversation_id`, `client_message_id`, `workflow_id`, and `super_run_id`. Waiting JSON results retain these IDs and add the answer and associated `run_ids`.
 - The target agent may use tools, think, and reason - but you only see their final response
 - To see the full conversation transcript (including tool calls), use `letta messages list --agent <id>` targeting the other agent
 
@@ -177,9 +207,8 @@ letta -p --from-agent $LETTA_AGENT_ID \
 When you send a message, the target agent receives it with a system reminder:
 ```
 <system-reminder>
-This message is from "YourAgentName" (agent ID: agent-xxx), an agent currently running inside the Letta Code CLI (docs.letta.com/letta-code).
-The sender will only see the final message you generate (not tool calls or reasoning).
-If you need to share detailed information, include it in your response text.
+This message is from agent agent-xxx, conversation conv-xxx.
+The sender will only see the final message you generate (not tool calls or reasoning). Include your answer in your final response.
 </system-reminder>
 ```
 

--- a/src/test-utils/fixtures/cloud-send-startup.ts
+++ b/src/test-utils/fixtures/cloud-send-startup.ts
@@ -1,0 +1,80 @@
+import { appendFileSync } from "node:fs";
+
+// Only HTTP is replaced. The test runs index.ts, settings, pinned-name lookup,
+// argument forwarding, and the enqueue path unchanged in a separate process.
+const agent = {
+  id: "agent-named-target",
+  name: "Named Recipient",
+  tags: [],
+  blocks: [],
+  tools: [],
+  llm_config: { model: "test-model", context_window: 32000 },
+};
+const logPath = process.env.CLI_STARTUP_REQUEST_LOG;
+if (!logPath) throw new Error("Missing startup fixture request log");
+
+globalThis.fetch = Object.assign(
+  async (
+    input: Parameters<typeof fetch>[0],
+    init?: RequestInit,
+  ): Promise<Response> => {
+    const request =
+      input instanceof Request
+        ? new Request(input, init)
+        : new Request(input.toString(), init);
+    const url = new URL(request.url);
+    const body = request.method === "GET" ? undefined : await request.text();
+    appendFileSync(
+      logPath,
+      `${JSON.stringify({ method: request.method, path: url.pathname, body })}\n`,
+    );
+    if (url.pathname === "/v1/models/catalog")
+      return Response.json({
+        models: [
+          {
+            id: "test-model",
+            handle: "test/model",
+            label: "Test model",
+            brand: "test",
+            maxContextWindow: 32000,
+            isDefault: true,
+          },
+        ],
+      });
+    if (
+      request.method === "GET" &&
+      url.pathname.replace(/\/$/, "") === "/v1/agents"
+    )
+      return Response.json([agent]);
+    if (request.method === "GET" && url.pathname === `/v1/agents/${agent.id}`)
+      return Response.json(agent);
+    if (
+      request.method === "POST" &&
+      url.pathname.replace(/\/$/, "") === "/v1/conversations"
+    ) {
+      if (url.searchParams.get("agent_id") !== agent.id)
+        throw new Error("Wrong named target");
+      return Response.json({ id: "conv-created", agent_id: agent.id });
+    }
+    if (
+      request.method === "POST" &&
+      url.pathname === "/v1/conversations/conv-created/messages/enqueue"
+    ) {
+      const message = JSON.parse(body ?? "{}");
+      return Response.json(
+        {
+          client_message_id: message.client_message_id,
+          workflow_id: "workflow-test",
+          super_run_id: "super-run-test",
+        },
+        { status: 202 },
+      );
+    }
+    // No network fallback, particularly for unexpected writes or model calls.
+    return Response.json(
+      { message: `Unimplemented fixture endpoint: ${url.pathname}` },
+      { status: 404 },
+    );
+  },
+  { preconnect: () => {} },
+);

--- a/src/utils/subagent-launch-marker.test.ts
+++ b/src/utils/subagent-launch-marker.test.ts
@@ -1,0 +1,18 @@
+import { expect, test } from "bun:test";
+import {
+  consumeSubagentLaunch,
+  SUBAGENT_LAUNCH_ENV,
+} from "./subagent-launch-marker";
+
+test("only the Agent-launched process consumes the marker; descendants still inherit parent identity", () => {
+  const env = {
+    [SUBAGENT_LAUNCH_ENV]: "1",
+    LETTA_CODE_AGENT_ROLE: "subagent",
+    LETTA_PARENT_AGENT_ID: "agent-parent",
+  };
+  expect(consumeSubagentLaunch(env)).toBe(true);
+  expect(env[SUBAGENT_LAUNCH_ENV]).toBeUndefined();
+  expect(env.LETTA_PARENT_AGENT_ID).toBe("agent-parent");
+  expect(env.LETTA_CODE_AGENT_ROLE).toBe("subagent");
+  expect(consumeSubagentLaunch({ ...env })).toBe(false);
+});

--- a/src/utils/subagent-launch-marker.ts
+++ b/src/utils/subagent-launch-marker.ts
@@ -1,0 +1,8 @@
+/** Consumed by the child entrypoint; shell commands from that child must not inherit it. */
+export const SUBAGENT_LAUNCH_ENV = "LETTA_SUBAGENT_LAUNCH";
+
+export function consumeSubagentLaunch(env: NodeJS.ProcessEnv): boolean {
+  const isLaunch = env[SUBAGENT_LAUNCH_ENV] === "1";
+  delete env[SUBAGENT_LAUNCH_ENV];
+  return isLaunch;
+}


### PR DESCRIPTION
## Summary

An agent should be able to send a message without starting another harness for the receiving conversation, and choose whether to wait for the answer. Ordinary Cloud conversation sends now use the conversation enqueue endpoint, including sends with `--computer`. `--no-wait` returns the server's acceptance receipt; the default still waits and prints the final answer.

The waiting CLI subscribes before submitting, follows the listener's `client_message_ids_by_run_id`, and reads the final assistant message from the associated run. A Skill result or task notification represented as a user message no longer cuts the answer off. A different human turn cannot supply the answer unless the listener explicitly associates that run with this send.

Receipts contain `agent_id`, `conversation_id`, `client_message_id`, `workflow_id`, and `super_run_id`, plus commands for reading the conversation's status and messages. Run IDs are added only after the listener reports them. Waiting receipts go to stderr so text, JSON, and stream-json stdout retain their existing formats. A timeout or lost connection stops waiting, not remote execution; an ambiguous submission failure does not claim rejection or retry locally.

Ordinary `Agent` child launches retain their existing execution path through a one-shot launch marker. The child consumes it before running tools, so a subsequent Bash message from that child can use enqueue. Fresh execution without message-destination flags and local/App Server execution remain unchanged. Recipient execution settings must be configured on the recipient; unsupported flags such as `--tools` and `--permission-mode` fail before submission instead of silently losing their restrictions.

## Recipient instructions

These prefixes are included in the **user** message before the supplied text. IDs below are placeholders.

Waiting send:

```text
<system-reminder>
This message is from agent agent-sender, conversation conv-sender.
The sender will only see the final message you generate (not tool calls or reasoning). Include your answer in your final response.
</system-reminder>
```

Non-waiting send:

```text
<system-reminder>
This message is from agent agent-sender, conversation conv-sender.
To reply to agent agent-sender, conversation conv-sender, use SendAgentMessage if available. Otherwise run letta -p --agent agent-sender --conversation conv-sender --no-wait "your reply". Ordinary assistant output is not forwarded to the sender.
</system-reminder>
```

Without a return conversation, the header omits `, conversation conv-sender`; a non-waiting send instead says:

```text
Ordinary assistant output is not forwarded to the sender. No return conversation was supplied.
```

Without sender identity, no prefix is added. `SendAgentMessage` itself is not added by this PR.

## Verification

- `bun test src/headless*.test.ts src/agent/subagent-env-composition.test.ts src/agent/subagent-model-resolution.test.ts src/agent/subagent-retry-parent-scope.test.ts src/tools/task-background-only.test.ts src/cli/args.test.ts src/cli/subcommands/messages.test.ts src/cli/subcommands/message-status.test.ts src/backend/api/conversation-enqueue.test.ts src/utils/subagent-launch-marker.test.ts`: 268 passed.
- `bun run check`: all 12 checks passed. `bun run build`: passed.
- Full CLI startup subprocesses verify `--name`/`-n` with all three computer flag spellings, both `--new-agent`/`--from-agent` rejection paths, and rejection of unsupported model/tool/permission settings before submission. Only HTTP is mocked; name lookup and argument forwarding run through `index.ts`. That name-to-agent handoff is unchanged from before this PR.
- Updated the live startup tests to use a valid-shaped nonexistent conversation ID and the model already configured on the recipient, rather than passing a model override to enqueue.
- Ran the built Node CLI against Cloud in isolated test conversations. Waiting across an actual Skill invocation returned the final `CLI_SKILL_WAIT_OK` answer from the continuation run. The unchanged old waiter fails on that message sequence with `Environment turn ended without an assistant reply`.
- Sent non-waiting messages in both directions between two isolated conversations and inspected the persisted sender/return addresses and answers. The test driver issued both CLI commands; this did not test a recipient independently invoking the unreleased CLI.
- Read a live receipt through `letta messages status` without a local task ID. This command reports current conversation state and the latest Super Run, not authoritative completion of an older send.
- After verifying the server prerequisite, the built CLI with `--computer cloud` returned `CLI_EXPLICIT_CLOUD_OK` and the associated run ID. An invalid computer selector returned HTTP 404 with `Computer not found`, without a local fallback. Named/device targeting, offline-computer 503, and active-computer conflict 409 remain covered by tests rather than separate live checks. No server deployment was performed by this implementation fork. Agent-launch compatibility is covered by tests, not a separate live child launch.

## Breadcrumbs

- Requested in: LET-12149. Completion-detection report: LET-11820. Explicit-computer server support: LET-12457.
- Origin: [environment-routed headless messages](https://github.com/letta-ai/letta-code/pull/3229); the existing waiter was later [moved to runtime-status reads](https://github.com/letta-ai/letta-code/pull/4174). This PR replaces completion lookup for ordinary Cloud sends, while preserving the legacy Agent-launch path.
- Internal live-test receipts and limitations are recorded on LET-12149.
- Letta conversation: [`conv-20d95134-104a-45d9-bbd2-a2c7359b3cb7`](https://chat.letta.com/chat/agent-b86b0d3a-c425-4c88-86b9-44171f178713?conversation=conv-20d95134-104a-45d9-bbd2-a2c7359b3cb7).

## AI Tool(s) Used

Letta Code researched, implemented, and verified this change.
