### PR TITLE
fix(cli): include status requirements in messages backend type

### DIFF
--- a/src/cli/subcommands/messages-evidence.test.ts
+++ b/src/cli/subcommands/messages-evidence.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import { Letta } from "@letta-ai/letta-client";
 import { ArrayPage } from "@letta-ai/letta-client/core/pagination";
 import type { Backend } from "@/backend";
+import { readMessageStatus } from "./message-status";
 import { runMessagesSubcommand } from "./messages";
 
 type Page = Awaited<ReturnType<Backend["listConversationMessages"]>>;
@@ -24,6 +25,25 @@ const listAgentMessages = mock(
   async (..._args: Parameters<Backend["listAgentMessages"]>) =>
     pages.shift() ?? page([]),
 );
+const retrieveConversation = mock(async (id: string) => ({
+  id,
+  agent_id: "agent-target",
+}));
+const backend = {
+  listConversationMessages,
+  listAgentMessages,
+  retrieveConversation,
+  capabilities: {
+    remoteMemfs: false,
+    serverSideToolManagement: false,
+    serverSecrets: false,
+    promptRecompile: false,
+    byokProviderRefresh: false,
+    localModelCatalog: false,
+    localMemfs: false,
+    environmentRouting: true,
+  },
+};
 const message = {
   id: "message-1",
   message_type: "assistant_message" as const,
@@ -42,6 +62,7 @@ beforeEach(() => {
   });
   listConversationMessages.mockClear();
   listAgentMessages.mockClear();
+  retrieveConversation.mockClear();
 });
 afterEach(() => logSpy.mockRestore());
 
@@ -50,12 +71,77 @@ async function run(action: string, args: string[]) {
     [action, "--agent", "agent-target", ...args],
     {
       initializeSettings: async () => {},
-      getBackend: () => ({ listConversationMessages, listAgentMessages }),
+      getBackend: () => backend,
     },
   );
   expect(code).toBe(0);
   return JSON.parse(stdout[0] ?? "");
 }
+
+test("status resolves the conversation through the injected backend", async () => {
+  const getAgentRuntimeStatus = mock(async () => ({
+    agent_id: "agent-target",
+    snapshot_at: 0,
+    statuses: [],
+  }));
+  const getLatestConversationSuperRun = mock(async () => ({
+    id: "sr-latest",
+    status: "COM",
+    completed_at: "2026-09-01T12:00:00Z",
+    errored_at: null,
+    cancelled_at: null,
+  }));
+  const code = await runMessagesSubcommand(
+    ["status", "--conversation", "conv-target"],
+    {
+      initializeSettings: async () => {},
+      getBackend: () => backend,
+      readMessageStatus: (conversationId, agentId, statusBackend) =>
+        readMessageStatus(conversationId, agentId, statusBackend, {
+          getAgentRuntimeStatus,
+          getLatestConversationSuperRun,
+        }),
+    },
+  );
+  expect(code).toBe(0);
+  expect(retrieveConversation).toHaveBeenCalledWith("conv-target");
+  expect(getAgentRuntimeStatus).toHaveBeenCalledWith("agent-target", [
+    "conv-target",
+  ]);
+  expect(getLatestConversationSuperRun).toHaveBeenCalledWith("conv-target");
+  expect(JSON.parse(stdout[0] ?? "")).toMatchObject({
+    agent_id: "agent-target",
+    conversation_id: "conv-target",
+    runtime_status: null,
+    latest_super_run: { id: "sr-latest", status: "COM" },
+  });
+  expect(listAgentMessages).not.toHaveBeenCalled();
+  expect(listConversationMessages).not.toHaveBeenCalled();
+});
+
+test("status rejects a backend without environment routing before retrieval", async () => {
+  const errorSpy = spyOn(console, "error").mockImplementation(() => {});
+  try {
+    const code = await runMessagesSubcommand(
+      ["status", "--conversation", "conv-target"],
+      {
+        initializeSettings: async () => {},
+        getBackend: () => ({
+          ...backend,
+          capabilities: { ...backend.capabilities, environmentRouting: false },
+        }),
+      },
+    );
+    expect(code).toBe(1);
+    expect(errorSpy).toHaveBeenCalledWith(
+      "Message status is only available for Cloud conversations.",
+    );
+    expect(retrieveConversation).not.toHaveBeenCalled();
+    expect(stdout).toEqual([]);
+  } finally {
+    errorSpy.mockRestore();
+  }
+});
 
 test.each(["default", "conv-target"])(
   "includes failed-step messages and preserves correlation IDs for %s",

--- a/src/cli/subcommands/messages.ts
+++ b/src/cli/subcommands/messages.ts
@@ -13,7 +13,10 @@ type MessagesSubcommandDeps = {
   initializeSettings?: () => Promise<void>;
   getBackend?: () => Pick<
     ReturnType<typeof getBackend>,
-    "listAgentMessages" | "listConversationMessages"
+    | "listAgentMessages"
+    | "listConversationMessages"
+    | "capabilities"
+    | "retrieveConversation"
   >;
   searchMessagesForBackend?: typeof searchMessagesForBackend;
   readMessageStatus?: typeof readMessageStatus;


### PR DESCRIPTION
## Summary

The injected backend type for `messages` omitted `capabilities` and `retrieveConversation`, even though the status reader requires both. Include those two members and complete the typed test fixture. Dependency injection, all messages subcommands, and the status reader contract remain unchanged; this does not change Agent launches.

## Verification

- Reproduced TS2345 at `messages.ts:209` on fresh main (`9a40d271`).
- `bun test src/cli/subcommands/messages-evidence.test.ts src/cli/subcommands/messages.test.ts src/cli/subcommands/message-status.test.ts`: 17 passed. New coverage runs the real status reader with injected backend/API fixtures and checks conversation resolution plus rejection of a backend without Cloud routing.
- `bun run check`: all 12 checks passed; commit hooks passed.
- No live Cloud requests were needed for this type-only repair.

## Breadcrumbs

- Origin — introduced by [#4375](https://github.com/letta-ai/letta-code/pull/4375): [9a40d271](https://github.com/letta-ai/letta-code/commit/9a40d271f8ff77a3f84e4544645c6226faab0dab) narrowed the backend after [#4383](https://github.com/letta-ai/letta-code/pull/4383) added status.
- Unblocks base validation for [#4389](https://github.com/letta-ai/letta-code/pull/4389), tracked under LET-12149.
- Letta conversation: [default](https://chat.letta.com/chat/agent-0efbb50b-fd39-4a9d-8169-42e061c72c24?conversation=default).

## AI Disclosure

AI-assisted implementation. The agent read the [AI Policy](https://github.com/letta-ai/letta-code/blob/main/AI_POLICY.md); no human review is claimed here.

## AI Tool(s) Used

Letta Code researched, implemented, and verified this change.

## Human Verification

Pending human review; this agent cannot provide a human attestation.

👾 Generated with [Letta Code](https://letta.com)