### PR TITLE
fix(test): remove timing race from headless Monitor test

### DIFF
--- a/src/headless-interrupt-recovery.test.ts
+++ b/src/headless-interrupt-recovery.test.ts
@@ -23,7 +23,7 @@ let turns = 0;
 const backend = new FakeHeadlessBackend("agent-headless-interrupt", {
   async execute(input) {
     turns++;
-    console.log(JSON.stringify({ type: "fixture_input", turn: turns, body: input.body }));
+    console.log(JSON.stringify({ type: "fixture_input", turn: turns, body: { messages: input.body.messages } }));
     if (turns === 1) {
       await monitor({ description: "Watch headless interrupt events", persistent: true,
         ws: { url: process.env.MONITOR_TEST_URL },
@@ -50,17 +50,34 @@ await handleHeadlessCommand(parseCliArgs([
 
 test("headless interrupt stops a real Monitor, preserves its queued event, and sends recovery on the next turn", async () => {
   const home = mkdtempSync(join(tmpdir(), "letta-headless-monitor-interrupt-"));
-  const server = new WebSocketServer({ host: "127.0.0.1", port: 0 });
+  let onHandshake!: (accept: (verified: boolean) => void) => void;
+  const handshakeRequested = new Promise<(verified: boolean) => void>(
+    (resolve) => {
+      onHandshake = resolve;
+    },
+  );
+  const server = new WebSocketServer({
+    host: "127.0.0.1",
+    port: 0,
+    verifyClient: (_info, done) => {
+      // Hold the handshake until the first turn is idle. This forces the
+      // ordering that used to let the test send before a socket existed.
+      onHandshake(done);
+    },
+  });
   await new Promise<void>((resolve) => server.once("listening", resolve));
   const address = server.address();
   if (!address || typeof address === "string")
     throw new Error("Missing socket address");
-  let socket: WebSocket | undefined;
+  let socket: WebSocket;
   let closed = false;
-  server.on("connection", (client) => {
-    socket = client;
-    client.once("close", () => {
-      closed = true;
+  const connected = new Promise<void>((resolve) => {
+    server.once("connection", (client) => {
+      socket = client;
+      client.once("close", () => {
+        closed = true;
+      });
+      resolve();
     });
   });
   const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
@@ -141,25 +158,39 @@ test("headless interrupt stops a real Monitor, preserves its queued event, and s
           if (event.type === "result") {
             results++;
             if (results === 1) {
-              // Result is emitted before the turn's finally block. Wait for
-              // that epilogue before testing an actually idle interrupt.
-              setTimeout(() => {
-                survivedCompletion = socket?.readyState === 1 && !closed;
-                interrupt("idle-interrupt");
-              }, 200);
+              // Unlike interrupt, initialize is handled by the main loop,
+              // after the turn's finally block has finished.
+              send({
+                type: "control_request",
+                request_id: "after-first-turn",
+                request: { subtype: "initialize" },
+              });
             } else if (results === 3) finish();
+          }
+          if (
+            event.type === "control_response" &&
+            (event.response as { request_id?: string })?.request_id ===
+              "after-first-turn"
+          ) {
+            void (async () => {
+              const accept = await handshakeRequested;
+              accept(true);
+              await connected;
+              survivedCompletion = socket.readyState === 1 && !closed;
+              interrupt("idle-interrupt");
+            })().catch(finish);
           }
           if (
             event.type === "control_response" &&
             (event.response as { request_id?: string })?.request_id ===
               "idle-interrupt"
           ) {
-            survivedIdleInterrupt = socket?.readyState === 1 && !closed;
+            survivedIdleInterrupt = socket.readyState === 1 && !closed;
             user("wait until interrupted");
           }
           if (event.type === "fixture_waiting") {
             waiting = true;
-            socket?.send("queued real Monitor event before interrupt");
+            socket.send("queued real Monitor event before interrupt");
           }
           if (waiting && !interrupted && event.type === "queue_blocked") {
             interrupted = true;


### PR DESCRIPTION
## Summary

The headless Monitor test should verify interrupt and queue recovery without depending on how quickly a CI runner opens a WebSocket. It previously waited 200 ms after the first result, then continued even if the socket was still missing. In that case `socket?.send(...)` sent nothing and the test timed out waiting for `queue_blocked`.

Wait for an `initialize` reply, which the headless main loop sends after turn cleanup, and for the WebSocket connection before continuing. The test deliberately holds the handshake until that reply so it exercises a late connection on every run. Fixture diagnostics now include messages rather than the full tool catalog, keeping timeout logs readable. No production code changes.

## Verification

On Linux, the original test passed normally but reproduced the 25-second timeout when I delayed its WebSocket handshake by one second. The fixed test passed ten consecutive runs with the handshake held until the first turn was idle. The headless process, Monitor socket, stdin interrupts, and queue are real; model/backend responses use the existing fake backend. The assertions still cover normal completion, an idle interrupt, active cancellation, the queued event, and the recovery text.

- `bun run check`: all 12 checks passed.
- Adjacent headless queue and Monitor event-stream tests: 20 passed.
- macOS verification is pending CI. The original CI log reaches `fixture_waiting` without the expected queue event; it does not record handshake timing, so the delayed-handshake sequence above is a local reproduction.

## Breadcrumbs

- Origin: test introduced by [PR 4377](https://github.com/letta-ai/letta-code/pull/4377).
- Reported on: [PR 4384](https://github.com/letta-ai/letta-code/pull/4384), whose teleport test passed; this is a separate test-only fix.
- Failure evidence: [macOS job 103509122621](https://github.com/letta-ai/letta-code/actions/runs/34677180752/job/103509122621), merge revision `9f9ffc67`, `headless-interrupt-recovery.test.ts` timed out after 25 seconds.
- Letta conversation: [conv-3498f03c-6e15-443f-b80b-f9988d7272ed](https://chat.letta.com/chat/agent-b86b0d3a-c425-4c88-86b9-44171f178713?conversation=conv-3498f03c-6e15-443f-b80b-f9988d7272ed).

## AI Disclosure

AI-authored internal team change requested by a maintainer.

## AI Tool(s) Used

Letta Code for investigation, implementation, and verification.

## Human Verification

Pending maintainer review.
